### PR TITLE
[WIP] Derivable templates

### DIFF
--- a/brian2/codegen/generators/cpp_generator.py
+++ b/brian2/codegen/generators/cpp_generator.py
@@ -110,6 +110,12 @@ class CPPCodeGenerator(CodeGenerator):
 
     class_name = 'cpp'
 
+    universal_support_code = '''
+    template<class T1, class T2> long _brian_mod(T1 x, T2 y) { return x%y; };
+    template<class T1> double _brian_mod(T1 x, double y) { return fmod((double)x, (double)y); };
+    template<class T2> double _brian_mod(double x, T2 y) { return fmod((double)x, (double)y); };
+    '''
+
     def __init__(self, *args, **kwds):
         super(CPPCodeGenerator, self).__init__(*args, **kwds)
         self.c_data_type = c_data_type
@@ -330,6 +336,9 @@ class CPPCodeGenerator(CodeGenerator):
             if func_namespace is not None:
                 self.variables.update(func_namespace)
 
+        support_code.append(self.universal_support_code)
+
+
         keywords = {'pointers_lines': stripped_deindented_lines('\n'.join(pointers)),
                     'support_code_lines': stripped_deindented_lines('\n'.join(support_code)),
                     'hashdefine_lines': stripped_deindented_lines('\n'.join(hash_defines)),
@@ -350,7 +359,6 @@ for func in ['sin', 'cos', 'tan', 'sinh', 'cosh', 'tanh', 'exp', 'log',
 
 # Functions that need a name translation
 for func, func_cpp in [('arcsin', 'asin'), ('arccos', 'acos'), ('arctan', 'atan'),
-                       ('mod', 'fmod'),
                        ]:
     DEFAULT_FUNCTIONS[func].implementations.add_implementation(CPPCodeGenerator,
                                                                code=None,

--- a/brian2/codegen/generators/cpp_generator.py
+++ b/brian2/codegen/generators/cpp_generator.py
@@ -111,9 +111,10 @@ class CPPCodeGenerator(CodeGenerator):
     class_name = 'cpp'
 
     universal_support_code = '''
-    template<class T1, class T2> long _brian_mod(T1 x, T2 y) { return x%y; };
-    template<class T1> double _brian_mod(T1 x, double y) { return fmod((double)x, (double)y); };
-    template<class T2> double _brian_mod(double x, T2 y) { return fmod((double)x, (double)y); };
+    // The ((x%y)+y)%y is to get Python semantics of mod
+    template<class T1, class T2> long _brian_mod(T1 x, T2 y) { return ((x%y)+y)%y; };
+    template<class T1> double _brian_mod(T1 x, double y) { return fmod(fmod((double)x, (double)y)+y, y); };
+    template<class T2> double _brian_mod(double x, T2 y) { return fmod(fmod((double)x, (double)y)+y, y); };
     '''
 
     def __init__(self, *args, **kwds):

--- a/brian2/codegen/generators/cython_generator.py
+++ b/brian2/codegen/generators/cython_generator.py
@@ -279,7 +279,7 @@ for func in ['sin', 'cos', 'tan', 'sinh', 'cosh', 'tanh', 'exp', 'log',
 
 # Functions that need a name translation
 for func, func_cpp in [('arcsin', 'asin'), ('arccos', 'acos'), ('arctan', 'atan'),
-                       ('abs', 'fabs'), ('mod', 'fmod')]:
+                       ('abs', 'fabs')]:
     DEFAULT_FUNCTIONS[func].implementations.add_implementation(CythonCodeGenerator,
                                                                code=None,
                                                                name=func_cpp)

--- a/brian2/codegen/runtime/cython_rt/templates/common.pyx
+++ b/brian2/codegen/runtime/cython_rt/templates/common.pyx
@@ -1,6 +1,6 @@
 #cython: boundscheck=False
 #cython: wraparound=False
-#cython: cdivision=True
+#cython: cdivision=False
 #cython: infer_types=True
 
 import numpy as _numpy

--- a/brian2/parsing/rendering.py
+++ b/brian2/parsing/rendering.py
@@ -234,6 +234,9 @@ class CPPNodeRenderer(NodeRenderer):
         if node.op.__class__.__name__=='Pow':
             return 'pow(%s, %s)' % (self.render_node(node.left),
                                     self.render_node(node.right))
+        elif node.op.__class__.__name__=='Mod':
+            return '_brian_mod(%s, %s)' % (self.render_node(node.left),
+                                           self.render_node(node.right))
         else:
             return NodeRenderer.render_BinOp(self, node)
 

--- a/brian2/parsing/sympytools.py
+++ b/brian2/parsing/sympytools.py
@@ -80,6 +80,8 @@ class CustomSympyPrinter(StrPrinter):
         # Special workaround for the int function
         if expr.func.__name__ == 'int_':
             return "int(%s)" % self.stringify(expr.args, ", ")
+        elif expr.func.__name__ == 'mod':
+            return '((%s)%%(%s))' % (self.doprint(expr.args[0]), self.doprint(expr.args[1]))
         else:
             return expr.func.__name__ + "(%s)" % self.stringify(expr.args, ", ")
 

--- a/brian2/tests/test_functions.py
+++ b/brian2/tests/test_functions.py
@@ -65,9 +65,7 @@ def test_math_functions_short():
 
         # Functions/operators
         scalar = 3
-        # TODO: We are not testing the modulo operator here since it does
-        #       not work for double values in C
-        for func, operator in [(np.power, '**')]:
+        for func, operator in [(np.power, '**'), (np.mod, '%')]:
 
             # Calculate the result directly
             numpy_result = func(test_array, scalar)

--- a/brian2/tests/test_neurongroup.py
+++ b/brian2/tests/test_neurongroup.py
@@ -55,10 +55,11 @@ def test_integer_variables_and_mod():
     '''
     n = 10
     eqs = '''
-    dv/dt = (a+j+k)/second : 1
+    dv/dt = (a+b+j+k)/second : 1
     j = i%n : integer
     k = i/n : integer
     a = v%(i+1) : 1
+    b = v%(2*v) : 1
     '''
     G = NeuronGroup(100, eqs)
     G.v = np.random.rand(len(G))

--- a/brian2/tests/test_neurongroup.py
+++ b/brian2/tests/test_neurongroup.py
@@ -48,6 +48,24 @@ def test_creation():
     # neither string nor Equations object as model description
     assert_raises(TypeError, lambda: NeuronGroup(1, object()))
 
+@attr('codegen-independent')
+def test_integer_variables_and_mod():
+    '''
+    Test that integer operations and variable definitions work.
+    '''
+    n = 10
+    eqs = '''
+    dv/dt = (a+j+k)/second : 1
+    j = i%n : integer
+    k = i/n : integer
+    a = v%(i+1) : 1
+    '''
+    G = NeuronGroup(100, eqs)
+    G.v = np.random.rand(len(G))
+    run(1*ms)
+    assert_equal(G.j[:], G.i[:]%n)
+    assert_equal(G.k[:], G.i[:]/n)
+    assert_equal(G.a[:], G.v[:]%(G.i[:]+1))
 
 @attr('codegen-independent')
 def test_variables():
@@ -1169,6 +1187,7 @@ def test_random_vector_values():
 
 if __name__ == '__main__':
     test_creation()
+    test_integer_variables_and_mod()
     test_variables()
     test_scalar_variable()
     test_referred_scalar_variable()

--- a/brian2/tests/test_parsing.py
+++ b/brian2/tests/test_parsing.py
@@ -8,6 +8,7 @@ from nose import SkipTest
 from numpy.testing import assert_allclose, assert_raises
 import numpy as np
 
+from brian2.codegen.generators.cpp_generator import CPPCodeGenerator
 from brian2.codegen.runtime.weave_rt.weave_rt import get_compiler_and_args
 from brian2.core.preferences import prefs
 from brian2.core.variables import Constant
@@ -119,6 +120,7 @@ def cpp_evaluator(expr, ns):
     compiler, extra_compile_args = get_compiler_and_args()
     with std_silent():
         return weave.inline('return_val = %s;' % expr, ns.keys(), local_dict=ns,
+                            support_code=CPPCodeGenerator.universal_support_code,
                             compiler=compiler,
                             extra_compile_args=extra_compile_args,
                             extra_link_args=prefs['codegen.cpp.extra_link_args'],
@@ -430,7 +432,7 @@ def test_sympytools():
 if __name__=='__main__':
     test_parse_expressions_python()
     test_parse_expressions_numpy()
-    #test_parse_expressions_cpp()
+    test_parse_expressions_cpp()
     test_parse_expressions_sympy()
     test_abstract_code_dependencies()
     test_is_boolean_expression()

--- a/brian2/tests/test_parsing.py
+++ b/brian2/tests/test_parsing.py
@@ -45,7 +45,6 @@ class SimpleGroup(Group):
         self.namespace = namespace
 
 
-# TODO: add some tests with e.g. 1.0%2.0 etc. once this is implemented in C++
 TEST_EXPRESSIONS = '''
     a+b+c*d-f+g-(b+d)-(a-c)
     a**b**2
@@ -66,6 +65,10 @@ TEST_EXPRESSIONS = '''
     a>0.5 and b>0.5 or c>0.5
     a>0.5 and b>0.5 or not c>0.5
     2%4
+    -1%4
+    2.3%5.6
+    2.3%5
+    -1.2%3.4
     17e-12
     42e17
     '''


### PR DESCRIPTION
This PR fixes #357.

It adds a new method ``derive(...)`` to ``Templater`` that creates a new ``Templater`` derived from the original one with an additional template package name and (optionally) new global environment variables. The old templates will be used as a fallback if the new package doesn't define them. This is defined at the Jinja level using ``ChoiceLoader`` so everything should work smoothly (e.g. template inheritance should still work, etc.). To use it, you simply do this:

```
templater = CPPCodeGenerator.templater.derive('new.package.name')
```

Still needs documentation and tests, but would be happy to take comments on the approach.