### PR TITLE
Build docs from release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,9 +41,10 @@ install:
     fi
   - source activate travis_conda
   - if [[ $CYTHON == 'yes' ]]; then conda install --yes cython; SETUP_ARGS=--with-cython; else SETUP_ARGS=""; fi
-  - pip install -q coveralls --use-mirrors
+  - pip install -q coveralls
   - python setup.py install $SETUP_ARGS --fail-on-error
   - if [[ $DOCS_ONLY == 'yes' ]]; then
+    pip install -q sphinxcontrib-issuetracker;
     python setup.py sdist;
     fi
 # command to run tests (make sure to not run it from the source directory)

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,11 @@
 language: python
 matrix:
-  include:    
+  include:
+      # test that the documentation can be built from the tarball -- we
+      # automatically build it from github master all the time, but downstream
+      # packaging will use the tarball as the basis
+    - python: "2.7"
+      env: DOCS_ONLY=yes
     - python: "2.7"
       env: STANDALONE=no CYTHON=yes MINIMAL_VERSIONS=no REPORT_COVERAGE=yes
     - python: "2.7"
@@ -15,7 +20,6 @@ matrix:
       env: STANDALONE=yes CYTHON=no MINIMAL_VERSIONS=no REPORT_COVERAGE=no
     - python: "2.7"  # test without installed cython
       env: STANDALONE=no CYTHON=no MINIMAL_VERSIONS=no REPORT_COVERAGE=no
-
 # Use miniconda to install binary versions of numpy etc. from continuum
 # analytic's repository. Follows an approach described by Dan Blanchard:
 # https://gist.github.com/dan-blanchard/7045057
@@ -39,11 +43,27 @@ install:
   - if [[ $CYTHON == 'yes' ]]; then conda install --yes cython; SETUP_ARGS=--with-cython; else SETUP_ARGS=""; fi
   - pip install -q coveralls --use-mirrors
   - python setup.py install $SETUP_ARGS --fail-on-error
+  - if [[ $DOCS_ONLY == 'yes' ]]; then
+    python setup.py sdist;
+    fi
 # command to run tests (make sure to not run it from the source directory)
 script:
-- export SRCDIR=$(pwd)
-- if [[ $STANDALONE == 'yes' ]]; then SCRIPTFILE=$SRCDIR/dev/tools/run_nose_tests_standalone.py; else SCRIPTFILE=$SRCDIR/dev/tools/run_nose_tests.py; fi
-- cd ~;coverage run --rcfile=$SRCDIR/.coveragerc $SCRIPTFILE
+- if [[ $DOCS_ONLY == 'yes' ]]; then
+    cd dist;
+    tar xvzf *.tar.gz;
+    cd Brian2*;
+    mkdir docs;
+    sphinx-build docs_sphinx docs;
+  else
+    export SRCDIR=$(pwd);
+    if [[ $STANDALONE == 'yes' ]]; then
+      SCRIPTFILE=$SRCDIR/dev/tools/run_nose_tests_standalone.py;
+    else
+      SCRIPTFILE=$SRCDIR/dev/tools/run_nose_tests.py;
+    fi;
+    cd ~;
+    coverage run --rcfile=$SRCDIR/.coveragerc $SCRIPTFILE;
+  fi
 # We only report coverage for one Python version
 after_success: if [[ $REPORT_COVERAGE == 'yes' ]]; then cp .coverage $SRCDIR; cd $SRCDIR; coveralls; fi
 notifications:

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,11 @@
 include ez_setup.py
+
+# Include documentation
+include docs_sphinx/conf.py
 recursive-include docs_sphinx *.rst
 prune docs_sphinx/reference
 prune docs_sphinx/examples
 prune docs_sphinx/resources
+
+# Include examples (but not tutorials)
+recursive-include examples *.py

--- a/brian2/sphinxext/generate_examples.py
+++ b/brian2/sphinxext/generate_examples.py
@@ -23,7 +23,10 @@ class GlobDirectoryWalker:
             except IndexError:
                 # pop next directory from stack
                 self.directory = self.stack.pop()
-                self.files = os.listdir(self.directory)
+                if os.path.isdir(self.directory):
+                    self.files = os.listdir(self.directory)
+                else:
+                    self.files = []
                 self.index = 0
             else:
                 # got a filename


### PR DESCRIPTION
This includes `conf.py` and the example files in the release tarball (increasing its size from 487KB to 517KB, which is not a big deal I think). This will allow to build the documentation (using something like `sphinx-build docs_sphinx target_dir`) from the release tarball. Previously, we did include the documentation from `docs_sphinx` but you could not actually build the docs. The generated docs will not be exactly like the docs on http://brian2.readthedocs.org, since the example images are not included and neither are the tutorials -- but clearly we don't want to include them in the release tarball and I don't think providing a separate `brian2-doc` package is worth the effort, given that readthedocs allows  you to download the complete documentation for offline use.

Thanks again to @sanjayankur31 for making us aware of this issue. 
Closes #453 -- ready to merge from my side.