### PR TITLE
[MRG] Allow instance methods as network operations

### DIFF
--- a/brian2/core/operations.py
+++ b/brian2/core/operations.py
@@ -56,6 +56,16 @@ class NetworkOperation(BrianObject):
                                      'has %d arguments.' % (function.__name__,
                                                             argcount)))
             else:
+                if (argcount >= 1 and
+                            function.func_code.co_varnames[0] == 'self'):
+                    raise TypeError('The first argument of the function "%s" '
+                                    'is "self", suggesting it is an instance '
+                                    'method and not a function. Did you use '
+                                    '@network_operation on a class method? '
+                                    'This will not work, explicitly create a '
+                                    'NetworkOperation object instead -- see '
+                                    'the documentation for more '
+                                    'details.' % function.__name__)
                 if argcount == 1:
                     self._has_arg = True
                 elif argcount == 0:

--- a/brian2/core/operations.py
+++ b/brian2/core/operations.py
@@ -42,7 +42,8 @@ class NetworkOperation(BrianObject):
 
         is_method = inspect.ismethod(function)
 
-        if hasattr(function, 'func_code'):
+        if (hasattr(function, 'func_code') or  # Python 2
+                hasattr(function, '__code__')):  # Python 3:
             argcount = function.func_code.co_argcount
             if is_method:
                 if argcount == 2:

--- a/brian2/tests/test_network.py
+++ b/brian2/tests/test_network.py
@@ -321,9 +321,30 @@ def test_network_operations():
 
     assert_equal(''.join(seq), 'bBacC'*10)
 
+@attr('codegen-independent')
+def test_incorrect_network_operations():
+    # Network operations with more than one argument are not allowed
+    def func(x, y):
+        pass
 
-# TODO: Test incorrect forms of NetworkOperation
+    class Container(object):
+        def func(self, x, y):
+            pass
+    c = Container()
 
+    assert_raises(TypeError, lambda: NetworkOperation(func))
+    assert_raises(TypeError, lambda: NetworkOperation(c.func))
+
+    # Incorrect use of @network_operation -- it does not work on an instance
+    # method
+    try:
+        class Container(object):
+            @network_operation
+            def func(self):
+                pass
+        raise AssertionError('expected a TypeError')
+    except TypeError:
+        pass  # this is what we expected
 
 @attr('codegen-independent')
 @with_setup(teardown=restore_initial_state)
@@ -921,6 +942,7 @@ if __name__=='__main__':
             test_magic_network,
             test_network_stop,
             test_network_operations,
+            test_incorrect_network_operations,
             test_network_active_flag,
             test_network_t,
             test_incorrect_dt_defaultclock,

--- a/brian2/units/fundamentalunits.py
+++ b/brian2/units/fundamentalunits.py
@@ -845,7 +845,7 @@ class Quantity(np.ndarray, object):
                                              'dim keyword',
                                              arr.dim, dim)
         elif hasattr(arr, 'unit'):
-            subarr.dim = arr.unit.dim
+            subarr.dim = arr.unit.dim if arr.unit is not None else None
             if not (dim is None) and not (dim is subarr.dim):
                 raise DimensionMismatchError('Conflicting dimension '
                                              'information between array and '


### PR DESCRIPTION
Not a very important feature, but in more complex frameworks it might be useful to have a network operation that accesses some parent object state via `self`. This pull request fixes this issue but more importantly does more strict error checking (before, an instance method with the `self` argument would be interpreted as a function with a single argument, i.e. the current time was passed as `self`, and functions with more than one argument did not raise an error until executed).
 
Closes #474