### PR TITLE
Standalone tests

### DIFF
--- a/brian2/devices/cpp_standalone/device.py
+++ b/brian2/devices/cpp_standalone/device.py
@@ -8,6 +8,7 @@ import inspect
 import platform
 from collections import defaultdict
 import numbers
+import tempfile
 
 import numpy as np
 
@@ -886,7 +887,24 @@ class RunFunctionContext(object):
     def __exit__(self, type, value, traceback):
         cpp_standalone_device.main_queue.append(('end_run_func', (self.name, self.include_in_parent)))
 
-
 cpp_standalone_device = CPPStandaloneDevice()
-
 all_devices['cpp_standalone'] = cpp_standalone_device
+
+
+class CPPStandaloneSimpleDevice(CPPStandaloneDevice):
+    def network_run(self, net, duration, report=None, report_period=10*second,
+                    namespace=None, profile=True, level=0, **kwds):
+        super(CPPStandaloneSimpleDevice, self).network_run(net, duration,
+                                                     report=report,
+                                                     report_period=report_period,
+                                                     namespace=namespace,
+                                                     profile=profile,
+                                                     level=level+1,
+                                                     **kwds)
+        tempdir = tempfile.mkdtemp()
+        self.build(directory=tempdir, compile=True, run=True, debug=False,
+                   with_output=False)
+
+cpp_standalone_simple_device = CPPStandaloneSimpleDevice()
+
+all_devices['cpp_standalone_simple'] = cpp_standalone_simple_device

--- a/brian2/devices/device.py
+++ b/brian2/devices/device.py
@@ -18,7 +18,7 @@ from brian2.utils.stringtools import code_representation, indent
 
 __all__ = ['Device', 'RuntimeDevice',
            'get_device', 'set_device',
-           'all_devices',
+           'all_devices', 'restore_device',
            'device',
            ]
 
@@ -287,6 +287,13 @@ class Device(object):
         For standalone projects, called when the project is ready to be built. Does nothing for runtime mode.
         '''
         pass
+
+    def reinit(self):
+        '''
+        Reinitialize the device. For standalone devices, clears all the internal
+        state of the device.
+        '''
+        pass
     
     
 class RuntimeDevice(Device):
@@ -418,6 +425,7 @@ def get_device():
     global active_device
     return active_device
 
+
 def set_device(device):
     '''
     Sets the active `Device` object
@@ -428,3 +436,11 @@ def set_device(device):
     active_device = device
     active_device.activate()
 
+
+def restore_device():
+    from brian2 import restore_initial_state  # avoids circular import
+
+    for device in all_devices.itervalues():
+        device.reinit()
+    set_device('runtime')
+    restore_initial_state()

--- a/brian2/tests/__init__.py
+++ b/brian2/tests/__init__.py
@@ -89,7 +89,7 @@ def run(codegen_targets=None, long_tests=False, test_codegen_independent=True,
             sys.stderr.write('Running tests for target %s:\n' % target)
             prefs.codegen.target = target
             prefs._backup()
-            exclude_str = "!standalone,!codegen-independent"
+            exclude_str = "!cpp_standalone,!codegen-independent"
             if not long_tests:
                 exclude_str += ',!long'
             # explicitly ignore the brian2.hears file for testing, otherwise the
@@ -105,17 +105,39 @@ def run(codegen_targets=None, long_tests=False, test_codegen_independent=True,
                                           '--nologcapture',
                                           '--exe']))
         if test_standalone:
-            sys.stderr.write('Running standalone tests\n')
+            from brian2.devices.device import get_device, set_device
+            previous_device = get_device()
+            set_device('cpp_standalone_simple')
+            sys.stderr.write('Running standalone-compatible standard tests\n')
             success.append(nose.run(argv=['', dirname,
                                           '-c=',  # no config file loading
                                           '-I', '^hears\.py$',
                                           '-I', '^\.',
                                           '-I', '^_',
                                           # Only run standalone tests
-                                          '-a', 'standalone',
+                                          '-a', 'standalone-compatible',
                                           '--nologcapture',
                                           '--exe']))
-        return all(success)
+            set_device(previous_device)
+            sys.stderr.write('Running standalone-specific tests\n')
+            success.append(nose.run(argv=['', dirname,
+                                          '-c=',  # no config file loading
+                                          '-I', '^hears\.py$',
+                                          '-I', '^\.',
+                                          '-I', '^_',
+                                          # Only run standalone tests
+                                          '-a', 'cpp_standalone',
+                                          '--nologcapture',
+                                          '--exe']))
+        all_success = all(success)
+        if not all_success:
+            sys.stderr.write(('ERROR: %d/%d test suite(s) did not complete '
+                              'successfully (see above).\n') % (len(success) - sum(success),
+                                                                len(success)))
+        else:
+            sys.stderr.write(('OK: %d/%d test suite(s) did complete '
+                              'successfully.\n') % (len(success), len(success)))
+        return all_success
 
     finally:
         # Restore the user preferences

--- a/brian2/tests/test_cpp_standalone.py
+++ b/brian2/tests/test_cpp_standalone.py
@@ -10,7 +10,7 @@ from brian2 import *
 from brian2.devices.cpp_standalone import cpp_standalone_device
 from brian2.devices.device import restore_device
 
-@attr('cpp_standalone')
+@attr('cpp_standalone', 'standalone-only')
 @with_setup(teardown=restore_device)
 def test_cpp_standalone(with_output=False):
     set_device('cpp_standalone')
@@ -50,7 +50,7 @@ def test_cpp_standalone(with_output=False):
     assert M.t[0] == 0.
     assert M.t[-1] == 100*ms - defaultclock.dt
 
-@attr('cpp_standalone')
+@attr('cpp_standalone', 'standalone-only')
 @with_setup(teardown=restore_device)
 def test_multiple_connects(with_output=False):
     set_device('cpp_standalone')
@@ -66,7 +66,7 @@ def test_multiple_connects(with_output=False):
                  with_output=True)
     assert len(S) == 2 and len(S.w[:]) == 2
 
-@attr('cpp_standalone')
+@attr('cpp_standalone', 'standalone-only')
 @with_setup(teardown=restore_device)
 def test_storing_loading(with_output=False):
     set_device('cpp_standalone')
@@ -104,7 +104,7 @@ def test_storing_loading(with_output=False):
     assert_allclose(G.b[:], b)
     assert_allclose(S.b_syn[:], b)
 
-@attr('cpp_standalone')
+@attr('cpp_standalone', 'standalone-only')
 @with_setup(teardown=restore_device)
 def test_openmp_consistency(with_output=False):
 
