### PR TITLE
Fix (and test) the sympy rendering of small values. Fixes #361

### DIFF
--- a/brian2/parsing/rendering.py
+++ b/brian2/parsing/rendering.py
@@ -214,7 +214,7 @@ class SympyNodeRenderer(NodeRenderer):
             return 'Symbol("%s", real=True)' % node.id
 
     def render_Num(self, node):
-        return 'Float(%f)' % node.n
+        return 'Float(%s)' % node.n
 
 
 class CPPNodeRenderer(NodeRenderer):

--- a/brian2/tests/test_parsing.py
+++ b/brian2/tests/test_parsing.py
@@ -60,6 +60,8 @@ TEST_EXPRESSIONS = '''
     a>0.5 and b>0.5 or c>0.5
     a>0.5 and b>0.5 or not c>0.5
     2%4
+    17e-12
+    42e17
     '''
 
 


### PR DESCRIPTION
This should fix the issue.

``` Python
>>> SympyNodeRenderer().render_expr("1.50000000e-10")
'Float(1.5e-10)'
```
