### PR TITLE
Raise an error if the name of a synaptic variable clashes with a pre- or postsynaptic variable name

### DIFF
--- a/brian2/synapses/synapses.py
+++ b/brian2/synapses/synapses.py
@@ -911,6 +911,16 @@ class Synapses(Group):
 
         # Add all the pre and post variables with _pre and _post suffixes
         for name in getattr(self.source, 'variables', {}).iterkeys():
+            # Raise an error if a variable name is also used for a synaptic
+            # variable
+            if name in equations.names:
+                error_msg = ('The post-synaptic variable {name} has the same '
+                             'name as a synaptic variable, rename the synaptic '
+                             'variable ').format(name=name)
+                if name+'_syn' not in self.variables:
+                    error_msg += ("(for example to '{name}_syn') ".format(name=name))
+                error_msg += 'to avoid confusion'
+                raise ValueError(error_msg)
             var = self.source.variables[name]
             index = '0' if var.scalar else '_presynaptic_idx'
             try:
@@ -924,13 +934,22 @@ class Synapses(Group):
                                                   synapses=self.name,
                                                   source=self.source.name))
         for name in getattr(self.target, 'variables', {}).iterkeys():
+            # Raise an error if a variable name is also used for a synaptic
+            # variable
+            if name in equations.names:
+                error_msg = ("The pre-synaptic variable '{name}' has the same "
+                             "name as a synaptic variable, rename the synaptic "
+                             "variable ").format(name=name)
+                if name+'_syn' not in self.variables:
+                    error_msg += ("(for example to '{name}_syn') ".format(name=name))
+                error_msg += 'to avoid confusion'
+                raise ValueError(error_msg)
             var = self.target.variables[name]
             index = '0' if var.scalar else '_postsynaptic_idx'
             try:
                 self.variables.add_reference(name + '_post', self.target, name,
                                              index=index)
-                # Also add all the post variables without a suffix -- note that
-                # a reference will never overwrite the name of an existing name
+                # Also add all the post variables without a suffix
                 self.variables.add_reference(name, self.target, name,
                                              index=index)
             except TypeError:

--- a/brian2/tests/test_cpp_standalone.py
+++ b/brian2/tests/test_cpp_standalone.py
@@ -88,27 +88,27 @@ def test_storing_loading(with_output=False):
     G.x = x
     G.n = n
     G.b = b
-    S = Synapses(G, G, '''v : volt
-                          x : 1
-                          n : integer
-                          b : boolean''', connect='i==j')
-    S.v = v
-    S.x = x
-    S.n = n
-    S.b = b
+    S = Synapses(G, G, '''v_syn : volt
+                          x_syn : 1
+                          n_syn : integer
+                          b_syn : boolean''', connect='i==j')
+    S.v_syn = v
+    S.x_syn = x
+    S.n_syn = n
+    S.b_syn = b
     run(0*ms)
     tempdir = tempfile.mkdtemp()
     if with_output:
         print tempdir
     device.build(directory=tempdir, compile=True, run=True, with_output=True)
     assert_allclose(G.v[:], v)
-    assert_allclose(S.v[:], v)
+    assert_allclose(S.v_syn[:], v)
     assert_allclose(G.x[:], x)
-    assert_allclose(S.x[:], x)
+    assert_allclose(S.x_syn[:], x)
     assert_allclose(G.n[:], n)
-    assert_allclose(S.n[:], n)
+    assert_allclose(S.n_syn[:], n)
     assert_allclose(G.b[:], b)
-    assert_allclose(S.b[:], b)
+    assert_allclose(S.b_syn[:], b)
 
 @attr('standalone')
 @with_setup(teardown=restore_device)

--- a/brian2/tests/test_subgroup.py
+++ b/brian2/tests/test_subgroup.py
@@ -256,30 +256,30 @@ def test_subexpression_references():
 
     S1 = Synapses(SG1, SG2, '''w : 1
                           u = v2_post + 1 : 1
-                          v = v2_pre + 1 : 1''')
+                          x = v2_pre + 1 : 1''')
     S1.connect('i==(5-1-j)')
     assert_equal(S1.i[:], np.arange(5))
     assert_equal(S1.j[:], np.arange(5)[::-1])
     assert_equal(S1.u[:], np.arange(10)[:-6:-1]*2+1)
-    assert_equal(S1.v[:], np.arange(5)*2+1)
+    assert_equal(S1.x[:], np.arange(5)*2+1)
 
     S2 = Synapses(G, SG2, '''w : 1
                              u = v2_post + 1 : 1
-                             v = v2_pre + 1 : 1''')
+                             x = v2_pre + 1 : 1''')
     S2.connect('i==(5-1-j)')
     assert_equal(S2.i[:], np.arange(5))
     assert_equal(S2.j[:], np.arange(5)[::-1])
     assert_equal(S2.u[:], np.arange(10)[:-6:-1]*2+1)
