### PR TITLE
Check dependency versions at runtime

### DIFF
--- a/brian2/__init__.py
+++ b/brian2/__init__.py
@@ -3,6 +3,7 @@ Brian 2.0
 '''
 # Check basic dependencies
 import sys
+from distutils.version import StrictVersion
 missing = []
 try:
     import numpy
@@ -59,3 +60,27 @@ __version__ = '2.0beta'
 __release_date__ = '2014-11-03'
 
 from brian2.only import *
+
+# Check for outdated dependency versions
+def _check_dependency_version(name, version):
+    from core.preferences import prefs
+    from utils.logger import get_logger
+    logger = get_logger(__name__)
+
+    module = sys.modules[name]
+    if not isinstance(module.__version__, basestring):  # mocked module
+        return
+    if not StrictVersion(module.__version__) >= StrictVersion(version):
+        message = '%s is outdated (got version %s, need version %s)' % (name,
+                                                                        module.__version__,
+                                                                        version)
+        if prefs.core.outdated_dependency_error:
+            raise ImportError(message)
+        else:
+
+            logger.warn(message, 'outdated_dependency')
+
+for name, version in [('numpy', '1.8.0'),
+                      ('scipy', '0.13.3'),
+                      ('sympy', '0.7.6')]:
+    _check_dependency_version(name, version)

--- a/brian2/core/core_preferences.py
+++ b/brian2/core/core_preferences.py
@@ -21,8 +21,15 @@ prefs.register_preferences('core', 'Core Brian preferences',
     default_integer_dtype=BrianPreference(
         default=int32,
         docs='''
-        Default dtype for all arrays of integer scalars'
+        Default dtype for all arrays of integer scalars.
         ''',
         representor=dtype_repr,
+        ),
+    outdated_dependency_error=BrianPreference(
+        default=True,
+        docs='''
+        Whether to raise an error for outdated dependencies (``True``) or just
+        a warning (``False``).
+        '''
         )
     )

--- a/docs_sphinx/user/import.rst
+++ b/docs_sphinx/user/import.rst
@@ -37,3 +37,14 @@ Note that it is safe to use e.g. ``np.sin`` and ``numpy.sin`` after a
 ``from brian2 import *``.
 
 .. _matplotlib: http://matplotlib.org/
+
+Dependency checks
+-----------------
+Brian will check the dependency versions during import and raise an error for
+an outdated dependency. An outdated dependency does not necessarily mean that
+Brian cannot be run with it, it only means that Brian is untested on that
+version. If you want to force Brian to run despite the outdated dependency, set
+the `core.outdated_dependency_error` preference to ``False``. Note that this
+cannot be done in a script, since you do not have access to the preferences
+before importing `brian2`. See :doc:`../advanced/preferences` for instructions
+how to set preferences in a file.


### PR DESCRIPTION
Does what the title says. I did not find a simple straightforward way to share the dependency information with `setup.py`, but I think given that we change our dependencies quite rarely, it isn't really worth the effort of coming up with an elaborate system.