### PR TITLE
Scipy removal

### DIFF
--- a/brian2/__init__.py
+++ b/brian2/__init__.py
@@ -11,11 +11,6 @@ except ImportError as ex:
     sys.stderr.write('Importing numpy failed: %s\n' % ex)
     missing.append('numpy')
 try:
-    import scipy
-except ImportError as ex:
-    sys.stderr.write('Importing scipy failed: %s\n' % ex)
-    missing.append('scipy')
-try:
     import sympy
 except ImportError as ex:
     sys.stderr.write('Importing sympy failed: %s\n' % ex)
@@ -81,6 +76,5 @@ def _check_dependency_version(name, version):
             logger.warn(message, 'outdated_dependency')
 
 for name, version in [('numpy', '1.8.0'),
-                      ('scipy', '0.13.3'),
                       ('sympy', '0.7.6')]:
     _check_dependency_version(name, version)

--- a/brian2/codegen/generators/numpy_generator.py
+++ b/brian2/codegen/generators/numpy_generator.py
@@ -121,8 +121,13 @@ class NumpyCodeGenerator(CodeGenerator):
         return lines
 
     def determine_keywords(self):
-        # For numpy, no addiional keywords are provided to the template
-        return {}
+        try:
+            import scipy
+            scipy_available = True
+        except ImportError:
+            scipy_available = False
+
+        return {'_scipy_available': scipy_available}
 
 ################################################################################
 # Implement functions

--- a/brian2/codegen/generators/numpy_generator.py
+++ b/brian2/codegen/generators/numpy_generator.py
@@ -138,7 +138,8 @@ for func_name, func in [('sin', np.sin), ('cos', np.cos), ('tan', np.tan),
                         ('exp', np.exp), ('log', np.log), ('log10', np.log10),
                         ('sqrt', np.sqrt), ('arcsin', np.arcsin),
                         ('arccos', np.arccos), ('arctan', np.arctan),
-                        ('abs', np.abs), ('mod', np.fmod)]:
+                        ('abs', np.abs), ('mod', np.fmod),
+                        ('sign', np.sign)]:
     DEFAULT_FUNCTIONS[func_name].implementations.add_implementation(NumpyCodeGenerator,
                                                                     code=func)
 

