### PR TITLE
Heun stateupdater

### DIFF
--- a/brian2/groups/neurongroup.py
+++ b/brian2/groups/neurongroup.py
@@ -370,7 +370,7 @@ class NeuronGroup(Group, SpikeSource):
     add_to_magic_network = True
 
     def __init__(self, N, model,
-                 method=('linear', 'euler', 'heun', 'milstein'),
+                 method=('linear', 'euler', 'heun'),
                  threshold=None,
                  reset=None,
                  refractory=False,

--- a/brian2/groups/neurongroup.py
+++ b/brian2/groups/neurongroup.py
@@ -370,7 +370,7 @@ class NeuronGroup(Group, SpikeSource):
     add_to_magic_network = True
 
     def __init__(self, N, model,
-                 method=('linear', 'euler', 'milstein'),
+                 method=('linear', 'euler', 'heun', 'milstein'),
                  threshold=None,
                  reset=None,
                  refractory=False,

--- a/brian2/spatialneuron/spatialneuron.py
+++ b/brian2/spatialneuron/spatialneuron.py
@@ -96,7 +96,7 @@ class SpatialNeuron(NeuronGroup):
                  threshold_location=None,
                  dt=None, clock=None, order=0, Cm=0.9 * uF / cm ** 2, Ri=150 * ohm * cm,
                  name='spatialneuron*', dtype=None, namespace=None,
-                 method=('linear', 'exponential_euler', 'rk2', 'milstein')):
+                 method=('linear', 'exponential_euler', 'rk2', 'heun', 'milstein')):
 
         # #### Prepare and validate equations
         if isinstance(model, basestring):

--- a/brian2/spatialneuron/spatialneuron.py
+++ b/brian2/spatialneuron/spatialneuron.py
@@ -96,7 +96,7 @@ class SpatialNeuron(NeuronGroup):
                  threshold_location=None,
                  dt=None, clock=None, order=0, Cm=0.9 * uF / cm ** 2, Ri=150 * ohm * cm,
                  name='spatialneuron*', dtype=None, namespace=None,
-                 method=('linear', 'exponential_euler', 'rk2', 'heun', 'milstein')):
+                 method=('linear', 'exponential_euler', 'rk2', 'heun')):
 
         # #### Prepare and validate equations
         if isinstance(model, basestring):

--- a/brian2/stateupdaters/__init__.py
+++ b/brian2/stateupdaters/__init__.py
@@ -16,5 +16,6 @@ StateUpdateMethod.register('euler', euler)
 StateUpdateMethod.register('rk2', rk2)
 StateUpdateMethod.register('rk4', rk4)
 StateUpdateMethod.register('milstein', milstein)
+StateUpdateMethod.register('heun', heun)
 
 

--- a/brian2/stateupdaters/explicit.py
+++ b/brian2/stateupdaters/explicit.py
@@ -697,3 +697,11 @@ milstein = ExplicitStateUpdater('''
     k = 1/(2*dt**.5)*(g_support - g(x, t))*(dW**2)
     x_new = x + dt*f(x,t) + g(x, t) * dW + k
     ''', stochastic='multiplicative', custom_check=diagonal_noise)
+
+#: Stochastic Heun method (for multiplicative Stratonovic SDEs with non-diagonal
+#  diffusion matrix)
+heun = brian2.ExplicitStateUpdater('''
+    x_support = x + g(x,t) * dW
+    g_support = g(x_support,t+dt)
+    x_new = x + dt*f(x,t) + .5*dW*(g(x,t)+g_support)
+    ''', stochastic='multiplicative')

--- a/brian2/stateupdaters/explicit.py
+++ b/brian2/stateupdaters/explicit.py
@@ -14,7 +14,7 @@ from brian2.parsing.sympytools import str_to_sympy, sympy_to_str
 
 from .base import StateUpdateMethod
 
-__all__ = ['milstein', 'euler', 'rk2', 'rk4', 'ExplicitStateUpdater']
+__all__ = ['milstein', 'heun', 'euler', 'rk2', 'rk4', 'ExplicitStateUpdater']
 
 
 #===============================================================================
