### PR TITLE
Standalone customization

### DIFF
--- a/brian2/codegen/cpp_prefs.py
+++ b/brian2/codegen/cpp_prefs.py
@@ -120,8 +120,7 @@ def get_compiler_and_args():
         compiler = get_default_compiler()
     extra_compile_args = prefs['codegen.cpp.extra_compile_args']
     if extra_compile_args is None:
-        if compiler == 'gcc' or compiler == 'unix':
-            compiler = 'gcc'
+        if compiler in ('gcc', 'unix'):
             extra_compile_args = prefs['codegen.cpp.extra_compile_args_gcc']
         if compiler == 'msvc':
             extra_compile_args = prefs['codegen.cpp.extra_compile_args_msvc']

--- a/brian2/codegen/cpp_prefs.py
+++ b/brian2/codegen/cpp_prefs.py
@@ -25,7 +25,7 @@ prefs.register_preferences(
         Should be gcc or msvc.
         '''
         ),
-    extra_compile_args = BrianPreference(
+    extra_compile_args=BrianPreference(
         default=None,
         validator=lambda v: True,
         docs='''
@@ -33,19 +33,26 @@ prefs.register_preferences(
         ``extra_compile_args_gcc`` or ``extra_compile_args_msvs``).
         '''
         ),
-    extra_compile_args_gcc = BrianPreference(
+    extra_compile_args_gcc=BrianPreference(
         default=['-w', '-O3'],
         docs='''
         Extra compile arguments to pass to GCC compiler
         '''
         ),
-    extra_compile_args_msvc = BrianPreference(
+    extra_compile_args_msvc=BrianPreference(
         default=['/Ox', '/EHsc', '/w'],
         docs='''
         Extra compile arguments to pass to MSVC compiler
         '''
         ),
-    include_dirs = BrianPreference(
+    extra_link_args=BrianPreference(
+        default=[],
+        docs='''
+        Any extra platform- and compiler-specific information to use when
+        linking object files together.
+        '''
+    ),
+    include_dirs=BrianPreference(
         default=[],
         docs='''
         Include directories to use. Note that ``$prefix/include`` will be
@@ -53,12 +60,39 @@ prefs.register_preferences(
         site-specific directory prefix as returned by `sys.prefix`.
         '''
         ),
-    msvc_vars_location = BrianPreference(
+    library_dirs=BrianPreference(
+        default=[],
+        docs='''
+        List of directories to search for C/C++ libraries at link time.
+        '''
+    ),
+    runtime_library_dirs=BrianPreference(
+        default=[],
+        docs='''
+        List of directories to search for C/C++ libraries at run time.
+        '''
+    ),
+    libraries=BrianPreference(
+        default=[],
+        docs='''
+        List of library names (not filenames or paths) to link against.
+        '''
+    ),
+    define_macros=BrianPreference(
+        default=[],
+        docs='''
+        List of macros to define; each macro is defined using a 2-tuple,
+        where 'value' is either the string to define it to or None to
+        define it without a particular value (equivalent of "#define
+        FOO" in source or -DFOO on Unix C compiler command line).
+        '''
+    ),
+    msvc_vars_location=BrianPreference(
         default='',
         docs='''
         Location of the MSVC command line tool (or search for best by default).
         '''),
-    msvc_architecture = BrianPreference(
+    msvc_architecture=BrianPreference(
         default='',
         docs='''
         MSVC architecture name (or use system architectue by default).

--- a/brian2/codegen/cpp_prefs.py
+++ b/brian2/codegen/cpp_prefs.py
@@ -78,6 +78,15 @@ prefs.register_preferences(
         List of library names (not filenames or paths) to link against.
         '''
     ),
+    headers=BrianPreference(
+        default=[],
+        docs='''
+        A list of strings specifying header files to use when compiling the
+        code. The list might look like ["<vector>","'my_header'"]. Note that
+        the header strings need to be in a form than can be pasted at the end
+        of a #include statement in the C++ code.
+        '''
+    ),
     define_macros=BrianPreference(
         default=[],
         docs='''

--- a/brian2/codegen/runtime/cython_rt/cython_rt.py
+++ b/brian2/codegen/runtime/cython_rt/cython_rt.py
@@ -40,7 +40,7 @@ class CythonCodeObject(NumpyCodeObject):
                                                variable_indices,
                                                template_name, template_source,
                                                name=name)
-        _, self.extra_compile_args = get_compiler_and_args()
+        self.compiler, self.extra_compile_args = get_compiler_and_args()
         self.extra_link_args = list(prefs['codegen.cpp.extra_link_args'])
         self.include_dirs = list(prefs['codegen.cpp.include_dirs'])
         self.include_dirs += [os.path.join(sys.prefix, 'include')]
@@ -74,7 +74,8 @@ class CythonCodeObject(NumpyCodeObject):
                                                                        extra_compile_args=self.extra_compile_args,
                                                                        extra_link_args=self.extra_link_args,
                                                                        include_dirs=self.include_dirs,
-                                                                       library_dirs=self.library_dirs)
+                                                                       library_dirs=self.library_dirs,
+                                                                       compiler=self.compiler)
         
     def run(self):
         return self.compiled_code.main(self.namespace)

--- a/brian2/codegen/runtime/cython_rt/extension_manager.py
+++ b/brian2/codegen/runtime/cython_rt/extension_manager.py
@@ -90,6 +90,13 @@ class CythonExtensionManager(object):
             if 'numpy' in code:
                 import numpy
                 c_include_dirs.append(numpy.get_include())
+
+            # TODO: We should probably have a special folder just for header
+            # files that are shared between different codegen targets
+            import brian2.synapses as synapses
+            synapses_dir = os.path.dirname(synapses.__file__)
+            c_include_dirs.append(synapses_dir)
+
             pyx_file = os.path.join(lib_dir, module_name + '.pyx')
             # ignore Python 3 unicode stuff for the moment
             #pyx_file = py3compat.cast_bytes_py2(pyx_file, encoding=sys.getfilesystemencoding())

--- a/brian2/codegen/runtime/cython_rt/extension_manager.py
+++ b/brian2/codegen/runtime/cython_rt/extension_manager.py
@@ -41,6 +41,7 @@ class CythonExtensionManager(object):
                          extra_compile_args=None,
                          extra_link_args=None,
                          libraries=None,
+                         compiler=None,
                          ):
 
         if Cython is None:
