### PR TITLE
Make sure that arrays have unique names in C++ standalone

### DIFF
--- a/brian2/devices/cpp_standalone/device.py
+++ b/brian2/devices/cpp_standalone/device.py
@@ -66,8 +66,8 @@ class CPPWriter(object):
             if open(fullfilename, 'r').read()==contents:
                 return
         open(fullfilename, 'w').write(contents)
-        
-        
+
+
 def invert_dict(x):
     return dict((v, k) for k, v in x.iteritems())
 
@@ -158,17 +158,41 @@ class CPPStandaloneDevice(Device):
         # Note that a dynamic array variable is added to both the arrays and
         # the _dynamic_array dictionary
         if isinstance(var, DynamicArrayVariable):
-            name = '_dynamic_array_%s_%s' % (var.owner.name, var.name)
+            # The code below is slightly more complicated than just looking
+            # for a unique name as above for static_array, the name has
+            # potentially to be unique for more than one dictionary, with
+            # different prefixes. This is because dynamic arrays are added to
+            # a ``dynamic_arrays`` dictionary (with a `_dynamic` prefix) and to
+            # the general ``arrays`` dictionary. We want to make sure that we
+            # use the same name in the two dictionaries, not for example
+            # ``_dynamic_array_source_name_2`` and ``_array_source_name_1``
+            # (this would work fine, but it would make the code harder to read).
+            orig_dynamic_name = dynamic_name = '_dynamic_array_%s_%s' % (var.owner.name, var.name)
+            orig_array_name = array_name = '_array_%s_%s' % (var.owner.name, var.name)
+            suffix = 0
+
             if var.dimensions == 1:
-                self.dynamic_arrays[var] = name
+                dynamic_dict = self.dynamic_arrays
             elif var.dimensions == 2:
-                self.dynamic_arrays_2d[var] = name
+                dynamic_dict = self.dynamic_arrays_2d
             else:
                 raise AssertionError(('Did not expect a dynamic array with %d '
                                       'dimensions.') % var.dimensions)
+            while (dynamic_name in dynamic_dict.values() or
+                   array_name in self.arrays.values()):
+                suffix += 1
+                dynamic_name = orig_dynamic_name + '_%d' % suffix
+                array_name = orig_array_name + '_%d' % suffix
+            dynamic_dict[var] = dynamic_name
+            self.arrays[var] = array_name
+        else:
+            orig_array_name = array_name = '_array_%s_%s' % (var.owner.name, var.name)
+            suffix = 0
+            while (array_name in self.arrays.values()):
+                suffix += 1
+                array_name = orig_array_name + '_%d' % suffix
+            self.arrays[var] = array_name
 
-        name = '_array_%s_%s' % (var.owner.name, var.name)
-        self.arrays[var] = name
 
     def init_with_zeros(self, var):
         self.zero_arrays.append(var)

--- a/brian2/synapses/synapses.py
+++ b/brian2/synapses/synapses.py
@@ -635,7 +635,7 @@ class Synapses(Group):
         self._enable_group_attributes()
 
     def __len__(self):
-        return self._N
+        return len(self.variables['_synaptic_pre'].get_value())
 
     def before_run(self, run_namespace=None, level=0):
         self.lastupdate = self.clock.t

--- a/brian2/tests/test_cpp_standalone.py
+++ b/brian2/tests/test_cpp_standalone.py
@@ -9,6 +9,7 @@ from brian2.devices.cpp_standalone import cpp_standalone_device
 
 
 def restore_device():
+    #Network.__instances__().clear()  #TODO
     cpp_standalone_device.reinit()
     set_device('runtime')
     restore_initial_state()
@@ -16,7 +17,6 @@ def restore_device():
 
 @with_setup(teardown=restore_device)
 def test_cpp_standalone(with_output=False):
-    Synapses.__instances__().clear()  # TODO: Shouldn't clear do this?
     set_device('cpp_standalone')
     ##### Define the model
     tau = 1*ms
@@ -53,8 +53,28 @@ def test_cpp_standalone(with_output=False):
     assert len(M.t) == len(M.i)
     assert M.t[0] == 0.
     assert M.t[-1] == 100*ms - defaultclock.dt
-    
+
+@with_setup(teardown=restore_device)
+def test_multiple_connects(with_output=False):
+    set_device('cpp_standalone')
+    G = NeuronGroup(10, 'v:1')
+    S = Synapses(G, G, 'w:1')
+    S.connect([0], [0])
+    S.connect([1], [1])
+    tempdir = tempfile.mkdtemp()
+    if with_output:
+        print tempdir
+    device.build(project_dir=tempdir, compile_project=True, run_project=True,
+                 with_output=True)
+    assert len(S) == 2 and len(S.w[:]) == 2
+
+
 if __name__=='__main__':
     # Print the debug output when testing this file only but not when running
     # via nose test
-    test_cpp_standalone(with_output=True)
+    for t in [
+             test_cpp_standalone,
+             test_multiple_connects
+             ]:
+        t(with_output=True)
+        restore_device()


### PR DESCRIPTION
The reason for the problem in #302 was that for the synapse creation from arrays we create new arrays of name `source` and `target` in the context of the `Synapses` object. The `CPPStandaloneDevice.add_array` method simply used the owner name and the variable name to create a name for the array. Most of the times this is fine, since we don't have overlapping variable names for the same object. In the case of synapse creation, we do however. I changed the `add_array` method so that it creates unique names using our standard approach (suffixing the name with `_1` etc.). I made the code slightly more complicated than necessary for fixing this bug, it also covers the situation for dynamical arrays which are inserted in two dictionaries (see code comments). I don't really see that we'll ever have the kind of situation it guards against, but better safe than sorry.

The commit also adds a test using the example from #302.

Ready to merge.
