### PR TITLE
[MRG] Improve stochastic parsing

### DIFF
--- a/brian2/equations/codestrings.py
+++ b/brian2/equations/codestrings.py
@@ -68,16 +68,30 @@ class Expression(CodeString):
 
     Parameters
     ----------
-    code : str
+    code : str, optional
         The expression. Note that the expression has to be written in a form
-        that is parseable by sympy.
+        that is parseable by sympy. Alternatively, a sympy expression can be
+        provided (in the ``sympy_expression`` argument).
+    sympy_expression : sympy expression, optional
+        A sympy expression. Alternatively, a plain string expression can be
+        provided (in the ``code`` argument).
     '''
 
-    def __init__(self, code):
-        CodeString.__init__(self, code)
+    def __init__(self, code=None, sympy_expression=None):
+        if code is None and sympy_expression is None:
+            raise TypeError('Have to provide either a string or a sympy expression')
+        if code is not None and sympy_expression is not None:
+            raise TypeError('Provide a string expression or a sympy expression, not both')
+
+        if code is None:
+            code = sympy_to_str(sympy_expression)
+        if sympy_expression is None:
+            sympy_expression = str_to_sympy(code)
+
+        super(Expression, self).__init__(code=code)
 
         # : The expression as a sympy object
-        self.sympy_expr = str_to_sympy(self.code)
+        self.sympy_expr = sympy_expression
 
     stochastic_variables = property(lambda self: set([variable for variable in self.identifiers
                                                       if variable =='xi' or variable.startswith('xi_')]),
@@ -122,7 +136,7 @@ class Expression(CodeString):
         f_expr = None
         stochastic_expressions = {}
         for var, expr in collected.iteritems():
-            expr = Expression(sympy_to_str(expr))
+            expr = Expression(sympy_expression=expr)
             if var == 1:
                 f_expr = expr
             elif var in stochastic_symbols:

--- a/brian2/equations/codestrings.py
+++ b/brian2/equations/codestrings.py
@@ -114,12 +114,10 @@ class Expression(CodeString):
         if not len(stochastic_variables):
             return (self, None)
 
-        s_expr = self.sympy_expr.expand()
-
         stochastic_symbols = [sympy.Symbol(variable, real=True)
                               for variable in stochastic_variables]
 
-        collected = s_expr.collect(stochastic_symbols, evaluate=False)
+        collected = self.sympy_expr.collect(stochastic_symbols, evaluate=False)
 
         f_expr = None
         stochastic_expressions = {}

--- a/brian2/stateupdaters/explicit.py
+++ b/brian2/stateupdaters/explicit.py
@@ -269,12 +269,14 @@ class ExplicitStateUpdater(StateUpdateMethod):
     def can_integrate(self, equations, variables):
         # Non-stochastic numerical integrators should work for all equations,
         # except for stochastic equations
-        if equations.is_stochastic and self.stochastic is None:
-            return False
-        elif (equations.stochastic_type == 'multiplicative' and
-              self.stochastic != 'multiplicative'):
-            return False
-        elif self.custom_check and not self.custom_check(equations, variables):
+        if equations.is_stochastic:
+            if self.stochastic is None:
+                return False
+            if (self.stochastic != 'multiplicative' and
+                        equations.stochastic_type == 'multiplicative'):
+                return False
+
+        if self.custom_check and not self.custom_check(equations, variables):
             return False
         else:
             return True
@@ -677,6 +679,9 @@ def diagonal_noise(equations, variables):
     Checks whether we deal with diagonal noise, i.e. one independent noise
     variable per variable.
     '''
+    if not equations.is_stochastic:
+        return True
+
     stochastic_vars = []
     for _, expr in equations.substituted_expressions:
         expr_stochastic_vars = expr.stochastic_variables


### PR DESCRIPTION
This branch contains a few improvements for dealing with complex, in particular stochastic, equations. In `Expression.split_stochastic`, the use of sympy's `expand` could result in very big strings that made everything slow and could even lead to memory errors (for the example provided on the mailing list https://groups.google.com/d/topic/brian-development/fL8wfggCMrw/discussion it resulted into a > 2MB string...). I removed the `expand` and also replaced the quite demanding `match` by a simple `collect`, it seems to work fine. The branch also contains a few smaller improvements that should avoid a few unnecessary sympy operations.