### PR TITLE
Make `PopulationRateMonitor` take subgroups into account correctly.

### DIFF
--- a/brian2/codegen/runtime/numpy_rt/templates/ratemonitor.py_
+++ b/brian2/codegen/runtime/numpy_rt/templates/ratemonitor.py_
@@ -1,5 +1,8 @@
-{# USES_VARIABLES { rate, t, _spikespace, _num_source_neurons, _clock_t, _clock_dt } #}
+{# USES_VARIABLES { rate, t, _spikespace, _num_source_neurons,
+                    _clock_t, _clock_dt, _source_start, _source_stop } #}
 _spikes = {{_spikespace}}[:{{_spikespace}}[-1]]
+# Take subgroups into account
+_spikes = _spikes[(_spikes >= _source_start) & (_spikes < _source_stop)]
 _new_len = len({{_dynamic_t}}) + 1
 _owner.resize(_new_len)
 # Note that _t refers directly to the underlying array which might have changed

--- a/brian2/codegen/runtime/weave_rt/templates/ratemonitor.cpp
+++ b/brian2/codegen/runtime/weave_rt/templates/ratemonitor.cpp
@@ -1,9 +1,32 @@
 {% import 'common_macros.cpp' as common with context %}
 {% macro main() %}
     {{ common.insert_group_preamble() }}
-    {# USES_VARIABLES { t, rate, _clock_t, _clock_dt, _spikespace, _num_source_neurons } #}
-	const int _num_spikes = {{_spikespace}}[_num_spikespace-1];
-
+    {# USES_VARIABLES { t, rate, _clock_t, _clock_dt, _spikespace,
+                        _num_source_neurons, _source_start, _source_stop } #}
+	int _num_spikes = {{_spikespace}}[_num_spikespace-1];
+    // For subgroups, we do not want to record all spikes
+    // We assume that spikes are ordered
+    int _start_idx = 0;
+    int _end_idx = - 1;
+    for(int _j=0; _j<_num_spikes; _j++)
+    {
+        const int _idx = {{_spikespace}}[_j];
+        if (_idx >= _source_start) {
+            _start_idx = _j;
+            break;
+        }
+    }
+    for(int _j=_start_idx; _j<_num_spikes; _j++)
+    {
+        const int _idx = {{_spikespace}}[_j];
+        if (_idx >= _source_stop) {
+            _end_idx = _j;
+            break;
+        }
+    }
+    if (_end_idx == -1)
+        _end_idx =_num_spikes;
+    _num_spikes = _end_idx - _start_idx;
     // Calculate the new length for the arrays
     const npy_int _new_len = (npy_int)({{_dynamic_t}}.attr("shape")[0]) + 1;
 

--- a/brian2/codegen/runtime/weave_rt/templates/spikemonitor.cpp
+++ b/brian2/codegen/runtime/weave_rt/templates/spikemonitor.cpp
@@ -9,7 +9,6 @@
     {
         // For subgroups, we do not want to record all spikes
         // We assume that spikes are ordered
-        // TODO: Will this assumption ever be violated?
         int _start_idx = 0;
         int _end_idx = - 1;
         for(int _j=0; _j<_num_spikes; _j++)

--- a/brian2/devices/cpp_standalone/templates/ratemonitor.cpp
+++ b/brian2/devices/cpp_standalone/templates/ratemonitor.cpp
@@ -1,9 +1,33 @@
 {% extends 'common_group.cpp' %}
 
 {% block maincode %}
-	{# USES_VARIABLES { rate, t, _spikespace, _clock_t, _clock_dt, _num_source_neurons } #}
+	{# USES_VARIABLES { rate, t, _spikespace, _clock_t, _clock_dt,
+	                    _num_source_neurons, _source_start, _source_stop } #}
 
 	int _num_spikes = {{_spikespace}}[_num_spikespace-1];
+	// For subgroups, we do not want to record all spikes
+    // We assume that spikes are ordered
+    int _start_idx = 0;
+    int _end_idx = - 1;
+    for(int _j=0; _j<_num_spikes; _j++)
+    {
+        const int _idx = {{_spikespace}}[_j];
+        if (_idx >= _source_start) {
+            _start_idx = _j;
+            break;
+        }
+    }
+    for(int _j=_start_idx; _j<_num_spikes; _j++)
+    {
+        const int _idx = {{_spikespace}}[_j];
+        if (_idx >= _source_stop) {
+            _end_idx = _j;
+            break;
+        }
+    }
+    if (_end_idx == -1)
+        _end_idx =_num_spikes;
+    _num_spikes = _end_idx - _start_idx;
 	{{_dynamic_rate}}.push_back(1.0*_num_spikes/_clock_dt/_num_source_neurons);
 	{{_dynamic_t}}.push_back(_clock_t);
 {% endblock %}

--- a/brian2/monitors/ratemonitor.py
+++ b/brian2/monitors/ratemonitor.py
@@ -41,6 +41,11 @@ class PopulationRateMonitor(Group, CodeRunner):
         self.add_dependency(source)
 
         self.variables = Variables(self)
+        # Handle subgroups correctly
+        start = getattr(source, 'start', 0)
+        stop = getattr(source, 'stop', len(source))
+        self.variables.add_constant('_source_start', Unit(1), start)
+        self.variables.add_constant('_source_stop', Unit(1), stop)
         self.variables.add_reference('_spikespace', source)
         self.variables.add_reference('_clock_t', source, 't')
         self.variables.add_reference('_clock_dt', source, 'dt')


### PR DESCRIPTION
This fixes #282, using the same code we use for dealing with subgroups in `SpikeMonitor`. This could certainly be improved from a performance point of view, we are currently doing the whole subgroup-related check even if we are recording from a whole group. But I don't expect a simulation to spend any significant amount of computation in this code and either way, correctness is more important.

Ready to merge.