-    assert_equal(S2.v[:], np.arange(5)*2+1)
+    assert_equal(S2.x[:], np.arange(5)*2+1)
 
     S3 = Synapses(SG1, G, '''w : 1
                              u = v2_post + 1 : 1
-                             v = v2_pre + 1 : 1''')
+                             x = v2_pre + 1 : 1''')
     S3.connect('i==(10-1-j)')
     assert_equal(S3.i[:], np.arange(5))
     assert_equal(S3.j[:], np.arange(10)[:-6:-1])
     assert_equal(S3.u[:], np.arange(10)[:-6:-1]*2+1)
-    assert_equal(S3.v[:], np.arange(5)*2+1)
+    assert_equal(S3.x[:], np.arange(5)*2+1)
 
 
 def test_subexpression_no_references():
@@ -295,30 +295,30 @@ def test_subexpression_no_references():
 
     S1 = Synapses(G[:5], G[5:], '''w : 1
                           u = v2_post + 1 : 1
-                          v = v2_pre + 1 : 1''')
+                          x = v2_pre + 1 : 1''')
     S1.connect('i==(5-1-j)')
     assert_equal(S1.i[:], np.arange(5))
     assert_equal(S1.j[:], np.arange(5)[::-1])
     assert_equal(S1.u[:], np.arange(10)[:-6:-1]*2+1)
-    assert_equal(S1.v[:], np.arange(5)*2+1)
+    assert_equal(S1.x[:], np.arange(5)*2+1)
 
     S2 = Synapses(G, G[5:], '''w : 1
                              u = v2_post + 1 : 1
-                             v = v2_pre + 1 : 1''')
+                             x = v2_pre + 1 : 1''')
     S2.connect('i==(5-1-j)')
     assert_equal(S2.i[:], np.arange(5))
     assert_equal(S2.j[:], np.arange(5)[::-1])
     assert_equal(S2.u[:], np.arange(10)[:-6:-1]*2+1)
-    assert_equal(S2.v[:], np.arange(5)*2+1)
+    assert_equal(S2.x[:], np.arange(5)*2+1)
 
     S3 = Synapses(G[:5], G, '''w : 1
                              u = v2_post + 1 : 1
-                             v = v2_pre + 1 : 1''')
+                             x = v2_pre + 1 : 1''')
     S3.connect('i==(10-1-j)')
     assert_equal(S3.i[:], np.arange(5))
     assert_equal(S3.j[:], np.arange(10)[:-6:-1])
     assert_equal(S3.u[:], np.arange(10)[:-6:-1]*2+1)
-    assert_equal(S3.v[:], np.arange(5)*2+1)
+    assert_equal(S3.x[:], np.arange(5)*2+1)
 
 
 def test_synaptic_propagation():

--- a/brian2/tests/test_synapses.py
+++ b/brian2/tests/test_synapses.py
@@ -38,6 +38,21 @@ def test_creation():
     assert S.source.name == S.target.name == G.name
 
 
+@attr('codegen-independent')
+def test_name_clashes():
+    # Using identical names for synaptic and pre- or post-synaptic variables
+    # is confusing and should be forbidden
+    G1 = NeuronGroup(1, 'a : 1')
+    G2 = NeuronGroup(1, 'b : 1')
+    assert_raises(ValueError, lambda: Synapses(G1, G2, 'a : 1'))
+    assert_raises(ValueError, lambda: Synapses(G1, G2, 'b : 1'))
+
+    # this should all be ok
+    Synapses(G1, G2, 'c : 1')
+    Synapses(G1, G2, 'a_syn : 1')
+    Synapses(G1, G2, 'b_syn : 1')
+
+
 def test_incoming_outgoing():
     '''
     Test the count of outgoing/incoming synapses per neuron.
@@ -444,10 +459,10 @@ def test_subexpression_references():
     G.v = np.arange(10)
     S = Synapses(G, G, '''w : 1
                           u = v2_post + 1 : 1
-                          v = v2_pre + 1 : 1''')
+                          x = v2_pre + 1 : 1''')
     S.connect('i==(10-1-j)')
     assert_equal(S.u[:], np.arange(10)[::-1]*2+1)
-    assert_equal(S.v[:], np.arange(10)*2+1)
+    assert_equal(S.x[:], np.arange(10)*2+1)
 
 
 def test_delay_specification():
@@ -804,6 +819,7 @@ def test_variables_by_owner():
 
 if __name__ == '__main__':
     test_creation()
+    test_name_clashes()
     test_incoming_outgoing()
     test_connection_string_deterministic()
     test_connection_random()


### PR DESCRIPTION
Does what the title says. As discussed in #348, this only deals with the error case. Warnings about clashes between pre- and postsynaptic variables are still up for discussion (see #406)