### PR TITLE
[MRG] Let `StateMonitor` record in the start slot by default

### DIFF
--- a/brian2/tests/test_monitor.py
+++ b/brian2/tests/test_monitor.py
@@ -192,9 +192,9 @@ def test_state_monitor():
 
     # Check v recording
     assert_allclose(v_mon.v.T,
-                    np.exp(np.tile(-v_mon.t - defaultclock.dt, (2, 1)).T / (10*ms)))
+                    np.exp(np.tile(-v_mon.t, (2, 1)).T / (10*ms)))
     assert_allclose(v_mon.v_.T,
-                    np.exp(np.tile(-v_mon.t_ - defaultclock.dt_, (2, 1)).T / float(10*ms)))
+                    np.exp(np.tile(-v_mon.t_, (2, 1)).T / float(10*ms)))
     assert_array_equal(v_mon.v, multi_mon.v)
     assert_array_equal(v_mon.v_, multi_mon.v_)
     assert_array_equal(v_mon.v, all_mon.v)
@@ -214,6 +214,24 @@ def test_state_monitor():
     # Synapses
     assert_allclose(synapse_mon.w[:], np.tile(S.j[:]*nS,
                                               (synapse_mon.w[:].shape[1], 1)).T)
+
+@attr('standalone-compatible')
+@with_setup(teardown=restore_device)
+def test_state_monitor_record_single_timestep():
+    G = NeuronGroup(1, 'dv/dt = -v/(5*ms) : 1')
+    G.v = 1
+    mon = StateMonitor(G, 'v', record=True)
+    # Recording before a run should not work
+    assert_raises(TypeError, lambda: mon.record_single_timestep())
+    run(0.5*ms)
+    assert mon.t[0] == 0*ms
+    assert mon[0].v[0] == 1
+    assert_allclose(mon.t[-1], 0.5*ms-defaultclock.dt)
+    assert len(mon.t) == 5
+    mon.record_single_timestep()
+    assert_allclose(mon.t[-1], 0.5*ms)
+    assert len(mon.t) == 6
+    assert mon[0].v[-1] == G.v
 
 @attr('standalone-compatible')
 @with_setup(teardown=restore_device)
@@ -287,6 +305,7 @@ if __name__ == '__main__':
     test_spike_monitor_variables()
     test_event_monitor()
     test_state_monitor()
+    test_state_monitor_record_single_timestep()
     test_state_monitor_indexing()
     test_rate_monitor()
     test_rate_monitor_subgroups()

--- a/brian2/tests/test_poissoninput.py
+++ b/brian2/tests/test_poissoninput.py
@@ -24,7 +24,7 @@ def test_poissoninput():
     sometimes_update = PoissonInput(G, 'z', 10000, 50*Hz, weight=0.5*volt)
     sometimes_update2 = PoissonInput(G, 'z2', 10000, 50*Hz, weight='w*volt')
 
-    mon = StateMonitor(G, ['x', 'y', 'y2', 'z', 'z2'], record=True)
+    mon = StateMonitor(G, ['x', 'y', 'y2', 'z', 'z2'], record=True, when='end')
 
     run(1*ms)
     assert_equal(0, mon.x[:])

--- a/brian2/tests/test_refractory.py
+++ b/brian2/tests/test_refractory.py
@@ -31,7 +31,7 @@ def test_refractoriness_basic():
                         refractory=5*ms)
     # It should take 10ms to reach the threshold, then v should stay at 0
     # for 5ms, while w continues to increase
-    mon = StateMonitor(G, ['v', 'w'], record=True)
+    mon = StateMonitor(G, ['v', 'w'], record=True, when='end')
     run(20*ms)
     # No difference before the spike
     assert_equal(mon[0].v[mon.t < 10*ms], mon[0].w[mon.t < 10*ms])
@@ -68,7 +68,7 @@ def test_refractoriness_variables():
         G.ref_no_unit = 5
         # It should take 10ms to reach the threshold, then v should stay at 0
         # for 5ms, while w continues to increase
-        mon = StateMonitor(G, ['v', 'w'], record=True)
+        mon = StateMonitor(G, ['v', 'w'], record=True, when='end')
         run(20*ms)
         try:
             # No difference before the spike

