### PR TITLE
Scalar delays in standalone

### DIFF
--- a/brian2/core/variables.py
+++ b/brian2/core/variables.py
@@ -1473,7 +1473,7 @@ class Variables(collections.Mapping):
 
     def add_dynamic_array(self, name, unit, size, dtype=None, constant=False,
                           constant_size=True, read_only=False, unique=False,
-                          index=None):
+                          scalar=False, index=None):
         '''
         Add a dynamic array.
 
@@ -1494,6 +1494,9 @@ class Variables(collections.Mapping):
         constant_size : bool, optional
             Whether the size of the variable is constant during a run.
             Defaults to ``True``.
+        scalar : bool, optional
+            Whether this is a scalar variable. Defaults to ``False``, if set to
+            ``True``, also implies that `size` equals 1.
         read_only : bool, optional
             Whether this is a read-only variable, i.e. a variable that is set
             internally and cannot be changed by the user. Defaults
@@ -1508,6 +1511,7 @@ class Variables(collections.Mapping):
                                    device=self.device,
                                    size=size, dtype=dtype,
                                    constant=constant, constant_size=constant_size,
+                                   scalar=scalar,
                                    read_only=read_only, unique=unique)
         self._add_variable(name, var, index)
 

--- a/brian2/devices/cpp_standalone/device.py
+++ b/brian2/devices/cpp_standalone/device.py
@@ -251,7 +251,6 @@ class CPPStandaloneDevice(Device):
                 array_name = orig_array_name + '_%d' % suffix
             self.arrays[var] = array_name
 
-
     def init_with_zeros(self, var):
         self.zero_arrays.append(var)
 
@@ -278,6 +277,10 @@ class CPPStandaloneDevice(Device):
             static_array_name = self.static_array(array_name, arr)
             self.main_queue.append(('set_by_array', (array_name,
                                                      static_array_name)))
+
+    def resize(self, var, new_size):
+        array_name = self.get_array_name(var, access_data=False)
+        self.main_queue.append(('resize_array', (array_name, new_size)))
 
     def variableview_set_with_index_array(self, variableview, item,
                                           value, check_units):
@@ -484,6 +487,10 @@ class CPPStandaloneDevice(Device):
                 '''.format(arrayname=arrayname, staticarrayname_index=staticarrayname_index,
                            staticarrayname_value=staticarrayname_value, pragma=openmp_pragma('static'))
                 main_lines.extend(code.split('\n'))
+            elif func=='resize_array':
+                array_name, new_size = args
+                main_lines.append("{array_name}.resize({new_size});".format(array_name=array_name,
+                                                                            new_size=new_size))
             elif func=='insert_code':
                 main_lines.append(args)
             elif func=='start_run_func':

--- a/brian2/devices/cpp_standalone/device.py
+++ b/brian2/devices/cpp_standalone/device.py
@@ -265,12 +265,15 @@ class CPPStandaloneDevice(Device):
     def fill_with_array(self, var, arr):
         arr = np.asarray(arr)
         array_name = self.get_array_name(var, access_data=False)
-        if arr.shape == ():
+        if arr.shape == () and var.size == 1:
+            value = CPPNodeRenderer().render_expr(repr(arr.item(0)))
             # For a single assignment, generate a code line instead of storing the array
             self.main_queue.append(('set_by_single_value', (array_name,
                                                             0,
-                                                            arr.item(0))))
+                                                            value)))
         else:
+            if arr.shape == ():
+                arr = np.repeat(arr, var.size)
             # Using the std::vector instead of a pointer to the underlying
             # data for dynamic arrays is fast enough here and it saves us some
             # additional work to set up the pointer
@@ -290,10 +293,11 @@ class CPPStandaloneDevice(Device):
 
         if (isinstance(item, int) or (isinstance(item, np.ndarray) and item.shape==())) and value.size == 1:
             array_name = self.get_array_name(variableview.variable, access_data=False)
