### PR TITLE
Use filenames that are guaranteed to be unique for standalone

### DIFF
--- a/brian2/devices/cpp_standalone/templates/objects.cpp
+++ b/brian2/devices/cpp_standalone/templates/objects.cpp
@@ -113,7 +113,7 @@ void _write_arrays()
 	{% for var, varname in array_specs | dictsort(by='value') %}
 	{% if not (var in dynamic_array_specs or var in dynamic_array_2d_specs) %}
 	ofstream outfile_{{varname}};
-	outfile_{{varname}}.open("results/{{varname}}", ios::binary | ios::out);
+	outfile_{{varname}}.open("{{get_array_filename(var)}}", ios::binary | ios::out);
 	if(outfile_{{varname}}.is_open())
 	{
 		outfile_{{varname}}.write(reinterpret_cast<char*>({{varname}}), {{var.size}}*sizeof({{varname}}[0]));
@@ -127,7 +127,7 @@ void _write_arrays()
 
 	{% for var, varname in dynamic_array_specs | dictsort(by='value') %}
 	ofstream outfile_{{varname}};
-	outfile_{{varname}}.open("results/{{varname}}", ios::binary | ios::out);
+	outfile_{{varname}}.open("{{get_array_filename(var)}}", ios::binary | ios::out);
 	if(outfile_{{varname}}.is_open())
 	{
 		outfile_{{varname}}.write(reinterpret_cast<char*>(&{{varname}}[0]), {{varname}}.size()*sizeof({{varname}}[0]));
@@ -140,7 +140,7 @@ void _write_arrays()
 
 	{% for var, varname in dynamic_array_2d_specs | dictsort(by='value') %}
 	ofstream outfile_{{varname}};
-	outfile_{{varname}}.open("results/{{varname}}", ios::binary | ios::out);
+	outfile_{{varname}}.open("{{get_array_filename(var)}}", ios::binary | ios::out);
 	if(outfile_{{varname}}.is_open())
 	{
         for (int n=0; n<{{varname}}.n; n++)

--- a/brian2/devices/cpp_standalone/templates/objects.cpp
+++ b/brian2/devices/cpp_standalone/templates/objects.cpp
@@ -113,7 +113,7 @@ void _write_arrays()
 	{% for var, varname in array_specs | dictsort(by='value') %}
 	{% if not (var in dynamic_array_specs or var in dynamic_array_2d_specs) %}
 	ofstream outfile_{{varname}};
-	outfile_{{varname}}.open("{{get_array_filename(var)}}", ios::binary | ios::out);
+	outfile_{{varname}}.open("{{get_array_filename(var) | replace('\\', '\\\\')}}", ios::binary | ios::out);
 	if(outfile_{{varname}}.is_open())
 	{
 		outfile_{{varname}}.write(reinterpret_cast<char*>({{varname}}), {{var.size}}*sizeof({{varname}}[0]));
@@ -127,7 +127,7 @@ void _write_arrays()
 
 	{% for var, varname in dynamic_array_specs | dictsort(by='value') %}
 	ofstream outfile_{{varname}};
-	outfile_{{varname}}.open("{{get_array_filename(var)}}", ios::binary | ios::out);
+	outfile_{{varname}}.open("{{get_array_filename(var) | replace('\\', '\\\\')}}", ios::binary | ios::out);
 	if(outfile_{{varname}}.is_open())
 	{
 		outfile_{{varname}}.write(reinterpret_cast<char*>(&{{varname}}[0]), {{varname}}.size()*sizeof({{varname}}[0]));
@@ -140,7 +140,7 @@ void _write_arrays()
 
 	{% for var, varname in dynamic_array_2d_specs | dictsort(by='value') %}
 	ofstream outfile_{{varname}};
-	outfile_{{varname}}.open("{{get_array_filename(var)}}", ios::binary | ios::out);
+	outfile_{{varname}}.open("{{get_array_filename(var) | replace('\\', '\\\\')}}", ios::binary | ios::out);
 	if(outfile_{{varname}}.is_open())
 	{
         for (int n=0; n<{{varname}}.n; n++)

--- a/brian2/tests/__init__.py
+++ b/brian2/tests/__init__.py
@@ -62,10 +62,9 @@ def run(codegen_targets=None, long_tests=False, test_codegen_independent=True,
     sys.stderr.write('Running tests in "%s" ' % dirname)
     if codegen_targets:
         sys.stderr.write('for targets %s' % (', '.join(codegen_targets)))
-        ex_in = 'including' if long_tests else 'excluding'
-        sys.stderr.write(' (%s long tests)\n' % ex_in)
-    else:
-        sys.stderr.write('\n')
+    ex_in = 'including' if long_tests else 'excluding'
+    sys.stderr.write(' (%s long tests)\n' % ex_in)
+
     if test_standalone:
         if not isinstance(test_standalone, basestring):
             raise ValueError('test_standalone argument has to be the name of a '
@@ -128,13 +127,14 @@ def run(codegen_targets=None, long_tests=False, test_codegen_independent=True,
             set_device(test_standalone + '_simple')
             sys.stderr.write('Testing standalone device "%s"\n' % test_standalone)
             sys.stderr.write('Running standalone-compatible standard tests\n')
+            exclude_str = ',!long' if not long_tests else ''
             success.append(nose.run(argv=['', dirname,
                                           '-c=',  # no config file loading
                                           '-I', '^hears\.py$',
                                           '-I', '^\.',
                                           '-I', '^_',
                                           # Only run standalone tests
-                                          '-a', 'standalone-compatible',
+                                          '-a', 'standalone-compatible'+exclude_str,
                                           '--nologcapture',
                                           '--exe']))
             set_device(previous_device)
@@ -145,7 +145,7 @@ def run(codegen_targets=None, long_tests=False, test_codegen_independent=True,
                                           '-I', '^\.',
                                           '-I', '^_',
                                           # Only run standalone tests
-                                          '-a', test_standalone,
+                                          '-a', test_standalone+exclude_str,
                                           '--nologcapture',
                                           '--exe']))
         all_success = all(success)


### PR DESCRIPTION
Arrays were previously stored in the results directory using the name of the array as the filename. On file systems that are not case sensitive (e.g. Windows), this is not guaranteed to work. The most common situation were this leads to problems is with a variable "I" in a neuron group, since it also contains the variable "i" by default. As an easy fix, the filename now uses the name of the variable plus its hash value. Note that users should never have to construct such file names manually, if for any reasons they cannot access the values via the normal state variable mechanism, they should use `device.get_array_filename` to get the filename.