--- a/brian2/codegen/runtime/numpy_rt/templates/spatialstateupdate.py_
+++ b/brian2/codegen/runtime/numpy_rt/templates/spatialstateupdate.py_
@@ -10,7 +10,6 @@
 Solves the cable equation (spatial diffusion of currents).
 This is where most time-consuming time computations are done.
 '''
-from scipy.linalg import solve_banded
 from numpy.linalg import solve
 from numpy import zeros
 
@@ -22,27 +21,66 @@ _vectorisation_idx = 1
 _vectorisation_idx = N
 {{vector_code|autoindent}}
 
-# Particular solution
-b=-({{Cm}}/dt*{{v}})-_I0
-ab = zeros((3,N))
-ab[0,:]={{ab_star0}}
-ab[1,:]={{ab_star1}}
-ab[2,:]={{ab_star2}}
-ab[1,:]-=_gtot
-{{v_star}}[:]=solve_banded((1,1),ab,b,overwrite_ab=True,overwrite_b=True)
-# Homogeneous solutions
-b[:]={{b_plus}}
-ab[0,:]={{ab_plus0}}
-ab[1,:]={{ab_plus1}}
-ab[2,:]={{ab_plus2}}
-ab[1,:]-=_gtot
-{{u_plus}}[:]=solve_banded((1,1),ab,b,overwrite_ab=True,overwrite_b=True)
-b[:]={{b_minus}}
-ab[0,:]={{ab_minus0}}
-ab[1,:]={{ab_minus1}}
-ab[2,:]={{ab_minus2}}
-ab[1,:]-=_gtot
-{{u_minus}}[:]=solve_banded((1,1),ab,b,overwrite_ab=True,overwrite_b=True)
+c = zeros(N)
+ab = zeros((3, N))
+_gtot_all = zeros(N)
+_gtot_all[:] = _gtot
+b = -({{Cm}} / dt*{{v}}) - _I0
+
+# Tridiagonal solving
+# Pass 1
+for i in range(N):
+    {{v_star}}[i] = b[i]  # RHS -> v_star (solution)
+    bi = {{ab_star1}}[i] - _gtot_all[i]  # main diagonal
+    if i < N-1:
+        c[i] = {{ab_star0}}[i+1]  # superdiagonal
+    if i>0:
+        ai = {{ab_star2}}[i-1]  # subdiagonal
+        _m = 1.0/(bi-ai*c[i-1])
+        c[i] = c[i]*_m
+        {{v_star}}[i] = ({{v_star}}[i] - ai*{{v_star}}[i-1])*_m
+    else:
+        c[0]=c[0]/bi
+        {{v_star}}[0]={{v_star}}[0]/bi
+
+for i in range(N-2, -1, -1):
+    {{v_star}}[i] = {{v_star}}[i] - c[i]*{{v_star}}[i+1]
+
+# Pass 2
+for i in range(N):
+    {{u_plus}}[i] = {{b_plus}}[i]  # RHS -> v_star (solution)
+    bi = {{ab_plus1}}[i] - _gtot_all[i]  # main diagonal
+    if i < N-1:
+        c[i] = {{ab_plus0}}[i+1]  # superdiagonal
+    if (i>0):
+        ai = {{ab_plus2}}[i-1]  # subdiagonal
+        _m = 1.0/(bi-ai*c[i-1])
+        c[i] = c[i]*_m
+        {{u_plus}}[i] = ({{u_plus}}[i] - ai*{{u_plus}}[i-1])*_m
+    else:
+        c[0] = c[0]/bi
+        {{u_plus}}[0] = {{u_plus}}[0]/bi
+
+for i in range(N-2, -1, -1):
+    {{u_plus}}[i]={{u_plus}}[i] - c[i]*{{u_plus}}[i+1];
+
+# Pass 3
+for i in range(N):
+    {{u_minus}}[i] = {{b_minus}}[i]  # RHS -> v_star (solution)
+    bi = {{ab_minus1}}[i] - _gtot_all[i]  # main diagonal
+    if i < N-1:
+        c[i] = {{ab_minus0}}[i+1]  # superdiagonal
+    if i > 0:
+        ai = {{ab_minus2}}[i-1]  # subdiagonal
+        _m = 1.0/(bi-ai*c[i-1]);
+        c[i] = c[i]*_m
+        {{u_minus}}[i] = ({{u_minus}}[i] - ai*{{u_minus}}[i-1])*_m
+    else:
+        c[0] = c[0]/bi
+        {{u_minus}}[0] = {{u_minus}}[0]/bi
+
+for i in range(N-2, -1, -1):
+    {{u_minus}}[i] = {{u_minus}}[i] - c[i]*{{u_minus}}[i+1]
 
 # Prepare matrix for solving the linear system
 _n_segments = len({{_B}})

--- a/brian2/codegen/runtime/numpy_rt/templates/spatialstateupdate.py_
+++ b/brian2/codegen/runtime/numpy_rt/templates/spatialstateupdate.py_
@@ -21,6 +21,33 @@ _vectorisation_idx = 1
 _vectorisation_idx = N
 {{vector_code|autoindent}}
 
+{%if _scipy_available %}
+from scipy.linalg import solve_banded
+
+# Particular solution
+b=-({{Cm}}/dt*{{v}})-_I0
+ab = zeros((3,N))
+ab[0,:]={{ab_star0}}
+ab[1,:]={{ab_star1}}
+ab[2,:]={{ab_star2}}
+ab[1,:]-=_gtot
+{{v_star}}[:]=solve_banded((1,1),ab,b,overwrite_ab=True,overwrite_b=True)
+# Homogeneous solutions
+b[:]={{b_plus}}
+ab[0,:]={{ab_plus0}}
+ab[1,:]={{ab_plus1}}
+ab[2,:]={{ab_plus2}}
+ab[1,:]-=_gtot
+{{u_plus}}[:]=solve_banded((1,1),ab,b,overwrite_ab=True,overwrite_b=True)
+b[:]={{b_minus}}
+ab[0,:]={{ab_minus0}}
+ab[1,:]={{ab_minus1}}
+ab[2,:]={{ab_minus2}}
+ab[1,:]-=_gtot
+{{u_minus}}[:]=solve_banded((1,1),ab,b,overwrite_ab=True,overwrite_b=True)
+{% else %}
+# Pure numpy solution, very slow because it needs forward and backward passes
+# along the array that can't be vectorized
 c = zeros(N)
 ab = zeros((3, N))
 _gtot_all = zeros(N)
@@ -85,6 +112,7 @@ for i in forward:
 
 for i in backward:
     {{u_minus}}[i] -= c[i]*{{u_minus}}[i+1]
+{% endif %}
 
 # Prepare matrix for solving the linear system
 _n_segments = len({{_B}})

--- a/brian2/codegen/runtime/numpy_rt/templates/spatialstateupdate.py_
+++ b/brian2/codegen/runtime/numpy_rt/templates/spatialstateupdate.py_
@@ -28,59 +28,63 @@ _gtot_all[:] = _gtot
 b = -({{Cm}} / dt*{{v}}) - _I0
 
 # Tridiagonal solving
-# Pass 1
-for i in range(N):
-    {{v_star}}[i] = b[i]  # RHS -> v_star (solution)
-    bi = {{ab_star1}}[i] - _gtot_all[i]  # main diagonal
-    if i < N-1:
-        c[i] = {{ab_star0}}[i+1]  # superdiagonal
-    if i>0:
-        ai = {{ab_star2}}[i-1]  # subdiagonal
-        _m = 1.0/(bi-ai*c[i-1])
-        c[i] = c[i]*_m
-        {{v_star}}[i] = ({{v_star}}[i] - ai*{{v_star}}[i-1])*_m
-    else:
-        c[0]=c[0]/bi
-        {{v_star}}[0]={{v_star}}[0]/bi
+forward = range(1, N)
+backward = range(N-2, -1, -1)
 
-for i in range(N-2, -1, -1):
-    {{v_star}}[i] = {{v_star}}[i] - c[i]*{{v_star}}[i+1]
+# Pass 1
+bi = {{ab_star1}} - _gtot_all  # main diagonal
+
+# First compartment
+c[0] = {{ab_star0}}[1] / bi[0]
+{{v_star}}[0] = b[0] / bi[0]
+
+# Other compartments
+c[1:-1] = {{ab_star0}}[2:]
+for i in forward:
+    ai = {{ab_star2}}[i-1]  # subdiagonal
+    _m = 1.0/(bi[i]-ai*c[i-1])
+    c[i] *= _m
+    {{v_star}}[i] = (b[i] - ai*{{v_star}}[i-1])*_m
+
+for i in backward:
+    {{v_star}}[i] -= c[i]*{{v_star}}[i+1]
 
 # Pass 2
-for i in range(N):
-    {{u_plus}}[i] = {{b_plus}}[i]  # RHS -> v_star (solution)
-    bi = {{ab_plus1}}[i] - _gtot_all[i]  # main diagonal
-    if i < N-1:
-        c[i] = {{ab_plus0}}[i+1]  # superdiagonal
-    if (i>0):
-        ai = {{ab_plus2}}[i-1]  # subdiagonal
-        _m = 1.0/(bi-ai*c[i-1])
-        c[i] = c[i]*_m
-        {{u_plus}}[i] = ({{u_plus}}[i] - ai*{{u_plus}}[i-1])*_m
-    else:
-        c[0] = c[0]/bi
-        {{u_plus}}[0] = {{u_plus}}[0]/bi
+bi = {{ab_plus1}} - _gtot_all  # main diagonal
 
-for i in range(N-2, -1, -1):
-    {{u_plus}}[i]={{u_plus}}[i] - c[i]*{{u_plus}}[i+1];
+# First compartment
+c[0] = {{ab_plus0}}[1]/bi[0]
+{{u_plus}}[0] = {{b_plus}}[0]/bi[0]
+
+# Other compartments
+c[1:-1] = {{ab_plus0}}[2:]  # superdiagonal
+
+for i in forward:
+    ai = {{ab_plus2}}[i-1]  # subdiagonal
+    _m = 1.0/(bi[i]-ai*c[i-1])
+    c[i] *= _m
+    {{u_plus}}[i] = ({{b_plus}}[i] - ai*{{u_plus}}[i-1])*_m
+
+for i in backward:
+    {{u_plus}}[i] -= c[i]*{{u_plus}}[i+1]
 
 # Pass 3
-for i in range(N):
-    {{u_minus}}[i] = {{b_minus}}[i]  # RHS -> v_star (solution)
-    bi = {{ab_minus1}}[i] - _gtot_all[i]  # main diagonal
-    if i < N-1:
-        c[i] = {{ab_minus0}}[i+1]  # superdiagonal
-    if i > 0:
-        ai = {{ab_minus2}}[i-1]  # subdiagonal
-        _m = 1.0/(bi-ai*c[i-1]);
-        c[i] = c[i]*_m
-        {{u_minus}}[i] = ({{u_minus}}[i] - ai*{{u_minus}}[i-1])*_m
-    else:
-        c[0] = c[0]/bi
-        {{u_minus}}[0] = {{u_minus}}[0]/bi
+bi = {{ab_minus1}} - _gtot_all  # main diagonal
 
-for i in range(N-2, -1, -1):
-    {{u_minus}}[i] = {{u_minus}}[i] - c[i]*{{u_minus}}[i+1]
+# First compartment
+c[0] = {{ab_minus0}}[1]/bi[0]
+{{u_minus}}[0] = {{b_minus}}[0]/bi[0]
+
+# Other compartments
+c[1:-1] = {{ab_minus0}}[2:]  # superdiagonal
+for i in forward:
+    ai = {{ab_minus2}}[i-1]  # subdiagonal
+    _m = 1.0/(bi[i]-ai*c[i-1]);
+    c[i] *= _m
+    {{u_minus}}[i] = ({{b_minus}}[i] - ai*{{u_minus}}[i-1])*_m
+
+for i in backward:
+    {{u_minus}}[i] -= c[i]*{{u_minus}}[i+1]
 
 # Prepare matrix for solving the linear system
 _n_segments = len({{_B}})

--- a/brian2/codegen/runtime/weave_rt/weave_rt.py
+++ b/brian2/codegen/runtime/weave_rt/weave_rt.py
@@ -10,8 +10,12 @@ try:
     from scipy import weave
     from scipy.weave.c_spec import num_to_c_types
 except ImportError:
-    # No weave for Python 3
-    weave = None
+    try:  # weave as an independent package
+        import weave
+        from weave.c_spec import num_to_c_types
+    except ImportError:
+        # No weave for Python 3
+        weave = None
 
 from brian2.core.variables import (DynamicArrayVariable, ArrayVariable,
                                    AttributeVariable, AuxiliaryVariable,

--- a/brian2/spatialneuron/spatialneuron.py
+++ b/brian2/spatialneuron/spatialneuron.py
@@ -410,6 +410,20 @@ class SpatialStateUpdater(CodeRunner, Group):
                                                           run_namespace=run_namespace,
                                                           level=level+1)
         self._prepare_codeobj()
+        # Raise a warning if the slow pure numpy version is used
+        # For simplicity, we check which CodeObject class the _prepare_codeobj
+        # is using, this will be the same as the main state updater
+        from brian2.codegen.runtime.numpy_rt.numpy_rt import NumpyCodeObject
+        if isinstance(self._prepare_codeobj, NumpyCodeObject):
+            # If numpy is used, raise a warning if scipy is not present
+            try:
+                import scipy
+            except ImportError:
+                logger.warn(('SpatialNeuron will use numpy to do the numerical '
+                             'integration -- this will be very slow. Either '
+                             'switch to a different code generation target '
+                             '(e.g. weave or cython) or install scipy.'),
+                            once=True)
         CodeRunner.before_run(self, run_namespace, level=level + 1)
 
     def _pre_calc_iteration(self, morphology, counter=0):

--- a/brian2/tests/__init__.py
+++ b/brian2/tests/__init__.py
@@ -44,7 +44,11 @@ def run(codegen_targets=None, long_tests=False, test_codegen_independent=True,
             import scipy.weave
             codegen_targets.append('weave')
         except ImportError:
-            pass
+            try:
+                import weave
+                codegen_targets.append('weave')
+            except ImportError:
+                pass
         try:
             import Cython
             codegen_targets.append('cython')

--- a/brian2/tests/test_parsing.py
+++ b/brian2/tests/test_parsing.py
@@ -30,7 +30,10 @@ from brian2.units import (volt, amp, DimensionMismatchError,
 try:
     from scipy import weave
 except ImportError:
-    weave = None
+    try:
+        import weave
+    except ImportError:
+        weave = None
 import nose
 
 

--- a/brian2/utils/logger.py
+++ b/brian2/utils/logger.py
@@ -15,7 +15,17 @@ import time
 from warnings import warn
 
 import numpy
-import scipy
+try:
+    import scipy
+except ImportError:
+    scipy = None
+try:
+    import scipy.weave as weave
+except ImportError:
+    try:
+        import weave
+    except ImportError:
+        weave = None
 import sympy
 
 import brian2
@@ -180,7 +190,8 @@ logger.debug('Python interpreter: %s' % sys.executable)
 logger.debug('Platform: %s' % sys.platform)
 version_infos = {'brian': brian2.__version__,
                  'numpy': numpy.__version__,
-                 'scipy': scipy.__version__,
+                 'scipy': scipy.__version__ if scipy else 'not installed',
+                 'weave': weave.__version__ if weave else 'not installed',
                  'sympy': sympy.__version__,
                  'python': sys.version,
                  }

--- a/setup.py
+++ b/setup.py
@@ -144,7 +144,6 @@ setup(name='Brian2',
                     'brian2': ['default_preferences']
                     },
       install_requires=['numpy>=1.8.0',
-                        'scipy>=0.13.3',
                         'sympy>=0.7.6',
                         'pyparsing',
                         'jinja2>=2.7',


### PR DESCRIPTION
In this branch, I added a pure-numpy implementation of the `spatialstateupdate` template, i.e. one that does not use `solve_banded` from scipy. This was the only place in the code where we used scipy and listing it as a dependency meant that users installing brian via pip or easy_install had to download the full 10MB source code and wait for its compilation to finish (which takes a couple of minutes).

The problem is that the algorithm is really straightforward to implement in C (i.e., with loops) but its forward and backward passes over arrays are not vectoriseable using numpy syntax (at least I don't know how). Therefore, even after a bit of optimisation, the numpy solution is very slow -- about 10x as slow as the version using scipy... I therefore thought that the best approach is to:
* No longer list scipy as a dependency, but...
* ... still include both algorithms (pure numpy and scipy) in the `spatialstateupdate` template, using the scipy version if it is available
* emit a warning if the numpy-only algorithm is used, recommending the user to use weave/cython or to install scipy

While this makes the `spatialstateupdate` template a bit more complex than I'd like it to be, I think this is the best solution, it would be hard to justify to drastically reduce the performance of some code for users that are happily using numpy+scipy right now. @thesamovar, @romainbrette what do you think?

This branch also fixes #386, i.e. it allows for the independent `weave` package as an alternative to `scipy.weave`. I decided against raising a warning if `scipy.weave` is used because for example the Anaconda distribution does not ship the `weave` package.