### PR TITLE
Small change to the algorithm for `SpikeGeneratorGroup`

### DIFF
--- a/brian2/codegen/runtime/cython_rt/templates/spikegenerator.pyx
+++ b/brian2/codegen/runtime/cython_rt/templates/spikegenerator.pyx
@@ -12,13 +12,7 @@
     cdef double _spike_time
 
     # We need some precomputed values that will be used during looping
-    not_first_spike = {{_lastindex}}[0] > 0
-    not_end_period  = abs(padding_after) > (dt - epsilon)
-
-    # If there is a periodicity in the SpikeGenerator, we need to reset the lastindex 
-    # when all spikes have been played and at the end of the period
-    if not_first_spike and ({{spike_time}}[{{_lastindex}}[0] - 1] > padding_before):
-        {{_lastindex}}[0] = 0
+    not_end_period  = abs(padding_after) > (dt - epsilon) and abs(padding_after) < (period - epsilon)
 
     for _idx in range({{_lastindex}}[0], _num{{spike_time}}):
         _spike_time = {{spike_time}}[_idx]
@@ -34,6 +28,12 @@
         _cpp_numspikes += 1
 
     {{_spikespace}}[N] = _cpp_numspikes
-    {{_lastindex}}[0] += _cpp_numspikes
+
+    # If there is a periodicity in the SpikeGenerator, we need to reset the lastindex
+    # when all spikes have been played and at the end of the period
+    if not_end_period:
+        {{_lastindex}}[0] += _cpp_numspikes
+    else:
+        {{_lastindex}}[0] = 0
 
 {% endblock %}

--- a/brian2/codegen/runtime/numpy_rt/templates/spikegenerator.py_
+++ b/brian2/codegen/runtime/numpy_rt/templates/spikegenerator.py_
@@ -9,21 +9,19 @@ _n_spikes      = 0
 epsilon        = 1e-3*dt
 
 # We need some precomputed values that will be used during looping
-not_first_spike = {{_lastindex}}[0] > 0
-not_end_period  = abs(padding_after) > (dt - epsilon)
-
-# If there is a periodicity in the SpikeGenerator, we need to reset the lastindex 
-# when all spikes have been played and at the end of the period
-if not_first_spike and ({{spike_time}}[{{_lastindex}}[0] - 1] > padding_before):
-    {{_lastindex}}[0] = 0
+not_end_period  = abs(padding_after) > (dt - epsilon) and abs(padding_after) < (period - epsilon)
+_lastindex_before = {{_lastindex}}[0]
 
 if not_end_period:
-    _n_spikes = np.searchsorted({{spike_time}}[{{_lastindex}}[0]:], padding_after - epsilon, side='right')
+    _n_spikes = np.searchsorted({{spike_time}}[_lastindex_before:], padding_after - epsilon, side='right')
+    {{_lastindex}}[0]  += _n_spikes
 else:
-    _n_spikes = np.searchsorted({{spike_time}}[{{_lastindex}}[0]:], period, side='right')
+    _n_spikes = np.searchsorted({{spike_time}}[_lastindex_before:], period, side='right')
+    # If there is a periodicity in the SpikeGenerator, we need to reset the lastindex
+    # when all spikes have been played and at the end of the period
+    {{_lastindex}}[0] = 0
 
-_indices = {{neuron_index}}[{{_lastindex}}[0]:{{_lastindex}}[0]+_n_spikes]
+_indices = {{neuron_index}}[_lastindex_before:_lastindex_before+_n_spikes]
 
 {{_spikespace}}[:_n_spikes] = _indices
 {{_spikespace}}[-1] = _n_spikes
-{{_lastindex}}[0]  += _n_spikes

--- a/brian2/devices/cpp_standalone/templates/spikegenerator.cpp
+++ b/brian2/devices/cpp_standalone/templates/spikegenerator.cpp
@@ -3,13 +3,12 @@
 {% block maincode %}
     {# USES_VARIABLES {_spikespace, N, t, dt, neuron_index, spike_time, period, _lastindex } #}
 
-    double padding_before = fmod(t, period);
-    double padding_after  = fmod(t+dt, period);
-    double epsilon       = 1e-3*dt;
+    const double padding_before = fmod(t, period);
+    const double padding_after  = fmod(t+dt, period);
+    const double epsilon        = 1e-3*dt;
 
     // We need some precomputed values that will be used during looping
-    bool not_first_spike = ({{_lastindex}}[0] > 0);
-    bool not_end_period  = (fabs(padding_after) > epsilon);
+    const bool not_end_period  = (fabs(padding_after) > epsilon) && (fabs(padding_after) < (period - epsilon));
     bool test;
 
     // TODO: We don't deal with more than one spike per neuron yet
@@ -17,12 +16,6 @@
 
     {{ openmp_pragma('single') }}
     {
-
-        if (not_first_spike && ({{spike_time}}[{{_lastindex}}[0] - 1] > padding_before))
-        {
-            {{_lastindex}}[0] = 0;
-        }
-        
         for(int _idx={{_lastindex}}[0]; _idx < _numspike_time; _idx++)
         {
             if (not_end_period)
@@ -37,7 +30,13 @@
         }       
 
         {{_spikespace}}[N] = _cpp_numspikes;
-        {{_lastindex}}[0] += _cpp_numspikes;
+
+        // If there is a periodicity in the SpikeGenerator, we need to reset the lastindex
+        // when all spikes have been played and at the end of the period
+        if (! not_end_period)
+            {{_lastindex}}[0] = 0;
+        else
+            {{_lastindex}}[0] += _cpp_numspikes;
     }
 
 {% endblock %}


### PR DESCRIPTION
I changed the algorithm slightly, and now I'm getting correct rounding behaviour for spike times at multiples of dt for long simulations. I added two tests that check this, they take quite some time to run and are therefore only tested when running the long test suite.

@thesamovar Could you run the long test suite on your machine and merge if it passes -- our automatic testing on travis and appveyor will not run those tests.