### PR TITLE
Allow to optionally not have refractoriness in a model

### DIFF
--- a/brian2/codegen/runtime/numpy_rt/templates/threshold.py_
+++ b/brian2/codegen/runtime/numpy_rt/templates/threshold.py_
@@ -1,4 +1,7 @@
-# USES_VARIABLES { not_refractory, lastspike, t, _spikespace }
+# USES_VARIABLES { t, _spikespace }
+# not_refractory and lastspike are added as needed_variables in the
+# Thresholder class, we cannot use the USES_VARIABLE mechanism
+# conditionally
 # ITERATE_ALL { _idx }
 
 _vectorisation_idx = N
@@ -9,6 +12,8 @@ _vectorisation_idx = N
 _spikes, = _cond.nonzero()
 _spikespace[-1] = len(_spikes)
 _spikespace[:len(_spikes)] = _spikes
+{% if _uses_refractory %}
 # Set the neuron to refractory
 not_refractory[_spikes] = False
 lastspike[_spikes] = t
+{% endif %}

--- a/brian2/codegen/runtime/weave_rt/templates/threshold.cpp
+++ b/brian2/codegen/runtime/weave_rt/templates/threshold.cpp
@@ -1,7 +1,11 @@
 {% extends 'common_group.cpp' %}
 
 {% block maincode %}
-	// USES_VARIABLES { not_refractory, lastspike, t, _spikespace }
+	// USES_VARIABLES { t, _spikespace }
+	// not_refractory and lastspike are added as needed_variables in the
+	// Thresholder class, we cannot use the USES_VARIABLE mechanism
+	// conditionally
+
 	//// MAIN CODE ////////////
 	long _cpp_numspikes = 0;
 	for(int _idx=0; _idx<N; _idx++)
@@ -10,11 +14,13 @@
 		{{ super() }}
 		if(_cond) {
 			_spikespace[_cpp_numspikes++] = _idx;
+			{% if _uses_refractory %}
 			// We have to use the pointer names directly here: The condition
 			// might contain references to not_refractory or lastspike and in
 			// that case the names will refer to a single entry.
 			_ptr{{_array_not_refractory}}[_idx] = false;
 			_ptr{{_array_lastspike}}[_idx] = t;
+			{% endif %}
 		}
 	}
 	_spikespace[N] = _cpp_numspikes;

--- a/brian2/groups/group.py
+++ b/brian2/groups/group.py
@@ -368,7 +368,7 @@ def create_runner_codeobj(group, code, template_name,
     needed_variables: list of str, optional
         A list of variables that are neither present in the abstract code, nor
         in the ``USES_VARIABLES`` statement in the template. This is only
-        rarely necessary, an exception being a `StateMonitor` where the
+        rarely necessary, an example being a `StateMonitor` where the
         names of the variables are neither known to the template nor included
         in the abstract code statements.
     additional_variables : dict-like, optional
@@ -509,14 +509,24 @@ class GroupCodeRunner(BrianObject):
         values)
     template_kwds : dict, optional
         A dictionary of additional information that is passed to the template.
+    needed_variables: list of str, optional
+        A list of variables that are neither present in the abstract code, nor
+        in the ``USES_VARIABLES`` statement in the template. This is only
+        rarely necessary, an example being a `StateMonitor` where the
+        names of the variables are neither known to the template nor included
+        in the abstract code statements.
     '''
     def __init__(self, group, template, code=None, when=None,
-                 name='coderunner*', check_units=True, template_kwds=None):
+                 name='coderunner*', check_units=True, template_kwds=None,
+                 needed_variables=None):
         BrianObject.__init__(self, when=when, name=name)
         self.group = weakref.proxy(group)
         self.template = template
         self.abstract_code = code
         self.check_units = check_units
+        if needed_variables is None:
+            needed_variables = []
+        self.needed_variables = needed_variables
         self.template_kwds = template_kwds
     
     def update_abstract_code(self):
@@ -545,6 +555,7 @@ class GroupCodeRunner(BrianObject):
                                              check_units=self.check_units,
                                              additional_variables=additional_variables,
                                              additional_namespace=namespace,
+                                             needed_variables=self.needed_variables,
                                              template_kwds=self.template_kwds)
         self.code_objects[:] = [weakref.proxy(self.codeobj)]
         self.updaters[:] = [self.codeobj.get_updater()]

--- a/brian2/groups/poissongroup.py
+++ b/brian2/groups/poissongroup.py
@@ -58,28 +58,16 @@ class PoissonGroup(Group, SpikeSource):
                                                                  '_spikespace',
                                                                  size=N+1,
                                                                  unit=1,
-                                                                 dtype=np.int32),
-                               'not_refractory': get_device().array(self,
-                                                                    '_not_refractory',
-                                                                    N, 1,
-                                                                    dtype=np.bool),
-                               'lastspike': get_device().array(self,
-                                                               '_lastspike',
-                                                               N, 1)})
+                                                                 dtype=np.int32)})
         self.start = 0
         self.stop = N
         self.namespace = create_namespace(None)
 
         self.threshold = 'rand() < rates * dt'
+        self._refractory = False
         self.thresholder = Thresholder(self)
         self.contained_objects.append(self.thresholder)
 
-        # This is quite inefficient, we need a state updater to reset
-        # not_refractory after every time step
-        self.equations = Equations([])
-        self._refractory = False
-        self.state_updater = StateUpdater(self, method='independent')
-        self.contained_objects.append(self.state_updater)
         self._enable_group_attributes()
 
         # Set the rates according to the argument

--- a/brian2/tests/test_neurongroup.py
+++ b/brian2/tests/test_neurongroup.py
@@ -51,9 +51,14 @@ def test_variables():
     '''
     G = NeuronGroup(1, 'dv/dt = -v/(10*ms) : 1')
     assert 'v' in G.variables and 't' in G.variables and 'dt' in G.variables
-    
+    assert 'not_refractory' not in G.variables and 'lastspike' not in G.variables
+
     G = NeuronGroup(1, 'dv/dt = -v/tau + xi*tau**-0.5: 1')
     assert not 'tau' in G.variables and 'xi' in G.variables
+
+    # NeuronGroup with refractoriness
+    G = NeuronGroup(1, 'dv/dt = -v/(10*ms) : 1', refractory=5*ms)
+    assert 'not_refractory' in G.variables and 'lastspike' in G.variables
 
 
 def test_stochastic_variable():


### PR DESCRIPTION
Relatively simple change to close #125 and make the refractoriness code optional (`NeuronGroup`'s refractory argument has to be set to something else than `False`). Simplifies `PoissonGroup` a bit which no longer needs a state updater just to reset the refractoriness in every time step... I think it's ready to merge as it is.
