### PR TITLE
Allow comments in abstract code statements and include them in the gener...

### DIFF
--- a/brian2/codegen/generators/base.py
+++ b/brian2/codegen/generators/base.py
@@ -98,7 +98,7 @@ class CodeGenerator(object):
         read = set()
         write = set()
         for stmt in statements:
-            ids = set(get_identifiers(stmt.expr))
+            ids = get_identifiers(stmt.expr)
             # if the operation is inplace this counts as a read.
             if stmt.inplace:
                 ids.add(stmt.var)

--- a/brian2/codegen/generators/cpp_generator.py
+++ b/brian2/codegen/generators/cpp_generator.py
@@ -134,7 +134,8 @@ class CPPCodeGenerator(CodeGenerator):
         return CPPNodeRenderer().render_expr(expr).strip()
 
     def translate_statement(self, statement):
-        var, op, expr = statement.var, statement.op, statement.expr
+        var, op, expr, comment = (statement.var, statement.op,
+                                  statement.expr, statement.comment)
         if op == ':=':
             decl = self.c_data_type(statement.dtype) + ' '
             op = '='
@@ -142,7 +143,10 @@ class CPPCodeGenerator(CodeGenerator):
                 decl = 'const ' + decl
         else:
             decl = ''
-        return decl + var + ' ' + op + ' ' + self.translate_expression(expr) + ';'
+        code = decl + var + ' ' + op + ' ' + self.translate_expression(expr) + ';'
+        if len(comment):
+            code += ' // ' + comment
+        return code
     
     def translate_to_read_arrays(self, statements):
         read, write, indices, conditional_write_vars = self.arrays_helper(statements)

--- a/brian2/codegen/generators/numpy_generator.py
+++ b/brian2/codegen/generators/numpy_generator.py
@@ -32,10 +32,14 @@ class NumpyCodeGenerator(CodeGenerator):
     def translate_statement(self, statement):
         # TODO: optimisation, translate arithmetic to a sequence of inplace
         # operations like a=b+c -> add(b, c, a)
-        var, op, expr = statement.var, statement.op, statement.expr
+        var, op, expr, comment = (statement.var, statement.op,
+                                  statement.expr, statement.comment)
         if op == ':=':
             op = '='
-        return var + ' ' + op + ' ' + self.translate_expression(expr)
+        code = var + ' ' + op + ' ' + self.translate_expression(expr)
+        if len(comment):
+            code += ' # ' + comment
+        return code
         
     def translate_one_statement_sequence(self, statements):
         variables = self.variables

--- a/brian2/codegen/statements.py
+++ b/brian2/codegen/statements.py
@@ -38,11 +38,12 @@ class Statement(object):
     ``inplace``
         True or False depending if the operation is in-place or not.
     '''
-    def __init__(self, var, op, expr, dtype,
+    def __init__(self, var, op, expr, comment, dtype,
                  constant=False, subexpression=False, scalar=False):
         self.var = var.strip()
         self.op = op.strip()
         self.expr = expr
+        self.comment = comment
         self.dtype = dtype
         self.constant = constant
         self.subexpression = subexpression
@@ -62,6 +63,8 @@ class Statement(object):
             s += ' (subexpression)'
         if self.inplace:
             s += ' (in-place)'
+        if len(self.comment):
+            s += ' # ' + self.comment
         return s
     __repr__ = __str__
 

--- a/brian2/equations/codestrings.py
+++ b/brian2/equations/codestrings.py
@@ -33,7 +33,7 @@ class CodeString(object):
         self.code = code
 
         # : Set of identifiers in the code string
-        self.identifiers = set(get_identifiers(code))
+        self.identifiers = get_identifiers(code)
 
     def __str__(self):
         return self.code

--- a/brian2/equations/unitcheck.py
+++ b/brian2/equations/unitcheck.py
@@ -81,7 +81,7 @@ def check_units_statements(code, variables):
         if not len(line):
             continue  # skip empty lines
         
-        varname, op, expr = parse_statement(line)
+        varname, op, expr, comment = parse_statement(line)
         if op in ('+=', '-=', '*=', '/=', '%='):
             # Replace statements such as "w *=2" by "w = w * 2"
             expr = '{var} {op_first} {expr}'.format(var=varname,

--- a/brian2/tests/test_codegen.py
+++ b/brian2/tests/test_codegen.py
@@ -45,7 +45,8 @@ def test_get_identifiers_recursively():
                                        owner=FakeGroup(variables={}),
                                        device=None),
                  'x': Variable(unit=None, name='x')}
-    identifiers = get_identifiers_recursively('_x = sub1 + x', variables)
+    identifiers = get_identifiers_recursively(['_x = sub1 + x'],
+                                              variables)
     assert identifiers == set(['x', '_x', 'y', 'z', 'sub1', 'sub2'])
 
 


### PR DESCRIPTION
This rewrites mostly the `get_identifiers` and the `parse_statements` functions so that abstract code statements are now allowed to contain comments (i.e., closes #261). These comments are also included in the generated code (as `# comment` in python and `// comment` in C++).

Note that this pull request changes nothing for equations (#40).
