### PR TITLE
[MRG] Treat `i` and `t` in the same way as other variables in `StateMonitor`

### DIFF
--- a/brian2/codegen/runtime/cython_rt/templates/spikemonitor.pyx
+++ b/brian2/codegen/runtime/cython_rt/templates/spikemonitor.pyx
@@ -1,7 +1,7 @@
 {% extends 'common.pyx' %}
 
 {% block maincode %}
-    {# USES_VARIABLES { t, i, _clock_t, count,
+    {# USES_VARIABLES { N, _clock_t, count,
                         _source_start, _source_stop} #}
 
     {#  Get the name of the array that stores these events (e.g. the spikespace array) #}
@@ -9,8 +9,6 @@
 
     cdef int _num_events = {{_eventspace}}[_num{{_eventspace}}-1]
     cdef int _start_idx, _end_idx, _curlen, _newlen, _j
-    cdef double[:] _t_view
-    cdef int32_t[:] _i_view
     {% for varname, var in record_variables.items() %}
     cdef {{cpp_dtype(var.dtype)}}[:] _{{varname}}_view
     {% endfor %}
@@ -35,14 +33,10 @@
             # scalar code
             _vectorisation_idx = 1
             {{ scalar_code|autoindent }}
-            # Get the current length and new length of t and i arrays
-            _curlen = {{_dynamic_t}}.shape[0]
+            _curlen = {{N}}[0]
             _newlen = _curlen + _num_events
             # Resize the arrays
             _owner.resize(_newlen)
-            # Get the potentially newly created underlying data arrays
-            _t_view = {{_dynamic_t}}.data
-            _i_view = {{_dynamic_i}}.data
             {% for varname, var in record_variables.items() %}
             _{{varname}}_view = {{get_array_name(var, access_data=False)}}.data
             {% endfor %}
@@ -51,10 +45,9 @@
                 _idx = {{_eventspace}}[_j]
                 _vectorisation_idx = _idx
                 {{ vector_code|autoindent }}
-                _t_view[_curlen + _j - _start_idx] = _clock_t
-                _i_view[_curlen + _j - _start_idx] = _idx - _source_start
                 {% for varname in record_variables %}
                 _{{varname}}_view [_curlen + _j - _start_idx] = _to_record_{{varname}}
                 {% endfor %}
                 {{count}}[_idx - _source_start] += 1
+            {{N}}[0] += _num_events
 {% endblock %}

--- a/brian2/codegen/runtime/numpy_rt/templates/spikemonitor.py_
+++ b/brian2/codegen/runtime/numpy_rt/templates/spikemonitor.py_
@@ -1,4 +1,4 @@
-{# USES_VARIABLES {i, t, count, _clock_t, _source_start, _source_stop} #}
+{# USES_VARIABLES {N, count, _clock_t, _source_start, _source_stop} #}
 import numpy as _numpy
 
 {#  Get the name of the array that stores these events (e.g. the spikespace array) #}
@@ -7,17 +7,13 @@ import numpy as _numpy
 _events = {{_eventspace}}[:{{_eventspace}}[-1]]
 # Take subgroups into account
 _events = _events[(_events >= _source_start) & (_events < _source_stop)]
-_events -= _source_start
 _n_events = len(_events)
 _vectorisation_idx = 1
 {{scalar_code|autoindent}}
 if _n_events > 0:
-
-    _curlen = len({{_dynamic_t}})
+    _curlen = {{N}}
     _newlen = _curlen + _n_events
     _owner.resize(_newlen)
-    {{_dynamic_t}}[_curlen:_newlen] = _clock_t
-    {{_dynamic_i}}[_curlen:_newlen] = _events
     _vectorisation_idx = _n_events
     _idx = _events
     {{vector_code|autoindent}}
@@ -25,4 +21,5 @@ if _n_events > 0:
     {% set dynamic_varname = get_array_name(var, access_data=False) %}
     {{dynamic_varname}}[_curlen:_newlen] = _to_record_{{varname}}
     {% endfor %}
-    {{count}}[_events] += 1
+    {{count}}[_events - _source_start] += 1
+    {{N}} += _n_events

--- a/brian2/codegen/runtime/weave_rt/templates/spikemonitor.cpp
+++ b/brian2/codegen/runtime/weave_rt/templates/spikemonitor.cpp
@@ -2,7 +2,7 @@
 {% macro main() %}
     {{ common.insert_pointers_lines() }}
 
-    {# USES_VARIABLES { t, i, _clock_t, count,
+    {# USES_VARIABLES { N, _clock_t, count,
                         _source_start, _source_stop} #}
     {#  Get the name of the array that stores these events (e.g. the spikespace array) #}
     {% set _eventspace = get_array_name(eventspace_variable) %}
@@ -34,17 +34,12 @@
         if (_num_events > 0) {
             const int _vectorisation_idx = 1;
             {{scalar_code|autoindent}}
-            // Get the current length and new length of t and i arrays
-            const int _curlen = {{_dynamic_t}}.attr("shape")[0];
+            const int _curlen = {{N}}[0];
             const int _newlen = _curlen + _num_events;
             // Resize the arrays
             py::tuple _newlen_tuple(1);
             _newlen_tuple[0] = _newlen;
             _owner.mcall("resize", _newlen_tuple);
-            // Get the potentially newly created underlying data arrays
-            double *_t_data = (double*)(((PyArrayObject*)(PyObject*){{_dynamic_t}}.attr("data"))->data);
-            // TODO: How to get the correct datatype automatically here?
-            npy_int32 *_i_data = (npy_int32*)(((PyArrayObject*)(PyObject*){{_dynamic_i}}.attr("data"))->data);
             {% for varname, var in record_variables.items() %}
             {{c_data_type(var.dtype)}}* _{{varname}}_data = ({{c_data_type(var.dtype)}}*)(((PyArrayObject*)(PyObject*){{get_array_name(var, access_data=False)}}.attr("data"))->data);
             {% endfor %}
@@ -54,13 +49,12 @@
                 const int _idx = {{_eventspace}}[_j];
                 const int _vectorisation_idx = _idx;
                 {{vector_code|autoindent}}
-                _t_data[_curlen + _j - _start_idx] = _clock_t;
-                _i_data[_curlen + _j - _start_idx] = _idx - _source_start;
                 {% for varname in record_variables | sort%}
                 _{{varname}}_data[_curlen + _j - _start_idx] = _to_record_{{varname}};
                 {% endfor %}
                 {{count}}[_idx - _source_start]++;
             }
+            {{N}}[0] += _num_events;
         }
 	}
 {% endmacro %}

--- a/brian2/devices/cpp_standalone/templates/spikemonitor.cpp
+++ b/brian2/devices/cpp_standalone/templates/spikemonitor.cpp
@@ -3,7 +3,7 @@
 
 {% block maincode %}
 	//// MAIN CODE ////////////
-    {# USES_VARIABLES { t, i, _clock_t, count,
+    {# USES_VARIABLES { N, _clock_t, count,
                         _source_start, _source_stop} #}
     {#  Get the name of the array that stores these events (e.g. the spikespace array) #}
     {% set _eventspace = get_array_name(eventspace_variable) %}
@@ -41,13 +41,12 @@
                     const int _idx = {{_eventspace}}[_j];
                     const int _vectorisation_idx = _idx;
                     {{vector_code|autoindent}}
-                    {{_dynamic_i}}.push_back(_idx-_source_start);
-                    {{_dynamic_t}}.push_back(_clock_t);
                     {% for varname, var in record_variables.items() %}
                     {{get_array_name(var, access_data=False)}}.push_back(_to_record_{{varname}});
                     {% endfor %}
                     {{count}}[_idx-_source_start]++;
                 }
+                {{N}}[0] += _num_events;
             }
         }
     }
@@ -58,7 +57,10 @@
 void _debugmsg_{{codeobj_name}}()
 {
 	using namespace brian;
-	std::cout << "Number of spikes: " << {{_dynamic_i}}.size() << endl;
+	{# We need the pointers and constants here to get the access to N working #}
+    %CONSTANTS%
+    {{pointers_lines|autoindent}}
+	std::cout << "Number of spikes: " << {{N}}[0] << endl;
 }
 {% endblock %}
 

--- a/brian2/monitors/spikemonitor.py
+++ b/brian2/monitors/spikemonitor.py
@@ -314,7 +314,7 @@ class EventMonitor(Group, CodeRunner):
         '''
         Returns the total number of recorded events.
         '''
-        return self.N
+        return self.N[:]
 
     def __repr__(self):
         description = '<{classname}, recording event "{event}" from {source}>'

--- a/brian2/monitors/spikemonitor.py
+++ b/brian2/monitors/spikemonitor.py
@@ -4,7 +4,6 @@ import numpy as np
 
 from brian2.core.variables import Variables
 from brian2.core.names import Nameable
-from brian2.units.allunits import second
 from brian2.units.fundamentalunits import Unit, Quantity
 from brian2.groups.group import CodeRunner, Group
 
@@ -25,14 +24,14 @@ class EventMonitor(Group, CodeRunner):
     ----------
     source : `NeuronGroup`
         The source of events to record.
-    record : bool
-        Whether or not to record each event in `i` and `t` (the `count` will
-        always be recorded).
     event : str
         The name of the event to record
     variables : str or sequence of str, optional
         Which variables to record at the time of the event (in addition to the
         index of the neuron). Can be the name of a variable or a list of names.
+    record : bool, optional
+        Whether or not to record each event in `i` and `t` (the `count` will
+        always be recorded). Defaults to ``True``.
     when : str, optional
         When to record the events, by default records events in the same slot
         where the event is emitted.
@@ -53,10 +52,13 @@ class EventMonitor(Group, CodeRunner):
     invalidates_magic_network = False
     add_to_magic_network = True
 
-    def __init__(self, source, event, variables=None, when=None, order=None,
-                 name='eventmonitor*', codeobj_class=None):
+    def __init__(self, source, event, variables=None, record=True,
+                 when=None, order=None, name='eventmonitor*',
+                 codeobj_class=None):
         #: The source we are recording from
         self.source = source
+        #: Whether to record times and indices of events
+        self.record = record
 
         if when is None:
             if order is not None:
@@ -74,17 +76,20 @@ class EventMonitor(Group, CodeRunner):
         self.event = event
 
         if variables is None:
-            variables = []
+            variables = {}
         elif isinstance(variables, basestring):
-            variables = [variables]
+            variables = {variables}
 
         #: The additional variables that will be recorded
-        self.record_variables = variables
+        self.record_variables = set(variables)
 
         for variable in variables:
             if variable not in source.variables:
                 raise ValueError(("'%s' is not a variable of the recorded "
                                   "group" % variable))
+
+        if self.record:
+            self.record_variables |= {'i', 't'}
 
         # Some dummy code so that code generation takes care of the indexing
         # and subexpressions
@@ -107,10 +112,7 @@ class EventMonitor(Group, CodeRunner):
 
         self.variables = Variables(self)
         self.variables.add_reference(eventspace_name, source)
-        self.variables.add_dynamic_array('i', size=0, unit=Unit(1),
-                                         dtype=np.int32, constant_size=False)
-        self.variables.add_dynamic_array('t', size=0, unit=second,
-                                         constant_size=False)
+
         for variable in self.record_variables:
             source_var = source.variables[variable]
             self.variables.add_reference('_source_%s' % variable,
@@ -122,20 +124,21 @@ class EventMonitor(Group, CodeRunner):
                                              unit=source_var.unit,
                                              dtype=source_var.dtype,
                                              constant_size=False)
-        self.variables.add_arange('_source_i', size=len(source))
+        self.variables.add_arange('_source_idx', size=len(source))
         self.variables.add_array('count', size=len(source), unit=Unit(1),
                                  dtype=np.int32, read_only=True,
-                                 index='_source_i')
+                                 index='_source_idx')
         self.variables.add_constant('_source_start', Unit(1), start)
         self.variables.add_constant('_source_stop', Unit(1), stop)
-        self.variables.add_attribute_variable('N', unit=Unit(1), obj=self,
-                                              attribute='_N', dtype=np.int32)
+        self.variables.add_array('N', unit=Unit(1), size=1, dtype=np.int32,
+                                 read_only=True, scalar=True)
 
         record_variables = {varname: self.variables[varname]
                             for varname in self.record_variables}
         template_kwds = {'eventspace_variable': source.variables[eventspace_name],
-                         'record_variables': record_variables}
-        needed_variables = [eventspace_name] + self.record_variables
+                         'record_variables': record_variables,
+                         'record': self.record}
+        needed_variables = {eventspace_name} | self.record_variables
         CodeRunner.__init__(self, group=self, code=code, template='spikemonitor',
                             name=None,  # The name has already been initialized
                             clock=source.clock, when=when,
@@ -148,18 +151,12 @@ class EventMonitor(Group, CodeRunner):
         self.add_dependency(source)
         self._enable_group_attributes()
 
-    @property
-    def _N(self):
-        return len(self.variables['t'].get_value())
-
     def resize(self, new_size):
-        self.variables['i'].resize(new_size)
-        self.variables['t'].resize(new_size)
         for variable in self.record_variables:
             self.variables[variable].resize(new_size)
 
     def __len__(self):
-        return self._N
+        return self.N
 
     def reinit(self):
         '''
@@ -172,6 +169,10 @@ class EventMonitor(Group, CodeRunner):
         '''
         Returns the pair (`i`, `t`).
         '''
+        if not self.record:
+            raise AttributeError('Indices and times have not been recorded.'
+                                 'Set the record argument to True to record '
+                                 'them.')
         return self.i, self.t
 
     @property
@@ -179,6 +180,11 @@ class EventMonitor(Group, CodeRunner):
         '''
         Returns the pair (`i`, `t_`).
         '''
+        if not self.record:
+            raise AttributeError('Indices and times have not been recorded.'
+                                 'Set the record argument to True to record '
+                                 'them.')
+
         return self.i, self.t_
 
     def _values_dict(self, first_pos, sort_indices, used_indices, var):
@@ -231,6 +237,10 @@ class EventMonitor(Group, CodeRunner):
         >>> v_values[1]
         array([ 1.,  1.])
         '''
+        if not self.record:
+            raise AttributeError('Indices and times have not been recorded.'
+                                 'Set the record argument to True to record '
+                                 'them.')
         indices = self.i[:]
         sort_indices = np.argsort(indices)
         used_indices, first_pos = np.unique(self.i[:][sort_indices],
@@ -266,12 +276,16 @@ class EventMonitor(Group, CodeRunner):
         >>> all_values['v'][0]
         array([ 0.5,  0.5,  0.5,  0.5])
         '''
+        if not self.record:
+            raise AttributeError('Indices and times have not been recorded.'
+                                 'Set the record argument to True to record '
+                                 'them.')
         indices = self.i[:]
         sort_indices = np.argsort(indices)
         used_indices, first_pos = np.unique(self.i[:][sort_indices],
                                             return_index=True)
         all_values_dict = {}
-        for varname in ['t'] + self.record_variables:
+        for varname in self.record_variables - {'i'}:
             all_values_dict[varname] = self._values_dict(first_pos,
                                                          sort_indices,
                                                          used_indices,
@@ -300,13 +314,14 @@ class EventMonitor(Group, CodeRunner):
         '''
         Returns the total number of recorded events.
         '''
-        return self._N
+        return self.N
 
     def __repr__(self):
         description = '<{classname}, recording event "{event}" from {source}>'
         return description.format(classname=self.__class__.__name__,
                                   event=self.event,
                                   source=self.group.name)
+
 
 class SpikeMonitor(EventMonitor):
     '''
@@ -323,12 +338,12 @@ class SpikeMonitor(EventMonitor):
     ----------
     source : (`NeuronGroup`, `SpikeSource`)
         The source of spikes to record.
-    record : bool
-        Whether or not to record each spike in `i` and `t` (the `count` will
-        always be recorded).
     variables : str or sequence of str, optional
         Which variables to record at the time of the spike (in addition to the
         index of the neuron). Can be the name of a variable or a list of names.
+    record : bool, optional
+        Whether or not to record each spike in `i` and `t` (the `count` will
+        always be recorded). Defaults to ``True``.
     when : str, optional
         When to record the events, by default records events in the same slot
         where the event is emitted.
@@ -367,11 +382,11 @@ class SpikeMonitor(EventMonitor):
     >>> crossings.v
     <crossings.v: array([ 0.00995017,  0.13064176,  0.27385096,  0.39950442])>
     '''
-    def __init__(self, source, variables=None, when=None, order=None,
-             name='spikemonitor*', codeobj_class=None):
+    def __init__(self, source, variables=None, record=True, when=None,
+                 order=None, name='spikemonitor*', codeobj_class=None):
         super(SpikeMonitor, self).__init__(source, event='spike',
-                                           variables=variables, when=when,
-                                           order=order, name=name,
+                                           variables=variables, record=record,
+                                           when=when, order=order, name=name,
                                            codeobj_class=codeobj_class)
 
     @property

--- a/docs_sphinx/user/recording.rst
+++ b/docs_sphinx/user/recording.rst
@@ -36,6 +36,11 @@ Example::
     run(runtime)
     plot(M.t/ms, M.i, '.')
 
+If you are only interested in summary statistics but not the individual spikes,
+you can set the ``record`` argument to ``False``. You will then not have access
+to ``i`` and ``t`` but you can still get the ``count`` and the total number of
+spikes (``num_spikes``).
+
 .. _recording_variables_spike_time:
 
 Recording variables at spike time


### PR DESCRIPTION
Do not record them with `record=False`.

Closes #510

Unfortunately this will break templates for other devices (CC @tnowotny @moritzaugustin @Kwartke). For full support (including the new support for recording arbitrary variables introduced with #498), the templates have to be adapted analogue to the C++ standalone templates. Alternatively, a quick fix would be to raise a `NotImplementedError` if `SpikeMonitor.record` is False and/or `SpikeMonitor.record_variables` is not simply `{'i', 't'}`. 