### PR TITLE
[MRG] Faster resize for dynamic array

### DIFF
--- a/brian2/codegen/runtime/cython_rt/templates/statemonitor.pyx
+++ b/brian2/codegen/runtime/cython_rt/templates/statemonitor.pyx
@@ -8,10 +8,8 @@
     cdef int _curlen = {{_dynamic_t}}.shape[0]
     cdef int _new_len = _curlen + 1
 
-    # Resize the arrays
-    _owner.resize(_new_len)
-    # Get the potentially newly created underlying data arrays and copy the
-    # data (this will translate to a Python statement but it's only one off)
+    # Resize the recorded times
+    {{_dynamic_t}}.resize(_new_len)
     {{_dynamic_t}}[_new_len-1] = _clock_t
 
     # scalar code
@@ -23,6 +21,9 @@
     {% for varname, var in _recorded_variables.items() %}
     {% set c_type = cpp_dtype(variables[varname].dtype) %}
     {% set np_type = numpy_dtype(variables[varname].dtype) %}
+    # Resize the recorded variable "{{varname}}" and get the (potentially
+    # changed) reference to the underlying data
+    {{get_array_name(var, access_data=False)}}.resize_along_first((_new_len, _num{{_indices}}))
     cdef {{c_type}}[:, :] _record_data_{{varname}} = {{get_array_name(var, access_data=False)}}.data.view(_numpy.{{np_type}})
     for _i in range(_num{{_indices}}):
         # vector code

--- a/brian2/codegen/runtime/weave_rt/templates/statemonitor.cpp
+++ b/brian2/codegen/runtime/weave_rt/templates/statemonitor.cpp
@@ -6,11 +6,10 @@
     // Get the current length and new length of t and value arrays
     const int _curlen = {{_dynamic_t}}.attr("shape")[0];
     const int _new_len = _curlen + 1;
-    // Resize the arrays
-    PyObject_CallMethod(_owner, "resize", "i", _new_len);
 
-    // Get the potentially newly created underlying data arrays and copy the
-    // data
+    // Resize the recorded times and get the (potentially changed) reference to
+    // the underlying data
+    PyObject_CallMethod({{_dynamic_t}}, "resize", "i", _new_len);
     double *_t_data = (double*)(((PyArrayObject*)(PyObject*){{_dynamic_t}}.attr("data"))->data);
     _t_data[_new_len - 1] = _clock_t;
 
@@ -22,6 +21,9 @@
     {% for varname, var in _recorded_variables.items() %}
     {%set c_type = c_data_type(variables[varname].dtype) %}
     {
+        // Resize the recorded variable "{{varname}}" and get the (potentially
+        // changed) reference to the underlying data
+        PyObject_CallMethod({{get_array_name(var, access_data=False)}}, "resize_along_first", "((ii))", _new_len, _num_indices);
         PyArrayObject *_record_data = (((PyArrayObject*)(PyObject*){{get_array_name(var, access_data=False)}}.attr("data")));
         const npy_intp* _record_strides = _record_data->strides;
         for (int _i = 0; _i < _num_indices; _i++)

--- a/brian2/core/variables.py
+++ b/brian2/core/variables.py
@@ -572,7 +572,7 @@ class DynamicArrayVariable(ArrayVariable):
     '''
 
     def __init__(self, name, unit, owner, size, device, dtype=None,
-                 constant=False, constant_size=True,
+                 constant=False, constant_size=True, resize_along_first=False,
                  scalar=False, read_only=False, unique=False):
 
         if isinstance(size, int):
@@ -587,6 +587,10 @@ class DynamicArrayVariable(ArrayVariable):
             raise ValueError('A variable cannot be constant and change in size')
         #: Whether the size of the variable is constant during a run.
         self.constant_size = constant_size
+
+        #: Whether this array will be only resized along the first dimension
+        self.resize_along_first = resize_along_first
+
         super(DynamicArrayVariable, self).__init__(unit=unit,
                                                    owner=owner,
                                                    name=name,
@@ -598,6 +602,7 @@ class DynamicArrayVariable(ArrayVariable):
                                                    dynamic=True,
                                                    read_only=read_only,
                                                    unique=unique)
+
     def resize(self, new_size):
         '''
         Resize the dynamic array. Calls `self.device.resize` to do the
@@ -608,8 +613,13 @@ class DynamicArrayVariable(ArrayVariable):
         new_size : int or tuple of int
             The new size.
         '''
-        self.device.resize(self, new_size)
+        if self.resize_along_first:
+            self.device.resize_along_first(self, new_size)
+        else:
+            self.device.resize(self, new_size)
+
         self.size = new_size
+
 
 
 class Subexpression(Variable):
@@ -1473,7 +1483,8 @@ class Variables(collections.Mapping):
             self.device.init_with_array(var, values)
 
     def add_dynamic_array(self, name, unit, size, values=None, dtype=None,
-                          constant=False, constant_size=True, read_only=False,
+                          constant=False, constant_size=True,
+                          resize_along_first=False, read_only=False,
                           unique=False, scalar=False, index=None):
         '''
         Add a dynamic array.
@@ -1515,6 +1526,7 @@ class Variables(collections.Mapping):
                                    device=self.device,
                                    size=size, dtype=dtype,
                                    constant=constant, constant_size=constant_size,
+                                   resize_along_first=resize_along_first,
                                    scalar=scalar,
                                    read_only=read_only, unique=unique)
         self._add_variable(name, var, index)

