### PR TITLE
Fix SpikeMonitor for subgroups (weave, cython, cpp_standalone)

### DIFF
--- a/brian2/codegen/runtime/cython_rt/templates/spikemonitor.pyx
+++ b/brian2/codegen/runtime/cython_rt/templates/spikemonitor.pyx
@@ -11,8 +11,8 @@
         # For subgroups, we do not want to record all spikes
         # We assume that spikes are ordered
         # TODO: Will this assumption ever be violated?
-        _start_idx = 0
-        _end_idx = - 1
+        _start_idx = _num_spikes
+        _end_idx = _num_spikes
         for _j in range(_num_spikes):
             _idx = {{_spikespace}}[_j]
             if _idx >= _source_start:
@@ -23,8 +23,6 @@
             if _idx >= _source_stop:
                 _end_idx = _j
                 break
-        if _end_idx == -1:
-            _end_idx =_num_spikes
         _num_spikes = _end_idx - _start_idx
         if _num_spikes > 0:
             # Get the current length and new length of t and i arrays

--- a/brian2/codegen/runtime/weave_rt/templates/spikemonitor.cpp
+++ b/brian2/codegen/runtime/weave_rt/templates/spikemonitor.cpp
@@ -9,8 +9,8 @@
     {
         // For subgroups, we do not want to record all spikes
         // We assume that spikes are ordered
-        int _start_idx = 0;
-        int _end_idx = - 1;
+        int _start_idx = _num_spikes;
+        int _end_idx = _num_spikes;
         for(int _j=0; _j<_num_spikes; _j++)
         {
             const int _idx = {{_spikespace}}[_j];
@@ -27,8 +27,6 @@
                 break;
             }
         }
-        if (_end_idx == -1)
-            _end_idx =_num_spikes;
         _num_spikes = _end_idx - _start_idx;
         if (_num_spikes > 0) {
             // Get the current length and new length of t and i arrays

--- a/brian2/devices/cpp_standalone/templates/spikemonitor.cpp
+++ b/brian2/devices/cpp_standalone/templates/spikemonitor.cpp
@@ -11,8 +11,8 @@
     {
         if (_num_spikes > 0)
         {
-            int _start_idx = 0;
-            int _end_idx = - 1;
+            int _start_idx = _num_spikes;
+            int _end_idx = _num_spikes;
             for(int _j=0; _j<_num_spikes; _j++)
             {
                 const int _idx = {{_spikespace}}[_j];
@@ -29,8 +29,6 @@
                     break;
                 }
             }
-            if (_end_idx == -1)
-                _end_idx =_num_spikes;
             _num_spikes = _end_idx - _start_idx;
             if (_num_spikes > 0) {
                 for(int _j=_start_idx; _j<_end_idx; _j++)


### PR DESCRIPTION
For subgroups not starting at 0, the code for searching through the list of all spikes for spikes that should be recorded was not correct. If some neuron in the full group spiked, but none of them >= the start index of the recorded subgroup, then all (instead of none) spikes were recorded. The good news is that this should not have led to undetected incorrect recordings because 1) it would have recorded spikes with negative indices, which would be incorrect in an obvious way and 2) it most of the time should have led to a segmentation fault due to accessing the `_count` array with negative indices (this is the way I encountered the issue). Nevertheless, an important bug.