### PR TITLE
Prevent race condition when making cython_extensions/.

### DIFF
--- a/brian2/codegen/runtime/cython_rt/extension_manager.py
+++ b/brian2/codegen/runtime/cython_rt/extension_manager.py
@@ -44,8 +44,11 @@ class CythonExtensionManager(object):
         code = deindent(code)
 
         lib_dir = os.path.expanduser('~/.brian/cython_extensions')
-        if not os.path.exists(lib_dir):
+        try:
             os.makedirs(lib_dir)
+        except OSError as e:
+            if not os.path.exists(lib_dir):
+                raise OSError(e)
 
         key = code, sys.version_info, sys.executable, Cython.__version__
             


### PR DESCRIPTION
When running parallel simulations and using cython as the code generator, I've been encountering a race condition in the creation of the ~/.brian/cython_extensions directory.  This commit avoids that race condition.