### PR TITLE
[MRG] Fix OpenMP profiling

### DIFF
--- a/brian2/devices/cpp_standalone/codeobject.py
+++ b/brian2/devices/cpp_standalone/codeobject.py
@@ -35,6 +35,11 @@ def openmp_pragma(pragma_type):
             return '1'
         else:
             return '%d' %nb_threads
+    elif pragma_type == 'with_openmp':
+        # The returned value is a proper Python boolean, i.e. not something
+        # that should be included in the generated code but rather for use
+        # in {% if ... %} statements in the template
+        return openmp_on
 
     ## Then by default, if openmp is off, we do not return any pragma statement in the templates
     elif not openmp_on:

--- a/brian2/devices/cpp_standalone/templates/common_group.cpp
+++ b/brian2/devices/cpp_standalone/templates/common_group.cpp
@@ -24,7 +24,11 @@ void _run_{{codeobj_name}}()
 {	
 	using namespace brian;
 
+    {% if openmp_pragma('with_openmp') %}
+    const double _start_time = omp_get_wtime();
+    {% else %}
     const std::clock_t _start_time = std::clock();
+    {% endif %}
 
 	///// CONSTANTS ///////////
 	%CONSTANTS%
@@ -47,9 +51,13 @@ void _run_{{codeobj_name}}()
 	}
 	{% endblock %}
 
-    {{ openmp_pragma('single') }}
+    {{ openmp_pragma('master') }}
     {
+        {% if openmp_pragma('with_openmp') %}
+        const double _run_time = omp_get_wtime() -_start_time;
+        {% else %}
         const double _run_time = (double)(std::clock() -_start_time)/CLOCKS_PER_SEC;
+        {% endif %}
         {{codeobj_name}}_profiling_info += _run_time;
     }
 }

--- a/brian2/devices/cpp_standalone/templates/synapses.cpp
+++ b/brian2/devices/cpp_standalone/templates/synapses.cpp
@@ -35,7 +35,7 @@
 	}
 	{% else %}
 	{{ openmp_pragma('static') }}
-	for(unsigned int _spiking_synapse_idx=0;
+	for(int _spiking_synapse_idx=0;
 		_spiking_synapse_idx<_num_spiking_synapses;
 		_spiking_synapse_idx++)
 	{

--- a/brian2/devices/cpp_standalone/templates/synapses.cpp
+++ b/brian2/devices/cpp_standalone/templates/synapses.cpp
@@ -3,7 +3,7 @@
 
 {% set _non_synaptic = [] %}
 {% for var in variables %}
-    {% if variable_indices[var] != '_idx' %}
+    {% if variable_indices[var] not in ('_idx', '0') %}
         {# This is a trick to get around the scoping problem #}
         {% if _non_synaptic.append(1) %}{% endif %}
     {% endif %}


### PR DESCRIPTION
This has two small fixes to the OpenMP support: in the synapses template, every code that used a scalar variable incorrectly triggered the use of the single-thread code (affecting the post code in STDP). The second fix is to use `omp_get_wtime` instead of `std::clock` to count runtimes, this avoid the weird profiling results and makes it unnecessary to divide by number of threads etc.

It's all fairly simple changes and it would be ready to merge but the OpenMP test now apparently no longer compiles on Windows. @thesamovar could you have a look at it? It does not give any helpful output in the log and trying to figure this out in my Windows VM is way too annoying for a Friday evening...