### PR TITLE
[MRG] `get_states` improvements

### DIFF
--- a/brian2/groups/group.py
+++ b/brian2/groups/group.py
@@ -421,7 +421,10 @@ class Group(BrianObject):
     def get_states(self, vars=None, units=True, format='dict',
                    subexpressions=False, level=0):
         '''
-        Return a copy of the current state variable values.
+        Return a copy of the current state variable values. The returned arrays
+        are copies of the actual arrays that store the state variable values,
+        therefore changing the values in the returned dictionary will not affect
+        the state variables.
 
         Parameters
         ----------

--- a/brian2/groups/group.py
+++ b/brian2/groups/group.py
@@ -11,7 +11,8 @@ import numpy as np
 from brian2.core.base import BrianObject
 from brian2.core.preferences import prefs
 from brian2.core.variables import (Variables, Constant, Variable,
-                                   ArrayVariable, DynamicArrayVariable)
+                                   ArrayVariable, DynamicArrayVariable,
+                                   Subexpression)
 from brian2.core.functions import Function
 from brian2.core.namespace import (get_local_namespace,
                                    DEFAULT_FUNCTIONS,
@@ -417,7 +418,8 @@ class Group(BrianObject):
                                  'an attribute of this group.' % name)
         object.__setattr__(self, name, None)
 
-    def get_states(self, vars=None, units=True, format='dict', level=0):
+    def get_states(self, vars=None, units=True, format='dict',
+                   subexpressions=False, level=0):
         '''
         Return a copy of the current state variable values.
 
@@ -426,12 +428,17 @@ class Group(BrianObject):
         vars : list of str, optional
             The names of the variables to extract. If not specified, extract
             all state variables (except for internal variables, i.e. names that
-            start with ``'_'``).
+            start with ``'_'``). If the ``subexpressions`` argument is ``True``,
+            the current values of all subexpressions are returned as well.
         units : bool, optional
             Whether to include the physical units in the return value. Defaults
             to ``True``.
         format : str, optional
             The output format. Defaults to ``'dict'``.
+        subexpressions: bool, optional
+            Whether to return subexpressions when no list of variable names
+            is given. Defaults to ``False``. This argument is ignored if an
+            explicit list of variable names is given in ``vars``.
         level : int, optional
             How much higher to go up the stack to resolve external variables.
             Only relevant if extracting subexpressions that refer to external
@@ -448,8 +455,9 @@ class Group(BrianObject):
         if format != 'dict':
             raise NotImplementedError("Format '%s' is not supported" % format)
         if vars is None:
-            vars = [name for name in self.variables.iterkeys()
-                    if not name.startswith('_')]
+            vars = [name for name, var in self.variables.iteritems()
+                    if not name.startswith('_') and
+                    (subexpressions or not isinstance(var, Subexpression))]
         data = {}
         for var in vars:
             data[var] = np.array(self.state(var, use_units=units,

--- a/brian2/tests/test_neurongroup.py
+++ b/brian2/tests/test_neurongroup.py
@@ -1147,8 +1147,10 @@ def test_get_states():
     assert_equal(states['subexpr2'], 11*np.arange(10))
 
     all_states = G.get_states(units=True)
-    assert set(all_states.keys()) == {'v', 'x', 'subexpr', 'subexpr2', 'N', 't',
-                                      'dt', 'i'}
+    assert set(all_states.keys()) == {'v', 'x', 'N', 't', 'dt', 'i'}
+    all_states = G.get_states(units=True, subexpressions=True)
+    assert set(all_states.keys()) == {'v', 'x', 'N', 't', 'dt', 'i',
+                                      'subexpr', 'subexpr2'}
 
 
 def test_random_vector_values():
@@ -1213,7 +1215,7 @@ if __name__ == '__main__':
     test_scalar_subexpression()
     test_indices()
     test_repr()
-    test_ipython_html()    
+    test_ipython_html()
     test_get_dtype()
     if prefs.codegen.target == 'numpy':
         test_aliasing_in_statements()

--- a/docs_sphinx/user/models.rst
+++ b/docs_sphinx/user/models.rst
@@ -118,6 +118,28 @@ For shared variables, such string expressions can only refer to shared values:
     >>> print G.shared_input
     <neurongroup.shared_input: 4.2579690100000001 * mvolt>
 
+Sometimes it can be convenient to access multiple state variables at once, e.g.
+to set initial values from a dictionary of values or to store all the values of
+a group on disk. This can be done with the `Group.get_states` and
+`Group.set_states` methods:
+
+.. doctest::
+
+    >>> group = NeuronGroup(5, '''dv/dt = -v/tau : 1
+    ...                           tau : second''')
+    >>> initial_values = {'v': [0, 1, 2, 3, 4],
+    ...                   'tau': [10, 20, 10, 20, 10]*ms}
+    >>> group.set_states(initial_values)
+    >>> group.v[:]
+    array([ 0.,  1.,  2.,  3.,  4.])
+    >>> group.tau[:]
+    array([ 10.,  20.,  10.,  20.,  10.]) * msecond
+    >>> states = group.get_states()
+    >>> states['v']
+    array([ 0.,  1.,  2.,  3.,  4.])
+    >>> sorted(states.keys())
+    ['N', 'dt', 'i', 't', 'tau', 'v']
+
 
 Subgroups
 ---------

--- a/docs_sphinx/user/recording.rst
+++ b/docs_sphinx/user/recording.rst
@@ -6,6 +6,10 @@ Specifically, spikes are recorded with `SpikeMonitor`, the time evolution of
 variables with `StateMonitor` and the firing rate of a population of neurons
 with `PopulationRateMonitor`.
 
+Note that all monitors are implement as "groups", so you can get all the stored
+values in a monitor with the `Group.get_states` method, which can be useful to
+dump all recorded data to disk, for example.
+
 Recording spikes
 ----------------
 


### PR DESCRIPTION
...aaand this is ready to merge as well. It makes the `get_states` method more useful, in particular it fixes it for `StateMonitor`. This is a small detail but it makes it much easier to dump everything that a `StateMonitor` recorded to disk, which is something that quite a few users want to do, I think.