@@ -107,7 +108,7 @@ class CythonExtensionManager(object):
                 libraries=libraries,
                 language='c++',
                 )
-            build_extension = self._get_build_extension()
+            build_extension = self._get_build_extension(compiler=compiler)
             try:
                 opts = dict(
                     quiet=True,
@@ -151,7 +152,7 @@ class CythonExtensionManager(object):
             _path_created.clear()
 
 
-    def _get_build_extension(self):
+    def _get_build_extension(self, compiler=None):
         self._clear_distutils_mkpath_cache()
         dist = Distribution()
         config_files = dist.find_config_files()
@@ -161,6 +162,8 @@ class CythonExtensionManager(object):
             pass
         dist.parse_config_files(config_files)
         build_extension = build_ext(dist)
+        if compiler is not None:
+            build_extension.compiler = compiler
         build_extension.finalize_options()
         return build_extension
 

--- a/brian2/codegen/runtime/cython_rt/extension_manager.py
+++ b/brian2/codegen/runtime/cython_rt/extension_manager.py
@@ -35,7 +35,12 @@ class CythonExtensionManager(object):
         self._code_cache = {}
         
     def create_extension(self, code, force=False, name=None,
-                         include=None, library_dirs=None, compile_args=None, link_args=None, lib=None,
+                         include_dirs=None,
+                         library_dirs=None,
+                         runtime_library_dirs=None,
+                         extra_compile_args=None,
+                         extra_link_args=None,
+                         libraries=None,
                          ):
 
         if Cython is None:
@@ -69,18 +74,18 @@ class CythonExtensionManager(object):
         have_module = os.path.isfile(module_path)
         
         if not have_module:
-            if include is None:
-                include = []
+            if include_dirs is None:
+                include_dirs = []
             if library_dirs is None:
                 library_dirs = []
-            if compile_args is None:
-                compile_args = []
-            if link_args is None:
-                link_args = []
-            if lib is None:
-                lib = []
-                
-            c_include_dirs = include
+            if extra_compile_args is None:
+                extra_compile_args = []
+            if extra_link_args is None:
+                extra_link_args = []
+            if libraries is None:
+                libraries = []
+
+            c_include_dirs = include_dirs
             if 'numpy' in code:
                 import numpy
                 c_include_dirs.append(numpy.get_include())
@@ -96,9 +101,10 @@ class CythonExtensionManager(object):
                 sources=[pyx_file],
                 include_dirs=c_include_dirs,
                 library_dirs=library_dirs,
-                extra_compile_args=compile_args,
-                extra_link_args=link_args,
-                libraries=lib,
+                runtime_library_dirs=runtime_library_dirs,
+                extra_compile_args=extra_compile_args,
+                extra_link_args=extra_link_args,
+                libraries=libraries,
                 language='c++',
                 )
             build_extension = self._get_build_extension()

