### PR TITLE
[MRG] Fix (and test) the HTML representation for `NeuronGroup`

### DIFF
--- a/brian2/groups/neurongroup.py
+++ b/brian2/groups/neurongroup.py
@@ -638,7 +638,6 @@ class NeuronGroup(Group, SpikeSource):
                                                'to non-shared variable %s.')
                                               % (eq.varname, identifier))
 
-
     def before_run(self, run_namespace=None, level=0):
         # Check units
         self.equations.check_units(self, run_namespace=run_namespace,
@@ -648,8 +647,7 @@ class NeuronGroup(Group, SpikeSource):
         text = [r'NeuronGroup "%s" with %d neurons.<br>' % (self.name, self._N)]
         text.append(r'<b>Model:</b><nr>')
         text.append(sympy.latex(self.equations))
-        text.append(r'<b>Integration method:</b><br>')
-        text.append(sympy.latex(self.state_updater.method)+'<br>')
+
         if self.threshold is not None:
             text.append(r'<b>Threshold condition:</b><br>')
             text.append('<code>%s</code><br>' % str(self.threshold))
@@ -658,5 +656,5 @@ class NeuronGroup(Group, SpikeSource):
             text.append(r'<b>Reset statement:</b><br>')            
             text.append(r'<code>%s</code><br>' % str(self.reset))
             text.append('')
-                    
+
         return '\n'.join(text)

--- a/brian2/tests/test_network.py
+++ b/brian2/tests/test_network.py
@@ -13,7 +13,7 @@ from brian2 import (Clock, Network, ms, second, BrianObject, defaultclock,
                     NeuronGroup, StateMonitor, SpikeMonitor,
                     PopulationRateMonitor, MagicNetwork, magic_network,
                     PoissonGroup, Hz, collect, store, restore, BrianLogger,
-                    start_scope, prefs)
+                    start_scope, prefs, profiling_summary)
 from brian2.devices.device import restore_device, Device, all_devices, set_device, get_device
 from brian2.utils.logger import catch_logs
 
@@ -865,6 +865,17 @@ def test_profile():
 
 
 @attr('codegen-independent')
+def test_profile_ipython_html():
+    G = NeuronGroup(10, 'dv/dt = -v / (10*ms) : 1', threshold='v>1',
+                    reset='v=0', name='profile_test')
+    G.v = 1.1
+    net = Network(G)
+    net.run(1*ms, profile=True)
+    summary = profiling_summary(net)
+    assert len(summary._repr_html_())
+
+
+@attr('codegen-independent')
 @with_setup(teardown=restore_initial_state)
 def test_magic_scope():
     '''
@@ -921,6 +932,7 @@ if __name__=='__main__':
             test_multiple_runs_defaultclock,
             test_multiple_runs_defaultclock_incorrect,
             test_profile,
+            test_profile_ipython_html,
             test_magic_scope,
             ]:
         t()

--- a/brian2/tests/test_neurongroup.py
+++ b/brian2/tests/test_neurongroup.py
@@ -1006,6 +1006,16 @@ def test_repr():
             assert len(func(eq))
 
 @attr('codegen-independent')
+def test_ipython_html():
+    G = NeuronGroup(10, '''dv/dt = -(v + Inp) / tau : volt
+                           Inp = sin(2*pi*freq*t) : volt
+                           freq : Hz''')
+
+    # Test that HTML representation in IPython does not raise errors
+    assert len(G._repr_html_())
+
+
+@attr('codegen-independent')
 def test_indices():
     G = NeuronGroup(10, 'v : 1')
     G.v = 'i'
@@ -1159,6 +1169,7 @@ if __name__ == '__main__':
     test_scalar_subexpression()
     test_indices()
     test_repr()
+    test_ipython_html()
     test_get_dtype()
     if prefs.codegen.target == 'numpy':
         test_aliasing_in_statements()


### PR DESCRIPTION
Closes #460

This is a trivial fix that simply removes the lines that stated the used state update method from the HTML output of a `NeuronGroup`. The state update method is not necessarily fixed at this point yet and I don't think getting it to work here for the cases when it is (the user explicitly provided a `method` argument) is worth the effort.