### PR TITLE
[MRG] Support for general events

### DIFF
--- a/brian2/codegen/runtime/cython_rt/templates/reset.pyx
+++ b/brian2/codegen/runtime/cython_rt/templates/reset.pyx
@@ -1,16 +1,16 @@
 {% extends 'common.pyx' %}
 
 {% block maincode %}
-    {# USES_VARIABLES { _spikespace } #}
-    
     # scalar code
     _vectorisation_idx = 1
     {{scalar_code|autoindent}}
+    {#  Get the name of the array that stores these events (e.g. the spikespace array) #}
+    {% set _eventspace = get_array_name(eventspace_variable) %}
 
-    cdef int _num_spikes = {{_spikespace}}[_num{{_spikespace}}-1]
-    for _index_spikes in range(_num_spikes):
+    cdef int _num_events = {{_eventspace}}[_num{{_eventspace}}-1]
+    for _index_events in range(_num_events):
         # vector code
-        _idx = {{_spikespace}}[_index_spikes]
+        _idx = {{_eventspace}}[_index_events]
         _vectorisation_idx = _idx
         {{ vector_code | autoindent }}
 {% endblock %}

--- a/brian2/codegen/runtime/cython_rt/templates/spikemonitor.pyx
+++ b/brian2/codegen/runtime/cython_rt/templates/spikemonitor.pyx
@@ -1,33 +1,37 @@
 {% extends 'common.pyx' %}
 
 {% block maincode %}
-    {# USES_VARIABLES { t, i, _clock_t, _spikespace, _count,
+    {# USES_VARIABLES { t, i, _clock_t, _count,
                         _source_start, _source_stop} #}
-    cdef int _num_spikes = {{_spikespace}}[_num{{_spikespace}}-1]
+
+    {#  Get the name of the array that stores these events (e.g. the spikespace array) #}
+    {% set _eventspace = get_array_name(eventspace_variable) %}
+
+    cdef int _num_events = {{_eventspace}}[_num{{_eventspace}}-1]
     cdef int _start_idx, _end_idx, _curlen, _newlen, _j
     cdef double[:] _t_view
     cdef int32_t[:] _i_view
-    if _num_spikes > 0:
+    if _num_events > 0:
         # For subgroups, we do not want to record all spikes
         # We assume that spikes are ordered
         # TODO: Will this assumption ever be violated?
-        _start_idx = _num_spikes
-        _end_idx = _num_spikes
-        for _j in range(_num_spikes):
-            _idx = {{_spikespace}}[_j]
+        _start_idx = _num_events
+        _end_idx = _num_events
+        for _j in range(_num_events):
+            _idx = {{_eventspace}}[_j]
             if _idx >= _source_start:
                 _start_idx = _j
                 break
-        for _j in range(_start_idx, _num_spikes):
-            _idx = {{_spikespace}}[_j]
+        for _j in range(_start_idx, _num_events):
+            _idx = {{_eventspace}}[_j]
             if _idx >= _source_stop:
                 _end_idx = _j
                 break
-        _num_spikes = _end_idx - _start_idx
-        if _num_spikes > 0:
+        _num_events = _end_idx - _start_idx
+        if _num_events > 0:
             # Get the current length and new length of t and i arrays
             _curlen = {{_dynamic_t}}.shape[0]
-            _newlen = _curlen + _num_spikes
+            _newlen = _curlen + _num_events
             # Resize the arrays
             _owner.resize(_newlen)
             # Get the potentially newly created underlying data arrays
@@ -35,7 +39,7 @@
             _i_view = {{_dynamic_i}}.data
             # Copy the values across
             for _j in range(_start_idx, _end_idx):
-                _idx = {{_spikespace}}[_j]
+                _idx = {{_eventspace}}[_j]
                 _t_view[_curlen + _j - _start_idx] = _clock_t
                 _i_view[_curlen + _j - _start_idx] = _idx - _source_start
                 {{_count}}[_idx - _source_start] += 1

--- a/brian2/codegen/runtime/cython_rt/templates/spikemonitor.pyx
+++ b/brian2/codegen/runtime/cython_rt/templates/spikemonitor.pyx
@@ -1,7 +1,7 @@
 {% extends 'common.pyx' %}
 
 {% block maincode %}
-    {# USES_VARIABLES { t, i, _clock_t, _count,
+    {# USES_VARIABLES { t, i, _clock_t, count,
                         _source_start, _source_stop} #}
 
     {#  Get the name of the array that stores these events (e.g. the spikespace array) #}
@@ -42,6 +42,6 @@
                 _idx = {{_eventspace}}[_j]
                 _t_view[_curlen + _j - _start_idx] = _clock_t
                 _i_view[_curlen + _j - _start_idx] = _idx - _source_start
-                {{_count}}[_idx - _source_start] += 1
+                {{count}}[_idx - _source_start] += 1
                 
 {% endblock %}

--- a/brian2/codegen/runtime/cython_rt/templates/threshold.pyx
+++ b/brian2/codegen/runtime/cython_rt/templates/threshold.pyx
@@ -2,17 +2,19 @@
 {# USES_VARIABLES { N } #}
 
 {% block maincode %}
-    {# USES_VARIABLES {_spikespace } #}
-    # t, not_refractory and lastspike are added as needed_variables in the
-    # Thresholder class, we cannot use the USES_VARIABLE mechanism
-    # conditionally
+    {# t, not_refractory and lastspike are added as needed_variables in the
+       Thresholder class, we cannot use the USES_VARIABLE mechanism
+       conditionally #}
 
     # scalar code
     _vectorisation_idx = 1;
     {{ scalar_code | autoindent }}
 
-    cdef long _cpp_numspikes = 0
-    
+    cdef long _cpp_numevents = 0
+
+    {#  Get the name of the array that stores these events (e.g. the spikespace array) #}
+    {% set _eventspace = get_array_name(eventspace_variable) %}
+
     for _idx in range(N):
         
         # vector code
@@ -20,13 +22,13 @@
         {{ vector_code | autoindent }}
 
         if _cond:
-            {{_spikespace}}[_cpp_numspikes] = _idx
-            _cpp_numspikes += 1
+            {{_eventspace}}[_cpp_numevents] = _idx
+            _cpp_numevents += 1
             {% if _uses_refractory %}
             {{not_refractory}}[_idx] = False
             {{lastspike}}[_idx] = t
             {% endif %}
             
-    {{_spikespace}}[N] = _cpp_numspikes
+    {{_eventspace}}[N] = _cpp_numevents
     
 {% endblock %}

--- a/brian2/codegen/runtime/numpy_rt/templates/reset.py_
+++ b/brian2/codegen/runtime/numpy_rt/templates/reset.py_
@@ -11,6 +11,6 @@ _vectorisation_idx = 1
 {% set _eventspace = get_array_name(eventspace_variable) %}
 
 # vector code
-_idx = {{_eventspace}}[:{{_spikespace}}[-1]]
+_idx = {{_eventspace}}[:{{_eventspace}}[-1]]
 _vectorisation_idx = _idx
 {{vector_code|autoindent}}

--- a/brian2/codegen/runtime/numpy_rt/templates/reset.py_
+++ b/brian2/codegen/runtime/numpy_rt/templates/reset.py_
@@ -1,5 +1,3 @@
-{# USES_VARIABLES { _spikespace } #}
-
 {# Note that we don't write to scalar variables conditionally. The scalar code
    should therefore only include the calculation of scalar expressions
    that are used below for writing to a vector variable #}
@@ -9,7 +7,10 @@ import numpy as _numpy
 _vectorisation_idx = 1
 {{scalar_code|autoindent}}
 
+{#  Get the name of the array that stores these events (e.g. the spikespace array) #}
+{% set _eventspace = get_array_name(eventspace_variable) %}
+
 # vector code
-_idx = {{_spikespace}}[:{{_spikespace}}[-1]]
+_idx = {{_eventspace}}[:{{_spikespace}}[-1]]
 _vectorisation_idx = _idx
 {{vector_code|autoindent}}

--- a/brian2/codegen/runtime/numpy_rt/templates/spikemonitor.py_
+++ b/brian2/codegen/runtime/numpy_rt/templates/spikemonitor.py_
@@ -1,4 +1,4 @@
-{# USES_VARIABLES {i, t, _count, _clock_t, _source_start, _source_stop} #}
+{# USES_VARIABLES {i, t, count, _clock_t, _source_start, _source_stop} #}
 import numpy as _numpy
 
 {#  Get the name of the array that stores these events (e.g. the spikespace array) #}
@@ -17,4 +17,4 @@ if _n_events > 0:
     {{_dynamic_t}}[_curlen:_newlen] = _clock_t
     {{_dynamic_i}}[_curlen:_newlen] = _events
 
-    {{_count}}[_events] += 1
+    {{count}}[_events] += 1

--- a/brian2/codegen/runtime/numpy_rt/templates/spikemonitor.py_
+++ b/brian2/codegen/runtime/numpy_rt/templates/spikemonitor.py_
@@ -1,17 +1,20 @@
-{# USES_VARIABLES {i, t, _spikespace, _count, _clock_t, _source_start, _source_stop} #}
+{# USES_VARIABLES {i, t, _count, _clock_t, _source_start, _source_stop} #}
 import numpy as _numpy
 
-_spikes = {{_spikespace}}[:{{_spikespace}}[-1]]
+{#  Get the name of the array that stores these events (e.g. the spikespace array) #}
+{% set _eventspace = get_array_name(eventspace_variable) %}
+
+_events = {{_eventspace}}[:{{_eventspace}}[-1]]
 # Take subgroups into account
-_spikes = _spikes[(_spikes >= _source_start) & (_spikes < _source_stop)]
-_spikes -= _source_start
-_n_spikes = len(_spikes)
-if _n_spikes > 0:
+_events = _events[(_events >= _source_start) & (_events < _source_stop)]
+_events -= _source_start
+_n_events = len(_events)
+if _n_events > 0:
 
     _curlen = len({{_dynamic_t}})
-    _newlen = _curlen + _n_spikes
+    _newlen = _curlen + _n_events
     _owner.resize(_newlen)
     {{_dynamic_t}}[_curlen:_newlen] = _clock_t
-    {{_dynamic_i}}[_curlen:_newlen] = _spikes
+    {{_dynamic_i}}[_curlen:_newlen] = _events
 
-    {{_count}}[_spikes] += 1
+    {{_count}}[_events] += 1

--- a/brian2/codegen/runtime/numpy_rt/templates/threshold.py_
+++ b/brian2/codegen/runtime/numpy_rt/templates/threshold.py_
@@ -1,7 +1,9 @@
-{# USES_VARIABLES { _spikespace, N } #}
-# t, not_refractory and lastspike are added as needed_variables in the
-# Thresholder class, we cannot use the USES_VARIABLE mechanism
-# conditionally
+{# USES_VARIABLES { N } #}
+{# t, not_refractory and lastspike are added as needed_variables in the
+  Thresholder class, we cannot use the USES_VARIABLE mechanism
+  conditionally
+  Same goes for "eventspace" (e.g. spikespace) which depends on the type of
+  event #}
 {# ITERATE_ALL { _idx } #}
 import numpy as _numpy
 
@@ -16,13 +18,17 @@ _vectorisation_idx = N
 
 {{vector_code|autoindent}}
 if _cond is True or _cond is numpy_True:
-    _spikes = _numpy.arange(_vectorisation_idx)
+    _events = _numpy.arange(_vectorisation_idx)
 else:
-    _spikes, = _cond.nonzero()
-{{_spikespace}}[-1] = len(_spikes)
-{{_spikespace}}[:len(_spikes)] = _spikes
+    _events, = _cond.nonzero()
+
+{#  Get the name of the array that stores these events (e.g. the spikespace array) #}
+{% set _eventspace = get_array_name(eventspace_variable) %}
+
+{{_eventspace}}[-1] = len(_events)
+{{_eventspace}}[:len(_events)] = _events
 {% if _uses_refractory %}
 # Set the neuron to refractory
-{{not_refractory}}[_spikes] = False
-{{lastspike}}[_spikes] = t
+{{not_refractory}}[_events] = False
+{{lastspike}}[_events] = t
 {% endif %}

--- a/brian2/codegen/runtime/weave_rt/templates/reset.cpp
+++ b/brian2/codegen/runtime/weave_rt/templates/reset.cpp
@@ -1,17 +1,18 @@
 {% extends 'common_group.cpp' %}
 
 {% block maincode %}
-    {# USES_VARIABLES { _spikespace } #}
     //// MAIN CODE ////////////
     // scalar code
     const int _vectorisation_idx = 1;
     {{scalar_code|autoindent}}
 
-    const int _num_spikes = {{_spikespace}}[_num_spikespace-1];
-    for(int _index_spikes=0; _index_spikes<_num_spikes; _index_spikes++)
+    {#  Get the name of the array that stores these events (e.g. the spikespace array) #}
+    {% set _eventspace = get_array_name(eventspace_variable) %}
+    const int _num_events = {{_eventspace}}[_num{{eventspace_variable.name}}-1];
+    for(int _index_events=0; _index_events<_num_events; _index_events++)
     {
         // vector code
-        const int _idx = {{_spikespace}}[_index_spikes];
+        const int _idx = {{_eventspace}}[_index_events];
         const int _vectorisation_idx = _idx;
         {{ super() }}
     }

--- a/brian2/codegen/runtime/weave_rt/templates/spikemonitor.cpp
+++ b/brian2/codegen/runtime/weave_rt/templates/spikemonitor.cpp
@@ -2,7 +2,7 @@
 {% macro main() %}
     {{ common.insert_pointers_lines() }}
 
-    {# USES_VARIABLES { t, i, _clock_t, _count,
+    {# USES_VARIABLES { t, i, _clock_t, count,
                         _source_start, _source_stop} #}
     {#  Get the name of the array that stores these events (e.g. the spikespace array) #}
     {% set _eventspace = get_array_name(eventspace_variable) %}
@@ -49,7 +49,7 @@
                 const int _idx = {{_eventspace}}[_j];
                 _t_data[_curlen + _j - _start_idx] = _clock_t;
                 _i_data[_curlen + _j - _start_idx] = _idx - _source_start;
-                {{_count}}[_idx - _source_start]++;
+                {{count}}[_idx - _source_start]++;
             }
         }
 	}

--- a/brian2/codegen/runtime/weave_rt/templates/spikemonitor.cpp
+++ b/brian2/codegen/runtime/weave_rt/templates/spikemonitor.cpp
@@ -2,36 +2,39 @@
 {% macro main() %}
     {{ common.insert_pointers_lines() }}
 
-    {# USES_VARIABLES { t, i, _clock_t, _spikespace, _count,
+    {# USES_VARIABLES { t, i, _clock_t, _count,
                         _source_start, _source_stop} #}
-	int _num_spikes = {{_spikespace}}[_num_spikespace-1];
-    if (_num_spikes > 0)
+    {#  Get the name of the array that stores these events (e.g. the spikespace array) #}
+    {% set _eventspace = get_array_name(eventspace_variable) %}
+
+	int _num_events = {{_eventspace}}[_num{{eventspace_variable.name}}-1];
+    if (_num_events > 0)
     {
         // For subgroups, we do not want to record all spikes
         // We assume that spikes are ordered
-        int _start_idx = _num_spikes;
-        int _end_idx = _num_spikes;
-        for(int _j=0; _j<_num_spikes; _j++)
+        int _start_idx = _num_events;
+        int _end_idx = _num_events;
+        for(int _j=0; _j<_num_events; _j++)
         {
-            const int _idx = {{_spikespace}}[_j];
+            const int _idx = {{_eventspace}}[_j];
             if (_idx >= _source_start) {
                 _start_idx = _j;
                 break;
             }
         }
-        for(int _j=_start_idx; _j<_num_spikes; _j++)
+        for(int _j=_start_idx; _j<_num_events; _j++)
         {
-            const int _idx = {{_spikespace}}[_j];
+            const int _idx = {{_eventspace}}[_j];
             if (_idx >= _source_stop) {
                 _end_idx = _j;
                 break;
             }
         }
-        _num_spikes = _end_idx - _start_idx;
-        if (_num_spikes > 0) {
+        _num_events = _end_idx - _start_idx;
+        if (_num_events > 0) {
             // Get the current length and new length of t and i arrays
             const int _curlen = {{_dynamic_t}}.attr("shape")[0];
-            const int _newlen = _curlen + _num_spikes;
+            const int _newlen = _curlen + _num_events;
             // Resize the arrays
             py::tuple _newlen_tuple(1);
             _newlen_tuple[0] = _newlen;
@@ -43,7 +46,7 @@
             // Copy the values across
             for(int _j=_start_idx; _j<_end_idx; _j++)
             {
-                const int _idx = {{_spikespace}}[_j];
+                const int _idx = {{_eventspace}}[_j];
                 _t_data[_curlen + _j - _start_idx] = _clock_t;
                 _i_data[_curlen + _j - _start_idx] = _idx - _source_start;
                 {{_count}}[_idx - _source_start]++;

--- a/brian2/codegen/runtime/weave_rt/templates/threshold.cpp
+++ b/brian2/codegen/runtime/weave_rt/templates/threshold.cpp
@@ -2,29 +2,34 @@
 {# USES_VARIABLES { N } #}
 
 {% block maincode %}
-	{# USES_VARIABLES {_spikespace } #}
-	// t, not_refractory and lastspike are added as needed_variables in the
-	// Thresholder class, we cannot use the USES_VARIABLE mechanism
-	// conditionally
+	{# t, not_refractory and lastspike are added as needed_variables in the
+	   Thresholder class, we cannot use the USES_VARIABLE mechanism
+	   conditionally.
+	   Same goes for "eventspace" (e.g. spikespace) which depends on the type of
+       event #}
 
 	//// MAIN CODE ////////////
 	// scalar code
 	const int _vectorisation_idx = 1;
 	{{scalar_code|autoindent}}
 
-	long _cpp_numspikes = 0;
+	long _cpp_numevents = 0;
+
+	{#  Get the name of the array that stores these events (e.g. the spikespace array) #}
+    {% set _eventspace = get_array_name(eventspace_variable) %}
+
 	for(int _idx=0; _idx<N; _idx++)
 	{
 	    // vector code
 	    const int _vectorisation_idx = _idx;
 		{{ super() }}
 		if(_cond) {
-			{{_spikespace}}[_cpp_numspikes++] = _idx;
+			{{_eventspace}}[_cpp_numevents++] = _idx;
 			{% if _uses_refractory %}
 			{{not_refractory}}[_idx] = false;
 			{{lastspike}}[_idx] = t;
 			{% endif %}
 		}
 	}
-	{{_spikespace}}[N] = _cpp_numspikes;
+	{{_eventspace}}[N] = _cpp_numevents;
 {% endblock %}

--- a/brian2/devices/cpp_standalone/templates/reset.cpp
+++ b/brian2/devices/cpp_standalone/templates/reset.cpp
@@ -1,21 +1,23 @@
 {# IS_OPENMP_COMPATIBLE #}
 {% extends 'common_group.cpp' %}
 {% block maincode %}
-	{# USES_VARIABLES { _spikespace, N } #}
+	{# USES_VARIABLES { N } #}
 
-	const int32_t *_spikes = {{_spikespace}};
-	const int32_t _num_spikes = {{_spikespace}}[N];
+    {#  Get the name of the array that stores these events (e.g. the spikespace array) #}
+    {% set _eventspace = get_array_name(eventspace_variable) %}
+	const int32_t *_events = {{_eventspace}};
+	const int32_t _num_events = {{_eventspace}}[N];
 
 	//// MAIN CODE ////////////	
 	// scalar code
 	const int _vectorisation_idx = -1;
 	{{scalar_code|autoindent}}
-    
+
 	{{ openmp_pragma('static') }}
-	for(int _index_spikes=0; _index_spikes<_num_spikes; _index_spikes++)
+	for(int _index_events=0; _index_events<_num_events; _index_events++)
 	{
 	    // vector code
-		const int _idx = _spikes[_index_spikes];
+		const int _idx = _events[_index_events];
 		const int _vectorisation_idx = _idx;
         {{vector_code|autoindent}}
 	}

--- a/brian2/devices/cpp_standalone/templates/spikemonitor.cpp
+++ b/brian2/devices/cpp_standalone/templates/spikemonitor.cpp
@@ -3,7 +3,7 @@
 
 {% block maincode %}
 	//// MAIN CODE ////////////
-    {# USES_VARIABLES { t, i, _clock_t, _count,
+    {# USES_VARIABLES { t, i, _clock_t, count,
                         _source_start, _source_stop} #}
     {#  Get the name of the array that stores these events (e.g. the spikespace array) #}
     {% set _eventspace = get_array_name(eventspace_variable) %}
@@ -39,7 +39,7 @@
                     const int _idx = {{_eventspace}}[_j];
                     {{_dynamic_i}}.push_back(_idx-_source_start);
                     {{_dynamic_t}}.push_back(_clock_t);
-                    {{_count}}[_idx-_source_start]++;
+                    {{count}}[_idx-_source_start]++;
                 }
             }
         }

--- a/brian2/devices/cpp_standalone/templates/spikemonitor.cpp
+++ b/brian2/devices/cpp_standalone/templates/spikemonitor.cpp
@@ -3,37 +3,40 @@
 
 {% block maincode %}
 	//// MAIN CODE ////////////
-    {# USES_VARIABLES { t, i, _clock_t, _spikespace, _count,
+    {# USES_VARIABLES { t, i, _clock_t, _count,
                         _source_start, _source_stop} #}
-	int32_t _num_spikes = {{_spikespace}}[_num_spikespace-1];
-    
+    {#  Get the name of the array that stores these events (e.g. the spikespace array) #}
+    {% set _eventspace = get_array_name(eventspace_variable) %}
+
+	int32_t _num_events = {{_eventspace}}[_num{{eventspace_variable.name}}-1];
+
     {{ openmp_pragma('single-nowait') }}
     {
-        if (_num_spikes > 0)
+        if (_num_events > 0)
         {
-            int _start_idx = _num_spikes;
-            int _end_idx = _num_spikes;
-            for(int _j=0; _j<_num_spikes; _j++)
+            int _start_idx = _num_events;
+            int _end_idx = _num_events;
+            for(int _j=0; _j<_num_events; _j++)
             {
-                const int _idx = {{_spikespace}}[_j];
+                const int _idx = {{_eventspace}}[_j];
                 if (_idx >= _source_start) {
                     _start_idx = _j;
                     break;
                 }
             }
-            for(int _j=_start_idx; _j<_num_spikes; _j++)
+            for(int _j=_start_idx; _j<_num_events; _j++)
             {
-                const int _idx = {{_spikespace}}[_j];
+                const int _idx = {{_eventspace}}[_j];
                 if (_idx >= _source_stop) {
                     _end_idx = _j;
                     break;
                 }
             }
-            _num_spikes = _end_idx - _start_idx;
-            if (_num_spikes > 0) {
+            _num_events = _end_idx - _start_idx;
+            if (_num_events > 0) {
                 for(int _j=_start_idx; _j<_end_idx; _j++)
                 {
-                    const int _idx = {{_spikespace}}[_j];
+                    const int _idx = {{_eventspace}}[_j];
                     {{_dynamic_i}}.push_back(_idx-_source_start);
                     {{_dynamic_t}}.push_back(_clock_t);
                     {{_count}}[_idx-_source_start]++;

--- a/brian2/devices/cpp_standalone/templates/synapses_push_spikes.cpp
+++ b/brian2/devices/cpp_standalone/templates/synapses_push_spikes.cpp
@@ -3,9 +3,6 @@
 //// MAIN CODE /////////////////////////////////////////////////////////////
 
 {% macro cpp_file() %}
-
-{# USES_VARIABLES { _spikespace } #}
-
 #include "code_objects/{{codeobj_name}}.h"
 #include<math.h>
 #include<stdint.h>
@@ -22,8 +19,10 @@ void _run_{{codeobj_name}}()
     //// MAIN CODE ////////////
 	// we do advance at the beginning rather than at the end because it saves us making
 	// a copy of the current spiking synapses
+    {#  Get the name of the array that stores these events (e.g. the spikespace array) #}
+    {% set _eventspace = get_array_name(eventspace_variable) %}
 	{{owner.name}}.advance();
-	{{owner.name}}.push({{_spikespace}}, {{_spikespace}}[_num_spikespace-1]);
+	{{owner.name}}.push({{_spikespace}}, {{_eventspace}}[_num{{eventspace_variable.name}}-1]);
 	//{{owner.name}}.queue->peek();
 }
 {% endmacro %}

--- a/brian2/devices/cpp_standalone/templates/synapses_push_spikes.cpp
+++ b/brian2/devices/cpp_standalone/templates/synapses_push_spikes.cpp
@@ -22,7 +22,7 @@ void _run_{{codeobj_name}}()
     {#  Get the name of the array that stores these events (e.g. the spikespace array) #}
     {% set _eventspace = get_array_name(eventspace_variable) %}
 	{{owner.name}}.advance();
-	{{owner.name}}.push({{_spikespace}}, {{_eventspace}}[_num{{eventspace_variable.name}}-1]);
+	{{owner.name}}.push({{_eventspace}}, {{_eventspace}}[_num{{eventspace_variable.name}}-1]);
 	//{{owner.name}}.queue->peek();
 }
 {% endmacro %}

--- a/brian2/groups/group.py
+++ b/brian2/groups/group.py
@@ -820,6 +820,11 @@ class Group(BrianObject):
         codeobj_class : class, optional
             The `CodeObject` class to run code with. If not specified, defaults
             to the `group`'s ``codeobj_class`` attribute.
+
+        Returns
+        -------
+        obj : `CodeRunner`
+            A reference to the object that will be run.
         '''
         if name is None:
             name = self.name + '_run_regularly*'

--- a/brian2/groups/group.py
+++ b/brian2/groups/group.py
@@ -785,12 +785,20 @@ class Group(BrianObject):
 
     def runner(self, *args, **kwds):
         raise AttributeError("The 'runner' method has been renamed to "
-                             "'custom_operation'")
+                             "'run_regularly'.")
 
-    def custom_operation(self, code, dt=None, clock=None, when='start',
-                         order=0, name=None, codeobj_class=None):
+    def custom_operation(self, *args, **kwds):
+        raise AttributeError("The 'custom_operation' method has been renamed "
+                             "to 'run_regularly'.")
+
+    def run_regularly(self, code, dt=None, clock=None, when='start',
+                      order=0, name=None, codeobj_class=None):
         '''
-        Returns a `CodeRunner` that runs abstract code in the group's namespace.
+        Run abstract code in the group's namespace. The created `CodeRunner`
+        object will be automatically added to the group, it therefore does not
+        need to be added to the network manually. However, a reference to the
+        object will be returned, which can be used to later remove it from the
+        group or to set it to inactive.
 
         Parameters
         ----------
@@ -806,7 +814,7 @@ class Group(BrianObject):
             When to run within a time step, defaults to the ``'start'`` slot.
         name : str, optional
             A unique name, if non is given the name of the group appended with
-            'custom_operation', 'custom_operation_1', etc. will be used. If a
+            'run_regularly', 'run_regularly_1', etc. will be used. If a
             name is given explicitly, it will be used as given (i.e. the group
             name will not be prepended automatically).
         codeobj_class : class, optional
@@ -814,7 +822,7 @@ class Group(BrianObject):
             to the `group`'s ``codeobj_class`` attribute.
         '''
         if name is None:
-            name = self.name + '_custom_operation*'
+            name = self.name + '_run_regularly*'
 
         if dt is None and clock is None:
             clock = self._clock
@@ -822,8 +830,8 @@ class Group(BrianObject):
         runner = CodeRunner(self, 'stateupdate', code=code, name=name,
                             dt=dt, clock=clock, when=when, order=order,
                             codeobj_class=codeobj_class)
+        self.contained_objects.append(runner)
         return runner
-
 
 
 class CodeRunner(BrianObject):

--- a/brian2/groups/neurongroup.py
+++ b/brian2/groups/neurongroup.py
@@ -470,7 +470,7 @@ class NeuronGroup(Group, SpikeSource):
             # creating a Thresholder will take care of checking the validity
             # of the condition
             thresholder = Thresholder(self, event=event_name, when=when)
-            self.thresholder['spike'] = thresholder
+            self.thresholder[event_name] = thresholder
             self.contained_objects.append(thresholder)
 
         if reset is not None:
@@ -561,7 +561,7 @@ class NeuronGroup(Group, SpikeSource):
             raise ValueError(("Cannot add code for event '%s', code for this "
                               "event has already been added.") % event)
         self.event_codes[event] = code
-        resetter = Resetter(self, when=when, order=order)
+        resetter = Resetter(self, when=when, order=order, event=event)
         self.resetter[event] = resetter
         self.contained_objects.append(resetter)
 

--- a/brian2/groups/neurongroup.py
+++ b/brian2/groups/neurongroup.py
@@ -677,7 +677,6 @@ class NeuronGroup(Group, SpikeSource):
                                                'to non-shared variable %s.')
                                               % (eq.varname, identifier))
 
-
     def before_run(self, run_namespace=None, level=0):
         # Check units
         self.equations.check_units(self, run_namespace=run_namespace,
@@ -687,15 +686,27 @@ class NeuronGroup(Group, SpikeSource):
         text = [r'NeuronGroup "%s" with %d neurons.<br>' % (self.name, self._N)]
         text.append(r'<b>Model:</b><nr>')
         text.append(sympy.latex(self.equations))
-        text.append(r'<b>Integration method:</b><br>')
-        text.append(sympy.latex(self.state_updater.method)+'<br>')
-        if self.threshold is not None:
+
+        if 'spike' in self.events:
+            threshold, reset = self.events['spike']
+        else:
+            threshold = reset = None
+        if threshold is not None:
             text.append(r'<b>Threshold condition:</b><br>')
-            text.append('<code>%s</code><br>' % str(self.threshold))
+            text.append('<code>%s</code><br>' % str(threshold))
             text.append('')
-        if self.reset is not None:
-            text.append(r'<b>Reset statement:</b><br>')            
-            text.append(r'<code>%s</code><br>' % str(self.reset))
+        if reset is not None:
+            text.append(r'<b>Reset statement(s):</b><br>')
+            text.append(r'<code>%s</code><br>' % str(reset))
             text.append('')
-                    
+        for event, (condition, statements) in self.events.iteritems():
+            if event != 'spike':  # we dealt with this already above
+                text.append(r'<b>Condition for event "%s"</b><br>' % event)
+                text.append('<code>%s</code><br>' % str(condition))
+                text.append('')
+                if statements is not None:
+                    text.append(r'<b>Executed statement(s):</b><br>')
+                    text.append(r'<code>%s</code><br>' % str(statements))
+                    text.append('')
+
         return '\n'.join(text)

--- a/brian2/groups/neurongroup.py
+++ b/brian2/groups/neurongroup.py
@@ -424,6 +424,9 @@ class NeuronGroup(Group, SpikeSource):
                 self.resetter.append(Resetter(self))
 
         for event, event_tuple in events.iteritems():
+            if isinstance(event_tuple, basestring):
+                # a single string is interpreted as the threshold
+                event_tuple = (event_tuple, None)
             if not isinstance(event_tuple, tuple) or len(event_tuple) != 2:
                 raise TypeError(('Values in the events dictionary have to be '
                                  'tuples of length 2: (condition, statements)'))

--- a/brian2/groups/subgroup.py
+++ b/brian2/groups/subgroup.py
@@ -46,6 +46,8 @@ class Subgroup(Group, SpikeSource):
         self.start = start
         self.stop = stop
 
+        self.events = self.source.events
+
         # All the variables have to go via the _sub_idx to refer to the
         # appropriate values in the source group
         self.variables = Variables(self, default_index='_sub_idx')

--- a/brian2/input/poissongroup.py
+++ b/brian2/input/poissongroup.py
@@ -78,9 +78,9 @@ class PoissonGroup(Group, SpikeSource):
 
         # To avoid a warning about the local variable rates, we set the real
         # threshold condition only after creating the object
-        self.threshold = 'False'
+        self.events = {'spike': ('False', None)}
         self.thresholder = Thresholder(self)
-        self.threshold = 'rand() < rates * dt'
+        self.events = {'spike': ('rand() < rates * dt', None)}
         self.contained_objects.append(self.thresholder)
 
         self._enable_group_attributes()

--- a/brian2/input/poissongroup.py
+++ b/brian2/input/poissongroup.py
@@ -78,9 +78,9 @@ class PoissonGroup(Group, SpikeSource):
 
         # To avoid a warning about the local variable rates, we set the real
         # threshold condition only after creating the object
-        self.events = {'spike': ('False', None)}
+        self.events = {'spike': 'False'}
         self.thresholder = Thresholder(self)
-        self.events = {'spike': ('rand() < rates * dt', None)}
+        self.events = {'spike': 'rand() < rates * dt'}
         self.contained_objects.append(self.thresholder)
 
         self._enable_group_attributes()

--- a/brian2/input/spikegeneratorgroup.py
+++ b/brian2/input/spikegeneratorgroup.py
@@ -66,6 +66,9 @@ class SpikeGeneratorGroup(Group, CodeRunner, SpikeSource):
 
         Group.__init__(self, dt=dt, clock=clock, when=when, order=order, name=name)
 
+        # Let other objects know that we emit spikes events
+        self.events = {'spike': None}
+
         self.codeobj_class = codeobj_class
 
         if N < 1 or int(N) != N:

--- a/brian2/monitors/spikemonitor.py
+++ b/brian2/monitors/spikemonitor.py
@@ -79,7 +79,7 @@ class EventMonitor(Group, CodeRunner):
         self.variables.add_dynamic_array('t', size=0, unit=second,
                                          constant_size=False)
         self.variables.add_arange('_source_i', size=len(source))
-        self.variables.add_array('_count', size=len(source), unit=Unit(1),
+        self.variables.add_array('count', size=len(source), unit=Unit(1),
                                  dtype=np.int32, read_only=True,
                                  index='_source_i')
         self.variables.add_constant('_source_start', Unit(1), start)
@@ -106,11 +106,6 @@ class EventMonitor(Group, CodeRunner):
         Clears all recorded spikes
         '''
         raise NotImplementedError()
-
-    # TODO: Maybe there's a more elegant solution for the count attribute?
-    @property
-    def count(self):
-        return self.variables['_count'].get_value().copy()
 
     @property
     def it(self):

--- a/brian2/synapses/synapses.py
+++ b/brian2/synapses/synapses.py
@@ -556,6 +556,11 @@ class Synapses(Group):
         argument, but instead set the delays via the attribute of the pathway,
         e.g. ``S.pre.delay = ...`` (or ``S.delay = ...`` as an abbreviation),
         ``S.post.delay = ...``, etc.
+    events : str or dict, optional
+        Define the events which trigger the pre and post pathways. By default,
+        both pathways are triggered by the ``'spike'`` event, i.e. the event
+        that is triggered by the ``threshold`` condition in the connected
+        groups.
     namespace : dict, optional
         A dictionary mapping identifier names to objects. If not given, the
         namespace will be filled in at the time of the call of `Network.run`,
@@ -585,8 +590,8 @@ class Synapses(Group):
         The name for this object. If none is given, a unique name of the form
         ``synapses``, ``synapses_1``, etc. will be automatically chosen.
     '''
-
     add_to_magic_network = True
+
     def __init__(self, source, target=None, model=None, pre=None, post=None,
                  connect=False, delay=None, events='spike',
                  namespace=None, dtype=None,
@@ -629,7 +634,7 @@ class Synapses(Group):
         model._equations['lastupdate'] = SingleEquation(PARAMETER,
                                                         'lastupdate',
                                                         second)
-        self._create_variables(model)
+        self._create_variables(model, user_dtype=dtype)
 
         # Separate the equations into event-driven equations,
         # continuously updated equations and summed variable updates

--- a/brian2/synapses/synapses.py
+++ b/brian2/synapses/synapses.py
@@ -556,7 +556,7 @@ class Synapses(Group):
         argument, but instead set the delays via the attribute of the pathway,
         e.g. ``S.pre.delay = ...`` (or ``S.delay = ...`` as an abbreviation),
         ``S.post.delay = ...``, etc.
-    events : str or dict, optional
+    on_event : str or dict, optional
         Define the events which trigger the pre and post pathways. By default,
         both pathways are triggered by the ``'spike'`` event, i.e. the event
         that is triggered by the ``threshold`` condition in the connected
@@ -593,7 +593,7 @@ class Synapses(Group):
     add_to_magic_network = True
 
     def __init__(self, source, target=None, model=None, pre=None, post=None,
-                 connect=False, delay=None, events='spike',
+                 connect=False, delay=None, on_event='spike',
                  namespace=None, dtype=None,
                  codeobj_class=None,
                  dt=None, clock=None, order=0,
@@ -685,11 +685,11 @@ class Synapses(Group):
         #: List of all `SynapticPathway` objects
         self._pathways = []
 
-        if isinstance(events, basestring):
-            events_dict = collections.defaultdict(lambda: events)
+        if isinstance(on_event, basestring):
+            events_dict = collections.defaultdict(lambda: on_event)
         else:
             events_dict = collections.defaultdict(lambda: 'spike')
-            events_dict.update(events)
+            events_dict.update(on_event)
 
         #: "Events" for all the pathways
         self.events = events_dict

--- a/brian2/synapses/synapses.py
+++ b/brian2/synapses/synapses.py
@@ -248,12 +248,23 @@ class SynapticPathway(CodeRunner, Group):
 
         # we insert rather than replace because CodeRunner puts a CodeObject in updaters already
         if self._pushspikes_codeobj is None:
+            # Since this now works for general events not only spikes, we have to
+            # pass the information about which variable to use to the template,
+            # it can not longer simply refer to "_spikespace"
+            # Strictly speaking this is only true for the standalone mode at the
+            # moment, since in runtime, all the template does is to call
+            # SynapticPathway.push_spike
+            eventspace_name = '_{}space'.format(self.event)
+            template_kwds = {'eventspace_variable': self.source.variables[eventspace_name]}
+            needed_variables= [eventspace_name]
             self._pushspikes_codeobj = create_runner_codeobj(self,
                                                              '', # no code
                                                              'synapses_push_spikes',
                                                              name=self.name+'_push_spikes',
                                                              check_units=False,
                                                              additional_variables=self.variables,
+                                                             needed_variables=needed_variables,
+                                                             template_kwds=template_kwds,
                                                              run_namespace=run_namespace,
                                                              level=level+2)
 

--- a/brian2/synapses/synapses.py
+++ b/brian2/synapses/synapses.py
@@ -838,6 +838,9 @@ class Synapses(Group):
         else:
             raise ValueError(('"prepost" argument has to be "pre" or "post", '
                               'is "%s".') % prepost)
+        if event not in spike_group.events:
+            raise ValueError(("%s group does not define an event "
+                              "'%s'.") % (group_name, event))
 
         if not isinstance(spike_group, SpikeSource) or not hasattr(spike_group, 'clock'):
             raise TypeError(('%s has to be a SpikeSource with spikes and'

--- a/brian2/tests/test_functions.py
+++ b/brian2/tests/test_functions.py
@@ -443,8 +443,8 @@ def test_function_dependencies_weave():
         return 84*mV
 
     G = NeuronGroup(5, 'v : volt')
-    updater = G.custom_operation('v = bar(v)')
-    net = Network(G, updater)
+    G.run_regularly('v = bar(v)')
+    net = Network(G)
     net.run(defaultclock.dt)
 
     assert_allclose(G.v_[:], 84*0.001)
@@ -474,8 +474,8 @@ def test_function_dependencies_cython():
         return 84*mV
 
     G = NeuronGroup(5, 'v : volt')
-    updater = G.custom_operation('v = bar(v)')
-    net = Network(G, updater)
+    G.run_regularly('v = bar(v)')
+    net = Network(G)
     net.run(defaultclock.dt)
 
     assert_allclose(G.v_[:], 84*0.001)
@@ -511,8 +511,8 @@ def test_function_dependencies_numpy():
         return 2*foo(x)
 
     G = NeuronGroup(5, 'v : volt')
-    updater = G.custom_operation('v = bar(v)')
-    net = Network(G, updater)
+    G.run_regularly('v = bar(v)')
+    net = Network(G)
     net.run(defaultclock.dt)
 
     assert_allclose(G.v_[:], 84*0.001)
@@ -527,8 +527,8 @@ def test_binomial():
     # values
     G = NeuronGroup(1, '''x : 1
                           y : 1''')
-    updater = G.custom_operation('''x = binomial_f_approximated()
-                                    y = binomial_f()''')
+    G.run_regularly('''x = binomial_f_approximated()
+                       y = binomial_f()''')
     mon = StateMonitor(G, ['x', 'y'], record=0)
     run(1*ms)
     assert np.var(mon[0].x) > 0

--- a/brian2/tests/test_network.py
+++ b/brian2/tests/test_network.py
@@ -526,7 +526,7 @@ def test_network_access():
 @with_setup(teardown=restore_initial_state)
 def test_dependency_check():
     def create_net():
-        G = NeuronGroup(10, 'v: 1')
+        G = NeuronGroup(10, 'v: 1', threshold='False')
         dependent_objects = [
                              StateMonitor(G, 'v', record=True),
                              SpikeMonitor(G),
@@ -592,7 +592,7 @@ def test_magic_collect():
     Make sure all expected objects are collected in a magic network
     '''
     P = PoissonGroup(10, rates=100*Hz)
-    G = NeuronGroup(10, 'v:1')
+    G = NeuronGroup(10, 'v:1', threshold='False')
     S = Synapses(G, G, '')
     G_runner = G.custom_operation('')
     S_runner = S.custom_operation('')

--- a/brian2/tests/test_network.py
+++ b/brian2/tests/test_network.py
@@ -594,8 +594,6 @@ def test_magic_collect():
     P = PoissonGroup(10, rates=100*Hz)
     G = NeuronGroup(10, 'v:1', threshold='False')
     S = Synapses(G, G, '')
-    G_runner = G.custom_operation('')
-    S_runner = S.custom_operation('')
 
     state_mon = StateMonitor(G, 'v', record=True)
     spike_mon = SpikeMonitor(G)
@@ -603,7 +601,7 @@ def test_magic_collect():
 
     objects = collect()
 
-    assert len(objects) == 8, ('expected %d objects, got %d' % (8, len(objects)))
+    assert len(objects) == 6, ('expected %d objects, got %d' % (6, len(objects)))
 
 from contextlib import contextmanager
 from StringIO import StringIO

--- a/brian2/tests/test_neurongroup.py
+++ b/brian2/tests/test_neurongroup.py
@@ -629,6 +629,7 @@ def test_unit_errors_threshold_reset():
     # Unit error in reset
     assert_raises(DimensionMismatchError,
                   lambda: NeuronGroup(1, 'dv/dt = -v/(10*ms) : 1',
+                                      threshold='True',
                                       reset='v = -65*mV'))
 
     # More complicated unit reset with an intermediate variable
@@ -676,8 +677,8 @@ def test_syntax_errors():
     # Syntax error in reset
     assert_raises(Exception,
                   lambda: NeuronGroup(1, 'dv/dt = 5*Hz : 1',
+                                      threshold='True',
                                       reset='0'))
-
 
 def test_state_variables():
     '''

--- a/brian2/tests/test_neurongroup.py
+++ b/brian2/tests/test_neurongroup.py
@@ -646,17 +646,20 @@ def test_unit_errors_threshold_reset():
     # This should fail
     assert_raises(DimensionMismatchError,
                   lambda: NeuronGroup(1, 'dv/dt = -v/(10*ms) : 1',
+                                      threshold='False',
                                       reset='''temp_var = -65*mV
                                                v = temp_var'''))
 
     # Resets with an in-place modification
     # This should work
     NeuronGroup(1, 'dv/dt = -v/(10*ms) : 1',
+                threshold='False',
                 reset='''v /= 2''')
 
     # This should fail
     assert_raises(DimensionMismatchError,
                   lambda: NeuronGroup(1, 'dv/dt = -v/(10*ms) : 1',
+                                      threshold='False',
                                       reset='''v -= 60*mV'''))
 
 @attr('codegen-independent')

--- a/brian2/tests/test_neurongroup.py
+++ b/brian2/tests/test_neurongroup.py
@@ -1072,8 +1072,8 @@ def test_aliasing_in_statements():
                      x_0 = -1'''
     g = NeuronGroup(1, model='''x_0 : 1
                                 x_1 : 1 ''')
-    custom_code_obj = g.custom_operation(runner_code)
-    net = Network(g, custom_code_obj)
+    g.run_regularly(runner_code)
+    net = Network(g)
     net.run(defaultclock.dt)
     assert_equal(g.x_0_[:], np.array([-1]))
     assert_equal(g.x_1_[:], np.array([0]))

--- a/brian2/tests/test_neurongroup.py
+++ b/brian2/tests/test_neurongroup.py
@@ -528,7 +528,7 @@ def test_namespace_errors():
     assert_raises(KeyError, lambda: net.run(1*ms))
 
     # reset uses unknown identifier
-    G = NeuronGroup(1, 'dv/dt = -v/tau : 1', reset='v = v_r')
+    G = NeuronGroup(1, 'dv/dt = -v/tau : 1', threshold='False', reset='v = v_r')
     net = Network(G)
     assert_raises(KeyError, lambda: net.run(1*ms))
 
@@ -635,10 +635,12 @@ def test_unit_errors_threshold_reset():
     # More complicated unit reset with an intermediate variable
     # This should pass
     NeuronGroup(1, 'dv/dt = -v/(10*ms) : 1',
+                threshold='False',
                 reset='''temp_var = -65
                          v = temp_var''')
     # throw in an empty line (should still pass)
     NeuronGroup(1, 'dv/dt = -v/(10*ms) : 1',
+                threshold='False',
                 reset='''temp_var = -65
 
                          v = temp_var''')

--- a/brian2/tests/test_subgroup.py
+++ b/brian2/tests/test_subgroup.py
@@ -149,8 +149,8 @@ def test_shared_variable():
 
 
 def test_synapse_creation():
-    G1 = NeuronGroup(10, 'v:1')
-    G2 = NeuronGroup(20, 'v:1')
+    G1 = NeuronGroup(10, 'v:1', threshold='False')
+    G2 = NeuronGroup(20, 'v:1', threshold='False')
     G1.v = 'i'
     G2.v = '10 + i'
     SG1 = G1[:5]
@@ -182,9 +182,9 @@ def test_synapse_creation():
 
 
 def test_synapse_access():
-    G1 = NeuronGroup(10, 'v:1')
+    G1 = NeuronGroup(10, 'v:1', threshold='False')
     G1.v = 'i'
-    G2 = NeuronGroup(20, 'v:1')
+    G2 = NeuronGroup(20, 'v:1', threshold='False')
     G2.v = 'i'
     SG1 = G1[:5]
     SG2 = G2[10:]

--- a/brian2/tests/test_synapses.py
+++ b/brian2/tests/test_synapses.py
@@ -32,7 +32,7 @@ def test_creation():
     '''
     A basic test that creating a Synapses object works.
     '''
-    G = NeuronGroup(42, 'v: 1')
+    G = NeuronGroup(42, 'v: 1', threshold='False')
     S = Synapses(G, G, 'w:1', pre='v+=w')
     # We store weakref proxys, so we can't directly compare the objects
     assert S.source.name == S.target.name == G.name
@@ -62,8 +62,8 @@ def test_incoming_outgoing():
     (It will be also automatically tested for all connection patterns that
     use the above _compare function for testing)
     '''
-    G1 = NeuronGroup(5, 'v: 1')
-    G2 = NeuronGroup(5, 'v: 1')
+    G1 = NeuronGroup(5, 'v: 1', threshold='False')
+    G2 = NeuronGroup(5, 'v: 1', threshold='False')
     S = Synapses(G1, G2, 'w:1', pre='v+=w')
     S.connect([0, 0, 0, 1, 1, 2],
               [0, 1, 2, 1, 2, 3])
@@ -175,9 +175,9 @@ def test_connection_string_deterministic():
     '''
     Test connecting synapses with a deterministic string expression.
     '''
-    G = NeuronGroup(17, 'v : 1')
+    G = NeuronGroup(17, 'v : 1', threshold='False')
     G.v = 'i'
-    G2 = NeuronGroup(4, 'v : 1')
+    G2 = NeuronGroup(4, 'v : 1', threshold='False')
     G2.v = '17 + i'
 
     # Full connection
@@ -255,8 +255,8 @@ def test_connection_random():
     '''
     Test random connections.
     '''
-    G = NeuronGroup(4, 'v: 1')
-    G2 = NeuronGroup(7, 'v: 1')
+    G = NeuronGroup(4, 'v: 1', threshold='False')
+    G2 = NeuronGroup(7, 'v: 1', threshold='False')
     # We can only test probabilities 0 and 1 for strict correctness
     S = Synapses(G, G2, 'w:1', 'v+=w')
     S.connect('rand() < 0.')
@@ -313,8 +313,8 @@ def test_connection_multiple_synapses():
     '''
     Test multiple synapses per connection.
     '''
-    G = NeuronGroup(42, 'v: 1')
-    G2 = NeuronGroup(17, 'v: 1')
+    G = NeuronGroup(42, 'v: 1', threshold='False')
+    G2 = NeuronGroup(17, 'v: 1', threshold='False')
 
     S = Synapses(G, G2, 'w:1', 'v+=w')
     S.connect(True, n=0)
@@ -334,7 +334,7 @@ def test_state_variable_assignment():
     Assign values to state variables in various ways
     '''
 
-    G = NeuronGroup(10, 'v: volt')
+    G = NeuronGroup(10, 'v: volt', threshold='False')
     G.v = 'i*mV'
     S = Synapses(G, G, 'w:volt')
     S.connect(True)
@@ -466,7 +466,7 @@ def test_subexpression_references():
 def test_delay_specification():
     # By default delays are state variables (i.e. arrays), but if they are
     # specified in the initializer, they are scalars.
-    G = NeuronGroup(10, 'v:1')
+    G = NeuronGroup(10, 'v:1', threshold='False')
 
     # Array delay
     S = Synapses(G, G, 'w:1', pre='v+=w')
@@ -583,8 +583,8 @@ def test_clocks():
     source_dt = 0.05*ms
     target_dt = 0.1*ms
     synapse_dt = 0.2*ms
-    source = NeuronGroup(1, 'v:1', dt=source_dt)
-    target = NeuronGroup(1, 'v:1', dt=target_dt)
+    source = NeuronGroup(1, 'v:1', dt=source_dt, threshold='False')
+    target = NeuronGroup(1, 'v:1', dt=target_dt, threshold='False')
     synapse = Synapses(source, target, 'w:1', pre='v+=1', post='v+=1',
                        dt=synapse_dt, connect=True)
 
@@ -682,7 +682,7 @@ def test_summed_variable_errors():
 
 def test_scalar_parameter_access():
     G = NeuronGroup(10, '''v : 1
-                           scalar : Hz (shared)''')
+                           scalar : Hz (shared)''', threshold='False')
     S = Synapses(G, G, '''w : 1
                           s : Hz (shared)
                           number : 1 (shared)''',
@@ -721,7 +721,7 @@ def test_scalar_parameter_access():
 
 def test_scalar_subexpression():
     G = NeuronGroup(10, '''v : 1
-                           number : 1 (shared)''')
+                           number : 1 (shared)''', threshold='False')
     S = Synapses(G, G, '''s : 1 (shared)
                           sub = number_post + s : 1 (shared)''',
                  pre='v+=s', connect=True)
@@ -800,7 +800,7 @@ def test_event_driven():
 
 @attr('codegen-independent')
 def test_repr():
-    G = NeuronGroup(1, 'v: volt')
+    G = NeuronGroup(1, 'v: volt', threshold='False')
     S = Synapses(G, G,
                  '''w : 1
                     dApre/dt = -Apre/taupre : 1 (event-driven)

--- a/brian2/tests/test_synapses.py
+++ b/brian2/tests/test_synapses.py
@@ -157,9 +157,9 @@ def test_connection_string_deterministic_basic():
     '''
     Test connecting synapses with a deterministic string expression.
     '''
-    G = NeuronGroup(17, 'v : 1')
+    G = NeuronGroup(17, 'v : 1', threshold='False')
     G.v = 'i'
-    G2 = NeuronGroup(4, 'v : 1')
+    G2 = NeuronGroup(4, 'v : 1', threshold='False')
     G2.v = '17 + i'
 
     # Full connection
@@ -240,8 +240,8 @@ def test_connection_string_deterministic():
 
 
 def test_connection_random_basic():
-    G = NeuronGroup(4, 'v: 1')
-    G2 = NeuronGroup(7, 'v: 1')
+    G = NeuronGroup(4, 'v: 1', threshold='False')
+    G2 = NeuronGroup(7, 'v: 1', threshold='False')
 
     S = Synapses(G, G2, 'w:1', 'v+=w')
     S.connect(True, p=0.0)

--- a/docs_sphinx/advanced/custom_events.rst
+++ b/docs_sphinx/advanced/custom_events.rst
@@ -1,0 +1,49 @@
+Custom events
+=============
+
+In most simulations, a `NeuronGroup` defines a threshold on its membrane
+potential that triggers a spike event. This event can be monitored by a
+`SpikeMonitor`, it is used in synaptic interactions, and in integrate-and-fire
+models it also leads to the execution of one or more reset statements.
+
+Sometimes, it can be useful to define additional events, e.g. when an ion
+concentration in the cell crosses a certain threshold. This can be done with
+the ``events`` keyword in the `NeuronGroup` initializer::
+
+    group = NeuronGroup(N, '...', threshold='...', reset='...',
+                        events={'custom_event': 'x > x_th'})
+
+In this example, we define an event with the name ``custom_event`` that is
+triggered when the ``x`` variable crosses the threshold ``x_th``. Such events
+can be recorded with an `EventMonitor`::
+
+    event_mon = EventMonitor(group, 'custom_event')
+
+Such an `EventMonitor` can be used in the same way as a `SpikeMonitor` -- in
+fact, creating the `SpikeMonitor` is basically identical to recording the
+``spike`` event with an `EventMonitor`.
+
+If the event should trigger a series of statements (i.e. the equivalent of
+``reset`` statements), this can be added by calling `~NeuronGroup.run_on_event`::
+
+    group.run_on_event('custom_event', 'x=0')
+
+When neurons are connected by `Synapses`, the ``pre`` and ``post`` pathways
+are triggered by spike events by default. It is possible to change this by
+providing an ``events`` keyword that either specifies which event to use for all
+pathways, or a specific event for each pathway (where non-specified pathways use
+the default ``spike`` event)::
+
+    synapse_1 = Synapses(group, another_group, '...', pre='...', events='custom_event')
+    synapse_2 = Synapses(group, another_group, '...', pre='...', post='...',
+                         events={'pre': 'custom_event'})
+
+Scheduling
+----------
+By default, custom events are checked after the spiking threshold (in the
+``after_thresholds`` slots) and statements are executed after the reset (in
+the ``after_resets`` slots). The slot for the execution of custom
+event-triggered statements can be changed when it is added with the usual
+``when`` and ``order`` keyword arguments (see :doc:`scheduling` for details).
+To change the time when the condition is checked, use
+`NeuronGroup.set_event_schedule`.

--- a/docs_sphinx/advanced/custom_events.rst
+++ b/docs_sphinx/advanced/custom_events.rst
@@ -30,13 +30,13 @@ If the event should trigger a series of statements (i.e. the equivalent of
 
 When neurons are connected by `Synapses`, the ``pre`` and ``post`` pathways
 are triggered by spike events by default. It is possible to change this by
-providing an ``events`` keyword that either specifies which event to use for all
+providing an ``on_event`` keyword that either specifies which event to use for all
 pathways, or a specific event for each pathway (where non-specified pathways use
 the default ``spike`` event)::
 
-    synapse_1 = Synapses(group, another_group, '...', pre='...', events='custom_event')
+    synapse_1 = Synapses(group, another_group, '...', pre='...', on_event='custom_event')
     synapse_2 = Synapses(group, another_group, '...', pre='...', post='...',
-                         events={'pre': 'custom_event'})
+                         on_event={'pre': 'custom_event'})
 
 Scheduling
 ----------

--- a/docs_sphinx/advanced/index.rst
+++ b/docs_sphinx/advanced/index.rst
@@ -11,6 +11,7 @@ This section has additional information on details not covered in the
    namespaces
    refractoriness
    scheduling
+   custom_events
    state_update
    how_brian_works
    interface

--- a/docs_sphinx/user/equations.rst
+++ b/docs_sphinx/user/equations.rst
@@ -32,7 +32,7 @@ For stochastic equations with several ``xi`` values it is now necessary to make 
 or different noise instantiations. To make this distinction, an arbitrary suffix can be used, e.g. using ``xi_1`` several times
 refers to the same variable, ``xi_2`` (or ``xi_inh``, ``xi_alpha``, etc.) refers to another. An error will be raised if
 you use more than one plain ``xi``. Note that noise is always independent across neurons, you can only work around this
-restriction by defining your noise variable as a shared parameter and update it using a user-defined function (e.g. with a  `~Group.custom_operation`),
+restriction by defining your noise variable as a shared parameter and update it using a user-defined function (e.g. with `~Group.run_regularly`),
 or create a group that models the noise and link to its variable (see :ref:`linked_variables`).
 
 Flags

--- a/docs_sphinx/user/input.rst
+++ b/docs_sphinx/user/input.rst
@@ -137,11 +137,11 @@ the second::
                     threshold='v>1', reset='v=0')
 
 
-Custom operations
------------------
+Regular operations
+------------------
 An alternative to specifying a stimulus in advance is to run explicitly
 specified code at certain points during a simulation. This can be
-achieved with a :meth:`~brian2.groups.group.Group.custom_operation`.
+achieved with :meth:`~brian2.groups.group.Group.run_regularly`.
 One can think of these statements as
 equivalent to reset statements but executed unconditionally (i.e. for all
 neurons) and possibly on a different clock than the rest of the group. The
@@ -152,9 +152,9 @@ expressions to have the values only updated for the chosen subset of neurons
 
   G = NeuronGroup(100, '''dv/dt = (-v + I)/(10*ms) : 1
                           I : 1  # one stimulus per neuron''')
-  stim_updater = G.custom_operation('''change = int(rand() < 0.5)
-                                       I = change*(rand()*2) + (1-change)*I''',
-                                    dt=50*ms)
+  G.run_regularly('''change = int(rand() < 0.5)
+                     I = change*(rand()*2) + (1-change)*I''',
+                  dt=50*ms)
 
 .. _network_operation:
 

--- a/docs_sphinx/user/models.rst
+++ b/docs_sphinx/user/models.rst
@@ -34,8 +34,8 @@ be used::
 Sometimes it can also be useful to introduce shared variables or subexpressions,
 i.e. variables that have a common value for all neurons. In contrast to
 external variables (such as ``Cm`` above), such variables can change during a
-run, e.g. by using a :meth:`~brian2.groups.group.Group.custom_operation`. This can be for example
-used for an external stimulus that changes in the course of a run::
+run, e.g. by using :meth:`~brian2.groups.group.Group.run_regularly`. This can be
+for example used for an external stimulus that changes in the course of a run::
 
     G = NeuronGroup(10, '''shared_input : volt (shared)
                            dv/dt = (-v + shared_input)/tau : volt

--- a/examples/IF_curve_LIF.py
+++ b/examples/IF_curve_LIF.py
@@ -6,8 +6,7 @@ with an input parameter v0.
 The input is set differently for each neuron.
 '''
 from brian2 import *
-#prefs.codegen.target = 'cython'
-set_device('cpp_standalone_simple')
+
 n = 1000
 duration = 1*second
 tau = 10*ms
@@ -16,12 +15,11 @@ dv/dt = (v0 - v) / tau : volt (unless refractory)
 v0 : volt
 '''
 group = NeuronGroup(n, eqs, threshold='v > 10*mV', reset='v = 0*mV',
-                    refractory=5*ms,
-                    events={'myspike': ('v>10*mV', 'v=0*mV')})
+                    refractory=5*ms)
 group.v = 0*mV
 group.v0 = '20*mV * i / (n-1)'
 
-monitor = EventMonitor(group, 'myspike')
+monitor = SpikeMonitor(group)
 
 run(duration)
 plot(group.v0/mV, monitor.count / duration)

--- a/examples/IF_curve_LIF.py
+++ b/examples/IF_curve_LIF.py
@@ -6,7 +6,8 @@ with an input parameter v0.
 The input is set differently for each neuron.
 '''
 from brian2 import *
-
+#prefs.codegen.target = 'cython'
+set_device('cpp_standalone_simple')
 n = 1000
 duration = 1*second
 tau = 10*ms
@@ -15,11 +16,12 @@ dv/dt = (v0 - v) / tau : volt (unless refractory)
 v0 : volt
 '''
 group = NeuronGroup(n, eqs, threshold='v > 10*mV', reset='v = 0*mV',
-                    refractory=5*ms)
+                    refractory=5*ms,
+                    events={'myspike': ('v>10*mV', 'v=0*mV')})
 group.v = 0*mV
 group.v0 = '20*mV * i / (n-1)'
 
-monitor = SpikeMonitor(group)
+monitor = EventMonitor(group, 'myspike')
 
 run(duration)
 plot(group.v0/mV, monitor.count / duration)

--- a/examples/advanced/opencv_movie.py
+++ b/examples/advanced/opencv_movie.py
@@ -105,8 +105,8 @@ G.v_th = 1
 G.row = 'i/width'
 G.column = 'i%width'
 
-update_input = G.custom_operation('I = video_input(column, row)',
-                                  dt=time_between_frames)
+G.run_regularly('I = video_input(column, row)',
+                dt=time_between_frames)
 mon = SpikeMonitor(G)
 runtime = frame_count*time_between_frames
 run(runtime, report='text')

--- a/examples/compartmental/lfp.py
+++ b/examples/compartmental/lfp.py
@@ -45,7 +45,7 @@ neuron.gNa = gNa0
 neuron[5*cm:10*cm].gNa = 0*siemens/cm**2
 M = StateMonitor(neuron, 'v', record=True)
 
-store_v = neuron.custom_operation('previous_v = v',when='start')
+neuron.run_regularly('previous_v = v', when='start')
 
 # LFP recorder
 Ne = 5 # Number of electrodes

--- a/examples/frompapers/kremer_et_al_2011_barrel_cortex.py
+++ b/examples/frompapers/kremer_et_al_2011_barrel_cortex.py
@@ -78,7 +78,7 @@ stim_start_x = barrelarraysize / 2.0 - cos(direction)*stimradius
 stim_start_y = barrelarraysize / 2.0 - sin(direction)*stimradius
 stim_start_time = t
 '''
-stim_updater = layer4.custom_operation(runner_code, dt=60*ms, when='start')
+layer4.run_regularly(runner_code, dt=60*ms, when='start')
 
 # Layer 2/3
 # Model: IF with adaptive threshold


### PR DESCRIPTION
This introduces support for general events using the `events = {eventname: (condition, statement)}` syntax and an `EventMonitor` for recording such events. It is lacking tests, error-checking (e.g. for valid event names) and documentation but it seems to work fine.
Many of the tests fail currently, but that's because of a little change that we won't create a `_spikespace` array unconditionally anymore, but only if the `NeuronGroup` has a threshold. This makes quite a number of `Synapses` tests fail, where for simplicity, `Synapses` is connected to a `NeuronGroup` without a threshold. I'm not sure whether that's a bug or a feature, though -- but the error message is certainly not helpful at the moment.
One thing that came to my mind is that in the same way that this pull request generalizes threshold/reset/monitors for multiple events, synaptic pathways could easily connect to a different synaptic event type than spikes, which could be potentially useful (in our discussion in #106 we decided to not do this for simplicity, but the necessary changes are really not that big). Maybe worth opening a new issue for that (and/or discuss it in our meeting tomorrow).

This branch does not (yet):
* Rename reset/threshold ( #106)
* Rename the scheduling slots `resets` and `thresholds`
* Rename the templates `reset`, `threshold`, `spikemonitor` (which is potentially annoying for other people already working on devices, on the other hand we should make this change rather now or never)
