### PR TITLE
Make the direct use of `TimedArrays` in Python consistent with the interpretation during simulation

### DIFF
--- a/brian2/tests/test_timedarray.py
+++ b/brian2/tests/test_timedarray.py
@@ -1,9 +1,11 @@
 import numpy as np
 from numpy.testing.utils import assert_equal
+from nose.plugins.attrib import attr
 
 from brian2 import *
 
 
+@attr('codegen-independent')
 def test_timedarray_direct_use():
     ta = TimedArray(np.linspace(0, 10, 11), 1*ms)
     assert ta(-1*ms) == 0
@@ -15,6 +17,18 @@ def test_timedarray_direct_use():
     assert ta(5*ms) == 5*amp
     assert ta(10*ms) == 10*amp
     assert ta(15*ms) == 10*amp
+
+
+def test_timedarray_semantics():
+    # Make sure that timed arrays are interpreted as specifying the values
+    # between t and t+dt (not between t-dt/2 and t+dt/2 as in Brian1)
+    ta = TimedArray(array([0, 1]), dt=0.4*ms)
+    G = NeuronGroup(1, 'value = ta(t) : 1', dt=0.1*ms)
+    mon = StateMonitor(G, 'value', record=0)
+    net = Network(G, mon)
+    net.run(0.8*ms)
+    assert_equal(mon[0].value, [0, 0, 0, 0, 1, 1, 1, 1])
+    assert_equal(mon[0].value, ta(mon.t))
 
 
 def test_timedarray_no_units():
@@ -64,6 +78,7 @@ def test_long_timedarray():
 
 if __name__ == '__main__':
     test_timedarray_direct_use()
+    test_timedarray_semantics()
     test_timedarray_no_units()
     test_timedarray_with_units()
     test_timedarray_no_upsampling()


### PR DESCRIPTION
Small fix, now also uses the "upsampling" technique when directly calling a `TimedArray` from Python (which is something one would only do for interactive use or debugging, I think). There are some weird corner cases where this will not necessarily give consistent answers when the group using the `TimedArray` uses a dt that is much smaller than `defaulclock.dt`, but there's not really anything we can do about it.

I also added a test that explicitly checks for the `[t, t+dt)` semantics (as opposed to the `[t-dt/2, t+dt/2)` semantics in Brian 1).

Ready to merge from my side.
