### PR TITLE
Auto codegen target

### DIFF
--- a/brian2/codegen/_prefs.py
+++ b/brian2/codegen/_prefs.py
@@ -10,19 +10,21 @@ prefs.register_preferences(
     'codegen',
     'Code generation preferences',
     target=BrianPreference(
-        default='numpy',
+        default='auto',
         docs='''
         Default target for code generation.
         
         Can be a string, in which case it should be one of:
         
-        * ``'numpy'`` by default because this works on all platforms, but may not
-          be maximally efficient.
+        * ``'auto'`` the default, automatically chose the best code generation
+          target available.
         * `'weave'` uses ``scipy.weave`` to generate and compile C++ code,
           should work anywhere where ``gcc`` is installed and available at the
           command line.
         * ``'cython'``, uses the Cython package to generate C++ code. Needs a
           working installation of Cython and a C++ compiler.
+        * ``'numpy'`` works on all platforms and doesn't need a C compiler but
+          is often less efficient.
         
         Or it can be a ``CodeObject`` class.
         ''',
@@ -36,7 +38,7 @@ prefs.register_preferences(
         default numpy target, because the overhead of compiling code is not
         worth the speed gain for simple expressions.
 
-        Accepts the same arguments as `codegen.target`.
+        Accepts the same arguments as `codegen.target`, except for ``'auto'``
         ''',
         validator=lambda target: isinstance(target, basestring) or issubclass(target, CodeObject),
         ),

--- a/brian2/codegen/codeobject.py
+++ b/brian2/codegen/codeobject.py
@@ -51,6 +51,15 @@ class CodeObject(Nameable):
         self.template_name = template_name
         self.template_source = template_source
 
+    @classmethod
+    def is_available(cls):
+        '''
+        Whether this target for code generation is available. Should use a
+        minimal example to check whether code generation works in general.
+        '''
+        raise NotImplementedError("CodeObject class %s is missing an "
+                                  "'is_available' method." % (cls.__name__))
+
     def update_namespace(self):
         '''
         Update the namespace for this timestep. Should only deal with variables

--- a/brian2/codegen/runtime/cython_rt/cython_rt.py
+++ b/brian2/codegen/runtime/cython_rt/cython_rt.py
@@ -76,7 +76,10 @@ class CythonCodeObject(NumpyCodeObject):
             compiled.main()
             return True
         except Exception as ex:
-            logger.debug('Compilation with Cython failed: ' + str(ex))
+            logger.warn(('Cannot use Cython, a test compilation '
+                         'failed: %s (%s)' % (str(ex),
+                                              ex.__class__.__name__)) ,
+                        'failed_compile_test')
             return False
 
 

--- a/brian2/codegen/runtime/numpy_rt/numpy_rt.py
+++ b/brian2/codegen/runtime/numpy_rt/numpy_rt.py
@@ -51,6 +51,11 @@ class NumpyCodeObject(CodeObject):
                             template_name, template_source, name=name)
         self.variables_to_namespace()
 
+    @staticmethod
+    def is_available():
+        # no test necessary for numpy
+        return True
+
     def variables_to_namespace(self):
         # Variables can refer to values that are either constant (e.g. dt)
         # or change every timestep (e.g. t). We add the values of the

--- a/brian2/codegen/runtime/weave_rt/weave_rt.py
+++ b/brian2/codegen/runtime/weave_rt/weave_rt.py
@@ -123,8 +123,8 @@ include_dirs:
 
     @staticmethod
     def is_available():
-        with std_silent(False):
-            try:
+        try:
+            with std_silent(False):
                 compiler, extra_compile_args = get_compiler_and_args()
                 weave.inline('int x=0;', [],
                              compiler=compiler,
@@ -132,9 +132,12 @@ include_dirs:
                              extra_compile_args=extra_compile_args,
                              verbose=0)
                 return True
-            except Exception as ex:
-                logger.debug('Test compilation with weave failed: ' + str(ex))
-                return False
+        except Exception as ex:
+            logger.warn(('Cannot use weave, a test compilation '
+                         'failed: %s (%s)' % (str(ex),
+                                              ex.__class__.__name__)) ,
+                        'failed_compile_test')
+            return False
 
     def variables_to_namespace(self):
 

--- a/brian2/devices/device.py
+++ b/brian2/devices/device.py
@@ -30,20 +30,53 @@ all_devices = {}
 prefs.register_preferences('devices', 'Device preferences')
 
 
+#: caches the automatically determined code generation target
+_auto_target = None
+
+def auto_target():
+    '''
+    Automatically chose a code generation target (invoked when the
+    `codegen.target` preference is set to `'auto'`. Caches its result so it
+    only does the check once. Prefers weave > cython > numpy.
+
+    Returns
+    -------
+    target : class derived from `CodeObject`
+        The target to use
+    '''
+    global _auto_target
+    if _auto_target is None:
+        target_dict = dict((target.class_name, target)
+                           for target in codegen_targets
+                           if target.class_name)
+        if 'weave' in target_dict and target_dict['weave'].is_available():
+            _auto_target = target_dict['weave']
+        elif 'cython' in target_dict and target_dict['cython'].is_available():
+            _auto_target = target_dict['cython']
+        else:
+            _auto_target = target_dict['numpy']
+        logger.info(('Chosing %r as the code generation '
+                     'target.') % _auto_target.class_name)
+
+    return _auto_target
+
 def get_default_codeobject_class(pref='codegen.target'):
     '''
     Returns the default `CodeObject` class from the preferences.
     '''
     codeobj_class = prefs[pref]
     if isinstance(codeobj_class, str):
+        if codeobj_class == 'auto':
+            return auto_target()
         for target in codegen_targets:
             if target.class_name == codeobj_class:
                 return target
         # No target found
+        targets = ['auto'] + [target.class_name
+                              for target in codegen_targets
+                              if target.class_name]
         raise ValueError("Unknown code generation target: %s, should be "
-                         " one of %s"%(codeobj_class,
-                                       [target.class_name
-                                        for target in codegen_targets]))
+                         " one of %s" % (codeobj_class, targets))
     return codeobj_class
 
 

--- a/brian2/devices/device.py
+++ b/brian2/devices/device.py
@@ -49,14 +49,23 @@ def auto_target():
         target_dict = dict((target.class_name, target)
                            for target in codegen_targets
                            if target.class_name)
+        using_fallback = False
         if 'weave' in target_dict and target_dict['weave'].is_available():
             _auto_target = target_dict['weave']
         elif 'cython' in target_dict and target_dict['cython'].is_available():
             _auto_target = target_dict['cython']
         else:
             _auto_target = target_dict['numpy']
-        logger.info(('Chosing %r as the code generation '
-                     'target.') % _auto_target.class_name)
+            using_fallback = True
+
+        if using_fallback:
+            logger.warn('Cannot use compiled code, falling back to the numpy '
+                        'code generation target. Note that this will likely '
+                        'be slower than using compiled code.',
+                        'codegen_fallback')
+        else:
+            logger.info(('Chosing %r as the code generation '
+                         'target.') % _auto_target.class_name)
 
     return _auto_target
 

--- a/brian2/tests/test_codegen.py
+++ b/brian2/tests/test_codegen.py
@@ -10,12 +10,20 @@ from brian2.codegen.translation import (analyse_identifiers,
                                         apply_loop_invariant_optimisations
                                         )
 from brian2.codegen.statements import Statement
+from brian2.codegen.codeobject import CodeObject
 from brian2.core.variables import Subexpression, Variable, Constant
 from brian2.core.functions import Function, DEFAULT_FUNCTIONS
+from brian2.devices.device import auto_target
 from brian2.units.fundamentalunits import Unit
 from brian2.units import second, ms
 
 FakeGroup = namedtuple('FakeGroup', ['variables'])
+
+@attr('codegen-independent')
+def test_auto_target():
+    # very basic test that the "auto" codegen target is useable
+    assert issubclass(auto_target(), CodeObject)
+
 
 @attr('codegen-independent')
 def test_analyse_identifiers():
@@ -113,6 +121,7 @@ def test_apply_loop_invariant_optimisation_integer():
     assert len(scalar) == 0
 
 if __name__ == '__main__':
+    test_auto_target()
     test_analyse_identifiers()
     test_get_identifiers_recursively()
     test_nested_subexpressions()


### PR DESCRIPTION
This implements the mechanism we discussed in #379. I implemented the determination whether weave/cython works with a little code snippet that will be compiled. This can indeed take a considerable time (on the order of 3-5s if done from scratch without any caches) but I don't think this is a problem because:

1. This is only done if `'auto'` is actually used, i.e. it doesn't take any time if you explicitly set a codegen target
2. In most cases where a target is not available (e.g. Python 3 for weave, or no Cython installation), we don't even get that far
3. Most importantly: weave and Cython cache their codes on disk automatically already, i.e. when this has been executed once on a machine it is basically instantaneous the next time

I didn't realize this before but point 3 does really take the burden of doing some across-scripts caching ourselves.

I'm happy with this solution, let me know what you think.