### PR TITLE
Rename `Group.runner` to `Group.custom_operation`. 

### DIFF
--- a/brian2/groups/group.py
+++ b/brian2/groups/group.py
@@ -627,29 +627,29 @@ class Group(BrianObject):
 
         return resolutions
 
-    def runner(self, code, when=None, name=None):
+    def custom_operation(self, code, when=None, name=None):
         '''
-        Returns a `CodeRunner` that runs abstract code in the groups namespace
+        Returns a `CodeRunner` that runs abstract code in the group's namespace.
 
         Parameters
         ----------
         code : str
             The abstract code to run.
         when : `Scheduler`, optional
-            When to run, by default in the 'start' slot with the same clock as
-            the group.
+            When to run, by default in the 'stateupdate' slot with the same
+            clock as the group.
         name : str, optional
             A unique name, if non is given the name of the group appended with
-            'runner', 'runner_1', etc. will be used. If a name is given
-            explicitly, it will be used as given (i.e. the group name will not
-            be prepended automatically).
+            'custom_operation', 'custom_operation_1', etc. will be used. If a
+            name is given explicitly, it will be used as given (i.e. the group
+            name will not be prepended automatically).
         '''
         when = Scheduler(when)
         if not when.defined_clock:
             when.clock = self.clock
 
         if name is None:
-            name = self.name + '_runner*'
+            name = self.name + '_custom_operation*'
 
         runner = CodeRunner(self, 'stateupdate', code=code, name=name,
                             when=when)
@@ -658,9 +658,9 @@ class Group(BrianObject):
 
 class CodeRunner(BrianObject):
     '''
-    A "runner" that runs a `CodeObject` every timestep and keeps a reference to
-    the `Group`. Used in `NeuronGroup` for `Thresholder`, `Resetter` and
-    `StateUpdater`.
+    A "code runner" that runs a `CodeObject` every timestep and keeps a
+    reference to the `Group`. Used in `NeuronGroup` for `Thresholder`,
+    `Resetter` and `StateUpdater`.
     
     On creation, we try to run the before_run method with an empty additional
     namespace (see `Network.before_run`). If the namespace is already complete

--- a/brian2/tests/test_network.py
+++ b/brian2/tests/test_network.py
@@ -474,8 +474,8 @@ def test_magic_collect():
     P = PoissonGroup(10, rates=100*Hz)
     G = NeuronGroup(10, 'v:1')
     S = Synapses(G, G, '')
-    G_runner = G.runner('')
-    S_runner = S.runner('')
+    G_runner = G.custom_operation('')
+    S_runner = S.custom_operation('')
 
     state_mon = StateMonitor(G, 'v', record=True)
     spike_mon = SpikeMonitor(G)

--- a/brian2/tests/test_neurongroup.py
+++ b/brian2/tests/test_neurongroup.py
@@ -807,7 +807,7 @@ def test_aliasing_in_statements():
                      x_0 = -1'''
     g = NeuronGroup(1, model='''x_0 : 1
                                 x_1 : 1 ''', codeobj_class=NumpyCodeObject)
-    custom_code_obj = g.runner(runner_code)
+    custom_code_obj = g.custom_operation(runner_code)
     net = Network(g, custom_code_obj)
     net.run(defaultclock.dt)
     assert_equal(g.x_0_[:], np.array([-1]))

--- a/docs_sphinx/user/input.rst
+++ b/docs_sphinx/user/input.rst
@@ -73,19 +73,20 @@ Abstract code statements
 ------------------------
 An alternative to specifying a stimulus in advance is to run a series of
 abstract code statements at certain points during a simulation. This can be
-achieved with a `CodeRunner`, one can think of these statements as equivalent
-to reset statements but executed unconditionally (i.e. for all neurons) and
-possibly on a different clock as the rest of the group. The following code
-changes the stimulus strength of half of the neurons (randomly chosen) to a new
-random value every 50ms. Note that the statement uses logical expressions to
-have the values only updated for the chosen subset of neurons (where the
-newly introduced auxiliary variable ``change`` equals 1)::
+achieved with a *custom operation*, one can think of these statements as
+equivalent to reset statements but executed unconditionally (i.e. for all
+neurons) and possibly on a different clock as the rest of the group. The
+following code changes the stimulus strength of half of the neurons (randomly
+chosen) to a new random value every 50ms. Note that the statement uses logical
+expressions to have the values only updated for the chosen subset of neurons
+(where the newly introduced auxiliary variable ``change`` equals 1)::
 
   G = NeuronGroup(100, '''dv/dt = (-v + I)/(10*ms) : 1
                           I : 1  # one stimulus per neuron''')
-  stim_updater = G.runner('''change = int(rand() < 0.5)
-                             I = change*(rand()*2) + (1-change)*I''',
-                          when=Scheduler(clock=Clock(dt=50*ms), when='start'))
+  stim_updater = G.custom_operation('''change = int(rand() < 0.5)
+                                       I = change*(rand()*2) + (1-change)*I''',
+                                    when=Scheduler(clock=Clock(dt=50*ms),
+                                                   when='start'))
 
 
 Arbitrary Python code (network operations)

--- a/examples/synapses_barrelcortex.py
+++ b/examples/synapses_barrelcortex.py
@@ -74,13 +74,13 @@ stim_start_x = barrelarraysize / 2.0 - cos(direction)*stimradius
 stim_start_y = barrelarraysize / 2.0 - sin(direction)*stimradius
 stim_start_time = t
 '''
-stim_updater = layer4.runner(runner_code,
-                             when=Scheduler(clock=Clock(dt=60*ms), when='start'))
-
+stim_updater = layer4.custom_operation(runner_code,
+                                       when=Scheduler(clock=Clock(dt=60*ms),
+                                                      when='start'))
 
 # Layer 2/3
 # Model: IF with adaptive threshold
-eqs='''
+eqs = '''
 dv/dt=(ge+gi+El-v)/taum : volt
 dge/dt=-ge/taue : volt
 dgi/dt=-gi/taui : volt


### PR DESCRIPTION
As discussed in #220, this renames `runner` to `custom_operation`. I did not change the name of the `CodeRunner` class, but "custom" operation does not make much sense here, since e.g. `StateUpdater` inherits from this class.
