### PR TITLE
[MRG] Special case the getting of all values of a state variable

### DIFF
--- a/brian2/core/variables.py
+++ b/brian2/core/variables.py
@@ -1143,14 +1143,14 @@ class VariableView(object):
             if not (isinstance(item, slice) and item == slice(None)):
                 raise IndexError(('Illegal index for variable %s, it is a '
                                   'scalar variable.') % self.name)
-            indices = np.array(0)
+            indices = 0
+        elif (isinstance(item, slice) and item == slice(None)
+              and self.index_var == '_idx'):
+            indices = slice(None)
         else:
             indices = self.indexing(item, self.index_var)
 
-        if variable.scalar:
-            return variable.get_value()[0]
-        else:
-            return variable.get_value()[indices]
+        return variable.get_value()[indices]
 
     @device_override('variableview_get_subexpression_with_index_array')
     def get_subexpression_with_index_array(self, item, level=0, run_namespace=None):

--- a/brian2/core/variables.py
+++ b/brian2/core/variables.py
@@ -1220,7 +1220,10 @@ class VariableView(object):
             if not (isinstance(item, slice) and item == slice(None)):
                 raise IndexError(('Illegal index for variable %s, it is a '
                                   'scalar variable.') % self.name)
-            variable.get_value()[0] = value
+            indices = 0
+        elif (isinstance(item, slice) and item == slice(None)
+              and self.index_var == '_idx'):
+            indices = slice(None)
         else:
             indices = self.indexing(item, self.index_var)
 
@@ -1231,7 +1234,7 @@ class VariableView(object):
                                       'of the indices, '
                                       '%d != %d.') % (len(q),
                                                       len(indices)))
-            variable.get_value()[indices] = value
+        variable.get_value()[indices] = value
 
     # Allow some basic calculations directly on the ArrayView object
     def __array__(self, dtype=None):


### PR DESCRIPTION
This is a trivial fix to make getting `group.var[:]` use `slice(None)` instead of `np.arange(len(group))` for indexing, it makes indexing in these cases (which will also be triggered by simple `group.var` usages) significantly faster (though it will not have any measurable impact on the performance most likely). I had a look at implementing an improvement for setting variables as well (as stated in #195) but decided against it: it's somewhat complicated and would mean changes to templates (with different code generated depending on the kind of indexing). All that for a questionable gain, setting a variable of a group of a million neurons only takes milliseconds to complete as it is...

Closes #195