--- a/brian2/codegen/runtime/cython_rt/templates/common.pyx
+++ b/brian2/codegen/runtime/cython_rt/templates/common.pyx
@@ -9,7 +9,12 @@ from libc.math cimport sin, cos, tan, sinh, cosh, tanh, exp, log, log10, sqrt, a
 cdef extern from "math.h":
     double M_PI
 from libcpp cimport bool
-from libc.stdint cimport int32_t, int64_t, uint8_t
+
+cdef extern from "stdint_compat.h":
+    # Longness only used for type promotion
+    # Actual compile time size used for conversion
+    ctypedef signed int int32_t
+    ctypedef signed long int64_t
 
 # support code
 {{ support_code | autoindent }}

--- a/brian2/codegen/runtime/weave_rt/weave_rt.py
+++ b/brian2/codegen/runtime/weave_rt/weave_rt.py
@@ -99,6 +99,7 @@ class WeaveCodeObject(CodeObject):
         self.library_dirs = list(prefs['codegen.cpp.library_dirs'])
         self.runtime_library_dirs = list(prefs['codegen.cpp.runtime_library_dirs'])
         self.libraries = list(prefs['codegen.cpp.libraries'])
+        self.headers = ['<algorithm>', '<limits>'] + prefs['codegen.cpp.headers']
         self.annotated_code = self.code.main+'''
 /*
 The following code is just compiler options for the call to weave.inline.
@@ -214,7 +215,7 @@ libraries: {self.libraries}
                                    local_dict=self.namespace,
                                    support_code=self.code.support_code,
                                    compiler=self.compiler,
-                                   headers=['<algorithm>', '<limits>'],
+                                   headers=self.headers,
                                    define_macros=self.define_macros,
                                    libraries=self.libraries,
                                    extra_compile_args=self.extra_compile_args,

--- a/brian2/codegen/runtime/weave_rt/weave_rt.py
+++ b/brian2/codegen/runtime/weave_rt/weave_rt.py
@@ -215,6 +215,7 @@ libraries: {self.libraries}
                                    support_code=self.code.support_code,
                                    compiler=self.compiler,
                                    headers=['<algorithm>', '<limits>'],
+                                   define_macros=self.define_macros,
                                    libraries=self.libraries,
                                    extra_compile_args=self.extra_compile_args,
                                    extra_link_args=self.extra_link_args,

--- a/brian2/devices/cpp_standalone/device.py
+++ b/brian2/devices/cpp_standalone/device.py
@@ -402,6 +402,11 @@ class CPPStandaloneDevice(Device):
     def code_object(self, owner, name, abstract_code, variables, template_name,
                     variable_indices, codeobj_class=None, template_kwds=None,
                     override_conditional_write=None):
+        if template_kwds is None:
+            template_kwds = dict()
+        else:
+            template_kwds = dict(template_kwds)
+        template_kwds['user_headers'] = prefs['codegen.cpp.headers']
         codeobj = super(CPPStandaloneDevice, self).code_object(owner, name, abstract_code, variables,
                                                                template_name, variable_indices,
                                                                codeobj_class=codeobj_class,
@@ -437,7 +442,7 @@ class CPPStandaloneDevice(Device):
                         get_array_filename=self.get_array_filename)
         writer.write('objects.*', arr_tmp)
         
-    def generate_main_source(self, writer, main_includes):
+    def generate_main_source(self, writer):
         main_lines = []
         procedures = [('', main_lines)]
         runfuncs = {}
@@ -506,7 +511,7 @@ class CPPStandaloneDevice(Device):
                                                           code_objects=self.code_objects.values(),
                                                           report_func=self.report_func,
                                                           dt=float(defaultclock.dt),
-                                                          additional_headers=main_includes,
+                                                          user_headers=prefs['codegen.cpp.headers']
                                                           )
         writer.write('main.cpp', main_tmp)
         
@@ -568,10 +573,10 @@ class CPPStandaloneDevice(Device):
         synapses_classes_tmp = CPPStandaloneCodeObject.templater.synapses_classes(None, None)
         writer.write('synapses_classes.*', synapses_classes_tmp)
         
-    def generate_run_source(self, writer, run_includes):
+    def generate_run_source(self, writer):
         run_tmp = CPPStandaloneCodeObject.templater.run(None, None, run_funcs=self.runfuncs,
                                                         code_objects=self.code_objects.values(),
-                                                        additional_headers=run_includes,
+                                                        user_headers=prefs['codegen.cpp.headers']
                                                         )
         writer.write('run.*', run_tmp)
         
@@ -757,8 +762,7 @@ class CPPStandaloneDevice(Device):
     def build(self, directory='output',
               compile=True, run=True, debug=False, clean=True,
               with_output=True, native=True,
-              additional_source_files=None, additional_header_files=None,
-              main_includes=None, run_includes=None,
+              additional_source_files=None,
               run_args=None, **kwds):
         '''
         Build the project
