### PR TITLE
Add a `sign` function

### DIFF
--- a/brian2/codegen/generators/cpp_generator.py
+++ b/brian2/codegen/generators/cpp_generator.py
@@ -436,3 +436,12 @@ int_code = '''
 DEFAULT_FUNCTIONS['int'].implementations.add_implementation(CPPCodeGenerator,
                                                             code=int_code,
                                                             name='int_')
+
+sign_code = '''
+template <typename T> int sign_(T val) {
+    return (T(0) < val) - (val < T(0));
+}
+        '''
+DEFAULT_FUNCTIONS['sign'].implementations.add_implementation(CPPCodeGenerator,
+                                                             code=sign_code,
+                                                             name='sign_')

--- a/brian2/codegen/generators/cython_generator.py
+++ b/brian2/codegen/generators/cython_generator.py
@@ -324,6 +324,21 @@ DEFAULT_FUNCTIONS['int'].implementations.add_implementation(CythonCodeGenerator,
                                                             code=int_code,
                                                             name='_int')
 
+sign_code = '''
+ctypedef fused _to_sign:
+    char
+    short
+    int
+    float
+    double
+
+cdef int _int(_to_sign x):
+    return (0 < x) - (x < 0)
+'''
+DEFAULT_FUNCTIONS['sign'].implementations.add_implementation(CythonCodeGenerator,
+                                                             code=sign_code,
+                                                             name='_sign')
+
 clip_code = '''
 ctypedef fused _float_or_double:
     float

--- a/brian2/core/functions.py
+++ b/brian2/core/functions.py
@@ -453,6 +453,8 @@ DEFAULT_FUNCTIONS = {
     'mod': Function(np.mod,
                     sympy_func=sympy_mod.Mod,
                     arg_units=[None, None], return_unit=lambda u,v : u),
+    'sign': Function(pyfunc=np.sign, sympy_func=sympy.sign,
+                     arg_units=[None], return_unit=1),
     # functions that need special treatment
     'rand': Function(pyfunc=rand, arg_units=[], return_unit=1, stateless=False),
     'randn': Function(pyfunc=randn, arg_units=[], return_unit=1, stateless=False),

--- a/brian2/tests/test_functions.py
+++ b/brian2/tests/test_functions.py
@@ -101,7 +101,7 @@ def test_math_functions():
         for func in [cos, tan, sinh, cosh, tanh,
                      arcsin, arccos, arctan,
                      log, log10,
-                     np.ceil, np.floor]:
+                     np.ceil, np.floor, np.sign]:
 
             # Calculate the result directly
             numpy_result = func(test_array)
@@ -539,6 +539,7 @@ if __name__ == '__main__':
     for f in [
             test_constants_sympy,
             test_constants_values,
+            test_math_functions_short,
             test_math_functions,
             test_user_defined_function,
             test_user_defined_function_units,

--- a/docs_sphinx/user/functions.rst
+++ b/docs_sphinx/user/functions.rst
@@ -19,7 +19,7 @@ ready for use:
 * Random numbers: ``rand()``, ``randn()`` (Note that these functions should be
   called without arguments, the code generation process will take care of
   generating an array of numbers for numpy).
-* Elementary functions: ``sqrt``, ``exp``, ``log``, ``log10``, ``abs``
+* Elementary functions: ``sqrt``, ``exp``, ``log``, ``log10``, ``abs``, ``sign``
 * Trigonometric functions: ``sin``, ``cos``, ``tan``, ``sinh``, ``cosh``,
   ``tanh``, ``arcsin``, ``arccos``, ``arctan``
 * General utility functions: ``clip``, ``floor``, ``ceil``


### PR DESCRIPTION
Well, does what the title says. I needed a `sign` function (returning -1, 0 or 1) and did not want to fiddle around with complicated `int(...)` expressions.

From my side, it's ready to merge.