@@ -700,7 +700,7 @@ milstein = ExplicitStateUpdater('''
 
 #: Stochastic Heun method (for multiplicative Stratonovic SDEs with non-diagonal
 #  diffusion matrix)
-heun = brian2.ExplicitStateUpdater('''
+heun = ExplicitStateUpdater('''
     x_support = x + g(x,t) * dW
     g_support = g(x_support,t+dt)
     x_new = x + dt*f(x,t) + .5*dW*(g(x,t)+g_support)

--- a/brian2/stateupdaters/explicit.py
+++ b/brian2/stateupdaters/explicit.py
@@ -671,7 +671,6 @@ rk4 = ExplicitStateUpdater('''
     x_new = x+(k_1+2*k_2+2*k_3+k_4)/6
     ''')
 
-
 def diagonal_noise(equations, variables):
     '''
     Checks whether we deal with diagonal noise, i.e. one independent noise
@@ -689,7 +688,6 @@ def diagonal_noise(equations, variables):
     # have diagonal noise
     return len(stochastic_vars) == len(set(stochastic_vars))
 
-
 #: Derivative-free Milstein method
 milstein = ExplicitStateUpdater('''
     x_support = x + dt*f(x, t) + dt**.5 * g(x, t)
@@ -699,7 +697,7 @@ milstein = ExplicitStateUpdater('''
     ''', stochastic='multiplicative', custom_check=diagonal_noise)
 
 #: Stochastic Heun method (for multiplicative Stratonovic SDEs with non-diagonal
-#  diffusion matrix)
+#: diffusion matrix)
 heun = ExplicitStateUpdater('''
     x_support = x + g(x,t) * dW
     g_support = g(x_support,t+dt)

--- a/brian2/synapses/synapses.py
+++ b/brian2/synapses/synapses.py
@@ -599,7 +599,7 @@ class Synapses(Group):
                  namespace=None, dtype=None,
                  codeobj_class=None,
                  dt=None, clock=None, order=0,
-                 method=('linear', 'euler', 'heun', 'milstein'),
+                 method=('linear', 'euler', 'heun'),
                  name='synapses*'):
         self._N = 0
         Group.__init__(self, dt=dt, clock=clock, when='start', order=order,

--- a/brian2/synapses/synapses.py
+++ b/brian2/synapses/synapses.py
@@ -599,7 +599,7 @@ class Synapses(Group):
                  namespace=None, dtype=None,
                  codeobj_class=None,
                  dt=None, clock=None, order=0,
-                 method=('linear', 'euler', 'milstein'),
+                 method=('linear', 'euler', 'heun', 'milstein'),
                  name='synapses*'):
         self._N = 0
         Group.__init__(self, dt=dt, clock=clock, when='start', order=order,

--- a/docs_sphinx/user/models.rst
+++ b/docs_sphinx/user/models.rst
@@ -209,8 +209,8 @@ exactly first (for linear equations) and then resorting to numerical algorithms.
 It will also take care of integrating stochastic differential equations
 appropriately. Each class defines its own list of algorithms it tries to
 apply, `NeuronGroup` and `Synapses` will use the first suitable method out of
-the methods ``'linear'``, ``'euler'``, and ``'milstein'`` while `SpatialNeuron`
-objects will use ``'linear'``, ``'exponential_euler'``, ``'rk2'``, or
+the methods ``'linear'``, ``'euler'``, ``'heun'`` and ``'milstein'`` while `SpatialNeuron`
+objects will use ``'linear'``, ``'exponential_euler'``, ``'rk2'``, ``'heun'`` or
 ``'milstein'``.
 
 If you prefer to chose an integration algorithm yourself, you can do so using
@@ -226,6 +226,8 @@ The complete list of available methods is the following:
   differential equations using the Euler-Maruyama method)
 * ``'rk2'``: second order Runge-Kutta method (midpoint method)
 * ``'rk4'``: classical Runge-Kutta method (RK4)
+* ``'heun''``: stochastic Heun method for solving Stratonovich stochastic 
+  differential equations with non-diagonal multiplicative noise.
 * ``'milstein'``: derivative-free Milstein method for solving stochastic
   differential equations with diagonal multiplicative noise
 

--- a/docs_sphinx/user/models.rst
+++ b/docs_sphinx/user/models.rst
@@ -209,9 +209,8 @@ exactly first (for linear equations) and then resorting to numerical algorithms.
 It will also take care of integrating stochastic differential equations
 appropriately. Each class defines its own list of algorithms it tries to
 apply, `NeuronGroup` and `Synapses` will use the first suitable method out of
-the methods ``'linear'``, ``'euler'``, ``'heun'`` and ``'milstein'`` while `SpatialNeuron`
-objects will use ``'linear'``, ``'exponential_euler'``, ``'rk2'``, ``'heun'`` or
-``'milstein'``.
+the methods ``'linear'``, ``'euler'`` and ``'heun'`` while `SpatialNeuron`
+objects will use ``'linear'``, ``'exponential_euler'``, ``'rk2'`` or ``'heun'``.
 
 If you prefer to chose an integration algorithm yourself, you can do so using
 the ``method`` keyword for `NeuronGroup`, `Synapses`, or `SpatialNeuron`.


### PR DESCRIPTION
Here we have added the stochastic Heun method as a StateUpdateMethod. A description can be found in [sde tutorial](http://infoscience.epfl.ch/record/143450/files/sde_tutorial.pdf). It was tested with the [sde test example](https://brian2.readthedocs.org/en/2.0b4/examples/advanced.stochastic_odes.html). The results are comparable to the Milstein method:

![output_0_1](https://cloud.githubusercontent.com/assets/7713616/9231980/744c623e-412b-11e5-8ea1-d58ef236cec3.png)
