### PR TITLE
In generated numpy code, copy arrays that are also written to, otherwise...

### DIFF
--- a/brian2/codegen/generators/numpy_generator.py
+++ b/brian2/codegen/generators/numpy_generator.py
@@ -53,7 +53,10 @@ class NumpyCodeGenerator(CodeGenerator):
 #            line = line.format(varname=varname, array_name=self.get_array_name(var), index=index)
             line = varname + ' = ' + self.get_array_name(var)
             if not index in self.iterate_all:
-                line = line + '[' + index + ']'
+                line += '[' + index + ']'
+            elif varname in write:
+                # avoid potential issues with aliased variables, see github #259
+                line += '.copy()'
             lines.append(line)
         # the actual code
         created_vars = set([])

--- a/brian2/tests/test_neurongroup.py
+++ b/brian2/tests/test_neurongroup.py
@@ -577,6 +577,21 @@ def test_get_dtype():
     assert_raises(TypeError, lambda: get_dtype(eqs['b'], {'b': np.int32}))
 
 
+def test_aliasing_in_statements():
+    '''
+    Test an issue around variables aliasing other variables (#259)
+    '''
+    runner_code = '''x_1 = x_0
+                     x_0 = -1'''
+    g = NeuronGroup(1, model='''x_0 : 1
+                                x_1 : 1 ''', codeobj_class=NumpyCodeObject)
+    custom_code_obj = g.runner(runner_code)
+    net = Network(g, custom_code_obj)
+    net.run(defaultclock.dt)
+    assert_equal(g.x_0_[:], np.array([-1]))
+    assert_equal(g.x_1_[:], np.array([0]))
+
+
 if __name__ == '__main__':
     test_creation()
     test_variables()
@@ -599,3 +614,4 @@ if __name__ == '__main__':
     test_indices()
     test_repr()
     test_get_dtype()
+    test_aliasing_in_statements()


### PR DESCRIPTION
... it is possible that aliased variables lead to incorrect results that are difficult to debug. Fixes #259
