### PR TITLE
[MRG] Change some tests from long to short and raise error for float32

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -72,10 +72,9 @@ install:
     conda create -n travis_conda --yes pip python=$PYTHON numpy scipy nose sphinx ipython sympy pyparsing jinja2 setuptools coverage;
     fi
   - source activate travis_conda
-  - conda update --yes pip setuptools
   - if [[ $CYTHON == 'yes' ]]; then conda install --yes cython; SETUP_ARGS=--with-cython; else SETUP_ARGS=''; fi
   - if [[ $REPORT_COVERAGE == 'yes' ]]; then pip install -q coveralls; fi
-  - python setup.py install $SETUP_ARGS --fail-on-error
+  - python setup.py install $SETUP_ARGS --fail-on-error --single-version-externally-managed --record=record.txt
   - if [[ $DOCS_ONLY == 'yes' ]]; then
       pip install -q sphinxcontrib-issuetracker;
       python setup.py sdist;

--- a/brian2/core/core_preferences.py
+++ b/brian2/core/core_preferences.py
@@ -10,13 +10,19 @@ from brian2.core.preferences import BrianPreference, prefs
 def dtype_repr(dtype):
     return dtype.__name__
 
+def default_float_dtype_validator(dtype):
+    return dtype is float64
+
 prefs.register_preferences('core', 'Core Brian preferences',
     default_float_dtype=BrianPreference(
         default=float64,
         docs='''
         Default dtype for all arrays of scalars (state variables, weights, etc.).
+
+        Currently, this is not supported (only float64 can be used).
         ''',
         representor=dtype_repr,
+        validator=default_float_dtype_validator,
         ),
     default_integer_dtype=BrianPreference(
         default=int32,

--- a/brian2/tests/test_functions.py
+++ b/brian2/tests/test_functions.py
@@ -30,17 +30,21 @@ def test_constants_values():
     assert G.v == np.inf
 
 
-def test_math_functions_short():
+def test_math_functions():
     '''
     Test that math functions give the same result, regardless of whether used
-    directly or in generated Python or C++ code. Test only a few functions
+    directly or in generated Python or C++ code.
     '''
     default_dt = defaultclock.dt
     test_array = np.array([-1, -0.5, 0, 0.5, 1])
 
     with catch_logs() as _:  # Let's suppress warnings about illegal values
         # Functions with a single argument
-        for func in [exp, np.sqrt]:
+        for func in [cos, tan, sinh, cosh, tanh,
+                     arcsin, arccos, arctan,
+                     log, log10,
+                     exp, np.sqrt,
+                     np.ceil, np.floor, np.sign]:
 
             # Calculate the result directly
             numpy_result = func(test_array)
@@ -77,44 +81,6 @@ def test_math_functions_short():
             G = NeuronGroup(len(test_array),
                             '''func = variable {op} scalar : 1
                                variable : 1'''.format(op=operator))
-            G.variable = test_array
-            mon = StateMonitor(G, 'func', record=True)
-            net = Network(G, mon)
-            net.run(default_dt)
-
-            assert_allclose(numpy_result, mon.func_.flatten(),
-                            err_msg='Function %s did not return the correct values' % func.__name__)
-
-
-def test_math_functions():
-    '''
-    Test that math functions give the same result, regardless of whether used
-    directly or in generated Python or C++ code. Tests the remaining functions
-    that were not yet tested by test_math_functions_short
-    '''
-    default_dt = defaultclock.dt
-    test_array = np.array([-1, -0.5, 0, 0.5, 1])
-
-    with catch_logs() as _:  # Let's suppress warnings about illegal values
-        # Functions with a single argument
-        for func in [cos, tan, sinh, cosh, tanh,
-                     arcsin, arccos, arctan,
-                     log, log10,
-                     np.ceil, np.floor, np.sign]:
-
-            # Calculate the result directly
-            numpy_result = func(test_array)
-
-            # Calculate the result in a somewhat complicated way by using a
-            # subexpression in a NeuronGroup
-            if func.__name__ == 'absolute':
-                # we want to use the name abs instead of absolute
-                func_name = 'abs'
-            else:
-                func_name = func.__name__
-            G = NeuronGroup(len(test_array),
-                            '''func = {func}(variable) : 1
-                               variable : 1'''.format(func=func_name))
             G.variable = test_array
             mon = StateMonitor(G, 'func', record=True)
             net = Network(G, mon)
@@ -540,7 +506,6 @@ if __name__ == '__main__':
     for f in [
             test_constants_sympy,
             test_constants_values,
-            test_math_functions_short,
             test_math_functions,
             test_user_defined_function,
             test_user_defined_function_units,

--- a/brian2/tests/test_functions.py
+++ b/brian2/tests/test_functions.py
@@ -86,7 +86,6 @@ def test_math_functions_short():
                             err_msg='Function %s did not return the correct values' % func.__name__)
 
 
-@attr('long')
 def test_math_functions():
     '''
     Test that math functions give the same result, regardless of whether used
@@ -535,6 +534,9 @@ def test_binomial():
 
 
 if __name__ == '__main__':
+    from brian2 import prefs
+    #prefs.codegen.target = 'weave'
+    import time
     for f in [
             test_constants_sympy,
             test_constants_values,
@@ -554,6 +556,8 @@ if __name__ == '__main__':
             test_binomial
             ]:
         try:
+            start = time.time()
             f()
+            print 'Test', f.__name__, 'took', time.time()-start
         except SkipTest as e:
             print 'Skipping test', f.__name__, e

--- a/brian2/tests/test_spikegenerator.py
+++ b/brian2/tests/test_spikegenerator.py
@@ -375,6 +375,11 @@ def test_spikegenerator_standalone_change_period(with_output=False):
 
 
 if __name__ == '__main__':
+    from brian2 import prefs
+    # prefs.codegen.target = 'cython'
+    import time
+    start = time.time()
+
     test_spikegenerator_connected()
     test_spikegenerator_basic()
     test_spikegenerator_basic_sorted()
@@ -394,3 +399,5 @@ if __name__ == '__main__':
              ]:
         t(with_output=True)
         restore_device()
+
+    print 'Tests took', time.time()-start

--- a/brian2/tests/test_stateupdaters.py
+++ b/brian2/tests/test_stateupdaters.py
@@ -76,7 +76,6 @@ def test_multiple_noise_variables_basic():
         assert 'xi_2' in code
 
 
-@attr('long')
 def test_multiple_noise_variables_extended():
     # Some actual simulations with multiple noise variables
     eqs = '''dx/dt = y : 1
@@ -126,7 +125,6 @@ def restore_randn():
     DEFAULT_FUNCTIONS['randn'] = old_randn
 
 
-@attr('long')
 @with_setup(setup=store_randn, teardown=restore_randn)
 def test_multiple_noise_variables_deterministic_noise():
     # The "random" values are always 0.5
@@ -533,7 +531,6 @@ def test_subexpressions_basic():
     assert_equal(mon1.v, mon2.v, 'Results for method %s differed!' % method)
 
 
-@attr('long')
 def test_subexpressions():
     '''
     Make sure that the integration of a (non-stochastic) differential equation
@@ -619,6 +616,11 @@ def test_locally_constant_check():
     net.run(0*ms)
 
 if __name__ == '__main__':
+    from brian2 import prefs
+    # prefs.codegen.target = 'cython'
+    import time
+    start = time.time()
+
     test_determination()
     test_explicit_stateupdater_parsing()
     test_non_autonomous_equations()
@@ -636,3 +638,5 @@ if __name__ == '__main__':
     test_registration()
     test_subexpressions()
     test_locally_constant_check()
+
+    print 'Tests took', time.time()-start

--- a/brian2/tests/test_synapses.py
+++ b/brian2/tests/test_synapses.py
@@ -826,7 +826,7 @@ def test_event_driven():
     S2.w = 0.5*gmax
     run(25*ms)
     # The two formulations should yield identical results
-    assert_equal(S1.w[:], S2.w[:])
+    assert_allclose(S1.w[:], S2.w[:])
 
 
 @attr('codegen-independent')

--- a/brian2/tests/test_synapses.py
+++ b/brian2/tests/test_synapses.py
@@ -170,7 +170,6 @@ def test_connection_string_deterministic_basic():
     _compare(S, expected)
 
 
-@attr('long')
 def test_connection_string_deterministic():
     '''
     Test connecting synapses with a deterministic string expression.
@@ -250,7 +249,6 @@ def test_connection_random_basic():
     _compare(S, np.ones((len(G), len(G2))))
 
 
-@attr('long')
 def test_connection_random():
     '''
     Test random connections.
@@ -546,7 +544,6 @@ def test_invalid_custom_event():
     assert_raises(ValueError, lambda: Synapses(group2, group2, pre='v+=1',
                                                on_event='custom'))
 
-@attr('long')
 def test_transmission():
     default_dt = defaultclock.dt
     delays = [[0, 0] * ms, [1, 1] * ms, [1, 2] * ms]
@@ -783,7 +780,7 @@ def test_external_variables():
     assert target.v[0] == 2
 
 
-@attr('long', 'standalone-compatible')
+@attr('standalone-compatible')
 @with_setup(teardown=restore_device)
 def test_event_driven():
     # Fake example, where the synapse is actually not changing the state of the
@@ -1007,6 +1004,11 @@ def test_vectorisation_STDP_like():
 
 
 if __name__ == '__main__':
+    from brian2 import prefs
+    # prefs.codegen.target = 'numpy'
+    import time
+    start = time.time()
+
     test_creation()
     test_name_clashes()
     test_incoming_outgoing()
@@ -1042,3 +1044,5 @@ if __name__ == '__main__':
     test_permutation_analysis()
     test_vectorisation()
     test_vectorisation_STDP_like()
+
+    print 'Tests took', time.time()-start

--- a/dev/conda-recipe/bld.bat
+++ b/dev/conda-recipe/bld.bat
@@ -1,4 +1,4 @@
 xcopy /I /Y /e "%RECIPE_DIR%\..\..\brian2" "%SRC_DIR%\brian2\"
 xcopy "%RECIPE_DIR%\..\..\setup.py" "%SRC_DIR%"
-"%PYTHON%" "%SRC_DIR%"\setup.py install --with-cython --fail-on-error
+"%PYTHON%" "%SRC_DIR%"\setup.py install --with-cython --fail-on-error --single-version-externally-managed --record=record.txt
 if errorlevel 1 exit 1

--- a/dev/conda-recipe/build.sh
+++ b/dev/conda-recipe/build.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 cp -r $RECIPE_DIR/../../brian2 $SRC_DIR
 cp $RECIPE_DIR/../../setup.py $SRC_DIR
-$PYTHON $SRC_DIR/setup.py install --with-cython --fail-on-error
+$PYTHON $SRC_DIR/setup.py install --with-cython --fail-on-error --single-version-externally-managed --record=record.txt

--- a/dev/conda-recipe/meta.yaml
+++ b/dev/conda-recipe/meta.yaml
@@ -8,6 +8,7 @@ requirements:
     - python
     - cython >=0.18
     - setuptools >=6.0
+    - markupsafe
     - numpy
     - sympy >=0.7.6
     - pyparsing

--- a/examples/adaptive_threshold.py
+++ b/examples/adaptive_threshold.py
@@ -1,8 +1,8 @@
-from brian2 import *
 '''
 A model with adaptive threshold (increases with each spike)
 '''
-#set_device('cpp_standalone_simple')
+from brian2 import *
+
 eqs = '''
 dv/dt = -v/(10*ms) : volt
 dvt/dt = (10*mV-vt)/(15*ms) : volt


### PR DESCRIPTION
Somehow my changes for these two separate issues ended up in the same branch, but I think it's fine because they're both small changes. For float32 it's very simple, no more comment needed I think. When this is merged we can remove the 2.0 milestone for issue #417 but not close it. Detailed comments for long to short tests below.

I changed some tests from long to short. Here are the test timings on my computer. All times include compilation from scratch for numpy/weave/cython. The ones I changed are marked with CHANGED TO SHORT. Some tests probably don't need to be run for all of numpy/weave/cython, and I've marked those with ONLY NEEDS ONE. Perhaps we could have a new attr like 'long-for-cython', etc.

Total time added on my machine: ~9m. That's quite annoying I guess but it's valuable and I think that probably keeps us under the limit still for the CIs?

```
test_functions.py
	test_math_functions: CHANGE TO SHORT (because it's an important test for regressions)
		numpy: 1.5s
		weave: 29s
		cython: 77s
		
test_spatialneuron.py:
	6 tests marked long, didn't check yet because it's not clear if this will be
	officially marked as 'experimental' in 2.0
	
test_spikegenerator.py:
	test_spikegenerator_rounding_long: total is too long
		numpy: ~5m
		weave: ~3m
		cython: ~3m
	test_spikegenerator_rounding_period: total is too long
		numpy: ~4m
		weave: ~4m
		cython: ~3m
		
test_stateupdaters.py:
	test_multiple_noise_variables_extended: CHANGE TO SHORT, ONLY NEEDS ONE
		numpy: 1.8s
		weave: 16s
		cython: 33s
	test_multiple_noise_variables_deterministic_noise: CHANGE TO SHORT, ONLY NEEDS ONE
		numpy: 1.8s
		weave: 14s
		cython: 16s
	test_subexpressions: CHANGE TO SHORT, ONLY NEEDS ONE
		numpy: 3.5s
		weave: 23s
		cython: 32s
		
test_synapses.py:
	test_connection_string_deterministic: CHANGE TO SHORT
		numpy: 1.2s
		weave: 23s
		cython: 47s
	test_connection_random: CHANGE TO SHORT
		numpy: 1.3s
		weave: 22s
		cython: 52s
	test_transmission: CHANGE TO SHORT
		numpy: 2.3s
		weave: 45s
		cython: 50s
	test_event_driven: CHANGE TO SHORT, ONLY NEEDS ONE
		numpy: 4.3s
		weave: 16s
		cython: 24s
```

Fixes #504.