@@ -202,7 +202,7 @@ def test_openmp_consistency(with_output=False):
         assert_allclose(results[key1]['r'], results[key2]['r'])
         assert_allclose(results[key1]['s'], results[key2]['s'])
 
-@attr('cpp_standalone')
+@attr('cpp_standalone', 'standalone-only')
 @with_setup(teardown=restore_device)
 def test_timedarray(with_output=True):
     set_device('cpp_standalone')

--- a/brian2/tests/test_cpp_standalone.py
+++ b/brian2/tests/test_cpp_standalone.py
@@ -8,13 +8,7 @@ from numpy.testing.utils import assert_allclose, assert_equal
 
 from brian2 import *
 from brian2.devices.cpp_standalone import cpp_standalone_device
-
-
-def restore_device():
-    cpp_standalone_device.reinit()
-    set_device('runtime')
-    restore_initial_state()
-
+from brian2.devices.device import restore_device
 
 @attr('cpp_standalone')
 @with_setup(teardown=restore_device)

--- a/brian2/tests/test_cpp_standalone.py
+++ b/brian2/tests/test_cpp_standalone.py
@@ -16,7 +16,7 @@ def restore_device():
     restore_initial_state()
 
 
-@attr('standalone')
+@attr('cpp_standalone')
 @with_setup(teardown=restore_device)
 def test_cpp_standalone(with_output=False):
     set_device('cpp_standalone')
@@ -56,7 +56,7 @@ def test_cpp_standalone(with_output=False):
     assert M.t[0] == 0.
     assert M.t[-1] == 100*ms - defaultclock.dt
 
-@attr('standalone')
+@attr('cpp_standalone')
 @with_setup(teardown=restore_device)
 def test_multiple_connects(with_output=False):
     set_device('cpp_standalone')
@@ -72,7 +72,7 @@ def test_multiple_connects(with_output=False):
                  with_output=True)
     assert len(S) == 2 and len(S.w[:]) == 2
 
-@attr('standalone')
+@attr('cpp_standalone')
 @with_setup(teardown=restore_device)
 def test_storing_loading(with_output=False):
     set_device('cpp_standalone')
@@ -110,7 +110,7 @@ def test_storing_loading(with_output=False):
     assert_allclose(G.b[:], b)
     assert_allclose(S.b_syn[:], b)
 
-@attr('standalone')
+@attr('cpp_standalone')
 @with_setup(teardown=restore_device)
 def test_openmp_consistency(with_output=False):
 
@@ -208,7 +208,7 @@ def test_openmp_consistency(with_output=False):
         assert_allclose(results[key1]['r'], results[key2]['r'])
         assert_allclose(results[key1]['s'], results[key2]['s'])
 
-@attr('standalone')
+@attr('cpp_standalone')
 @with_setup(teardown=restore_device)
 def test_timedarray(with_output=True):
     set_device('cpp_standalone')

--- a/brian2/tests/test_equations.py
+++ b/brian2/tests/test_equations.py
@@ -418,7 +418,7 @@ def test_str_repr():
         assert(len(str(eq))) > 0
         assert(len(repr(eq))) > 0
 
-
+@attr('codegen-independent')
 def test_ipython_pprint():
     if pprint is None:
         raise SkipTest('ipython is not available')

--- a/brian2/tests/test_functions.py
+++ b/brian2/tests/test_functions.py
@@ -1,11 +1,11 @@
-from nose import SkipTest
+from nose import SkipTest, with_setup
 from nose.plugins.attrib import attr
 from numpy.testing import assert_equal, assert_raises, assert_allclose
 
 from brian2 import *
 from brian2.parsing.sympytools import str_to_sympy, sympy_to_str
 from brian2.utils.logger import catch_logs
-
+from brian2.devices.device import restore_device
 
 @attr('codegen-independent')
 def test_constants_sympy():
@@ -125,6 +125,8 @@ def test_math_functions():
                             err_msg='Function %s did not return the correct values' % func.__name__)
 
 
