### PR TITLE
Make the "loop-invariant optimisations" optional via a preference

### DIFF
--- a/brian2/codegen/_prefs.py
+++ b/brian2/codegen/_prefs.py
@@ -39,5 +39,15 @@ prefs.register_preferences(
         Accepts the same arguments as `codegen.target`.
         ''',
         validator=lambda target: isinstance(target, basestring) or issubclass(target, CodeObject),
+        ),
+    loop_invariant_optimisations=BrianPreference(
+        default=True,
+        docs='''
+        Whether to pull out scalar expressions out of the statements, so that
+        they are only evaluated once instead of once for every neuron/synapse/...
+        Can be switched off, e.g. because it complicates the code (and the same
+        optimisation is already performed by the compiler) or because the
+        code generation target does not deal well with it. Defaults to ``True``.
+        '''
     )
-    )
+)

--- a/brian2/codegen/translation.py
+++ b/brian2/codegen/translation.py
@@ -24,6 +24,7 @@ except ImportError:
 
 import numpy as np
 
+from brian2.core.preferences import prefs
 from brian2.core.variables import Variable, Subexpression, AuxiliaryVariable
 from brian2.core.functions import Function
 from brian2.utils.stringtools import (deindent, strip_empty_lines,
@@ -469,10 +470,12 @@ def make_statements(code, variables, dtype):
 
     scalar_statements = [s for s in statements if s.scalar]
     vector_statements = [s for s in statements if not s.scalar]
-    scalar_constants, vector_statements = apply_loop_invariant_optimisations(vector_statements,
-                                                                             variables,
-                                                                             dtype)
-    scalar_statements.extend(scalar_constants)
+
+    if prefs.codegen.loop_invariant_optimisations:
+        scalar_constants, vector_statements = apply_loop_invariant_optimisations(vector_statements,
+                                                                                 variables,
+                                                                                 dtype)
+        scalar_statements.extend(scalar_constants)
 
     return scalar_statements, vector_statements
 


### PR DESCRIPTION
As the title says... I briefly looked into making this an attribute of the `Device`, but we apply the optimisations in `make_statements` which is an early function that does not yet know about code generation targets, devices, etc. so it seemed wrong to introduce such a dependence there. The preference is quite straightforward and it can also be a useful future workaround if we encounter further issues with the mechanism, i.e. we can just tell users to switch it off until we fix the problem.