### PR TITLE
[MRG] Better unit errors

### DIFF
--- a/brian2/core/variables.py
+++ b/brian2/core/variables.py
@@ -1246,6 +1246,18 @@ class VariableView(object):
                               '"group.{var}"'.format(var=self.variable.name)))
         return np.asanyarray(self[:], dtype=dtype)
 
+    def __array_prepare__(self, array, context=None):
+        if self.unit is None:
+            return array
+        else:
+            return Quantity.__array_prepare__(self[:], array, context=context)
+
+    def __array_wrap__(self, out_arr, context=None):
+        if self.unit is None:
+            return out_arr
+        else:
+            return Quantity.__array_wrap__(self[:], out_arr, context=context)
+
     def __len__(self):
         return len(self.get_item(slice(None), level=1))
 
@@ -1256,40 +1268,40 @@ class VariableView(object):
         return self.get_item(slice(None), level=1)
 
     def __add__(self, other):
-        return self.get_item(slice(None), level=1) + other
+        return self.get_item(slice(None), level=1) + np.asanyarray(other)
 
     def __radd__(self, other):
-        return other + self.get_item(slice(None), level=1)
+        return np.asanyarray(other) + self.get_item(slice(None), level=1)
 
     def __sub__(self, other):
-        return self.get_item(slice(None), level=1) - other
+        return self.get_item(slice(None), level=1) - np.asanyarray(other)
 
     def __rsub__(self, other):
-        return other - self.get_item(slice(None), level=1)
+        return np.asanyarray(other) - self.get_item(slice(None), level=1)
 
     def __mul__(self, other):
-        return self.get_item(slice(None), level=1) * other
+        return self.get_item(slice(None), level=1) * np.asanyarray(other)
 
     def __rmul__(self, other):
-        return other * self.get_item(slice(None), level=1)
+        return np.asanyarray(other) * self.get_item(slice(None), level=1)
 
     def __div__(self, other):
-        return self.get_item(slice(None), level=1) / other
+        return self.get_item(slice(None), level=1) / np.asanyarray(other)
 
     def __truediv__(self, other):
-        return self.get_item(slice(None), level=1) / other
+        return self.get_item(slice(None), level=1) / np.asanyarray(other)
 
     def __floordiv__(self, other):
-        return self.get_item(slice(None), level=1) // other
+        return self.get_item(slice(None), level=1) // np.asanyarray(other)
 
     def __rdiv__(self, other):
-        return other / self.get_item(slice(None), level=1)
+        return np.asanyarray(other) / self.get_item(slice(None), level=1)
 
     def __rtruediv__(self, other):
-        return other / self.get_item(slice(None), level=1)
+        return np.asanyarray(other) / self.get_item(slice(None), level=1)
 
     def __rfloordiv__(self, other):
-        return other // self.get_item(slice(None), level=1)
+        return np.asanyarray(other) // self.get_item(slice(None), level=1)
 
     def __iadd__(self, other):
         if isinstance(other, basestring):
@@ -1299,7 +1311,7 @@ class VariableView(object):
         elif isinstance(self.variable, Subexpression):
             raise TypeError('Cannot assign to a subexpression.')
         else:
-            rhs = self[:] + other
+            rhs = self[:] + np.asanyarray(other)
         self[:] = rhs
         return self
 
@@ -1311,7 +1323,7 @@ class VariableView(object):
         elif isinstance(self.variable, Subexpression):
             raise TypeError('Cannot assign to a subexpression.')
         else:
-            rhs = self[:] - other
+            rhs = self[:] - np.asanyarray(other)
         self[:] = rhs
         return self
 
@@ -1323,7 +1335,7 @@ class VariableView(object):
         elif isinstance(self.variable, Subexpression):
             raise TypeError('Cannot assign to a subexpression.')
         else:
-            rhs = self[:] * other
+            rhs = self[:] * np.asanyarray(other)
         self[:] = rhs
         return self
 
@@ -1335,29 +1347,29 @@ class VariableView(object):
         elif isinstance(self.variable, Subexpression):
             raise TypeError('Cannot assign to a subexpression.')
         else:
-            rhs = self[:] / other
+            rhs = self[:] / np.asanyarray(other)
         self[:] = rhs
         return self
 
     # Also allow logical comparisons
 
     def __eq__(self, other):
-        return self.get_item(slice(None), level=1) == other
+        return self.get_item(slice(None), level=1) == np.asanyarray(other)
 
     def __ne__(self, other):