--- a/brian2/tests/test_spikegenerator.py
+++ b/brian2/tests/test_spikegenerator.py
@@ -19,7 +19,7 @@ def test_spikegenerator_connected():
     Test that `SpikeGeneratorGroup` connects properly.
     '''
     G = NeuronGroup(10, 'v:1')
-    mon = StateMonitor(G, 'v', record=True)
+    mon = StateMonitor(G, 'v', record=True, when='end')
     indices = np.array([3, 2, 1, 1, 4, 5])
     times =   np.array([6, 5, 4, 3, 3, 1]) * ms
     SG = SpikeGeneratorGroup(10, indices, times)

--- a/brian2/tests/test_synapses.py
+++ b/brian2/tests/test_synapses.py
@@ -514,7 +514,7 @@ def test_transmission_simple():
     source = SpikeGeneratorGroup(2, [0, 1], [2, 1] * ms)
     target = NeuronGroup(2, 'v : 1')
     syn = Synapses(source, target, pre='v += 1', connect='i==j')
-    mon = StateMonitor(target, 'v', record=True)
+    mon = StateMonitor(target, 'v', record=True, when='end')
     run(2.5*ms)
     assert_equal(mon[0].v[mon.t<2*ms], 0.)
     assert_equal(mon[0].v[mon.t>=2*ms], 1.)
@@ -529,7 +529,7 @@ def test_transmission_custom_event():
     target = NeuronGroup(2, 'v : 1')
     syn = Synapses(source, target, pre='v += 1', connect='i==j',
                    on_event='custom')
-    mon = StateMonitor(target, 'v', record=True)
+    mon = StateMonitor(target, 'v', record=True, when='end')
     run(2.5*ms)
     assert_equal(mon[0].v[mon.t<2*ms], 0.)
     assert_equal(mon[0].v[mon.t>=2*ms], 1.)
@@ -578,7 +578,7 @@ def test_transmission_scalar_delay():
     inp = SpikeGeneratorGroup(2, [0, 1], [0, 1]*ms)
     target = NeuronGroup(2, 'v:1')
     S = Synapses(inp, target, pre='v+=1', delay=0.5*ms, connect='i==j')
-    mon = StateMonitor(target, 'v', record=True)
+    mon = StateMonitor(target, 'v', record=True, when='end')
     run(2*ms)
     assert_equal(mon[0].v[mon.t<0.5*ms], 0)
     assert_equal(mon[0].v[mon.t>=0.5*ms], 1)
@@ -595,7 +595,7 @@ def test_transmission_scalar_delay_different_clocks():
                               name='sg_%d' % uuid.uuid4())
     target = NeuronGroup(2, 'v:1', dt=0.1*ms)
     S = Synapses(inp, target, pre='v+=1', delay=0.5*ms, connect='i==j')
-    mon = StateMonitor(target, 'v', record=True)
+    mon = StateMonitor(target, 'v', record=True, when='end')
 
     if get_device() == all_devices['runtime']:
         # We should get a warning when using inconsistent dts

--- a/brian2/tests/test_synapses.py
+++ b/brian2/tests/test_synapses.py
@@ -136,7 +136,7 @@ def test_connection_array_standalone():
     G2 = NeuronGroup(8, 'v:1')
     S = Synapses(G1, G2, '', pre='v+=1', dt=1*second)
     S.connect([0, 1, 2, 3], [0, 2, 4, 6])
-    mon = StateMonitor(G2, 'v', record=True, name='mon', dt=1*second)
+    mon = StateMonitor(G2, 'v', record=True, name='mon', dt=1*second, when='end')
     net = Network(G1, G2, S, mon)
     net.run(5*second)
     tempdir = tempfile.mkdtemp()

--- a/docs_sphinx/introduction/changes.rst
+++ b/docs_sphinx/introduction/changes.rst
@@ -131,6 +131,16 @@ for neuron i while the latter returns the value for the *ith* recorded neuron.::
     print mon[2].v  # v values for neuron number 2
     print mon.v[2]  # v values for neuron number 4
 
+Another change is that the `StateMonitor` now records in the ``'start'``
+scheduling slot by default. This leads to a more intuitive correspondence
+between the recorded times and the values: previously (where `StateMonitor`
+recorded in the ``'end'`` slot) the recorded value at 0ms was not the initial
+value of the variable but the value after integrating it for a single time
+step. The disadvantage of this new default is that the very last value at the
+end of the last time step of a simulation is not recorded anymore. However, this
+value can be manually added to the monitor by calling
+`StateMonitor.record_single_timestep`.
+
 Miscellaneous changes
 ~~~~~~~~~~~~~~~~~~~~~
 * New preferences system (see :doc:`../developer/preferences`)

--- a/docs_sphinx/user/recording.rst
+++ b/docs_sphinx/user/recording.rst
@@ -88,6 +88,29 @@ In this example, we record two variables v and u, and record from indices 0,
     plot(M.t/ms, M.v[0]/mV, label='v')
     plot(M.t/ms, M.u[0]/mV, label='u')
 
+There are two subtly different ways to get the values for specific neurons: you
+can either index the 2D array stored in the attribute with the variable name
+(as in the example above) or you can index the monitor itself. The former will
+use an index relative to the recorded neurons (e.g. `M.v[1]` will return the
+values for the second *recorded* neuron which is the neuron with the index 10
+whereas `M.v[10]` would raise an error because only three neurons have been
+recorded), whereas the latter will use an absolute index corresponding to the
+recorded group (e.g. `M[1].v` will raise an error because the neuron with the
+index 1 has not been recorded and `M[10].v` will return the values for the
+neuron with the index 10). If all neurons have been recorded (e.g. with
+``record=True``) then both forms give the same result.
+
+Note that for plotting all recorded values at once, you have to transpose the
+variable values::
+
+    plot(M.t/ms, M.v.T/mV)
+
+
+In contrast to previous versions of Brian, the values are recorded at the
+beginning of a time step and not at the end (you can set the ``when`` argument
+when creating a `StateMonitor`, details about scheduling can be
+found here: :doc:`../advanced/scheduling`).
+
 Recording population rates
 --------------------------
 


### PR DESCRIPTION
Also adds a convenience method for recording at the end.

Updates tests and documentation, ready-to-merge from my side.
Closes #452