@@ -783,12 +787,6 @@ class CPPStandaloneDevice(Device):
             Whether or not to clean the project before building
         additional_source_files : list of str
             A list of additional ``.cpp`` files to include in the build.
-        additional_header_files : list of str
-            A list of additional ``.h`` files to include in the build.
-        main_includes : list of str
-            A list of additional header files to include in ``main.cpp``.
-        run_includes : list of str
-            A list of additional header files to include in ``run.cpp``.
         '''
         renames = {'project_dir': 'directory',
                    'compile_project': 'compile',
@@ -805,12 +803,6 @@ class CPPStandaloneDevice(Device):
 
         if additional_source_files is None:
             additional_source_files = []
-        if additional_header_files is None:
-            additional_header_files = []
-        if main_includes is None:
-            main_includes = []
-        if run_includes is None:
-            run_includes = []
         if run_args is None:
             run_args = []
         self.project_dir = directory
@@ -859,15 +851,14 @@ class CPPStandaloneDevice(Device):
             net.after_run()
 
         self.generate_objects_source(writer, arange_arrays, self.net_synapses, self.static_array_specs, self.networks)
-        self.generate_main_source(writer, main_includes)
+        self.generate_main_source(writer)
         self.generate_codeobj_source(writer)
         self.generate_network_source(writer, compiler)
         self.generate_synapses_classes_source(writer)
-        self.generate_run_source(writer, run_includes)
+        self.generate_run_source(writer)
         self.copy_source_files(writer, directory)
         
         writer.source_files.extend(additional_source_files)
-        writer.header_files.extend(additional_header_files)
         
         self.generate_makefile(writer, compiler, native=native,
                                compiler_flags=' '.join(compiler_flags),

--- a/brian2/devices/cpp_standalone/device.py
+++ b/brian2/devices/cpp_standalone/device.py
@@ -9,7 +9,7 @@ import platform
 from collections import defaultdict
 import numbers
 import tempfile
-from distutils import ccompiler, msvc9compiler
+from distutils import ccompiler
 import numpy as np
 
 from brian2.codegen.cpp_prefs import get_compiler_and_args
@@ -686,6 +686,7 @@ class CPPStandaloneDevice(Device):
     def compile_source(self, directory, compiler, debug, clean, native):
         with in_directory(directory):
             if compiler == 'msvc':
+                from distutils import msvc9compiler
                 # TODO: handle debug
                 if debug:
                     logger.warn('Debug flag currently ignored for MSVC')

--- a/brian2/devices/cpp_standalone/device.py
+++ b/brian2/devices/cpp_standalone/device.py
@@ -809,9 +809,7 @@ class CPPStandaloneDevice(Device):
         ensure_directory(directory)
 
         compiler, extra_compile_args = get_compiler_and_args()
-        # We have to use the name 'unix' for the 'gcc' compiler
-        compiler_name = compiler if compiler != 'gcc' else 'unix'
-        compiler_obj = ccompiler.new_compiler(compiler=compiler_name)
+        compiler_obj = ccompiler.new_compiler(compiler=compiler)
         compiler_flags = (ccompiler.gen_preprocess_options(prefs['codegen.cpp.define_macros'],
                                                            prefs['codegen.cpp.include_dirs']) +
                           extra_compile_args)

--- a/brian2/devices/cpp_standalone/templates/common_group.cpp
+++ b/brian2/devices/cpp_standalone/templates/common_group.cpp
@@ -7,6 +7,9 @@
 #include<fstream>
 {% block extra_headers %}
 {% endblock %}
+{% for name in user_headers %}
+#include {{name}}
+{% endfor %}
 
 ////// SUPPORT CODE ///////
 namespace {

--- a/brian2/devices/cpp_standalone/templates/group_variable_set_conditional.cpp
+++ b/brian2/devices/cpp_standalone/templates/group_variable_set_conditional.cpp
@@ -6,9 +6,11 @@
 #include<stdint.h>
 #include<iostream>
 #include<fstream>
-
 {% block extra_headers %}
 {% endblock %}
+{% for name in user_headers %}
+#include {{name}}
+{% endfor %}
 
 ////// SUPPORT CODE ///////
 namespace {

--- a/brian2/devices/cpp_standalone/templates/main.cpp
+++ b/brian2/devices/cpp_standalone/templates/main.cpp
@@ -10,8 +10,8 @@
 #include "code_objects/{{codeobj.name}}.h"
 {% endfor %}
 
-{% for name in additional_headers %}
-#include "{{name}}"
+{% for name in user_headers %}
+#include {{name}}
 {% endfor %}
 
 #include <iostream>

--- a/brian2/devices/cpp_standalone/templates/makefile
+++ b/brian2/devices/cpp_standalone/templates/makefile
@@ -6,7 +6,7 @@ CC = @g++
 DEBUG = -g
 OPTIMISATIONS = {{ compiler_flags }}
 CFLAGS = -c -Wno-write-strings $(OPTIMISATIONS) -I. {{ openmp_pragma('compilation') }}
-LFLAGS = {{ openmp_pragma('compilation') }}
+LFLAGS = {{ openmp_pragma('compilation') }} {{ linker_flags }}
 DEPS = make.deps
 
 all: executable

--- a/brian2/devices/cpp_standalone/templates/makefile
+++ b/brian2/devices/cpp_standalone/templates/makefile
@@ -23,7 +23,7 @@ native: executable
 .PHONY: all debug native executable clean
 
 executable: $(OBJS) $(DEPS)
-	$(CC) $(LFLAGS) $(OBJS) -o $(PROGRAM)
+	$(CC) $(OBJS) -o $(PROGRAM) $(LFLAGS)
 
 clean:
 	{{ rm_cmd }}

--- a/brian2/devices/cpp_standalone/templates/run.cpp
+++ b/brian2/devices/cpp_standalone/templates/run.cpp
@@ -8,8 +8,8 @@
 #include "code_objects/{{codeobj.name}}.h"
 {% endfor %}
 
-{% for name in additional_headers %}
-#include "{{name}}"
+{% for name in user_headers %}
+#include {{name}}
 {% endfor %}
 
 void brian_start()

--- a/brian2/devices/cpp_standalone/templates/synapses_classes.cpp
+++ b/brian2/devices/cpp_standalone/templates/synapses_classes.cpp
@@ -52,7 +52,7 @@ public:
     	queue[{{ openmp_pragma('get_thread_num') }}]->advance();
     }
 
-	vector<DTYPE_int>* peek()
+	vector<int32_t>* peek()
     {
     	{{ openmp_pragma('static-ordered') }}
 		for(int _thread=0; _thread < {{ openmp_pragma('get_num_threads') }}; _thread++)

--- a/brian2/devices/cpp_standalone/templates/win_makefile
+++ b/brian2/devices/cpp_standalone/templates/win_makefile
@@ -12,4 +12,4 @@ clean:
 
 main.exe: {% for base in source_bases %}{{base}}.obj {% endfor %}
 
-    link {% for base in source_bases %}{{base}}.obj {% endfor %} /OUT:main.exe
+    link {% for base in source_bases %}{{base}}.obj {% endfor %} {{linker_flags}} /OUT:main.exe

--- a/brian2/tests/__init__.py
+++ b/brian2/tests/__init__.py
@@ -83,7 +83,6 @@ def run(codegen_targets=None, long_tests=False, test_codegen_independent=True,
     prefs.read_preference_file(StringIO(prefs.defaults_as_file))
 
     # Switch off code optimization to get faster compilation times
-    prefs['codegen.runtime.cython.extra_compile_args'] = ['-w', '-O0']
     prefs['codegen.cpp.extra_compile_args_gcc'] = ['-w', '-O0']
     
     try:

--- a/docs_sphinx/advanced/index.rst
+++ b/docs_sphinx/advanced/index.rst
@@ -13,3 +13,5 @@ This section has additional information on details not covered in the
    scheduling
    state_update
    how_brian_works
+   interface
+

--- a/docs_sphinx/advanced/interface.rst
+++ b/docs_sphinx/advanced/interface.rst
@@ -1,0 +1,22 @@
+Interfacing with external code
+==============================
+
+Some neural simulations benefit from a direct connections to external libraries,
+e.g. to support real-time input from a sensor (but note that Brian currently
+does not offer facilities to assure real-time processing) or to perform
+complex calculations during a simulation run.
+
+If the external library is written in Python (or is a library with Python
+bindings), then the connection can be made either using the mechanism for
+:ref:`user_functions`, or using a :ref:`network operation <network_operation>`.
+
+In case of C/C++ libraries, only the :ref:`user_functions` mechanism can be
+used. On the other hand, such simulations can use the same user-provided C++
+code to run both with the runtime ``weave`` target and with the
+:ref:`cpp_standalone` mode. In addition to that code, one generally needs to
+include additional header files and use compiler/linker options to interface
+with the external code. For this, several preferences can be used that will be
+taken into account for ``weave``, ``cython`` and the ``cpp_standalone`` device.
+These preferences are mostly equivalent to the respective keyword arguments for
+Python's `distutils.core.Extension` class, see the documentation of the
+`~brian2.codegen.cpp_prefs` module for more details.

--- a/docs_sphinx/user/functions.rst
+++ b/docs_sphinx/user/functions.rst
@@ -32,6 +32,8 @@ example, the following reset statement resets the variable `v` to either `v_r1`
 or `v_r2`, depending on the value of `w`:
 ``'v = v_r1 * int(w <= 0.5) + v_r2 * int(w > 0.5)'``
 
+.. _user_functions:
+
 User-provided functions
 -----------------------
 

--- a/docs_sphinx/user/input.rst
+++ b/docs_sphinx/user/input.rst
@@ -139,6 +139,7 @@ expressions to have the values only updated for the chosen subset of neurons
                                        I = change*(rand()*2) + (1-change)*I''',
                                     dt=50*ms)
 
