### PR TITLE
[MRG] Provide `get_states`/`set_states`  methods for networks

### DIFF
--- a/brian2/core/magic.py
+++ b/brian2/core/magic.py
@@ -246,6 +246,27 @@ class MagicNetwork(Network):
         super(MagicNetwork, self).restore(name=name)
         self.objects[:] = []
 
+    def get_states(self, units=True, format='dict', subexpressions=False,
+                   level=0):
+        '''
+        See `Network.get_states`.
+        '''
+        self._update_magic_objects(level=level+1)
+        states = super(MagicNetwork, self).get_states(units, format,
+                                                      subexpressions,
+                                                      level=level+1)
+        self.objects[:] = []
+        return states
+
+    def set_states(self, values, units=True, format='dict', level=0):
+        '''
+        See `Network.set_states`.
+        '''
+        self._update_magic_objects(level=level+1)
+        super(MagicNetwork, self).set_states(values, units, format,
+                                             level=level+1)
+        self.objects[:] = []
+
     def __str__(self):
         return 'MagicNetwork()'
     __repr__ = __str__

--- a/brian2/groups/group.py
+++ b/brian2/groups/group.py
@@ -419,7 +419,7 @@ class Group(BrianObject):
         object.__setattr__(self, name, None)
 
     def get_states(self, vars=None, units=True, format='dict',
-                   subexpressions=False, level=0):
+                   subexpressions=False, read_only_variables=True, level=0):
         '''
         Return a copy of the current state variable values. The returned arrays
         are copies of the actual arrays that store the state variable values,
@@ -442,6 +442,11 @@ class Group(BrianObject):
             Whether to return subexpressions when no list of variable names
             is given. Defaults to ``False``. This argument is ignored if an
             explicit list of variable names is given in ``vars``.
+        read_only_variables : bool, optional
+            Whether to return read-only variables (e.g. the number of neurons,
+            the time, etc.). Setting it to ``False`` will assure that the
+            returned state can later be used with `set_states`. Defaults to
+            ``True``.
         level : int, optional
             How much higher to go up the stack to resolve external variables.
             Only relevant if extracting subexpressions that refer to external
@@ -460,7 +465,8 @@ class Group(BrianObject):
         if vars is None:
             vars = [name for name, var in self.variables.iteritems()
                     if not name.startswith('_') and
-                    (subexpressions or not isinstance(var, Subexpression))]
+                    (subexpressions or not isinstance(var, Subexpression)) and
+                    (read_only_variables or not getattr(var, 'read_only', False))]
         data = {}
         for var in vars:
             data[var] = np.array(self.state(var, use_units=units,

--- a/brian2/tests/test_network.py
+++ b/brian2/tests/test_network.py
@@ -858,6 +858,25 @@ def test_continuation():
 
 @attr('codegen-independent')
 @with_setup(teardown=restore_initial_state)
+def test_get_set_states():
+    G = NeuronGroup(10, 'v:1', name='a_neurongroup')
+    G.v = 'i'
+    net = Network(G)
+    states1 = net.get_states()
+    states2 = magic_network.get_states()
+    states3 = net.get_states(read_only_variables=False)
+    assert set(states1.keys()) == set(states2.keys()) == set(states3.keys()) == {'a_neurongroup'}
+    assert set(states1['a_neurongroup'].keys()) == set(states2['a_neurongroup'].keys()) == {'i', 'dt', 'N', 't', 'v'}
+    assert set(states3['a_neurongroup']) == {'v'}
+
+    # Try re-setting the state
+    G.v = 0
+    net.set_states(states3)
+    assert_equal(G.v, np.arange(10))
+
+
+@attr('codegen-independent')
+@with_setup(teardown=restore_initial_state)
 def test_multiple_runs_defaultclock():
     defaultclock.dt = 0.1*ms
     G = NeuronGroup(1, 'dv/dt = -v / (10*ms) : 1')
@@ -971,6 +990,7 @@ if __name__=='__main__':
             test_defaultclock_dt_changes,
             test_dt_restore,
             test_continuation,
+            test_get_set_states,
             test_multiple_runs_defaultclock,
             test_multiple_runs_defaultclock_incorrect,
             test_profile,


### PR DESCRIPTION
This allows to conveniently get/set the states for all objects in a network. This is related to #29 but it is not a solution for it (see my comment there).