### PR TITLE
Use type inference support for Cython

### DIFF
--- a/brian2/codegen/runtime/cython_rt/templates/common.pyx
+++ b/brian2/codegen/runtime/cython_rt/templates/common.pyx
@@ -1,6 +1,7 @@
 #cython: boundscheck=False
 #cython: wraparound=False
 #cython: cdivision=True
+#cython: infer_types=True
 
 import numpy as _numpy
 cimport numpy as _numpy


### PR DESCRIPTION
Just added the ``infer_types=True`` argument for Cython. This can sometimes improve the quality of the generated C++ code (avoiding Python calls).