+@attr('standalone-compatible')
+@with_setup(teardown=restore_device)
 def test_user_defined_function():
     @implementation('cpp',"""
                 inline double usersin(double x)
@@ -153,6 +155,7 @@ def test_user_defined_function():
     assert_equal(np.sin(test_array), mon.func_.flatten())
 
 
+@with_setup(teardown=restore_device)
 def test_user_defined_function_units():
     '''
     Test the preparation of functions for use in code with check_units.
@@ -283,6 +286,7 @@ def test_manual_user_defined_function():
     net.run(default_dt)
 
     assert mon[0].func == [6] * volt
+
 
 def test_manual_user_defined_function_weave():
     if prefs.codegen.target != 'weave':

--- a/brian2/tests/test_monitor.py
+++ b/brian2/tests/test_monitor.py
@@ -1,9 +1,13 @@
-import numpy as np
 from numpy.testing.utils import assert_allclose, assert_array_equal, assert_raises
+from nose import with_setup
+from nose.plugins.attrib import attr
 
 from brian2 import *
+from brian2.devices.device import restore_device
 
 
+@attr('standalone-compatible')
+@with_setup(teardown=restore_device)
 def test_spike_monitor():
     G = NeuronGroup(2, '''dv/dt = rate : 1
                           rate: Hz''', threshold='v>1', reset='v=0')
@@ -29,7 +33,8 @@ def test_spike_monitor():
     assert_array_equal(t, mon.t)
     assert_array_equal(t_, mon.t_)
 
-
+@attr('standalone-compatible')
+@with_setup(teardown=restore_device)
 def test_state_monitor():
     # Check that all kinds of variables can be recorded
     G = NeuronGroup(2, '''dv/dt = -v / (10*ms) : 1
@@ -104,6 +109,9 @@ def test_state_monitor():
     assert_allclose(synapse_mon2[S['i==0 and j==1']].w, 1*nS)
     assert_allclose(synapse_mon2.w[1], 1*nS)
 
+@attr('standalone-compatible')
+@with_setup(teardown=restore_device)
+def test_state_monitor_indexing():
     # Check indexing semantics
     G = NeuronGroup(10, 'v:volt')
     G.v = np.arange(10) * volt
@@ -128,7 +136,8 @@ def test_state_monitor():
     assert_raises(TypeError, lambda: mon[5.0])
     assert_raises(TypeError, lambda: mon[[5.0, 6.0]])
 
-
+@attr('standalone-compatible')
+@with_setup(teardown=restore_device)
 def test_rate_monitor():
     G = NeuronGroup(5, 'v : 1', threshold='v>1') # no reset
     G.v = 1.1 # All neurons spike every time step
@@ -151,7 +160,8 @@ def test_rate_monitor():
     assert_array_equal(rate_mon.rate['t>0.5*ms'],
                  rate_mon.rate[np.nonzero(rate_mon.t>0.5*ms)[0]])
 
-
+@attr('standalone-compatible')
+@with_setup(teardown=restore_device)
 def test_rate_monitor_subgroups():
     old_dt = defaultclock.dt
     defaultclock.dt = 0.01*ms
@@ -174,5 +184,6 @@ def test_rate_monitor_subgroups():
 if __name__ == '__main__':
     test_spike_monitor()
     test_state_monitor()
+    test_state_monitor_indexing()
     test_rate_monitor()
     test_rate_monitor_subgroups()

--- a/brian2/tests/test_neurongroup.py
+++ b/brian2/tests/test_neurongroup.py
@@ -3,13 +3,14 @@ import uuid
 import sympy
 import numpy as np
 from numpy.testing.utils import assert_raises, assert_equal, assert_allclose
-from nose import SkipTest
+from nose import SkipTest, with_setup
 from nose.plugins.attrib import attr
 
 from brian2.core.variables import linked_var
 from brian2.core.network import Network
 from brian2.core.preferences import prefs
 from brian2.core.clocks import defaultclock
+from brian2.devices.device import restore_device
 from brian2.equations.equations import Equations
 from brian2.groups.group import get_dtype
 from brian2.groups.neurongroup import NeuronGroup
@@ -63,7 +64,8 @@ def test_variables():
     G = NeuronGroup(1, 'dv/dt = -v/(10*ms) : 1', refractory=5*ms)
     assert 'not_refractory' in G.variables and 'lastspike' in G.variables
 
-
+@attr('standalone-compatible')
+@with_setup(teardown=restore_device)
 def test_stochastic_variable():
     '''
     Test that a NeuronGroup with a stochastic variable can be simulated. Only
@@ -74,7 +76,8 @@ def test_stochastic_variable():
     net = Network(G)
     net.run(defaultclock.dt)
 
-
+@attr('standalone-compatible')
+@with_setup(teardown=restore_device)
 def test_stochastic_variable_multiplicative():
     '''
     Test that a NeuronGroup with multiplicative noise can be simulated. Only
@@ -106,7 +109,6 @@ def test_scalar_variable():
     net = Network(G)
     net.run(defaultclock.dt)
 
-
 def test_referred_scalar_variable():
     '''
     Test the correct handling of referred scalar variables in subexpressions
@@ -122,7 +124,8 @@ def test_referred_scalar_variable():
     net.run(.25*second)
     assert_allclose(G2.out[:], np.arange(10)+1)
 
-
+@attr('standalone-compatible')
+@with_setup(teardown=restore_device)
 def test_linked_variable_correct():
     '''
     Test correct uses of linked variables.
@@ -143,6 +146,7 @@ def test_linked_variable_correct():
     assert len(str(G2.v[:])) > 0
     assert len(repr(G2.v[:])) > 0
 
+@attr('codegen-independent')
 def test_linked_variable_incorrect():
     '''
     Test incorrect uses of linked variables.
@@ -163,7 +167,8 @@ def test_linked_variable_incorrect():
     # Not a linked variable
     assert_raises(TypeError, lambda: setattr(G3, 'not_linked', linked_var(G1.x)))
 
-
+@attr('standalone-compatible')
+@with_setup(teardown=restore_device)
 def test_linked_variable_scalar():
     '''
     Test linked variable from a size 1 group.
@@ -185,7 +190,7 @@ def test_linked_variable_scalar():
     assert len(str(G2.x[:])) > 0
     assert len(repr(G2.x[:])) > 0
 
-
+@attr('codegen-independent')
 def test_linked_variable_indexed():
     '''
     Test linking a variable with an index specified as an array
@@ -198,7 +203,7 @@ def test_linked_variable_indexed():
     # G.y should refer to an inverted version of G.x
     assert_equal(G.y[:], np.arange(10)[::-1]*0.1)
 
-
+@attr('codegen-independent')
 def test_linked_variable_repeat():
     '''
     Test a "repeat"-like connection between two groups of different size
@@ -209,7 +214,7 @@ def test_linked_variable_repeat():
     G1.w = np.arange(5) * 0.1
     assert_equal(G2.v[:], np.arange(5).repeat(2) * 0.1)
 
-
+@attr('codegen-independent')
 def test_linked_double_linked1():
     '''
     Linked to a linked variable, without indices
@@ -223,7 +228,7 @@ def test_linked_double_linked1():
     G1.x = np.arange(10)
     assert_equal(G3.z[:], np.arange(10))
 
-
+@attr('codegen-independent')
 def test_linked_double_linked2():
     '''
     Linked to a linked variable, first without indices, second with indices
@@ -238,8 +243,7 @@ def test_linked_double_linked2():
     G1.x = np.arange(5)*0.1
     assert_equal(G3.z[:], np.arange(5).repeat(2)*0.1)
 
-
-
+@attr('codegen-independent')
 def test_linked_double_linked3():
     '''
     Linked to a linked variable, first with indices, second without indices
@@ -253,7 +257,7 @@ def test_linked_double_linked3():
     G1.x = np.arange(5)*0.1
     assert_equal(G3.z[:], np.arange(5).repeat(2)*0.1)
 
-
+@attr('codegen-independent')
 def test_linked_double_linked4():
     '''
     Linked to a linked variable, both use indices
@@ -267,7 +271,7 @@ def test_linked_double_linked4():
     G1.x = np.arange(5)*0.1
     assert_equal(G3.z[:], np.arange(5).repeat(2)[::-1]*0.1)
 
-
+@attr('codegen-independent')
 def test_linked_triple_linked():
     '''
     Link to a linked variable that links to a linked variable, all use indices
@@ -286,7 +290,7 @@ def test_linked_triple_linked():
     G1.a = np.arange(2)*0.1
     assert_equal(G4.d[:], np.arange(2).repeat(2)[::-1].repeat(2)*0.1)
 
-
+@attr('codegen-independent')
 def test_linked_subgroup():
     '''
     Test linking a variable from a subgroup
@@ -299,7 +303,7 @@ def test_linked_subgroup():
 
     assert_equal(G3.y[:], (np.arange(5)+3)*0.1)
 
-
+@attr('codegen-independent')
 def test_linked_subgroup2():
     '''
     Test linking a variable from a subgroup with indexing
@@ -312,7 +316,8 @@ def test_linked_subgroup2():
 
     assert_equal(G3.y[:], (np.arange(5)+3).repeat(2)*0.1)
 
-
+@attr('standalone-compatible')
+@with_setup(teardown=restore_device)
 def test_linked_subexpression():
     '''
     Test a subexpression referring to a linked variable.
@@ -334,7 +339,8 @@ def test_linked_subexpression():
     assert all((all(mon[i].I == mon[0].I) for i in xrange(5)))
     assert all((all(mon[i+5].I == mon[5].I) for i in xrange(5)))
 
-
+@attr('standalone-compatible')
+@with_setup(teardown=restore_device)
 def test_linked_subexpression_2():
     '''
     Test a linked variable referring to a subexpression without indices
@@ -355,7 +361,8 @@ def test_linked_subexpression_2():
     assert all(mon[0].I_l == mon1[0].I)
     assert all(mon[1].I_l == mon1[1].I)
 
-
+@attr('standalone-compatible')
+@with_setup(teardown=restore_device)
 def test_linked_subexpression_3():
     '''
     Test a linked variable referring to a subexpression with indices
@@ -436,7 +443,9 @@ def test_linked_synapses():
     S = Synapses(G, G, 'w:1', connect=True)
     G2 = NeuronGroup(100, 'x : 1 (linked)')
     assert_raises(NotImplementedError, lambda: setattr(G2, 'x', linked_var(S, 'w')))
-    
+
+@attr('standalone-compatible')
+@with_setup(teardown=restore_device)
 def test_linked_var_in_reset():
     G1 = NeuronGroup(3, 'x:1')
     G2 = NeuronGroup(3, '''x_linked : 1 (linked)
@@ -450,7 +459,8 @@ def test_linked_var_in_reset():
     net.run(3*defaultclock.dt)
     assert_equal(G1.x[:], [0, 1, 0])
 
-
+@attr('standalone-compatible')
+@with_setup(teardown=restore_device)
 def test_linked_var_in_reset_size_1():
     G1 = NeuronGroup(1, 'x:1')
     G2 = NeuronGroup(1, '''x_linked : 1 (linked)
@@ -464,7 +474,7 @@ def test_linked_var_in_reset_size_1():
     net.run(3*defaultclock.dt)
     assert_equal(G1.x[:], 1)
 
-
+@attr('codegen-independent')
 def test_linked_var_in_reset_incorrect():
     # Raise an error if a scalar variable (linked variable from a group of size
     # 1 is set in a reset statement of a group with size > 1)
@@ -479,7 +489,6 @@ def test_linked_var_in_reset_incorrect():
     # (as for any other shared variable)
     assert_raises(SyntaxError, lambda: net.run(0*ms))
 
-
 @attr('codegen-independent')
 def test_unit_errors():
     '''
@@ -490,7 +499,6 @@ def test_unit_errors():
                   lambda: NeuronGroup(1, 'dv/dt = -v : 1'))
     assert_raises(DimensionMismatchError,
                   lambda: NeuronGroup(1, 'dv/dt = -v/(10*ms) + 2*mV: 1'))
-
 
 @attr('codegen-independent')
 def test_incomplete_namespace():
@@ -509,7 +517,6 @@ def test_incomplete_namespace():
     net = Network(G)
     net.run(0*ms)
 
-
 @attr('codegen-independent')
 def test_namespace_errors():
 
@@ -527,7 +534,6 @@ def test_namespace_errors():
     G = NeuronGroup(1, 'dv/dt = -v/tau : 1', threshold='v > v_th')
     net = Network(G)
     assert_raises(KeyError, lambda: net.run(1*ms))
-
 
 @attr('codegen-independent')
 def test_namespace_warnings():
@@ -588,7 +594,8 @@ def test_namespace_warnings():
         net.run(0*ms)
         assert len(l) == 0, 'got %s as warnings' % str(l)
 
-
+@attr('standalone-compatible')
+@with_setup(teardown=restore_device)
 def test_threshold_reset():
     '''
     Test that threshold and reset work in the expected way.
@@ -600,7 +607,6 @@ def test_threshold_reset():
     net = Network(G)
     net.run(defaultclock.dt)
     assert_equal(G.v[:], np.array([0, 1, 0.5]))
-
 
 @attr('codegen-independent')
 def test_unit_errors_threshold_reset():
@@ -643,7 +649,6 @@ def test_unit_errors_threshold_reset():
     assert_raises(DimensionMismatchError,
                   lambda: NeuronGroup(1, 'dv/dt = -v/(10*ms) : 1',
                                       reset='''v -= 60*mV'''))
-
 
 @attr('codegen-independent')
 def test_syntax_errors():
@@ -855,7 +860,6 @@ def test_state_variable_access_strings():
     G.v['v>=5*volt'] = 'i*volt'
     assert_equal(G.v[:], np.arange(10)*volt)
 
-
 @attr('codegen-independent')
 def test_unknown_state_variables():
     # Test how setting attribute names that do not correspond to a state
@@ -872,7 +876,7 @@ def test_unknown_state_variables():
     G.unknown = 42
     assert G.unknown == 42
 
-
+@attr('codegen-independent')
 def test_subexpression():
     G = NeuronGroup(10, '''dv/dt = freq : 1
                            freq : Hz
@@ -882,6 +886,7 @@ def test_subexpression():
     G.array = 5
     assert_equal(G.expr[:], 2*10*np.arange(10)*Hz + 5*Hz)
 
+@attr('codegen-independent')
 def test_subexpression_with_constant():
         g = 2
         G = NeuronGroup(1, '''x : 1
@@ -928,7 +933,7 @@ def test_subexpression_with_constant():
         assert(len(str(G.I)))
         assert(len(repr(G.I)))
 
-
+@attr('codegen-independent')
 def test_scalar_parameter_access():
     G = NeuronGroup(10, '''dv/dt = freq : 1
                            freq : Hz (shared)
@@ -960,6 +965,7 @@ def test_scalar_parameter_access():
     assert_raises(IndexError, lambda: G.freq.set_item('i>5', 100*Hz))
 
 
+@attr('codegen-independent')
 def test_scalar_subexpression():
     G = NeuronGroup(10, '''dv/dt = freq : 1
                            freq : Hz (shared)
@@ -978,7 +984,6 @@ def test_scalar_subexpression():
     # A scalar subexpresion cannot refer to implicitly vectorized functions
     assert_raises(SyntaxError, lambda: NeuronGroup(10, 'sub = rand() : 1 (shared)'))
 
-
 @attr('codegen-independent')
 def test_repr():
     G = NeuronGroup(10, '''dv/dt = -(v + Inp) / tau : volt
@@ -992,6 +997,7 @@ def test_repr():
         for eq in G.equations.itervalues():
             assert len(func(eq))
 
+@attr('codegen-independent')
 def test_indices():
     G = NeuronGroup(10, 'v : 1')
     G.v = 'i'
@@ -1000,7 +1006,6 @@ def test_indices():
     assert_equal(G.indices[5:], G.indices['i >= 5'])
     assert_equal(G.indices[5:], G.indices['i >= ext_var'])
     assert_equal(G.indices['v >= 5'], np.nonzero(G.v >= 5)[0])
-
 
 @attr('codegen-independent')
 def test_get_dtype():
@@ -1060,7 +1065,6 @@ def test_aliasing_in_statements():
     net.run(defaultclock.dt)
     assert_equal(g.x_0_[:], np.array([-1]))
     assert_equal(g.x_1_[:], np.array([0]))
-
 
 @attr('codegen-independent')
 def test_get_states():

--- a/brian2/tests/test_poissongroup.py
+++ b/brian2/tests/test_poissongroup.py
@@ -1,8 +1,13 @@
 from numpy.testing.utils import assert_equal
+from nose import with_setup
+from nose.plugins.attrib import attr
 
 from brian2 import *
+from brian2.devices.device import restore_device
 
 
+@attr('standalone-compatible')
+@with_setup(teardown=restore_device)
 def test_single_rates():
     # Specifying single rates
     P0 = PoissonGroup(10, 0*Hz)
@@ -18,7 +23,8 @@ def test_single_rates():
     assert_equal(spikes_P0.count, np.zeros(len(P0)))
     assert_equal(spikes_Pfull.count, 2 * np.ones(len(P0)))
 
-
+@attr('standalone-compatible')
+@with_setup(teardown=restore_device)
 def test_rate_arrays():
     P = PoissonGroup(2, np.array([0, 1./defaultclock.dt])*Hz)
     spikes = SpikeMonitor(P)
@@ -27,7 +33,8 @@ def test_rate_arrays():
 
     assert_equal(spikes.count, np.array([0, 2]))
 
-
+@attr('standalone-compatible')
+@with_setup(teardown=restore_device)
 def test_propagation():
     # Using a PoissonGroup as a source for Synapses should work as expected
     P = PoissonGroup(2, np.array([0, 1./defaultclock.dt])*Hz)

--- a/brian2/tests/test_refractory.py
+++ b/brian2/tests/test_refractory.py
@@ -1,8 +1,10 @@
+from nose import with_setup
 from nose.plugins.attrib import attr
 from numpy.testing.utils import assert_equal, assert_allclose, assert_raises
 
 from brian2 import *
 from brian2.equations.refractory import add_refractoriness
+from brian2.devices.device import restore_device
 
 
 @attr('codegen-independent')
@@ -18,6 +20,8 @@ def test_add_refractoriness():
     assert 'not_refractory' in eqs
     assert 'lastspike' in eqs
 
+@attr('standalone-compatible')
+@with_setup(teardown=restore_device)
 def test_refractoriness_basic():
     G = NeuronGroup(1, '''
         dv/dt = 100*Hz : 1 (unless refractory)
@@ -99,7 +103,8 @@ def test_refractoriness_threshold():
         net.run(16*ms)
         assert_allclose(spike_mon.t, [4.9, 15] * ms)
 
-
+@attr('standalone-compatible')
+@with_setup(teardown=restore_device)
 def test_refractoriness_threshold_basic():
     G = NeuronGroup(1, '''
     dv/dt = 200*Hz : 1
@@ -156,6 +161,8 @@ def test_conditional_write_set():
     assert G.variables['v'].conditional_write is G.variables['not_refractory']
     assert G.variables['w'].conditional_write is None
 
+@attr('standalone-compatible')
+@with_setup(teardown=restore_device)
 def test_conditional_write_behaviour():
     H = NeuronGroup(1, 'v:1', threshold='v>-1')
 

--- a/brian2/tests/test_spatialneuron.py
+++ b/brian2/tests/test_spatialneuron.py
@@ -98,7 +98,7 @@ def test_infinitecable():
     assert_allclose(v[t>0.5*ms],theory[t>0.5*ms],rtol=0.01) # 1% error tolerance (not exact because not infinite cable)
 
 
-@attr('long')
+@attr('long', 'standalone-compatible')
 @with_setup(teardown=restore_initial_state)
 def test_finitecable():
     '''
@@ -141,7 +141,6 @@ def test_finitecable():
 
 
 @attr('long')
-@with_setup(teardown=restore_initial_state)
 def test_rall():
     '''
     Test simulation of a cylinder plus two branches, with diameters according to Rall's formula

--- a/brian2/tests/test_spikegenerator.py
+++ b/brian2/tests/test_spikegenerator.py
@@ -10,14 +10,10 @@ from numpy.testing.utils import assert_raises, assert_equal
 
 from brian2 import *
 from brian2.devices.cpp_standalone import cpp_standalone_device
+from brian2.devices.device import restore_device
 
-
-def restore_device():
-    cpp_standalone_device.reinit()
-    set_device('runtime')
-    restore_initial_state()
-
-
+@attr('standalone-compatible')
+@with_setup(teardown=restore_device)
 def test_spikegenerator_connected():
     '''
     Test that `SpikeGeneratorGroup` connects properly.
@@ -42,7 +38,8 @@ def test_spikegenerator_connected():
     assert all(mon[1].v[(mon.t>=3*ms) & (mon.t<4*ms)] == 1)
     assert all(mon[1].v[(mon.t>=4*ms)] == 2)
 
-
+@attr('standalone-compatible')
+@with_setup(teardown=restore_device)
 def test_spikegenerator_basic():
     '''
     Basic test for `SpikeGeneratorGroup`.
@@ -58,7 +55,8 @@ def test_spikegenerator_basic():
         recorded_spikes = sorted([(idx, time) for time in s_mon.t['i==%d' % idx]])
         assert generator_spikes == recorded_spikes
 
-
+@attr('standalone-compatible')
+@with_setup(teardown=restore_device)
 def test_spikegenerator_basic_sorted():
     '''
     Basic test for `SpikeGeneratorGroup` with already sorted spike events.
@@ -74,7 +72,8 @@ def test_spikegenerator_basic_sorted():
         recorded_spikes = sorted([(idx, time) for time in s_mon.t['i==%d' % idx]])
         assert generator_spikes == recorded_spikes
 
-
+@attr('standalone-compatible')
+@with_setup(teardown=restore_device)
 def test_spikegenerator_period():
     '''
     Basic test for `SpikeGeneratorGroup`.
@@ -91,7 +90,8 @@ def test_spikegenerator_period():
         recorded_spikes = sorted([(idx, time) for time in s_mon.t['i==%d' % idx]])
         assert generator_spikes == recorded_spikes
 
-
+@attr('standalone-compatible')
+@with_setup(teardown=restore_device)
 def test_spikegenerator_period_repeat():
     '''
     Basic test for `SpikeGeneratorGroup`.
@@ -111,7 +111,7 @@ def test_spikegenerator_period_repeat():
         net.run(1*ms)
         assert (idx+1)*len(SG.spike_time) == s_mon.num_spikes
 
-
+@attr('codegen-independent')
 def test_spikegenerator_incorrect_period():
     '''
     Test that you cannot provide incorrect period arguments or combine
@@ -134,7 +134,8 @@ def test_spikegenerator_incorrect_period():
     net = Network(SG)
     assert_raises(ValueError, lambda: net.run(0*ms))
 
-
+@attr('standalone-compatible')
+@with_setup(teardown=restore_device)
 def test_spikegenerator_rounding():
     # all spikes should fall into the first time bin
     indices = np.arange(100)
@@ -184,7 +185,7 @@ def test_spikegenerator_multiple_spikes_per_bin():
     assert_raises(ValueError, lambda: net.run(0*ms))
 
 
-@attr('standalone')
+@attr('cpp_standalone')
 @with_setup(teardown=restore_device)
 def test_spikegenerator_standalone():
     '''

--- a/brian2/tests/test_spikegenerator.py
+++ b/brian2/tests/test_spikegenerator.py
@@ -185,7 +185,7 @@ def test_spikegenerator_multiple_spikes_per_bin():
     assert_raises(ValueError, lambda: net.run(0*ms))
 
 
-@attr('cpp_standalone')
+@attr('cpp_standalone', 'standalone-only')
 @with_setup(teardown=restore_device)
 def test_spikegenerator_standalone():
     '''

--- a/brian2/tests/test_stateupdaters.py
+++ b/brian2/tests/test_stateupdaters.py
@@ -8,6 +8,7 @@ from nose import with_setup
 from brian2 import *
 from brian2.utils.logger import catch_logs
 from brian2.core.variables import ArrayVariable, AttributeVariable, Variable
+from brian2.devices.device import restore_device
 
 
 @attr('codegen-independent')
@@ -507,7 +508,8 @@ def test_determination():
     # reset to state before the test
     StateUpdateMethod.stateupdaters = before
 
-
+@attr('standalone-compatible')
+@with_setup(teardown=restore_device)
 def test_subexpressions_basic():
     '''
     Make sure that the integration of a (non-stochastic) differential equation

--- a/brian2/tests/test_subgroup.py
+++ b/brian2/tests/test_subgroup.py
@@ -1,9 +1,10 @@
+from nose import with_setup
 from nose.plugins.attrib import attr
 from numpy.testing.utils import assert_raises, assert_equal, assert_allclose
 
 from brian2 import *
 from brian2.utils.logger import catch_logs
-
+from brian2.devices.device import restore_device
 
 @attr('codegen-independent')
 def test_str_repr():
@@ -99,6 +100,8 @@ def test_state_variables_group_as_index_problematic():
             assert all([entry[1].endswith('ambiguous_string_expression')
                         for entry in l])
 
+@attr('standalone-compatible')
+@with_setup(teardown=restore_device)
 def test_state_monitor():
     G = NeuronGroup(10, 'v : volt')
     G.v = np.arange(10) * volt
@@ -320,7 +323,8 @@ def test_subexpression_no_references():
     assert_equal(S3.u[:], np.arange(10)[:-6:-1]*2+1)
     assert_equal(S3.x[:], np.arange(5)*2+1)
 
-
+@attr('standalone-compatible')
+@with_setup(teardown=restore_device)
 def test_synaptic_propagation():
     G1 = NeuronGroup(10, 'v:1', threshold='v>1', reset='v=0')
     G1.v[1::2] = 1.1 # odd numbers should spike
@@ -336,7 +340,8 @@ def test_synaptic_propagation():
     expected[[10, 12, 14]] = 1
     assert_equal(np.asarray(G2.v).flatten(), expected)
 
-
+@attr('standalone-compatible')
+@with_setup(teardown=restore_device)
 def test_spike_monitor():
     G = NeuronGroup(10, 'v:1', threshold='v>1', reset='v=0')
     G.v[0] = 1.1
@@ -378,6 +383,8 @@ def test_no_reference_1():
     G.v = np.arange(10)
     assert_equal(G[:5].v[:], G.v[:5])
 
+@attr('standalone-compatible')
+@with_setup(teardown=restore_device)
 def test_no_reference_2():
     '''
     Using subgroups without keeping an explicit reference. Monitors
@@ -394,7 +401,8 @@ def test_no_reference_2():
     assert_equal(spike_mon.t[:], np.array([0])*second)
     assert_equal(rate_mon.rate[:], np.array([0.5, 0])/defaultclock.dt)
 
-
+@attr('standalone-compatible')
+@with_setup(teardown=restore_device)
 def test_no_reference_3():
     '''
     Using subgroups without keeping an explicit reference. Monitors
@@ -406,7 +414,8 @@ def test_no_reference_3():
     net.run(defaultclock.dt)
     assert_equal(G.v[:], np.array([0, 1]))
 
-
+@attr('standalone-compatible')
+@with_setup(teardown=restore_device)
 def test_no_reference_4():
     '''
     Using subgroups without keeping an explicit reference. Synapses

--- a/brian2/tests/test_synapses.py
+++ b/brian2/tests/test_synapses.py
@@ -125,7 +125,7 @@ def test_connection_arrays():
 
 from brian2.devices.cpp_standalone import cpp_standalone_device
 
-@attr('cpp_standalone')
+@attr('cpp_standalone', 'standalone-only')
 @with_setup(teardown=restore_device)
 def test_connection_array_standalone():
     set_device('cpp_standalone')

--- a/brian2/tests/test_synapses.py
+++ b/brian2/tests/test_synapses.py
@@ -10,6 +10,8 @@ import numpy as np
 from brian2 import *
 from brian2.core.variables import variables_by_owner
 from brian2.utils.logger import catch_logs
+from brian2.devices.device import restore_device
+
 
 def _compare(synapses, expected):
     conn_matrix = np.zeros((len(synapses.source), len(synapses.target)))
@@ -123,13 +125,7 @@ def test_connection_arrays():
 
 from brian2.devices.cpp_standalone import cpp_standalone_device
 
-
-def restore_device():
-    cpp_standalone_device.reinit()
-    set_device('runtime')
-    restore_initial_state()
-
-@attr('standalone')
+@attr('cpp_standalone')
 @with_setup(teardown=restore_device)
 def test_connection_array_standalone():
     set_device('cpp_standalone')
@@ -525,7 +521,8 @@ def test_transmission():
         assert_allclose(source_mon.t[source_mon.i==1],
                         target_mon.t[target_mon.i==1] - default_dt - delay[1])
 
-
+@attr('standalone-compatible')
+@with_setup(teardown=restore_device)
 def test_transmission_scalar_delay():
     inp = SpikeGeneratorGroup(2, [0, 1], [0, 1]*ms)
     target = NeuronGroup(2, 'v:1')
@@ -538,7 +535,8 @@ def test_transmission_scalar_delay():
     assert_equal(mon[1].v[mon.t<1.5*ms], 0)
     assert_equal(mon[1].v[mon.t>=1.5*ms], 1)
 
-
+@attr('standalone-compatible')
+@with_setup(teardown=restore_device)
 def test_transmission_scalar_delay_different_clocks():
 
     inp = SpikeGeneratorGroup(2, [0, 1], [0, 1]*ms, dt=0.5*ms,
@@ -619,7 +617,8 @@ def test_no_synapses():
         assert len(l) == 1, 'expected 1 warning, got %d' % len(l)
         assert l[0][1].endswith('.no_synapses')
 
-
+@attr('standalone-compatible')
+@with_setup(teardown=restore_device)
 def test_summed_variable():
     source = NeuronGroup(2, 'v : 1', threshold='v>1', reset='v=0')
     source.v = 1.1  # will spike immediately
@@ -719,7 +718,8 @@ def test_scalar_subexpression():
                                                      sub = v_post + s : 1 (shared)''',
                                                 pre='v+=s', connect=True))
 
-
+@attr('standalone-compatible')
+@with_setup(teardown=restore_device)
 def test_external_variables():
     # Make sure that external variables are correctly resolved
     source = SpikeGeneratorGroup(1, [0], [0]*ms)
@@ -733,7 +733,7 @@ def test_external_variables():
     assert target.v[0] == 2
 
 
-@attr('long')
+@attr('long', 'standalone-compatible')
 def test_event_driven():
     # Fake example, where the synapse is actually not changing the state of the
     # postsynaptic neuron, the pre- and post spiketrains are regular spike
@@ -797,7 +797,7 @@ def test_repr():
     for func in [str, repr, sympy.latex]:
         assert len(func(S.equations))
 
-
+@attr('codegen-independent')
 def test_variables_by_owner():
     # Test the `variables_by_owner` convenience function
     G = NeuronGroup(10, 'v : 1')

--- a/brian2/tests/test_thresholder.py
+++ b/brian2/tests/test_thresholder.py
@@ -1,8 +1,12 @@
+from nose import with_setup
+from nose.plugins.attrib import attr
 from numpy.testing import assert_equal
 
 from brian2 import *
+from brian2.devices.device import restore_device
 
-
+@attr('standalone-compatible')
+@with_setup(teardown=restore_device)
 def test_simple_threshold():
     G = NeuronGroup(4, 'v : 1', threshold='v > 1')
     G.v = [1.5, 0, 3, -1]
@@ -11,6 +15,8 @@ def test_simple_threshold():
     net.run(defaultclock.dt)
     assert_equal(s_mon.count, np.array([1, 0, 1, 0]))
 
+@attr('standalone-compatible')
+@with_setup(teardown=restore_device)
 def test_scalar_threshold():
     c = 2
     G = NeuronGroup(4, '', threshold='c > 1')

--- a/brian2/tests/test_timedarray.py
+++ b/brian2/tests/test_timedarray.py
@@ -1,9 +1,10 @@
 import numpy as np
 from numpy.testing.utils import assert_equal
+from nose import with_setup
 from nose.plugins.attrib import attr
 
 from brian2 import *
-
+from brian2.devices.device import restore_device
 
 @attr('codegen-independent')
 def test_timedarray_direct_use():
@@ -25,7 +26,8 @@ def test_timedarray_direct_use():
     assert_equal(ta2d(1*ms, [0, 1, 2]), [3, 4, 5]*amp)
     assert_equal(ta2d(15*ms, [0, 1, 2]), [9, 10, 11]*amp)
 
-
+@attr('standalone-compatible')
+@with_setup(teardown=restore_device)
 def test_timedarray_semantics():
     # Make sure that timed arrays are interpreted as specifying the values
     # between t and t+dt (not between t-dt/2 and t+dt/2 as in Brian1)
@@ -37,7 +39,8 @@ def test_timedarray_semantics():
     assert_equal(mon[0].value, [0, 0, 0, 0, 1, 1, 1, 1])
     assert_equal(mon[0].value, ta(mon.t))
 
-
+@attr('standalone-compatible')
+@with_setup(teardown=restore_device)
 def test_timedarray_no_units():
     ta = TimedArray(np.arange(10), dt=0.1*ms)
     G = NeuronGroup(1, 'value = ta(t) + 1: 1', dt=0.1*ms)
@@ -46,7 +49,8 @@ def test_timedarray_no_units():
     net.run(1.1*ms)
     assert_equal(mon[0].value_, np.clip(np.arange(len(mon[0].t)), 0, 9) + 1)
 
-
+@attr('standalone-compatible')
+@with_setup(teardown=restore_device)
 def test_timedarray_with_units():
     ta = TimedArray(np.arange(10)*amp, dt=0.1*ms)
     G = NeuronGroup(1, 'value = ta(t) + 2*nA: amp', dt=0.1*ms)
@@ -55,7 +59,8 @@ def test_timedarray_with_units():
     net.run(1.1*ms)
     assert_equal(mon[0].value, np.clip(np.arange(len(mon[0].t)), 0, 9)*amp + 2*nA)
 
-
+@attr('standalone-compatible')
+@with_setup(teardown=restore_device)
 def test_timedarray_2d():
     # 4 time steps, 3 neurons
     ta2d = TimedArray(np.arange(12).reshape(4, 3), dt=0.1*ms)
@@ -67,7 +72,8 @@ def test_timedarray_2d():
     assert_equal(mon[1].value_, np.array([1, 4, 7, 10, 10]) + 1)
     assert_equal(mon[2].value_, np.array([2, 5, 8, 11, 11]) + 1)
 
-
+@attr('standalone-compatible')
+@with_setup(teardown=restore_device)
 def test_timedarray_no_upsampling():
     # Test a TimedArray where no upsampling is necessary because the monitor's
     # dt is bigger than the TimedArray's
@@ -78,7 +84,8 @@ def test_timedarray_no_upsampling():
     net.run(2.1*ms)
     assert_equal(mon[0].value, [0, 9, 9])
 
-
+@attr('standalone-compatible')
+@with_setup(teardown=restore_device)
 def test_long_timedarray():
     '''
     Use a very long timedarray (with a big dt), where the upsampling can lead

--- a/brian2/tests/test_utils.py
+++ b/brian2/tests/test_utils.py
@@ -28,7 +28,7 @@ def test_environment():
     if not testing_under_ipython:
         del builtins.__IPYTHON__
 
-
+@attr('codegen-independent')
 def test_spell_check():
     checker = SpellChecker(['vm', 'alpha', 'beta'])
     assert checker.suggest('Vm') == {'vm'}

--- a/dev/tools/run_nose_tests_long_and_standalone.py
+++ b/dev/tools/run_nose_tests_long_and_standalone.py
@@ -2,5 +2,5 @@ import sys
 
 import brian2
 
-if not brian2.test(long_tests=True, test_standalone=True):
+if not brian2.test(long_tests=True, test_standalone='cpp_standalone'):
     sys.exit(1)

--- a/dev/tools/run_nose_tests_standalone.py
+++ b/dev/tools/run_nose_tests_standalone.py
@@ -6,5 +6,5 @@ import sys
 import brian2
 
 if not brian2.test([], test_codegen_independent=False,
-                       test_standalone=True):  # If the test fails, exit with a non-zero error code
+                       test_standalone='cpp_standalone'):  # If the test fails, exit with a non-zero error code
     sys.exit(1)

--- a/docs_sphinx/conf.py
+++ b/docs_sphinx/conf.py
@@ -295,11 +295,12 @@ texinfo_documents = [
 
 
 intersphinx_mapping = {
-                       'http://docs.python.org/': None,
-                        'http://docs.scipy.org/doc/numpy': None,
-                        'http://docs.scipy.org/doc/scipy/reference': None,
-                        'http://docs.sympy.org/dev/': None
-                       }
+    'http://docs.python.org/': None,
+    'http://docs.scipy.org/doc/numpy': None,
+    'http://docs.scipy.org/doc/scipy/reference': None,
+    'http://docs.sympy.org/dev/': None,
+    'https://nose.readthedocs.org/en/latest/': None
+}
 
 autodoc_default_flags = ['show-inheritance']
 

--- a/docs_sphinx/developer/guidelines/testing.rst
+++ b/docs_sphinx/developer/guidelines/testing.rst
@@ -151,6 +151,27 @@ As a rule of thumb:
   values after the run, mark it as ``standalone-compatible`` and register the
   `~brian2.devices.device.restore_device` teardown function
 
+Tests can also be written specifically for a standalone device (they then have
+to include the `~brian2.devices.device.set_device` and
+`~brian2.devices.device.Device.build` calls explicitly). In this case tests
+have to be annotated with the name of the device (e.g. ``'cpp_standalone'``)
+and with ``'standalone-only'`` to exclude this test from the runtime tests.
+Also, the device should be restored in the end::
+
+    from nose import with_setup
+    from nose.plugins.attrib import attr
+    from brian2 import *
+    from brian2.devices.device import restore_device
+
+    @attr('cpp_standalone', 'standalone-only')
+    @with_setup(teardown=restore_initial_state)
+    def test_cpp_standalone():
+        set_device('cpp_standalone')
+        # set up simulation
+        # run simulation
+        device.build(...)
+        # check simulation results
+
 Doctests
 ~~~~~~~~
 Doctests are executable documentation. In the ``Examples`` block of a class or

--- a/docs_sphinx/developer/guidelines/testing.rst
+++ b/docs_sphinx/developer/guidelines/testing.rst
@@ -98,6 +98,58 @@ mechanism <logging>` for details
 For simple functions, doctests (see below) are a great alternative to writing
 classical unit tests.
 
+By default, all tests are executed for all selected code generation targets
+(see `Running the test suite`_ above). This is not useful for all tests, some
+basic tests that for example test equation syntax or the use of physical units
+do not depend on code generation and need therefore not to be repeated. To
+execute such tests only once, they can be annotated with a
+``codegen-independent`` attribute, using the `~nose.plugins.attrib.attr`
+decorator::
+
+    from nose.plugins.attrib import attr
+    from brian2 import NeuronGroup
+
+    @attr('codegen-independent')
+    def test_simple():
+        # Test that the length of a NeuronGroup is correct
+        group = NeuronGroup(5, '')
+        assert len(group) == 5
+
+Tests that are not "codegen-independent" are by default only executed for the
+runtimes device, i.e. not for the ``cpp_standalone`` device, for example.
+However, many of those tests follow a common pattern that is compatible with
+standalone devices as well: they set up a network, run it, and check the state
+of the network afterwards. Such tests can be marked as
+``standalone-compatible``, using the `~nose.plugins.attrib.attr` decorator in
+the same way as for ``codegen-independent`` tests. Since standalone devices
+usually have an internal state where they store information about arrays,
+array assignments, etc., they need to be reinitialized after such a test. For
+that use the `~nose.with_setup` decorator and provide the
+`~brian2.devices.device.restore_device` function as the ``teardown``
+argument::
+
+    from nose import with_setup
+    from nose.plugins.attrib import attr
+    from numpy.testing.utils import assert_equal
+    from brian2 import *
+    from brian2.devices.device import restore_device
+
+    @attr('standalone-compatible')
+    @with_setup(teardown=restore_initial_state)
+    def test_simple_run():
+        # Check that parameter values of a neuron don't change after a run
+        group = NeuronGroup(5, 'v : volt')
+        group.v = 'i*mV'
+        run(1*ms)
+        assert_equal(group.v[:], np.arange(5)*mV)
+
+As a rule of thumb:
+
+* If a test does not have a `~brian2.core.network.Network.run` call, mark it as
+  ``codegen-independent``
+* If a test has only a single `~brian2.core.network.Network.run` and only reads state variable
+  values after the run, mark it as ``standalone-compatible`` and register the
+  `~brian2.devices.device.restore_device` teardown function
 
 Doctests
 ~~~~~~~~


### PR DESCRIPTION
This introduces a new category of tests, "standalone-compatible" tests. In addition to tests marked as `@attr('cpp_standalone')` (renamed from the previous `standalone`), tests can be marked as `@attr('standalone-compatible')`. They are then executed with the new `CPPStandaloneSimpleDevice` which directly calls `build` after a run. Unfortunately, nose does not offer a mechanism to simply call a teardown function after every single test, so "standalone-compatible" tests also have to use `with_setup(teardown=restore_device)`. From my side this is ready to merge.

BTW: The `cpp_standalone_simple` device could also be useful for users in general (you don't have to add a `device.build` call for simple simulations), I wonder whether we should advertise this use case. 