### PR TITLE
Linked var fixes

### DIFF
--- a/brian2/codegen/generators/base.py
+++ b/brian2/codegen/generators/base.py
@@ -106,7 +106,7 @@ class CodeGenerator(object):
             if stmt.inplace:
                 ids.add(stmt.var)
             read = read.union(ids)
-            if stmt.scalar:
+            if stmt.scalar or variable_indices[stmt.var] == '0':
                 if stmt.op != ':=' and not self.allows_scalar_write:
                     raise SyntaxError(('Writing to scalar variable %s '
                                        'not allowed in this context.' % stmt.var))

--- a/brian2/groups/group.py
+++ b/brian2/groups/group.py
@@ -199,6 +199,8 @@ class Indexing(object):
             if item is None:
                 item = slice(None)
             if isinstance(item, slice):
+                if index_var == '0':
+                    return 0
                 if index_var == '_idx':
                     start, stop, step = item.indices(self.N.get_value())
                 else:

--- a/brian2/groups/neurongroup.py
+++ b/brian2/groups/neurongroup.py
@@ -511,7 +511,7 @@ class NeuronGroup(Group, SpikeSource):
                                          values=index_array)
                 index = '_%s_indices' % key
             else:
-                if linked_var.scalar or var_length == 1:
+                if linked_var.scalar or (var_length == 1 and self._N != 1):
                     index = '0'
                 else:
                     index = value.group.variables.indices[value.name]

--- a/brian2/tests/test_neurongroup.py
+++ b/brian2/tests/test_neurongroup.py
@@ -137,7 +137,11 @@ def test_linked_variable_correct():
     net = Network(G1, G2, mon1, mon2)
     net.run(10*ms)
     assert_equal(mon1.v[:, :], mon2.v[:, :])
-
+    # Make sure that printing the variable values works
+    assert len(str(G2.v)) > 0
+    assert len(repr(G2.v)) > 0
+    assert len(str(G2.v[:])) > 0
+    assert len(repr(G2.v[:])) > 0
 
 def test_linked_variable_incorrect():
     '''
@@ -172,9 +176,14 @@ def test_linked_variable_scalar():
     G2.x = linked_var(G1.x)
     mon = StateMonitor(G2, 'y', record=True)
     net = Network(G1, G2, mon)
-    net.run(10*ms)
     # We don't test anything for now, except that it runs without raising an
     # error
+    net.run(10*ms)
+    # Make sure that printing the variable values works
+    assert len(str(G2.x)) > 0
+    assert len(repr(G2.x)) > 0
+    assert len(str(G2.x[:])) > 0
+    assert len(repr(G2.x[:])) > 0
 
 
 def test_linked_variable_indexed():
@@ -1021,48 +1030,48 @@ def test_get_states():
 
 
 if __name__ == '__main__':
-    # test_creation()
-    # test_variables()
-    # test_scalar_variable()
-    # test_referred_scalar_variable()
-    # test_linked_variable_correct()
-    # test_linked_variable_incorrect()
-    # test_linked_variable_scalar()
-    # test_linked_variable_indexed()
-    # test_linked_variable_repeat()
-    # test_linked_double_linked1()
-    # test_linked_double_linked2()
-    # test_linked_double_linked3()
-    # test_linked_double_linked4()
-    # test_linked_triple_linked()
-    # test_linked_subgroup()
-    # test_linked_subgroup2()
-    # test_linked_subexpression()
-    # test_linked_subexpression_2()
-    # test_linked_subexpression_3()
-    # test_linked_subexpression_synapse()
-    # test_linked_variable_indexed_incorrect()
-    # test_linked_synapses()
-    # test_stochastic_variable()
-    # test_stochastic_variable_multiplicative()
-    # test_unit_errors()
-    # test_threshold_reset()
-    # test_unit_errors_threshold_reset()
-    # test_incomplete_namespace()
-    # test_namespace_errors()
-    # test_namespace_warnings()
-    # test_syntax_errors()
-    # test_state_variables()
-    # test_state_variable_access()
-    # test_state_variable_access_strings()
-    # test_subexpression()
-    # test_subexpression_with_constant()
-    # test_scalar_parameter_access()
-    # test_scalar_subexpression()
-    # test_indices()
-    # test_repr()
-    # test_get_dtype()
-    # if prefs.codegen.target == 'numpy':
-    #     test_aliasing_in_statements()
+    test_creation()
+    test_variables()
+    test_scalar_variable()
+    test_referred_scalar_variable()
+    test_linked_variable_correct()
+    test_linked_variable_incorrect()
+    test_linked_variable_scalar()
+    test_linked_variable_indexed()
+    test_linked_variable_repeat()
+    test_linked_double_linked1()
+    test_linked_double_linked2()
+    test_linked_double_linked3()
+    test_linked_double_linked4()
+    test_linked_triple_linked()
+    test_linked_subgroup()
+    test_linked_subgroup2()
+    test_linked_subexpression()
+    test_linked_subexpression_2()
+    test_linked_subexpression_3()
+    test_linked_subexpression_synapse()
+    test_linked_variable_indexed_incorrect()
+    test_linked_synapses()
+    test_stochastic_variable()
+    test_stochastic_variable_multiplicative()
+    test_unit_errors()
+    test_threshold_reset()
+    test_unit_errors_threshold_reset()
+    test_incomplete_namespace()
+    test_namespace_errors()
+    test_namespace_warnings()
+    test_syntax_errors()
+    test_state_variables()
+    test_state_variable_access()
+    test_state_variable_access_strings()
+    test_subexpression()
+    test_subexpression_with_constant()
+    test_scalar_parameter_access()
+    test_scalar_subexpression()
+    test_indices()
+    test_repr()
+    test_get_dtype()
+    if prefs.codegen.target == 'numpy':
+        test_aliasing_in_statements()
     test_get_states()
 


### PR DESCRIPTION
This fixes some issues around linking variables from a group of size one, including the problem with writing to them in reset statements as described on the mailing list: https://groups.google.com/forum/#!topic/brian-development/13FQouRZz78

Also adds the corresponding tests.