### PR TITLE
[MRG] Allow multiple objects with the same name at creation time

### DIFF
--- a/brian2/core/names.py
+++ b/brian2/core/names.py
@@ -11,11 +11,13 @@ logger = get_logger(__name__)
 
 
 def find_name(name):
-    if name.endswith('*'):
-        name = name[:-1]
-        wildcard = True
-    else:
-        wildcard = False
+    if not name.endswith('*'):
+        # explicitly given names are used as given. Network.before_run (and
+        # the device in case of standalone) will check for name clashes later
+        return name
+
+    name = name[:-1]
+
     instances = set(Nameable.__instances__())
     allnames = set(obj().name for obj in instances
                    if hasattr(obj(), 'name'))
@@ -23,8 +25,6 @@ def find_name(name):
     # Try the name without any additions first:
     if name not in allnames:
         return name
-    elif not wildcard:
-        raise ValueError("An object with name "+name+" is already defined.")
 
     # Name is already taken, try _1, _2, etc.
     i = 1

--- a/brian2/core/network.py
+++ b/brian2/core/network.py
@@ -9,9 +9,8 @@ Preferences
 '''
 
 import sys
-import gc
 import time
-from collections import defaultdict, Sequence
+from collections import defaultdict, Sequence, Counter
 
 from brian2.utils.logger import get_logger
 from brian2.core.names import Nameable
@@ -563,7 +562,18 @@ class Network(Nameable):
         from brian2.devices.device import get_device, all_devices
 
         prefs.check_all_validated()
-        
+
+        # Check names in the network for uniqueness
+        names = [obj.name for obj in self.objects]
+        non_unique_names = [name for name, count in Counter(names).iteritems()
+                            if count > 1]
+        if len(non_unique_names):
+            formatted_names = ', '.join("'%s'" % name
+                                        for name in non_unique_names)
+            raise ValueError('All objects in a network need to have unique '
+                             'names, the following name(s) were used more than '
+                             'once: %s' % formatted_names)
+
         self._stopped = False
         Network._globally_stopped = False
 

--- a/brian2/devices/cpp_standalone/device.py
+++ b/brian2/devices/cpp_standalone/device.py
@@ -6,7 +6,7 @@ import shutil
 import subprocess
 import inspect
 import platform
-from collections import defaultdict
+from collections import defaultdict, Counter
 import numbers
 import tempfile
 from distutils import ccompiler
@@ -864,6 +864,17 @@ class CPPStandaloneDevice(Device):
         # for repeated runs of standalone (e.g. in the test suite).
         for net in self.networks:
             net.after_run()
+
+        # Check that all names are globally unique
+        names = [obj.name for net in self.networks for obj in net.objects]
+        non_unique_names = [name for name, count in Counter(names).iteritems()
+                            if count > 1]
+        if len(non_unique_names):
+            formatted_names = ', '.join("'%s'" % name
+                                        for name in non_unique_names)
+            raise ValueError('All objects need to have unique names in '
+                             'standalone mode, the following name(s) were used '
+                             'more than once: %s' % formatted_names)
 
         self.generate_objects_source(writer, arange_arrays, self.net_synapses, self.static_array_specs, self.networks)
         self.generate_main_source(writer)

--- a/brian2/tests/test_base.py
+++ b/brian2/tests/test_base.py
@@ -44,8 +44,24 @@ def test_names():
     assert_equal(obj.name, 'brianobject')
     assert_equal(obj2.name, 'brianobject_1')
     assert_equal(obj3.name, 'derivedbrianobject')
-    assert_raises(ValueError, lambda: BrianObject(name='brianobject'))
+
+@attr('codegen-independent')
+@with_setup(teardown=restore_initial_state)
+def test_duplicate_names():
+    # duplicate names are allowed, as long as they are not part of the
+    # same network
+    obj1 = BrianObject(name='name1')
+    obj2 = BrianObject(name='name2')
+    obj3 = BrianObject(name='name')
+    obj4 = BrianObject(name='name')
+    net = Network(obj1, obj2)
+    # all is good
+    net.run(0*ms)
+    net = Network(obj3, obj4)
+    assert_raises(ValueError, lambda: net.run(0*ms))
 
 if __name__=='__main__':
     test_base()
     test_names()
+    test_duplicate_names()
+


### PR DESCRIPTION
For wildcard names, the same mechanism as before is used but explicitly given names are not checked for uniqueness at creation time. Instead, `Network.before_run` checks that all names within the network are unique. In addition, `CPPStandaloneDevice.build` checks that names are globally unique. Closes #216 

This should be particularly useful in interactive consoles and ipython notebooks whenever explicit names for objects are used. Should also make @owenmackwood happy.