-        return self.get_item(slice(None), level=1) != other
+        return self.get_item(slice(None), level=1) != np.asanyarray(other)
 
     def __lt__(self, other):
-        return self.get_item(slice(None), level=1) < other
+        return self.get_item(slice(None), level=1) < np.asanyarray(other)
 
     def __le__(self, other):
-        return self.get_item(slice(None), level=1) <= other
+        return self.get_item(slice(None), level=1) <= np.asanyarray(other)
 
     def __gt__(self, other):
-        return self.get_item(slice(None), level=1) > other
+        return self.get_item(slice(None), level=1) > np.asanyarray(other)
 
     def __ge__(self, other):
-        return self.get_item(slice(None), level=1) >= other
+        return self.get_item(slice(None), level=1) >= np.asanyarray(other)
 
     def __repr__(self):
         varname = self.name

--- a/brian2/equations/unitcheck.py
+++ b/brian2/equations/unitcheck.py
@@ -38,8 +38,8 @@ def check_unit(expression, unit, variables):
     '''
     expr_unit = parse_expression_unit(expression, variables)
     fail_for_dimension_mismatch(expr_unit, unit, ('Expression %s does not '
-                                                  'have the expected units' %
-                                                  expression))
+                                                  'have the expected unit %r') %
+                                                  (expression.strip(), unit))
 
 
 def check_units_statements(code, variables):
@@ -96,10 +96,12 @@ def check_units_statements(code, variables):
         expr_unit = parse_expression_unit(expr, variables)
 
         if varname in variables:
-            fail_for_dimension_mismatch(variables[varname].unit,
-                                        expr_unit,
-                                        ('Code statement "%s" does not use '
-                                         'correct units' % line))
+            expected_unit = variables[varname].unit
+            fail_for_dimension_mismatch(expr_unit, expected_unit,
+                                        ('The right-hand-side of code '
+                                         'statement ""%s" does not have the '
+                                         'expected unit %r') % (line,
+                                                               expected_unit))
         elif varname in newly_defined:
             # note the unit for later
             variables[varname] = Variable(name=varname, unit=expr_unit,

--- a/brian2/groups/group.py
+++ b/brian2/groups/group.py
@@ -21,7 +21,7 @@ from brian2.core.namespace import (get_local_namespace,
 from brian2.codegen.codeobject import create_runner_codeobj, check_code_units
 from brian2.equations.equations import BOOLEAN, INTEGER, FLOAT
 from brian2.units.fundamentalunits import (fail_for_dimension_mismatch, Unit,
-                                           get_unit)
+                                           get_unit, DIMENSIONLESS)
 from brian2.units.allunits import second
 from brian2.utils.logger import get_logger
 from brian2.utils.stringtools import get_identifiers, SpellChecker
@@ -351,8 +351,18 @@ class Group(BrianObject):
         elif name in self.variables:
             var = self.variables[name]
             if not isinstance(val, basestring):
-                fail_for_dimension_mismatch(val, var.unit,
-                                            'Incorrect units for setting %s' % name)
+                if var.unit.dim is DIMENSIONLESS:
+                    fail_for_dimension_mismatch(val, var.unit,
+                                                ('%s should be set with a '
+                                                 'dimensionless value, but got '
+                                                 '{value}') % name,
+                                                value=val)
+                else:
+                    fail_for_dimension_mismatch(val, var.unit,
+                                                ('%s should be set with a '
+                                                 'value with units %r, but got '
+                                                 '{value}') % (name, var.unit),
+                                                value=val)
             if var.read_only:
                 raise TypeError('Variable %s is read-only.' % name)
             # Make the call X.var = ... equivalent to X.var[:] = ...

--- a/brian2/groups/neurongroup.py
+++ b/brian2/groups/neurongroup.py
@@ -8,7 +8,7 @@ import sympy
 from pyparsing import Word
 
 from brian2.equations.equations import (Equations, DIFFERENTIAL_EQUATION,
-                                        SUBEXPRESSION, PARAMETER, BOOLEAN)
+                                        SUBEXPRESSION, PARAMETER)
 from brian2.equations.refractory import add_refractoriness
 from brian2.stateupdaters.base import StateUpdateMethod
 from brian2.codegen.translation import analyse_identifiers
@@ -23,7 +23,8 @@ from brian2.utils.stringtools import get_identifiers
 from brian2.units.allunits import second
 from brian2.units.fundamentalunits import (Quantity, Unit,
                                            have_same_dimensions,
-                                           DimensionMismatchError)
+                                           DimensionMismatchError,
+                                           fail_for_dimension_mismatch)
 
 
 from .group import Group, CodeRunner, get_dtype
@@ -113,6 +114,12 @@ class StateUpdater(CodeRunner):
             # No refractoriness
             abstract_code = ''
         elif isinstance(ref, Quantity):
+            fail_for_dimension_mismatch(ref, second, ('Refractory period has to '
+                                                      'be specified in units '
+                                                      'of seconds but got '
+                                                      '{value}'),
+                                        value=ref)
+
             abstract_code = 'not_refractory = (t - lastspike) > %f\n' % ref
         else:
             identifiers = get_identifiers(ref)

--- a/brian2/synapses/synapses.py
+++ b/brian2/synapses/synapses.py
@@ -185,7 +185,9 @@ class SynapticPathway(CodeRunner, Group):
                                  'quantity with shape %s instead.') % str(delay.shape))
             fail_for_dimension_mismatch(delay, second, ('Delay has to be '
                                                         'specified in units '
-                                                        'of seconds'))
+                                                        'of seconds but got '
+                                                        '{value}'),
+                                        value=delay)
             # We use a "dynamic" array of constant size here because it makes
             # the generated code easier, we don't need to deal with a different
             # type for scalar and variable delays

--- a/brian2/units/fundamentalunits.py
+++ b/brian2/units/fundamentalunits.py
@@ -977,15 +977,17 @@ class Quantity(np.ndarray, object):
         elif uf.__name__ in UFUNCS_DIMENSIONLESS_TWOARGS:
             # Ok if both arguments are dimensionless
             fail_for_dimension_mismatch(args[0],
-                                        error_message=('First argument for '
-                                                       '%s should be '
-                                                       'dimensionless but was '
+                                        error_message=('Both arguments for '
+                                                       '"%s" should be '
+                                                       'dimensionless but '
+                                                       'first argument was '
                                                        '{value}') % uf.__name__,
                                         value=args[0])
             fail_for_dimension_mismatch(args[1],
-                                        error_message=('Second argument for '
-                                                       '%s should be '
-                                                       'dimensionless but was '
+                                        error_message=('Both arguments for '
+                                                       '"%s" should be '
+                                                       'dimensionless but '
+                                                       'second argument was '
                                                        '{value}') % uf.__name__,
                                         value=args[1])
         elif uf.__name__ == 'power':

--- a/brian2/units/fundamentalunits.py
+++ b/brian2/units/fundamentalunits.py
@@ -1515,31 +1515,34 @@ class Quantity(np.ndarray, object):
         return replace_with_quantity(np.asarray(self).tolist(), self.dim)
 
     #### COMPARISONS ####
-    def _comparison(self, other, message, operation):
+    def _comparison(self, other, operator_str, operation):
         is_scalar = is_scalar_type(other)
         if not is_scalar and not isinstance(other, np.ndarray):
             return NotImplemented
         if not is_scalar or not np.isinf(other):
-            fail_for_dimension_mismatch(self, other, message)
+                message = ('Cannot perform comparison {value1} %s {value2}, '
+                           'units do not match') % operator_str
+                fail_for_dimension_mismatch(self, other, message,
+                                            value1=self, value2=other)
         return operation(np.asarray(self), np.asarray(other))
 
     def __lt__(self, other):
-        return self._comparison(other, 'LessThan', operator.lt)
+        return self._comparison(other, '<', operator.lt)
 
     def __le__(self, other):
-        return self._comparison(other, 'LessEquals', operator.le)
+        return self._comparison(other, '<=', operator.le)
 
     def __gt__(self, other):
-        return self._comparison(other, 'GreaterThan', operator.gt)
+        return self._comparison(other, '>', operator.gt)
 
     def __ge__(self, other):
-        return self._comparison(other, 'GreaterEquals', operator.ge)
+        return self._comparison(other, '>=', operator.ge)
 
     def __eq__(self, other):
-        return self._comparison(other, 'Equals', operator.eq)
+        return self._comparison(other, '==', operator.eq)
 
     def __ne__(self, other):
-        return self._comparison(other, 'NotEquals', operator.ne)
+        return self._comparison(other, '!=', operator.ne)
 
     #### MAKE QUANTITY PICKABLE ####
     def __reduce__(self):

--- a/brian2/units/fundamentalunits.py
+++ b/brian2/units/fundamentalunits.py
@@ -521,8 +521,15 @@ class DimensionMismatchError(Exception):
                                self.desc, ', '.join(dims_repr))
 
     def __str__(self):
-        s = self.desc + ", dimensions were "
-        s += ' '.join(['(' + str(d) + ')' for d in self.dims])
+        s = self.desc
+        if len(self.dims) == 1:
+            s += ', unit was ' + repr(get_unit(self.dims[0]))
+        elif len(self.dims) == 2:
+            d1, d2 = self.dims
+            s += ', units were %r and %r' % (get_unit(d1), get_unit(d2))
+        else:
+            s += (', units were ' +
+                  ' '.join(['(' + repr(get_unit(d)) + ')' for d in self.dims]))
         return s
 
 def is_scalar_type(obj):
@@ -566,7 +573,10 @@ def get_dimensions(obj):
     """
     if (isinstance(obj, numbers.Number) or isinstance(obj, np.number) or
         isinstance(obj, np.ndarray) and not isinstance(obj, Quantity)):
-        return DIMENSIONLESS 
+        return DIMENSIONLESS
+    elif isinstance(obj, Dimension):
+        return obj
+
     try:
         return obj.dim
     except AttributeError:

--- a/brian2/units/fundamentalunits.py
+++ b/brian2/units/fundamentalunits.py
@@ -2258,7 +2258,7 @@ def get_unit_for_display(x):
     Return a string representation of the most appropriate unit or ``'1'`` for
     a dimensionless quantity
     '''