+.. _network_operation:
 
 Arbitrary Python code (network operations)
 ------------------------------------------

--- a/examples/advanced/opencv_movie.py
+++ b/examples/advanced/opencv_movie.py
@@ -1,0 +1,139 @@
+'''
+An example that uses a function from external C library (OpenCV in this case).
+Works for all C-based code generation targets (i.e. for weave,
+Cython and the cpp_standalone device) but not for numpy.
+'''
+import os
+import urllib2
+import cv2  # Import OpenCV2
+import cv2.cv as cv  # Import the cv subpackage, needed for some constants
+
+from brian2 import *
+
+defaultclock.dt = 1*ms
+prefs.codegen.target = 'weave'
+prefs.logging.std_redirection = False
+set_device('cpp_standalone')
+filename = 'Megamind.avi'
+
+if not os.path.exists(filename):
+    print 'Trying to download the video file'
+    response = urllib2.urlopen('http://docs.opencv.org/_downloads/Megamind.avi')
+    data = response.read()
+    with open(filename, 'wb') as f:
+        f.write(data)
+
+video = cv2.VideoCapture(filename)
+width, height, frame_count = (int(video.get(cv.CV_CAP_PROP_FRAME_WIDTH)),
+                              int(video.get(cv.CV_CAP_PROP_FRAME_HEIGHT)),
+                              int(video.get(cv.CV_CAP_PROP_FRAME_COUNT)))
+fps = 24
+time_between_frames = 1*second/fps
+print 'fps', fps, 'time between frames:', time_between_frames
+
+prefs.codegen.cpp.libraries += ['opencv_highgui']
+prefs.codegen.cpp.headers += ['<opencv2/core/core.hpp>', '<opencv2/highgui/highgui.hpp>']
+@implementation('cpp', '''
+double* get_frame(bool new_frame)
+{
+    static cv::VideoCapture source("%FILENAME%");
+    static cv::Mat frame;
+    static double* grayscale_frame = (double*)malloc(%WIDTH%*%HEIGHT%*sizeof(double));
+    if (new_frame)
+    {
+        source >> frame;
+        double mean_value = 0;
+        for (int row=0; row<%HEIGHT%; row++)
+            for (int col=0; col<%WIDTH%; col++)
+            {
+                const double grayscale_value = (frame.at<cv::Vec3b>(row, col)[0] +
+                                                frame.at<cv::Vec3b>(row, col)[1] +
+                                                frame.at<cv::Vec3b>(row, col)[2])/(3.0*128);
+                mean_value += grayscale_value / (%WIDTH% * %HEIGHT%);
+                grayscale_frame[row*%WIDTH% + col] = grayscale_value;
+            }
+        // subtract the mean
+        for (int i=0; i<%HEIGHT%*%WIDTH%; i++)
+            grayscale_frame[i] -= mean_value;
+    }
+    return grayscale_frame;
+}
+
+double video_input(const int x, const int y)
+{
+    // Get the current frame (or a new frame in case we are asked for the first
+    // element
+    double *frame = get_frame(x==0 && y==0);
+    return frame[y*%WIDTH% + x];
+}
+'''.replace('%FILENAME%', filename).replace('%WIDTH%', str(width)).replace('%HEIGHT%', str(height)))
+@check_units(x=1, y=1, result=1)
+def video_input(x, y):
+    # we assume this will only be called in the custom operation (and not for
+    # example in a reset or synaptic statement), so we don't need to do indexing
+    # but we can directly return the full result
+    _, frame = video.read()
+    grayscale = frame.mean(axis=2)
+    grayscale /= 128.  # scale everything between 0 and 2
+    return grayscale.ravel() - grayscale.ravel().mean()
+
+
+N = width * height
+tau, tau_th = 10*ms, time_between_frames
+G = NeuronGroup(N, '''dv/dt = (-v + I)/tau : 1
+                      dv_th/dt = -v_th/tau_th : 1
+                      row : integer
+                      column : integer
+                      I : 1   # input current''',
+                threshold='v>v_th', reset='v=0; v_th = 2*v_th + 0.5')
+G.row = 'i/width'
+G.column = 'i%width'
+
+update_input = G.custom_operation('I = video_input(column, row)',
+                                  dt=time_between_frames)
+mon = SpikeMonitor(G)
+state_mon = StateMonitor(G, ['v', 'v_th'], record=0)
+runtime = 1000*ms # 0.25*frame_count*time_between_frames
+run(runtime, report='text')
+device.build(compile=True, run=True)
+# plt.scatter(G.column[::7], G.row[::7], c=G.v[::7],
+#             edgecolor='none', cmap='gray')
+# plt.gca().invert_yaxis()
+# plt.figure()
+# plt.plot(state_mon.t/ms, state_mon[0].v)
+# plt.plot(state_mon.t/ms, state_mon[0].v_th)
+# print state_mon[0].v_th[:]
+# plt.show()
+
+# Avoid going through the whole Brian2 indexing machinery too much
+i, t, row, column = mon.i[:], mon.t[:], G.row[:], G.column[:]
+
+import matplotlib.animation as animation
+
+# TODO: Use overlapping windows
+stepsize = 100*ms
+def next_spikes():
+    step = next_spikes.step
+    if step*stepsize > runtime:
+        next_spikes.step=0
+        raise StopIteration()
+    spikes = i[(t>=step*stepsize) & (t<(step+1)*stepsize)]
+    next_spikes.step += 1
+    yield column[spikes], row[spikes]
+next_spikes.step = 0
+
+fig, ax = plt.subplots()
+dots, = ax.plot([], [], 'k.', markersize=2, alpha=.25)
+ax.set_xlim(0, width)
+ax.set_ylim(0, height)
+ax.invert_yaxis()
+def run(data):
+    x, y = data
+    dots.set_data(x, y)
+
+    # Clear the old dots
+    #return old_dots,
+
+ani = animation.FuncAnimation(fig, run, next_spikes, blit=False, repeat=True,
+                              repeat_delay=1000)
+plt.show()


### PR DESCRIPTION
This branch introduces more options to customize the compilation for standalone (useful to interface with external libraries) and also tries to use a consistent interface for cython, weave and standalone. The preferences in `codegen.cpp` now allow:
* to add include, library and runtime library directories
* to add libraries (e.g. adding `mylibrary` will link with `-lmylibrary` on Linux)
* to include additional headers in all files that contain user code
* to define macros
* to add additional linker arguments

I tried to use the general distutils mechanism to generate the compiler/linker options also for standalone (in the same way as it is done for weave and cython), this might buy us support for additional compilers etc. in the future.

There's a new example (`examples/advanced/opencv_movie.py`) that demonstrates the use of some of those preferences to read in a movie file with OpenCV. 

@owenmackwood: you were missing this kind of configurability, is there anything in addition that you'd need?
@thesamovar: this is basically ready to merge but I did not test any of this on Windows...