### PR TITLE
Enable tests for MacOSX

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,29 +20,51 @@ matrix:
       # packaging will use the tarball as the basis
     - python: "2.7"
       env: PYTHON="2.7" DOCS_ONLY=yes ARCHITECTURE="x86_64"
+      os: linux
     # Standard tests
     - python: "2.7"
       env: PYTHON="2.7" STANDALONE=no CYTHON=yes MINIMAL_VERSIONS=no  REPORT_COVERAGE=yes CONDA_PY="27" CONDA_NPY="19" CONDA_BUILD='yes' ARCHITECTURE="x86_64"
+      os: linux
+    - python: "2.7"
+      env: PYTHON="2.7" STANDALONE=no CYTHON=yes MINIMAL_VERSIONS=no  REPORT_COVERAGE=yes CONDA_PY="27" CONDA_NPY="19" CONDA_BUILD='yes' ARCHITECTURE="x86_64"
+      os: osx
     - python: "2.7"
       env: PYTHON="2.7" STANDALONE=no CYTHON=yes MINIMAL_VERSIONS=no  REPORT_COVERAGE=no  CONDA_PY="27" CONDA_NPY="19" CONDA_BUILD='yes' ARCHITECTURE="x86"
+      os: linux
     - python: "2.7"
       env: PYTHON="2.7" STANDALONE=no CYTHON=yes MINIMAL_VERSIONS=yes REPORT_COVERAGE=no  CONDA_PY="27" CONDA_NPY="19" CONDA_BUILD='no'  ARCHITECTURE="x86_64"
+      os: linux
     - python: "3.4"
       env: PYTHON="3.4" STANDALONE=no CYTHON=yes MINIMAL_VERSIONS=no  REPORT_COVERAGE=no  CONDA_PY="34" CONDA_NPY="19" CONDA_BUILD='yes' ARCHITECTURE="x86_64"
+      os: linux
+    - python: "3.4"
+      env: PYTHON="3.4" STANDALONE=no CYTHON=yes MINIMAL_VERSIONS=no  REPORT_COVERAGE=no  CONDA_PY="34" CONDA_NPY="19" CONDA_BUILD='yes' ARCHITECTURE="x86_64"
+      os: osx
     - python: "3.4"
       env: PYTHON="3.4" STANDALONE=no CYTHON=yes MINIMAL_VERSIONS=no  REPORT_COVERAGE=no  CONDA_PY="34" CONDA_NPY="19" CONDA_BUILD='yes' ARCHITECTURE="x86"
     # test standalone
     - python: "2.7"
       env: PYTHON="2.7" STANDALONE=yes CYTHON=no MINIMAL_VERSIONS=no REPORT_COVERAGE=no CONDA_BUILD='no' ARCHITECTURE="x86_64"
+      os: linux
+    - python: "2.7"
+      env: PYTHON="2.7" STANDALONE=yes CYTHON=no MINIMAL_VERSIONS=no REPORT_COVERAGE=no CONDA_BUILD='no' ARCHITECTURE="x86"
+      os: linux
     - python: "2.7"
       env: PYTHON="2.7" STANDALONE=yes CYTHON=no MINIMAL_VERSIONS=no REPORT_COVERAGE=no CONDA_BUILD='no' ARCHITECTURE="x86_64"
+      os: osx
+    - python: "3.4"
+      env: PYTHON="3.4" STANDALONE=yes CYTHON=no MINIMAL_VERSIONS=no REPORT_COVERAGE=no CONDA_BUILD='no' ARCHITECTURE="x86_64"
+      os: linux
     - python: "3.4"
       env: PYTHON="3.4" STANDALONE=yes CYTHON=no MINIMAL_VERSIONS=no REPORT_COVERAGE=no CONDA_BUILD='no' ARCHITECTURE="x86"
+      os: linux
     - python: "3.4"
-      env: PYTHON="3.4" STANDALONE=yes CYTHON=no MINIMAL_VERSIONS=no REPORT_COVERAGE=no CONDA_BUILD='no' ARCHITECTURE="x86"
+      env: PYTHON="3.4" STANDALONE=yes CYTHON=no MINIMAL_VERSIONS=no REPORT_COVERAGE=no CONDA_BUILD='no' ARCHITECTURE="x86_64"
+      os: osx
     # test without installed cython
     - python: "2.7"
       env: PYTHON="2.7" STANDALONE=no CYTHON=no MINIMAL_VERSIONS=no REPORT_COVERAGE=no ARCHITECTURE="x86_64"
+      os: linux
 
 
 # Use miniconda to install binary versions of numpy etc. from continuum
@@ -50,15 +72,23 @@ matrix:
 # https://gist.github.com/dan-blanchard/7045057
 before_install:
 - if [ ${PYTHON:0:1} == "2" ]; then
+    if [ "$TRAVIS_OS_NAME" == "linux" ]; then
     wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-$ARCHITECTURE.sh -O miniconda.sh;
     else
+    wget http://repo.continuum.io/miniconda/Miniconda-latest-MacOSX-$ARCHITECTURE.sh -O miniconda.sh;
+    fi;
+    else
+    if [ "$TRAVIS_OS_NAME" == "linux" ]; then
     wget http://repo.continuum.io/miniconda/Miniconda3-latest-Linux-$ARCHITECTURE.sh -O miniconda.sh;
+    else
+    wget http://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-$ARCHITECTURE.sh -O miniconda.sh;
+    fi;
   fi
 - chmod +x miniconda.sh
 # When we are installing the 32 Bit conda on a 64 Bit system, the miniconda
 # installer will ask for a "yes" despite the -b flag, so we pipe in a yes
 - yes | ./miniconda.sh -b
-- if [ ${PYTHON:0:1} == "2" ]; then export PATH=/home/travis/miniconda/bin:$PATH; else export PATH=/home/travis/miniconda3/bin:$PATH; fi
+- if [ ${PYTHON:0:1} == "2" ]; then export PATH=~/miniconda/bin:$PATH; else export PATH=~/miniconda3/bin:$PATH; fi
 
 # command to install dependencies
 install:

--- a/brian2/tests/test_cpp_standalone.py
+++ b/brian2/tests/test_cpp_standalone.py
@@ -1,13 +1,10 @@
 import tempfile
-import os
 
-from nose import with_setup
+from nose import with_setup, SkipTest
 from nose.plugins.attrib import attr
-import numpy
 from numpy.testing.utils import assert_allclose, assert_equal, assert_raises
 
 from brian2 import *
-from brian2.devices.cpp_standalone import cpp_standalone_device
 from brian2.devices.device import restore_device
 
 @attr('cpp_standalone', 'standalone-only')
@@ -113,6 +110,8 @@ def test_storing_loading(with_output=False):
 @attr('cpp_standalone', 'standalone-only')
 @with_setup(teardown=restore_device)
 def test_openmp_consistency(with_output=False):
+    if sys.platform.startswith('darwin'):
+        raise SkipTest('Skipping OpenMP on MacOSX')
     previous_device = get_device()
     n_cells    = 100
     n_recorded = 10


### PR DESCRIPTION
Seems to work fine, we should have some conda packages of the latest development version after it has been merged into master. I did not bother with getting OpenMP to run.

I'll take the liberty to merge this myself right away, not much to review here.