--- a/brian2/core/variables.py
+++ b/brian2/core/variables.py
@@ -1808,7 +1808,8 @@ class Variables(collections.Mapping):
             not confuse the dynamic array of recorded times with the current
             time in the recorded group.
         '''
-        for name in ['t', 'dt']:
+        for name, is_constant in [('t', False),
+                                  ('dt', True)]:
             if prefix+name in self._variables:
                 var = self._variables[prefix+name]
                 if not isinstance(var, AttributeVariable):
@@ -1819,4 +1820,6 @@ class Variables(collections.Mapping):
                 var.obj = clock # replace the clock object
             else:
                 self.add_attribute_variable(prefix+name, unit=second, obj=clock,
-                                            attribute=name+'_', dtype=np.float64)
+                                            attribute=name+'_',
+                                            dtype=np.float64,
+                                            constant=is_constant)

--- a/brian2/devices/device.py
+++ b/brian2/devices/device.py
@@ -209,6 +209,10 @@ class Device(object):
         '''
         raise NotImplementedError()
 
+    def resize_along_first(self, var, new_size):
+        # Can be overwritten with a better implementation
+        return self.resize(var, new_size)
+
     def code_object_class(self, codeobj_class=None):
         if codeobj_class is None:
             codeobj_class = get_default_codeobject_class()
@@ -366,6 +370,9 @@ class RuntimeDevice(Device):
 
     def resize(self, var, new_size):
         self.arrays[var].resize(new_size)
+
+    def resize_along_first(self, var, new_size):
+        self.arrays[var].resize_along_first(new_size)
 
     def init_with_zeros(self, var):
         self.arrays[var][:] = 0

--- a/brian2/monitors/statemonitor.py
+++ b/brian2/monitors/statemonitor.py
@@ -240,6 +240,7 @@ class StateMonitor(Group, CodeRunner):
                 self.variables.add_reference(index, source)
             self.variables.add_dynamic_array('_recorded_' + varname,
                                              size=(0, len(self.record)),
+                                             resize_along_first=True,
                                              unit=var.unit,
                                              dtype=var.dtype,
                                              constant=False,


### PR DESCRIPTION
This branch improves the performance of the resize operation for dynamic arrays quite significantly (in a long running complex example the time for `statemonitor` went down from 45s to 17s). It mostly does it by including a special function for resizing along the first dimension for multi-dimensional arrays.

I briefly played around with storing the size of the underlying data array in a separate variable (so that the weave code can directly check whether a resize is necessary), but this makes things very fragile because not calling `resize` also means that the numpy array view on the underlying data has the wrong size, so we have to update this in the end of the run, etc. I got the impression that it is easy to introduce hard-to-debug problems (say a user wants to access the data stored in a `StateMonitor` in a network operation) this way, and this should certainly not be rushed just for better performance. I therefore only did changes I'm reasonably confident to be safe.

This pull request also contains a small change that marks the `dt` variable as constant during a run, this prevents an unnecessary namespace update every time step.

Ready to merge from my side.