-    if x is DIMENSIONLESS:
+    if x is 1 or x is DIMENSIONLESS:
         return '1'
     else:
         return repr(get_unit(x))
@@ -2350,20 +2350,25 @@ def check_units(**au):
                                        not newkeyset[k] is None):
 
                     if not have_same_dimensions(newkeyset[k], au[k]):
-                        error_message = ('Function "' + f.__name__ +
-                                         '" variable "' + k +
-                                         '" has wrong dimensions')
+                        error_message = ('Function "{f.__name__}" '
+                                         'expected a quantitity with unit '
+                                         '{unit} for argument "{k}" but got '
+                                         '{value}').format(f=f, k=k,
+                                                           unit=repr(au[k]),
+                                                           value=newkeyset[k])
                         raise DimensionMismatchError(error_message,
-                                                     get_dimensions(newkeyset[k]),
-                                                     au[k])
+                                                     newkeyset[k])
             result = f(*args, **kwds)
             if 'result' in au:
                 if not have_same_dimensions(result, au['result']):
-                    error_message = ('The return value of function "' +
-                                     f.__name__ + '" has wrong dimensions')
+                    error_message = ('The return value of function '
+                                     '""{f.__name__}" was expected to have '
+                                     'unit {unit} but was '
+                                     '{value}').format(f=f,
+                                                       unit=repr(au['result']),
+                                                       value=result)
                     raise DimensionMismatchError(error_message,
-                                                 get_dimensions(result),
-                                                 get_dimensions(au['result']))
+                                                 get_dimensions(result))
             return result
         new_f._orig_func = f
         new_f.__doc__ = f.__doc__


### PR DESCRIPTION
This should give significantly better error messages for unit mismatches, e.g. instead of
```Python
>>> 3*mV + 1*mV + 3*ms
...
DimensionMismatchError: Addition, dimensions were (m^2 kg s^-3 A^-1) (s)
```
you'll now get
```Python
DimensionMismatchError: Cannot calculate 4. mV + 3. ms, units do not match (units are volt and second).
```

Instead of 
```Python
DimensionMismatchError: exp, dimensions were (m^2 kg s^-3 A^-1) (1)
```
you get
```Python
DimensionMismatchError: exp expects a dimensionless argument but got -70. mV (unit is volt).
```

and instead of
```Python
>>> G = NeuronGroup(1000, 'v : volt')
>>> G.v = np.arange(1000)*mA
...
DimensionMismatchError: Incorrect units for setting v, dimensions were (A) (m^2 kg s^-3 A^-1)
```
you get
```Python
DimensionMismatchError: v should be set with a value with units volt, but got [ 0.     0.001 ...,  0.998  0.999] A (unit is amp).
```

This is finished and in principle ready-to-merge but I did not yet check in detail all the error messages yet. 