+            value = CPPNodeRenderer().render_expr(repr(np.asarray(value).item(0)))
             # For a single assignment, generate a code line instead of storing the array
             self.main_queue.append(('set_by_single_value', (array_name,
                                                             item,
-                                                            float(value))))
+                                                            value)))
 
         elif (value.size == 1 and
               item == 'True' and
@@ -679,18 +683,6 @@ class CPPStandaloneDevice(Device):
         for net in networks:
             net_synapses = [s for s in net.objects if isinstance(s, Synapses)]
             synapses.extend(net_synapses)
-            # We don't currently support pathways with scalar delays
-            for synapse_obj in net_synapses:
-                for pathway in synapse_obj._pathways:
-                    if not isinstance(pathway.variables['delay'],
-                                      DynamicArrayVariable):
-                        error_msg = ('The "%s" pathway  uses a scalar '
-                                     'delay (instead of a delay per synapse). '
-                                     'This is not yet supported. Do not '
-                                     'specify a delay in the Synapses(...) '
-                                     'call but instead set its delay attribute '
-                                     'afterwards.') % (pathway.name)
-                        raise NotImplementedError(error_msg)
         self.networks = networks
         self.net_synapses = synapses
     

--- a/brian2/devices/cpp_standalone/device.py
+++ b/brian2/devices/cpp_standalone/device.py
@@ -265,15 +265,19 @@ class CPPStandaloneDevice(Device):
 
     def fill_with_array(self, var, arr):
         arr = np.asarray(arr)
-        if arr.shape == ():
-            arr = np.repeat(arr, var.size)
-        # Using the std::vector instead of a pointer to the underlying
-        # data for dynamic arrays is fast enough here and it saves us some
-        # additional work to set up the pointer
         array_name = self.get_array_name(var, access_data=False)
-        static_array_name = self.static_array(array_name, arr)
-        self.main_queue.append(('set_by_array', (array_name,
-                                                 static_array_name)))
+        if arr.shape == ():
+            # For a single assignment, generate a code line instead of storing the array
+            self.main_queue.append(('set_by_single_value', (array_name,
+                                                            0,
+                                                            arr.item(0))))
+        else:
+            # Using the std::vector instead of a pointer to the underlying
+            # data for dynamic arrays is fast enough here and it saves us some
+            # additional work to set up the pointer
+            static_array_name = self.static_array(array_name, arr)
+            self.main_queue.append(('set_by_array', (array_name,
+                                                     static_array_name)))
 
     def variableview_set_with_index_array(self, variableview, item,
                                           value, check_units):

--- a/brian2/devices/device.py
+++ b/brian2/devices/device.py
@@ -196,6 +196,19 @@ class Device(object):
         '''
         raise NotImplementedError()
 
+    def resize(self, var, new_size):
+        '''
+        Resize a `DynamicArrayVariable`.
+
+        Parameters
+        ----------
+        var : `DynamicArrayVariable`
+            The variable that should be resized.
+        new_size : int
+            The new size of the variable
+        '''
+        raise NotImplementedError()
+
     def code_object_class(self, codeobj_class=None):
         if codeobj_class is None:
             codeobj_class = get_default_codeobject_class()

--- a/brian2/synapses/spikequeue.py
+++ b/brian2/synapses/spikequeue.py
@@ -147,7 +147,7 @@ class SpikeQueue(object):
             self.n = np.zeros(n_steps, dtype=int) # number of events in each time step
 
         # Precompute offsets
-        if self._precompute_offsets:
+        if self._precompute_offsets and not self._homogeneous:
             self._do_precompute_offsets(n_synapses)
 
         # Re-insert the spikes into the data structure
@@ -264,11 +264,7 @@ class SpikeQueue(object):
         Precompute all offsets corresponding to delays. This assumes that
         delays will not change during the simulation.
         '''
-        if len(self._delays) == 1 and n_synapses != 1:
-            # We have a scalar delay value
-            delays = self._delays.repeat(n_synapses)
-        else:
-            delays = self._delays
+        delays = self._delays
         self._offsets = np.zeros_like(delays)
         index = 0
         for targets in self._neurons_to_synapses:

--- a/brian2/synapses/synapses.py
+++ b/brian2/synapses/synapses.py
@@ -184,8 +184,15 @@ class SynapticPathway(CodeRunner, Group):
             fail_for_dimension_mismatch(delay, second, ('Delay has to be '
                                                         'specified in units '
                                                         'of seconds'))
-            self.variables.add_array('delay', unit=second, size=1,
-                                     constant=True, scalar=True)
+            # We use a "dynamic" array of constant size here because it makes
+            # the generated code easier, we don't need to deal with a different
+            # type for scalar and variable delays
+            self.variables.add_dynamic_array('delay', unit=second,
+                                             size=1, constant=True,
+                                             constant_size=True, scalar=True)
+            # Since this array does not grow with the number of synapses, we
+            # have to resize it ourselves
+            self.variables['delay'].resize(1)
             self.variables['delay'].set_value(delay)
 
         self._delays = self.variables['delay']


### PR DESCRIPTION
In standalone mode, you could previously not use `Synapses(..., delay=1*ms)`, which sets a scalar delay for all synapses. Also, setting a scalar delay in this way was very inefficient because at the initialization phase of the C version of the spike queue, this delay was always stored once per synapse (see #169).

This pull request fixes those two issues, scalar delays are now stored as single values and they work for standalone as well (this also makes the "Brunel_Hakim_1999.py" and "Sturzl_et_al_2000.py" examples work in standalone mode now).