### PR TITLE
[MRG] Synapses to synapses connections

### DIFF
--- a/brian2/codegen/generators/cython_generator.py
+++ b/brian2/codegen/generators/cython_generator.py
@@ -187,6 +187,8 @@ class CythonCodeGenerator(CodeGenerator):
         handled_pointers = set()
         user_functions = []
         for varname, var in self.variables.items():
+            if isinstance(var, Variable) and not isinstance(var, (Subexpression, AuxiliaryVariable)):
+                load_namespace.append('_var_{0} = _namespace["_var_{1}"]'.format(varname, varname))
             if isinstance(var, AuxiliaryVariable):
                 line = "cdef {dtype} {varname}".format(
                                 dtype=get_cpp_dtype(var.dtype),

--- a/brian2/codegen/generators/cython_generator.py
+++ b/brian2/codegen/generators/cython_generator.py
@@ -235,7 +235,7 @@ class CythonCodeGenerator(CodeGenerator):
                 if not var.scalar:
                     newlines += ["cdef int _num{array_name} = len(_namespace['{array_name}'])"]
 
-                if var.array and var.scalar and var.constant:
+                if var.scalar and var.constant:
                     newlines += ['cdef {cpp_dtype} {varname} = _namespace["{varname}"]']
                 else:
                     newlines += ["cdef {cpp_dtype} {varname}"]

--- a/brian2/codegen/generators/cython_generator.py
+++ b/brian2/codegen/generators/cython_generator.py
@@ -235,7 +235,10 @@ class CythonCodeGenerator(CodeGenerator):
                 if not var.scalar:
                     newlines += ["cdef int _num{array_name} = len(_namespace['{array_name}'])"]
 
-                newlines += ["cdef {cpp_dtype} {varname}"]
+                if var.array and var.scalar and var.constant:
+                    newlines += ['cdef {cpp_dtype} {varname} = _namespace["{varname}"]']
+                else:
+                    newlines += ["cdef {cpp_dtype} {varname}"]
 
                 for line in newlines:
                     line = line.format(cpp_dtype=get_cpp_dtype(var.dtype),

--- a/brian2/codegen/runtime/cython_rt/cython_rt.py
+++ b/brian2/codegen/runtime/cython_rt/cython_rt.py
@@ -134,6 +134,10 @@ class CythonCodeObject(NumpyCodeObject):
                 self.namespace[dyn_array_name] = self.device.get_value(var,
                                                                        access_data=False)
 
+            # Also provide the Variable object itself in the namespace (can be
+            # necessary for resize operations, for example)
+            self.namespace['_var_'+name] = var
+
             # There are two kinds of objects that we have to inject into the
             # namespace with their current value at each time step:
             # * non-constant AttributeValue (this might be removed since it only

--- a/brian2/codegen/runtime/cython_rt/cython_rt.py
+++ b/brian2/codegen/runtime/cython_rt/cython_rt.py
@@ -123,6 +123,8 @@ class CythonCodeObject(NumpyCodeObject):
                 self.namespace[self.device.get_array_name(var,
                                                             self.variables)] = value
                 self.namespace['_num'+name] = var.get_len()
+                if var.scalar and var.constant:
+                    self.namespace[name] = value.item()
             else:
                 self.namespace[name] = value
 

--- a/brian2/codegen/runtime/cython_rt/templates/spikemonitor.pyx
+++ b/brian2/codegen/runtime/cython_rt/templates/spikemonitor.pyx
@@ -49,5 +49,4 @@
                 _{{varname}}_view [_curlen + _j - _start_idx] = _to_record_{{varname}}
                 {% endfor %}
                 {{count}}[_idx - _source_start] += 1
-            {{N}}[0] += _num_events
 {% endblock %}

--- a/brian2/codegen/runtime/cython_rt/templates/synapses_create.pyx
+++ b/brian2/codegen/runtime/cython_rt/templates/synapses_create.pyx
@@ -1,7 +1,7 @@
 {% extends 'common.pyx' %}
 {#
 USES_VARIABLES { _synaptic_pre, _synaptic_post, _all_pre, _all_post, rand,
-                 N_incoming, N_outgoing }
+                 N_incoming, N_outgoing, N }
 #}
 # ITERATE_ALL { _idx }
 
@@ -13,14 +13,14 @@ cdef int[:] _prebuf = _numpy.zeros(_buffer_size, dtype=_numpy.int32)
 cdef int[:] _postbuf = _numpy.zeros(_buffer_size, dtype=_numpy.int32)
 cdef int _curbuf = 0
 
-cdef void _flush_buffer(buf, dynarr, int N):
+cdef void _flush_buffer(buf, dynarr, int buf_len):
     _curlen = dynarr.shape[0]
-    _newlen = _curlen+N
+    _newlen = _curlen+buf_len
     # Resize the array
     dynarr.resize(_newlen)
     # Get the potentially newly created underlying data arrays
     data = dynarr.data
-    data[_curlen:_curlen+N] = buf[:N]
+    data[_curlen:_curlen+buf_len] = buf[:buf_len]
     
 {% endblock %}
 
@@ -78,5 +78,7 @@ cdef void _flush_buffer(buf, dynarr, int N):
     newsize = len({{_dynamic__synaptic_pre}})
     # now we need to resize all registered variables (via Python)
     _owner._resize(newsize)
+    # Set the total number of synapses
+    {{N}}[0] = newsize
 
 {% endblock %}

--- a/brian2/codegen/runtime/cython_rt/templates/synapses_create.pyx
+++ b/brian2/codegen/runtime/cython_rt/templates/synapses_create.pyx
@@ -84,9 +84,8 @@ cdef void _flush_buffer(buf, dynarr, int buf_len):
     _curbuf = 0  # reset the buffer for the next run
 
     newsize = len({{_dynamic__synaptic_pre}})
-    # now we need to resize all registered variables (via Python)
+    # now we need to resize all registered variables and set the total number
+    # of synapse (via Python)
     _owner._resize(newsize)
-    # Set the total number of synapses
-    {{N}}[0] = newsize
 
 {% endblock %}

--- a/brian2/codegen/runtime/cython_rt/templates/synapses_create_array.pyx
+++ b/brian2/codegen/runtime/cython_rt/templates/synapses_create_array.pyx
@@ -3,7 +3,8 @@
 {% block maincode %}
 
     {# USES_VARIABLES { _synaptic_pre, _synaptic_post, sources, targets
-                        N_incoming, N_outgoing, N }
+                        N_incoming, N_outgoing, N,
+                        N_pre, N_post, _source_offset, _target_offset }
     #}
     
     cdef int _old_num_synapses = {{N}}[0]
@@ -14,7 +15,14 @@
     # Get the potentially newly created underlying data arrays
     cdef int32_t[:] _synaptic_pre_data = {{_dynamic__synaptic_pre}}.data
     cdef int32_t[:] _synaptic_post_data = {{_dynamic__synaptic_post}}.data 
-    
+
+    # Resize N_incoming and N_outgoing according to the size of the
+    # source/target groups
+    _var_N_incoming.resize(N_post + _target_offset)
+    _var_N_outgoing.resize(N_pre + _source_offset)
+    cdef {{cpp_dtype(variables['N_incoming'].dtype)}}[:] _N_incoming = {{_dynamic_N_incoming}}.data.view(_numpy.{{numpy_dtype(variables['N_incoming'].dtype)}})
+    cdef {{cpp_dtype(variables['N_outgoing'].dtype)}}[:] _N_outgoing = {{_dynamic_N_outgoing}}.data.view(_numpy.{{numpy_dtype(variables['N_outgoing'].dtype)}})
+
     for _idx in range(_num{{sources}}):
         # After this code has been executed, the arrays _real_sources and
         # _real_variables contain the final indices. Having any code here it all is
@@ -23,8 +31,8 @@
         _synaptic_pre_data[_idx + _old_num_synapses] = _real_sources
         _synaptic_post_data[_idx + _old_num_synapses] = _real_targets
         # Update the number of total outgoing/incoming synapses per source/target neuron
-        {{N_outgoing}}[_real_sources] += 1
-        {{N_incoming}}[_real_targets] += 1
+        _N_outgoing[_real_sources] += 1
+        _N_incoming[_real_targets] += 1
     
     # now we need to resize all registered variables (via Python)
     _owner._resize(_new_num_synapses)

--- a/brian2/codegen/runtime/cython_rt/templates/synapses_create_array.pyx
+++ b/brian2/codegen/runtime/cython_rt/templates/synapses_create_array.pyx
@@ -3,10 +3,10 @@
 {% block maincode %}
 
     {# USES_VARIABLES { _synaptic_pre, _synaptic_post, sources, targets
-                     N_incoming, N_outgoing }
+                        N_incoming, N_outgoing, N }
     #}
     
-    cdef int _old_num_synapses = len({{_dynamic__synaptic_pre}})
+    cdef int _old_num_synapses = {{N}}[0]
     cdef int _new_num_synapses = _old_num_synapses + _num{{sources}}
 
     {{_dynamic__synaptic_pre}}.resize(_new_num_synapses)
@@ -28,5 +28,7 @@
     
     # now we need to resize all registered variables (via Python)
     _owner._resize(_new_num_synapses)
+    # Set the total number of synapses
+    {{N}}[0] = _new_num_synapses
 
 {% endblock %}

--- a/brian2/codegen/runtime/cython_rt/templates/synapses_create_array.pyx
+++ b/brian2/codegen/runtime/cython_rt/templates/synapses_create_array.pyx
@@ -34,9 +34,8 @@
         _N_outgoing[_real_sources] += 1
         _N_incoming[_real_targets] += 1
     
-    # now we need to resize all registered variables (via Python)
+    # now we need to resize all registered variables and set the total number
+    # of synapses (via Python)
     _owner._resize(_new_num_synapses)
-    # Set the total number of synapses
-    {{N}}[0] = _new_num_synapses
 
 {% endblock %}

--- a/brian2/codegen/runtime/numpy_rt/numpy_rt.py
+++ b/brian2/codegen/runtime/numpy_rt/numpy_rt.py
@@ -80,6 +80,8 @@ class NumpyCodeObject(CodeObject):
 
             if isinstance(var, ArrayVariable):
                 self.namespace[self.generator_class.get_array_name(var)] = value
+                if var.scalar and var.constant:
+                    self.namespace[name] = value[0]
             else:
                 self.namespace[name] = value
 

--- a/brian2/codegen/runtime/numpy_rt/numpy_rt.py
+++ b/brian2/codegen/runtime/numpy_rt/numpy_rt.py
@@ -91,6 +91,10 @@ class NumpyCodeObject(CodeObject):
                 self.namespace[dyn_array_name] = self.device.get_value(var,
                                                                        access_data=False)
 
+            # Also provide the Variable object itself in the namespace (can be
+            # necessary for resize operations, for example)
+            self.namespace['_var_'+name] = var
+
             # There are two kinds of objects that we have to inject into the
             # namespace with their current value at each time step:
             # * non-constant AttributeValue (this might be removed since it only

--- a/brian2/codegen/runtime/numpy_rt/templates/ratemonitor.py_
+++ b/brian2/codegen/runtime/numpy_rt/templates/ratemonitor.py_
@@ -1,10 +1,10 @@
 {# USES_VARIABLES { rate, t, _spikespace, _num_source_neurons,
-                    _clock_t, _clock_dt, _source_start, _source_stop } #}
+                    _clock_t, _clock_dt, _source_start, _source_stop, N } #}
 import numpy as _numpy
 _spikes = {{_spikespace}}[:{{_spikespace}}[-1]]
 # Take subgroups into account
 _spikes = _spikes[(_spikes >= _source_start) & (_spikes < _source_stop)]
-_new_len = len({{_dynamic_t}}) + 1
+_new_len = {{N}}[0] + 1
 _owner.resize(_new_len)
 # Note that _t refers directly to the underlying array which might have changed
 {{_dynamic_t}}[-1] = _clock_t

--- a/brian2/codegen/runtime/numpy_rt/templates/spikemonitor.py_
+++ b/brian2/codegen/runtime/numpy_rt/templates/spikemonitor.py_
@@ -11,7 +11,7 @@ _n_events = len(_events)
 _vectorisation_idx = 1
 {{scalar_code|autoindent}}
 if _n_events > 0:
-    _curlen = {{N}}
+    _curlen = {{N}}[0]
     _newlen = _curlen + _n_events
     _owner.resize(_newlen)
     _vectorisation_idx = _n_events
@@ -22,4 +22,3 @@ if _n_events > 0:
     {{dynamic_varname}}[_curlen:_newlen] = _to_record_{{varname}}
     {% endfor %}
     {{count}}[_events - _source_start] += 1
-    {{N}} += _n_events

--- a/brian2/codegen/runtime/numpy_rt/templates/synapses_create.py_
+++ b/brian2/codegen/runtime/numpy_rt/templates/synapses_create.py_
@@ -1,6 +1,6 @@
 {#
 USES_VARIABLES { _synaptic_pre, _synaptic_post, _all_pre, _all_post,
-                 N_incoming, N_outgoing }
+                 N_incoming, N_outgoing, N }
 #}
 {# ITERATE_ALL { _idx } #}
 import numpy as _numpy
@@ -9,7 +9,7 @@ numpy_False = _numpy.bool_(False)
 numpy_True = _numpy.bool_(True)
 
 # number of synapses in the beginning
-_old_num_synapses = len({{_dynamic__synaptic_pre}})
+_old_num_synapses = {{N}}[0]
 # number of synapses during the creation process
 _cur_num_synapses = _old_num_synapses
 
@@ -62,3 +62,5 @@ for _i in range(len({{_all_pre}})):
 
 # Resize all dependent dynamic arrays (synaptic weights, delays, etc.)
 _owner._resize(_cur_num_synapses)
+# Set the total number of synapses
+{{N}}[0] = _cur_num_synapses

--- a/brian2/codegen/runtime/numpy_rt/templates/synapses_create.py_
+++ b/brian2/codegen/runtime/numpy_rt/templates/synapses_create.py_
@@ -1,6 +1,7 @@
 {#
 USES_VARIABLES { _synaptic_pre, _synaptic_post, _all_pre, _all_post,
-                 N_incoming, N_outgoing, N }
+                 N_incoming, N_outgoing, N,
+                 N_pre, N_post, _source_offset, _target_offset }
 #}
 {# ITERATE_ALL { _idx } #}
 import numpy as _numpy
@@ -12,6 +13,11 @@ numpy_True = _numpy.bool_(True)
 _old_num_synapses = {{N}}[0]
 # number of synapses during the creation process
 _cur_num_synapses = _old_num_synapses
+
+# Resize N_incoming and N_outgoing according to the size of the
+# source/target groups
+_var_N_incoming.resize(N_post + _target_offset)
+_var_N_outgoing.resize(N_pre + _source_offset)
 
 # scalar code
 _vectorisation_idx = 1
@@ -57,8 +63,8 @@ for _i in range(len({{_all_pre}})):
     _cur_num_synapses += _numnew
 
 # Update the number of total outgoing/incoming synapses per source/target neuron
-{{N_outgoing}}[:] += _numpy.bincount({{_dynamic__synaptic_pre}}[_old_num_synapses:], minlength=len({{N_outgoing}}))
-{{N_incoming}}[:] += _numpy.bincount({{_dynamic__synaptic_post}}[_old_num_synapses:], minlength=len({{N_incoming}}))
+{{_dynamic_N_outgoing}}[:] += _numpy.bincount({{_dynamic__synaptic_pre}}[_old_num_synapses:], minlength=len({{_dynamic_N_outgoing}}))
+{{_dynamic_N_incoming}}[:] += _numpy.bincount({{_dynamic__synaptic_post}}[_old_num_synapses:], minlength=len({{_dynamic_N_incoming}}))
 
 # Resize all dependent dynamic arrays (synaptic weights, delays, etc.)
 _owner._resize(_cur_num_synapses)

--- a/brian2/codegen/runtime/numpy_rt/templates/synapses_create.py_
+++ b/brian2/codegen/runtime/numpy_rt/templates/synapses_create.py_
@@ -66,7 +66,6 @@ for _i in range(len({{_all_pre}})):
 {{_dynamic_N_outgoing}}[:] += _numpy.bincount({{_dynamic__synaptic_pre}}[_old_num_synapses:], minlength=len({{_dynamic_N_outgoing}}))
 {{_dynamic_N_incoming}}[:] += _numpy.bincount({{_dynamic__synaptic_post}}[_old_num_synapses:], minlength=len({{_dynamic_N_incoming}}))
 
-# Resize all dependent dynamic arrays (synaptic weights, delays, etc.)
+# Resize all dependent dynamic arrays (synaptic weights, delays, etc.) and set
+# the total number of synapses
 _owner._resize(_cur_num_synapses)
-# Set the total number of synapses
-{{N}}[0] = _cur_num_synapses

--- a/brian2/codegen/runtime/numpy_rt/templates/synapses_create_array.py_
+++ b/brian2/codegen/runtime/numpy_rt/templates/synapses_create_array.py_
@@ -1,6 +1,6 @@
 {#
 USES_VARIABLES { _synaptic_pre, _synaptic_post, sources, targets,
-                 N_incoming, N_outgoing }
+                 N_incoming, N_outgoing, N }
 #}
 
 {# This is to show that we don't need to index the sources/targets #}
@@ -12,7 +12,7 @@ USES_VARIABLES { _synaptic_pre, _synaptic_post, sources, targets,
 import numpy as _numpy
 {{vector_code|autoindent}}
 
-_old_num_synapses = len({{_dynamic__synaptic_pre}})
+_old_num_synapses = {{N}}[0]
 _new_num_synapses = _old_num_synapses + len({{sources}})
 {{_dynamic__synaptic_pre}}.resize(_new_num_synapses)
 {{_dynamic__synaptic_post}}.resize(_new_num_synapses)
@@ -25,3 +25,4 @@ _new_num_synapses = _old_num_synapses + len({{sources}})
 
 # Resize all dependent dynamic arrays (synaptic weights, delays, etc.)
 _owner._resize(_new_num_synapses)
+{{N}}[0] = _new_num_synapses

--- a/brian2/codegen/runtime/numpy_rt/templates/synapses_create_array.py_
+++ b/brian2/codegen/runtime/numpy_rt/templates/synapses_create_array.py_
@@ -1,6 +1,7 @@
 {#
 USES_VARIABLES { _synaptic_pre, _synaptic_post, sources, targets,
-                 N_incoming, N_outgoing, N }
+                 N_incoming, N_outgoing, N,
+                 N_pre, N_post, _source_offset, _target_offset }
 #}
 
 {# This is to show that we don't need to index the sources/targets #}
@@ -19,9 +20,13 @@ _new_num_synapses = _old_num_synapses + len({{sources}})
 {{_dynamic__synaptic_pre}}[_old_num_synapses:] = _real_sources
 {{_dynamic__synaptic_post}}[_old_num_synapses:] = _real_targets
 
+# Resize N_incoming and N_outgoing according to the size of the
+# source/target groups
+_var_N_incoming.resize(N_post + _target_offset)
+_var_N_outgoing.resize(N_pre + _source_offset)
 # Update the number of total outgoing/incoming synapses per source/target neuron
-{{N_outgoing}}[:] += _numpy.bincount(_real_sources, minlength=len({{N_outgoing}}))
-{{N_incoming}}[:] += _numpy.bincount(_real_targets, minlength=len({{N_incoming}}))
+{{_dynamic_N_incoming}}[:] += _numpy.bincount(_real_targets, minlength=len({{_dynamic_N_incoming}}))
+{{_dynamic_N_outgoing}}[:] += _numpy.bincount(_real_sources, minlength=len({{_dynamic_N_outgoing}}))
 
 # Resize all dependent dynamic arrays (synaptic weights, delays, etc.)
 _owner._resize(_new_num_synapses)

--- a/brian2/codegen/runtime/numpy_rt/templates/synapses_create_array.py_
+++ b/brian2/codegen/runtime/numpy_rt/templates/synapses_create_array.py_
@@ -28,6 +28,6 @@ _var_N_outgoing.resize(N_pre + _source_offset)
 {{_dynamic_N_incoming}}[:] += _numpy.bincount(_real_targets, minlength=len({{_dynamic_N_incoming}}))
 {{_dynamic_N_outgoing}}[:] += _numpy.bincount(_real_sources, minlength=len({{_dynamic_N_outgoing}}))
 
-# Resize all dependent dynamic arrays (synaptic weights, delays, etc.)
+# Resize all dependent dynamic arrays (synaptic weights, delays, etc.) and set
+# the total number of synapses
 _owner._resize(_new_num_synapses)
-{{N}}[0] = _new_num_synapses

--- a/brian2/codegen/runtime/weave_rt/templates/spikemonitor.cpp
+++ b/brian2/codegen/runtime/weave_rt/templates/spikemonitor.cpp
@@ -54,7 +54,6 @@
                 {% endfor %}
                 {{count}}[_idx - _source_start]++;
             }
-            {{N}}[0] += _num_events;
         }
 	}
 {% endmacro %}

--- a/brian2/codegen/runtime/weave_rt/templates/synapses_create.cpp
+++ b/brian2/codegen/runtime/weave_rt/templates/synapses_create.cpp
@@ -3,7 +3,7 @@
 {% block maincode %}
     {#
     USES_VARIABLES { _synaptic_pre, _synaptic_post, rand,
-                     N_incoming, N_outgoing }
+                     N_incoming, N_outgoing, N }
     #}
     srand((unsigned int)time(NULL));
     const int _buffer_size = 1024;
@@ -68,7 +68,8 @@
     py::tuple _newlen_tuple(1);
     _newlen_tuple[0] = newsize;
     _owner.mcall("_resize", _newlen_tuple);
-
+    // Set the total number of synapses
+    {{N}}[0] = newsize;
     delete [] _prebuf;
     delete [] _postbuf;
     delete [] _synprebuf;

--- a/brian2/codegen/runtime/weave_rt/templates/synapses_create.cpp
+++ b/brian2/codegen/runtime/weave_rt/templates/synapses_create.cpp
@@ -3,7 +3,8 @@
 {% block maincode %}
     {#
     USES_VARIABLES { _synaptic_pre, _synaptic_post, rand,
-                     N_incoming, N_outgoing, N }
+                     N_incoming, N_outgoing, N,
+                     N_pre, N_post, _source_offset, _target_offset}
     #}
     srand((unsigned int)time(NULL));
     const int _buffer_size = 1024;
@@ -13,6 +14,12 @@
     int *const _synpostbuf = new int[1];
     int _curbuf = 0;
 
+    // Resize N_incoming and N_outgoing according to the size of the
+    // source/target groups
+    PyObject_CallMethod(_var_N_incoming, "resize", "i", N_post + _target_offset);
+    PyObject_CallMethod(_var_N_outgoing, "resize", "i", N_pre + _source_offset);
+    int *_N_incoming = (int *)(((PyArrayObject*)(PyObject*){{_dynamic_N_incoming}}.attr("data"))->data);
+    int *_N_outgoing = (int *)(((PyArrayObject*)(PyObject*){{_dynamic_N_outgoing}}.attr("data"))->data);
     // scalar code
 	const int _vectorisation_idx = 1;
 	{{scalar_code|autoindent}}
@@ -43,8 +50,8 @@
                 }
 
                 for (int _repetition=0; _repetition<_n; _repetition++) {
-                    {{N_outgoing}}[_pre_idx] += 1;
-                    {{N_incoming}}[_post_idx] += 1;
+                    _N_outgoing[_pre_idx] += 1;
+                    _N_incoming[_post_idx] += 1;
                     _prebuf[_curbuf] = _pre_idx;
                     _postbuf[_curbuf] = _post_idx;
                     _curbuf++;

--- a/brian2/codegen/runtime/weave_rt/templates/synapses_create.cpp
+++ b/brian2/codegen/runtime/weave_rt/templates/synapses_create.cpp
@@ -69,12 +69,11 @@
     _flush_buffer(_postbuf, {{_dynamic__synaptic_post}}, _curbuf);
 
     const int newsize = {{_dynamic__synaptic_pre}}.size();
-    // now we need to resize all registered variables (via Python)
+    // now we need to resize all registered variables and set the total number
+    // of synapses (via Python)
     py::tuple _newlen_tuple(1);
     _newlen_tuple[0] = newsize;
     _owner.mcall("_resize", _newlen_tuple);
-    // Set the total number of synapses
-    {{N}}[0] = newsize;
     delete [] _prebuf;
     delete [] _postbuf;
 {% endblock %}

--- a/brian2/codegen/runtime/weave_rt/templates/synapses_create.cpp
+++ b/brian2/codegen/runtime/weave_rt/templates/synapses_create.cpp
@@ -10,8 +10,6 @@
     const int _buffer_size = 1024;
     int *const _prebuf = new int[_buffer_size];
     int *const _postbuf = new int[_buffer_size];
-    int *const _synprebuf = new int[1];
-    int *const _synpostbuf = new int[1];
     int _curbuf = 0;
 
     // Resize N_incoming and N_outgoing according to the size of the
@@ -79,8 +77,6 @@
     {{N}}[0] = newsize;
     delete [] _prebuf;
     delete [] _postbuf;
-    delete [] _synprebuf;
-    delete [] _synpostbuf;
 {% endblock %}
 
 {% block support_code_block %}

--- a/brian2/codegen/runtime/weave_rt/templates/synapses_create_array.cpp
+++ b/brian2/codegen/runtime/weave_rt/templates/synapses_create_array.cpp
@@ -2,11 +2,11 @@
 
 {% block maincode %}
 {# USES_VARIABLES { _synaptic_pre, _synaptic_post, sources, targets
-                 N_incoming, N_outgoing }
+                    N_incoming, N_outgoing, N }
 #}
 
 py::tuple _newlen_tuple(1);
-const int _old_num_synapses = {{_dynamic__synaptic_pre}}.size();
+const int _old_num_synapses = {{N}}[0];
 const int _new_num_synapses = _old_num_synapses + _numsources;
 
 _newlen_tuple[0] = _new_num_synapses;
@@ -30,4 +30,6 @@ for (int _idx=0; _idx<_numsources; _idx++) {
 
 // now we need to resize all registered variables (via Python)
 _owner.mcall("_resize", _newlen_tuple);
+// set the total number of synapses
+{{N}}[0] = _new_num_synapses;
 {% endblock %}

--- a/brian2/codegen/runtime/weave_rt/templates/synapses_create_array.cpp
+++ b/brian2/codegen/runtime/weave_rt/templates/synapses_create_array.cpp
@@ -2,7 +2,8 @@
 
 {% block maincode %}
 {# USES_VARIABLES { _synaptic_pre, _synaptic_post, sources, targets
-                    N_incoming, N_outgoing, N }
+                    N_incoming, N_outgoing, N,
+                    N_pre, N_post, _source_offset, _target_offset }
 #}
 
 py::tuple _newlen_tuple(1);
@@ -15,6 +16,12 @@ _newlen_tuple[0] = _new_num_synapses;
 // Get the potentially newly created underlying data arrays
 int *_synaptic_pre_data = (int*)(((PyArrayObject*)(PyObject*){{_dynamic__synaptic_pre}}.attr("data"))->data);
 int *_synaptic_post_data = (int*)(((PyArrayObject*)(PyObject*){{_dynamic__synaptic_post}}.attr("data"))->data);
+// Resize N_incoming and N_outgoing according to the size of the
+// source/target groups
+PyObject_CallMethod(_var_N_incoming, "resize", "i", N_post + _target_offset);
+PyObject_CallMethod(_var_N_outgoing, "resize", "i", N_pre + _source_offset);
+int *_N_incoming = (int *)(((PyArrayObject*)(PyObject*){{_dynamic_N_incoming}}.attr("data"))->data);
+int *_N_outgoing = (int *)(((PyArrayObject*)(PyObject*){{_dynamic_N_outgoing}}.attr("data"))->data);
 
 for (int _idx=0; _idx<_numsources; _idx++) {
     {# After this code has been executed, the arrays _real_sources and
@@ -24,12 +31,10 @@ for (int _idx=0; _idx<_numsources; _idx++) {
     _synaptic_pre_data[_idx + _old_num_synapses] = _real_sources;
     _synaptic_post_data[_idx + _old_num_synapses] = _real_targets;
     // Update the number of total outgoing/incoming synapses per source/target neuron
-    {{N_outgoing}}[_real_sources]++;
-    {{N_incoming}}[_real_targets]++;
+    _N_outgoing[_real_sources]++;
+    _N_incoming[_real_targets]++;
 }
 
 // now we need to resize all registered variables (via Python)
 _owner.mcall("_resize", _newlen_tuple);
-// set the total number of synapses
-{{N}}[0] = _new_num_synapses;
 {% endblock %}

--- a/brian2/codegen/runtime/weave_rt/templates/synapses_create_array.cpp
+++ b/brian2/codegen/runtime/weave_rt/templates/synapses_create_array.cpp
@@ -35,6 +35,7 @@ for (int _idx=0; _idx<_numsources; _idx++) {
     _N_incoming[_real_targets]++;
 }
 
-// now we need to resize all registered variables (via Python)
+// now we need to resize all registered variables and set the total number of
+// synapses (via Python)
 _owner.mcall("_resize", _newlen_tuple);
 {% endblock %}

--- a/brian2/codegen/runtime/weave_rt/weave_rt.py
+++ b/brian2/codegen/runtime/weave_rt/weave_rt.py
@@ -179,6 +179,10 @@ libraries: {self.libraries}
                 self.namespace[dyn_array_name] = self.device.get_value(var,
                                                                        access_data=False)
 
+            # Also provide the Variable object itself in the namespace (can be
+            # necessary for resize operations, for example)
+            self.namespace['_var_'+name] = var
+
             # There are two kinds of objects that we have to inject into the
             # namespace with their current value at each time step:
             # * non-constant AttributeValue (this might be removed since it only

--- a/brian2/codegen/runtime/weave_rt/weave_rt.py
+++ b/brian2/codegen/runtime/weave_rt/weave_rt.py
@@ -168,6 +168,8 @@ libraries: {self.libraries}
                 self.namespace[self.device.get_array_name(var,
                                                             self.variables)] = value
                 self.namespace['_num'+name] = var.get_len()
+                if var.scalar and var.constant:
+                    self.namespace[name] = value.item()
             else:
                 self.namespace[name] = value
 

--- a/brian2/codegen/templates.py
+++ b/brian2/codegen/templates.py
@@ -3,9 +3,8 @@ Handles loading templates from a directory.
 '''
 import os
 import re
-import collections
 
-from jinja2 import Environment, PackageLoader, ChoiceLoader
+from jinja2 import Environment, PackageLoader, ChoiceLoader, StrictUndefined
 
 from brian2.utils.stringtools import (indent, strip_empty_lines,
                                       get_identifiers)
@@ -69,7 +68,8 @@ class Templater(object):
         if isinstance(package_name, basestring):
             package_name = (package_name,)
         loader = ChoiceLoader([PackageLoader(name, 'templates') for name in package_name])
-        self.env = Environment(loader=loader, trim_blocks=True, lstrip_blocks=True)
+        self.env = Environment(loader=loader, trim_blocks=True,
+                               lstrip_blocks=True, undefined=StrictUndefined)
         self.env.globals['autoindent'] = autoindent
         self.env.filters['autoindent'] = autoindent
         if env_globals is not None:

--- a/brian2/core/variables.py
+++ b/brian2/core/variables.py
@@ -1182,7 +1182,7 @@ class VariableView(object):
         # Force the use of this variable as a replacement for the original
         # index variable
         using_orig_index = [varname for varname, index in self.group.variables.indices.iteritems()
-                            if index == self.index_var_name]
+                            if index == self.index_var_name and index != '0']
         for varname in using_orig_index:
             variables.indices[varname] = '_idx'
 
@@ -1440,6 +1440,11 @@ class Variables(collections.Mapping):
             # Tell the device to actually create the array (or note it down for
             # later code generation in standalone).
             self.device.add_array(var)
+
+        if getattr(var, 'scalar', False):
+            if index is not None:
+                raise ValueError('Cannot set an index for a scalar variable')
+            self.indices[name] = '0'
 
         if index is not None:
             self.indices[name] = index

--- a/brian2/core/variables.py
+++ b/brian2/core/variables.py
@@ -1442,7 +1442,7 @@ class Variables(collections.Mapping):
             self.device.add_array(var)
 
         if getattr(var, 'scalar', False):
-            if index is not None:
+            if index not in (None, '0'):
                 raise ValueError('Cannot set an index for a scalar variable')
             self.indices[name] = '0'
 

--- a/brian2/core/variables.py
+++ b/brian2/core/variables.py
@@ -125,9 +125,12 @@ class Variable(object):
         internally and cannot be changed by the user (this is used for example
         for the variable ``N``, the number of neurons in a group). Defaults
         to ``False``.
+    array : bool, optional
+        Whether this variable is an array. Allows for simpler check than testing
+        ``isinstance(var, ArrayVariable)``. Defaults to ``False``.
     '''
     def __init__(self, name, unit, owner=None, dtype=None, scalar=False,
-                 constant=False, read_only=False, dynamic=False):
+                 constant=False, read_only=False, dynamic=False, array=False):
         
         #: The variable's unit.
         self.unit = unit
@@ -158,6 +161,9 @@ class Variable(object):
         
         #: Whether the variable is dynamically sized (only for non-scalars)
         self.dynamic = dynamic
+
+        #: Whether the variable is an array
+        self.array = array
 
     @property
     def is_boolean(self):
@@ -479,7 +485,8 @@ class ArrayVariable(Variable):
                                             dtype=dtype, scalar=scalar,
                                             constant=constant,
                                             read_only=read_only,
-                                            dynamic=dynamic)
+                                            dynamic=dynamic,
+                                            array=True)
 
         #: Wether all values in this arrays are necessarily unique (only
         #: relevant for index variables).

--- a/brian2/devices/cpp_standalone/codeobject.py
+++ b/brian2/devices/cpp_standalone/codeobject.py
@@ -80,6 +80,19 @@ def openmp_pragma(pragma_type):
     else:
         raise ValueError('Unknown OpenMP pragma "%s"' % pragma_type)
 
+
+def constant_or_scalar(varname, variable):
+    '''
+    Convenience function to generate code to access the value of a variable.
+    Will return ``'varname'`` if the ``variable`` is a constant, and
+    ``array_name[0]`` if it is a scalar array.
+    '''
+    if variable.array:
+        return '%s[0]' % get_device().get_array_name(variable)
+    else:
+        return '%s' % varname
+
+
 class CPPStandaloneCodeObject(CodeObject):
     '''
     C++ standalone code object
@@ -90,7 +103,8 @@ class CPPStandaloneCodeObject(CodeObject):
     '''
     templater = Templater('brian2.devices.cpp_standalone',
                           env_globals={'c_data_type': c_data_type,
-                                       'openmp_pragma': openmp_pragma})
+                                       'openmp_pragma': openmp_pragma,
+                                       'constant_or_scalar': constant_or_scalar})
     generator_class = CPPCodeGenerator
 
     def __call__(self, **kwds):

--- a/brian2/devices/cpp_standalone/templates/common_group.cpp
+++ b/brian2/devices/cpp_standalone/templates/common_group.cpp
@@ -40,8 +40,17 @@ void _run_{{codeobj_name}}()
 	// scalar code
 	const int _vectorisation_idx = -1;
 	{{scalar_code|autoindent}}
+
+    {# N is a constant in most cases (NeuronGroup, etc.), but a scalar array for
+       synapses, we therefore have to take care to get its value in the right
+       way. #}
+	{% if variables['N'].array %}
+	const int _N = {{N}}[0];
+	{% else %}
+	const int _N = N;
+	{% endif %}
 	{{openmp_pragma('static')}} 
-	for(int _idx=0; _idx<N; _idx++)
+	for(int _idx=0; _idx<_N; _idx++)
 	{
 	    // vector code
 		const int _vectorisation_idx = _idx;

--- a/brian2/devices/cpp_standalone/templates/common_group.cpp
+++ b/brian2/devices/cpp_standalone/templates/common_group.cpp
@@ -44,12 +44,8 @@ void _run_{{codeobj_name}}()
     {# N is a constant in most cases (NeuronGroup, etc.), but a scalar array for
        synapses, we therefore have to take care to get its value in the right
        way. #}
-	{% if variables['N'].array %}
-	const int _N = {{N}}[0];
-	{% else %}
-	const int _N = N;
-	{% endif %}
-	{{openmp_pragma('static')}} 
+	const int _N = {{constant_or_scalar('N', variables['N'])}};
+	{{openmp_pragma('static')}}
 	for(int _idx=0; _idx<_N; _idx++)
 	{
 	    // vector code

--- a/brian2/devices/cpp_standalone/templates/group_variable_set_conditional.cpp
+++ b/brian2/devices/cpp_standalone/templates/group_variable_set_conditional.cpp
@@ -41,9 +41,17 @@ void _run_{{codeobj_name}}()
 	{{scalar_code['condition']|autoindent}}
 	{{scalar_code['statement']|autoindent}}
 
+    {# N is a constant in most cases (NeuronGroup, etc.), but a scalar array for
+       synapses, we therefore have to take care to get its value in the right
+       way. #}
+	{% if variables['N'].array %}
+	const int _N = {{N}}[0];
+	{% else %}
+	const int _N = N;
+	{% endif %}
 	//We add the parallel flag because this is executed outside the main run loop
 	{{ openmp_pragma('parallel-static') }}
-	for(int _idx=0; _idx<N; _idx++)
+	for(int _idx=0; _idx<_N; _idx++)
 	{
 	    // vector code
 		const int _vectorisation_idx = _idx;

--- a/brian2/devices/cpp_standalone/templates/group_variable_set_conditional.cpp
+++ b/brian2/devices/cpp_standalone/templates/group_variable_set_conditional.cpp
@@ -44,11 +44,8 @@ void _run_{{codeobj_name}}()
     {# N is a constant in most cases (NeuronGroup, etc.), but a scalar array for
        synapses, we therefore have to take care to get its value in the right
        way. #}
-	{% if variables['N'].array %}
-	const int _N = {{N}}[0];
-	{% else %}
-	const int _N = N;
-	{% endif %}
+	const int _N = {{constant_or_scalar('N', variables['N'])}};
+
 	//We add the parallel flag because this is executed outside the main run loop
 	{{ openmp_pragma('parallel-static') }}
 	for(int _idx=0; _idx<_N; _idx++)

--- a/brian2/devices/cpp_standalone/templates/objects.cpp
+++ b/brian2/devices/cpp_standalone/templates/objects.cpp
@@ -51,10 +51,8 @@ const int brian::_num_{{name}} = {{N}};
 //////////////// synapses /////////////////
 {% for S in synapses | sort(attribute='name') %}
 // {{S.name}}
-Synapses<double> brian::{{S.name}}({{S.source|length}}, {{S.target|length}});
 {% for path in S._pathways | sort(attribute='name') %}
 SynapticPathway<double> brian::{{path.name}}(
-		{{path.source|length}}, {{path.target|length}},
 		{{dynamic_array_specs[path.variables['delay']]}},
 		{{dynamic_array_specs[path.synapse_sources]}},
 		{{path.source.dt_}},
@@ -281,7 +279,6 @@ extern const int _num_{{name}};
 //////////////// synapses /////////////////
 {% for S in synapses | sort(attribute='name') %}
 // {{S.name}}
-extern Synapses<double> {{S.name}};
 {% for path in S._pathways | sort(attribute='name') %}
 extern SynapticPathway<double> {{path.name}};
 {% endfor %}

--- a/brian2/devices/cpp_standalone/templates/synapses_classes.cpp
+++ b/brian2/devices/cpp_standalone/templates/synapses_classes.cpp
@@ -95,8 +95,6 @@ template <class scalar>
 class Synapses
 {
 public:
-    int _N_value;
-    inline double _N() { return _N_value;};
 	int Nsource;
 	int Ntarget;
 	std::vector< std::vector<int> > _pre_synaptic;
@@ -109,7 +107,6 @@ public:
 			_pre_synaptic.push_back(std::vector<int>());
 		for(int i=0; i<Ntarget; i++)
 			_post_synaptic.push_back(std::vector<int>());
-		_N_value = 0;
 	};
 };
 

--- a/brian2/devices/cpp_standalone/templates/synapses_classes.cpp
+++ b/brian2/devices/cpp_standalone/templates/synapses_classes.cpp
@@ -13,7 +13,6 @@
 
 #include "brianlib/spikequeue.h"
 
-template<class scalar> class Synapses;
 template<class scalar> class SynapticPathway;
 
 template <class scalar>
@@ -26,9 +25,9 @@ public:
 	std::vector<int> all_peek;
 	scalar dt;
 	std::vector< CSpikeQueue<scalar> * > queue;
-	SynapticPathway(int _Nsource, int _Ntarget, std::vector<scalar>& _delay, std::vector<int> &_sources,
+	SynapticPathway(std::vector<scalar>& _delay, std::vector<int> &_sources,
 					scalar _dt, int _spikes_start, int _spikes_stop)
-		: Nsource(_Nsource), Ntarget(_Ntarget), delay(_delay), sources(_sources), dt(_dt)
+		: delay(_delay), sources(_sources), dt(_dt)
 	{
 	   _nb_threads = {{ openmp_pragma('get_num_threads') }};
 
@@ -68,9 +67,11 @@ public:
     	return &all_peek;
     }
 
-    void prepare(scalar *real_delays, unsigned int n_delays,
+    void prepare(int n_source, int n_target, scalar *real_delays, unsigned int n_delays,
                  int *sources, unsigned int n_synapses, double _dt)
     {
+        Nsource = n_source;
+        Ntarget = n_target;
     	{{ openmp_pragma('parallel') }}
     	{
             unsigned int length;
@@ -89,25 +90,6 @@ public:
     	}
     }
 
-};
-
-template <class scalar>
-class Synapses
-{
-public:
-	int Nsource;
-	int Ntarget;
-	std::vector< std::vector<int> > _pre_synaptic;
-	std::vector< std::vector<int> > _post_synaptic;
-
-	Synapses(int _Nsource, int _Ntarget)
-		: Nsource(_Nsource), Ntarget(_Ntarget)
-	{
-		for(int i=0; i<Nsource; i++)
-			_pre_synaptic.push_back(std::vector<int>());
-		for(int i=0; i<Ntarget; i++)
-			_post_synaptic.push_back(std::vector<int>());
-	};
 };
 
 #endif

--- a/brian2/devices/cpp_standalone/templates/synapses_create.cpp
+++ b/brian2/devices/cpp_standalone/templates/synapses_create.cpp
@@ -4,12 +4,11 @@
 {% block maincode %}
     #include<iostream>
 	{# USES_VARIABLES { _synaptic_pre, _synaptic_post, rand,
-	                    N_incoming, N_outgoing } #}
+	                    N_incoming, N_outgoing, N } #}
     
     // scalar code
     const int _vectorisation_idx = -1;
 	{{scalar_code|autoindent}}
-	
     for(int _i=0; _i<_num_all_pre; _i++)
 	{
 		for(int _j=0; _j<_num_all_post; _j++)
@@ -50,5 +49,5 @@
 	{{varname}}.resize(newsize);
 	{% endfor %}
 	// Also update the total number of synapses
-	{{owner.name}}._N_value = newsize;
+	{{N}}[0] = newsize;
 {% endblock %}

--- a/brian2/devices/cpp_standalone/templates/synapses_create.cpp
+++ b/brian2/devices/cpp_standalone/templates/synapses_create.cpp
@@ -4,8 +4,12 @@
 {% block maincode %}
     #include<iostream>
 	{# USES_VARIABLES { _synaptic_pre, _synaptic_post, rand,
-	                    N_incoming, N_outgoing, N } #}
-    
+	                    N_incoming, N_outgoing, N,
+	                    N_pre, N_post, _source_offset, _target_offset } #}
+
+    {{_dynamic_N_incoming}}.resize(N_post + _target_offset);
+    {{_dynamic_N_outgoing}}.resize(N_pre + _source_offset);
+
     // scalar code
     const int _vectorisation_idx = -1;
 	{{scalar_code|autoindent}}
@@ -33,8 +37,8 @@
 			            continue;
 			    }
 			    for (int _repetition=0; _repetition<_n; _repetition++) {
-			        {{N_outgoing}}[_pre_idx] += 1;
-			        {{N_incoming}}[_post_idx] += 1;
+			        {{_dynamic_N_outgoing}}[_pre_idx] += 1;
+			        {{_dynamic_N_incoming}}[_post_idx] += 1;
 			    	{{_dynamic__synaptic_pre}}.push_back(_pre_idx);
 			    	{{_dynamic__synaptic_post}}.push_back(_post_idx);
                 }

--- a/brian2/devices/cpp_standalone/templates/synapses_create.cpp
+++ b/brian2/devices/cpp_standalone/templates/synapses_create.cpp
@@ -7,8 +7,12 @@
 	                    N_incoming, N_outgoing, N,
 	                    N_pre, N_post, _source_offset, _target_offset } #}
 
-    {{_dynamic_N_incoming}}.resize(N_post + _target_offset);
-    {{_dynamic_N_outgoing}}.resize(N_pre + _source_offset);
+    {# Get N_post and N_pre in the correct way, regardless of whether they are
+    constants or scalar arrays#}
+    const int _N_pre = {{constant_or_scalar('N_pre', variables['N_pre'])}};
+    const int _N_post = {{constant_or_scalar('N_post', variables['N_post'])}};
+    {{_dynamic_N_incoming}}.resize(_N_post + _target_offset);
+    {{_dynamic_N_outgoing}}.resize(_N_pre + _source_offset);
 
     // scalar code
     const int _vectorisation_idx = -1;

--- a/brian2/devices/cpp_standalone/templates/synapses_create_array.cpp
+++ b/brian2/devices/cpp_standalone/templates/synapses_create_array.cpp
@@ -3,11 +3,15 @@
 
 {% block maincode %}
 {# USES_VARIABLES { _synaptic_pre, _synaptic_post, sources, targets
-                 N_incoming, N_outgoing, N }
+                    N_incoming, N_outgoing, N,
+                    N_pre, N_post, _source_offset, _target_offset }
 #}
 
 const int _old_num_synapses = {{N}}[0];
 const int _new_num_synapses = _old_num_synapses + _numsources;
+
+{{_dynamic_N_incoming}}.resize(N_post + _target_offset);
+{{_dynamic_N_outgoing}}.resize(N_pre + _source_offset);
 
 for (int _idx=0; _idx<_numsources; _idx++) {
     {# After this code has been executed, the arrays _real_sources and
@@ -18,8 +22,8 @@ for (int _idx=0; _idx<_numsources; _idx++) {
     {{_dynamic__synaptic_pre}}.push_back(_real_sources);
     {{_dynamic__synaptic_post}}.push_back(_real_targets);
     // Update the number of total outgoing/incoming synapses per source/target neuron
-    {{N_outgoing}}[_real_sources]++;
-    {{N_incoming}}[_real_targets]++;
+    {{_dynamic_N_outgoing}}[_real_sources]++;
+    {{_dynamic_N_incoming}}[_real_targets]++;
 }
 
 // now we need to resize all registered variables

--- a/brian2/devices/cpp_standalone/templates/synapses_create_array.cpp
+++ b/brian2/devices/cpp_standalone/templates/synapses_create_array.cpp
@@ -3,10 +3,10 @@
 
 {% block maincode %}
 {# USES_VARIABLES { _synaptic_pre, _synaptic_post, sources, targets
-                 N_incoming, N_outgoing }
+                 N_incoming, N_outgoing, N }
 #}
 
-const int _old_num_synapses = {{_dynamic__synaptic_pre}}.size();
+const int _old_num_synapses = {{N}}[0];
 const int _new_num_synapses = _old_num_synapses + _numsources;
 
 for (int _idx=0; _idx<_numsources; _idx++) {
@@ -29,5 +29,5 @@ const int newsize = {{_dynamic__synaptic_pre}}.size();
 {{varname}}.resize(newsize);
 {% endfor %}
 // Also update the total number of synapses
-{{owner.name}}._N_value = newsize;
+{{N}}[0] = newsize;
 {% endblock %}

--- a/brian2/devices/cpp_standalone/templates/synapses_create_array.cpp
+++ b/brian2/devices/cpp_standalone/templates/synapses_create_array.cpp
@@ -10,8 +10,12 @@
 const int _old_num_synapses = {{N}}[0];
 const int _new_num_synapses = _old_num_synapses + _numsources;
 
-{{_dynamic_N_incoming}}.resize(N_post + _target_offset);
-{{_dynamic_N_outgoing}}.resize(N_pre + _source_offset);
+{# Get N_post and N_pre in the correct way, regardless of whether they are
+constants or scalar arrays#}
+const int _N_pre = {{constant_or_scalar('N_pre', variables['N_pre'])}};
+const int _N_post = {{constant_or_scalar('N_post', variables['N_post'])}};
+{{_dynamic_N_incoming}}.resize(_N_post + _target_offset);
+{{_dynamic_N_outgoing}}.resize(_N_pre + _source_offset);
 
 for (int _idx=0; _idx<_numsources; _idx++) {
     {# After this code has been executed, the arrays _real_sources and

--- a/brian2/devices/cpp_standalone/templates/synapses_initialise_queue.cpp
+++ b/brian2/devices/cpp_standalone/templates/synapses_initialise_queue.cpp
@@ -9,7 +9,9 @@ void _run_{{codeobj_name}}() {
     int32_t* sources = {{pathobj}}.sources.empty() ? 0 : &({{pathobj}}.sources[0]);
     const unsigned int n_delays = {{pathobj}}.delay.size();
     const unsigned int n_synapses = {{pathobj}}.sources.size();
-    {{pathobj}}.prepare(_n_sources, _n_targets, real_delays, n_delays, sources,
+    {{pathobj}}.prepare({{constant_or_scalar('_n_sources', variables['_n_sources'])}},
+                        {{constant_or_scalar('_n_targets', variables['_n_targets'])}},
+                        real_delays, n_delays, sources,
                         n_synapses, {{pathobj}}.dt);
 }
 {% endmacro %}

--- a/brian2/devices/cpp_standalone/templates/synapses_initialise_queue.cpp
+++ b/brian2/devices/cpp_standalone/templates/synapses_initialise_queue.cpp
@@ -1,4 +1,5 @@
 {# IS_OPENMP_COMPATIBLE #}
+{# USES_VARIABLES { _n_sources, _n_targets } #}
 {% macro cpp_file() %}
 #include "code_objects/{{codeobj_name}}.h"
 {% set pathobj = owner.name %}
@@ -8,8 +9,8 @@ void _run_{{codeobj_name}}() {
     int32_t* sources = {{pathobj}}.sources.empty() ? 0 : &({{pathobj}}.sources[0]);
     const unsigned int n_delays = {{pathobj}}.delay.size();
     const unsigned int n_synapses = {{pathobj}}.sources.size();
-    {{pathobj}}.prepare(real_delays, n_delays, sources, n_synapses,
-                        {{pathobj}}.dt);
+    {{pathobj}}.prepare(_n_sources, _n_targets, real_delays, n_delays, sources,
+                        n_synapses, {{pathobj}}.dt);
 }
 {% endmacro %}
 

--- a/brian2/groups/group.py
+++ b/brian2/groups/group.py
@@ -274,6 +274,8 @@ class Group(BrianObject):
     def _enable_group_attributes(self):
         if not hasattr(self, 'variables'):
             raise ValueError('Classes derived from Group need variables attribute.')
+        if not 'N' in self.variables:
+            raise ValueError('Each group needs an "N" variable.')
         if not hasattr(self, 'codeobj_class'):
             self.codeobj_class = None
         if not hasattr(self, '_indices'):
@@ -285,6 +287,9 @@ class Group(BrianObject):
         if not hasattr(self, '_stored_clocks'):
             self._stored_clocks = {}
         self._group_attribute_access_active = True
+
+    def __len__(self):
+        return self.variables['N'].get_value()
 
     def state(self, name, use_units=True, level=0):
         '''

--- a/brian2/groups/neurongroup.py
+++ b/brian2/groups/neurongroup.py
@@ -505,12 +505,6 @@ class NeuronGroup(Group, SpikeSource):
         # Activate name attribute access
         self._enable_group_attributes()
 
-    def __len__(self):
-        '''
-        Return number of neurons in the group.
-        '''
-        return self.N
-
     @property
     def spikes(self):
         '''
@@ -747,12 +741,10 @@ class NeuronGroup(Group, SpikeSource):
                     constant = 'constant' in eq.flags
                     shared = 'shared' in eq.flags
                     size = 1 if shared else self._N
-                    index = '0' if shared else None
                     self.variables.add_array(eq.varname, size=size,
                                              unit=eq.unit, dtype=dtype,
                                              constant=constant,
-                                             scalar=shared,
-                                             index=index)
+                                             scalar=shared)
             elif eq.type == SUBEXPRESSION:
                 self.variables.add_subexpression(eq.varname, unit=eq.unit,
                                                  expr=str(eq.expr),

--- a/brian2/groups/subgroup.py
+++ b/brian2/groups/subgroup.py
@@ -100,9 +100,6 @@ class Subgroup(Group, SpikeSource):
                              (start, stop))
         return Subgroup(self.source, self.start + start, self.start + stop)
 
-    def __len__(self):
-        return self._N
-
     def __repr__(self):
         description = '<{classname} {name} of {source} from {start} to {end}>'
         return description.format(classname=self.__class__.__name__,

--- a/brian2/input/poissongroup.py
+++ b/brian2/input/poissongroup.py
@@ -101,9 +101,6 @@ class PoissonGroup(Group, SpikeSource):
         spikespace = self.variables['_spikespace'].get_value()
         return spikespace[:spikespace[-1]]
 
-    def __len__(self):
-        return self.N
-
     def __repr__(self):
         description = '{classname}({N}, rates=<...>)'
         return description.format(classname=self.__class__.__name__,

--- a/brian2/input/spikegeneratorgroup.py
+++ b/brian2/input/spikegeneratorgroup.py
@@ -264,9 +264,6 @@ class SpikeGeneratorGroup(Group, CodeRunner, SpikeSource):
         spikespace = self.variables['_spikespace'].get_value()
         return spikespace[:spikespace[-1]]
 
-    def __len__(self):
-        return self.N
-
     def __repr__(self):
         return ('{cls}({N}, indices=<length {l} array>, '
                 'times=<length {l} array>').format(cls=self.__class__.__name__,

--- a/brian2/monitors/ratemonitor.py
+++ b/brian2/monitors/ratemonitor.py
@@ -55,22 +55,16 @@ class PopulationRateMonitor(Group, CodeRunner):
         self.variables.add_dynamic_array('t', size=0, unit=second,
                                          constant_size=False)
         self.variables.add_reference('_num_source_neurons', source, 'N')
-        self.variables.add_attribute_variable('N', unit=Unit(1), obj=self,
-                                              attribute='_N', dtype=np.int32)
+        self.variables.add_array('N', unit=Unit(1), dtype=np.int32, size=1,
+                                 scalar=True, read_only=True)
         self.variables.create_clock_variables(self._clock,
                                               prefix='_clock_')
         self._enable_group_attributes()
 
-    @property
-    def _N(self):
-        return len(self.variables['t'].get_value())
-
     def resize(self, new_size):
+        self.variables['N'].set_value(new_size)
         self.variables['rate'].resize(new_size)
         self.variables['t'].resize(new_size)
-
-    def __len__(self):
-        return self._N
 
     def reinit(self):
         '''

--- a/brian2/monitors/spikemonitor.py
+++ b/brian2/monitors/spikemonitor.py
@@ -152,11 +152,9 @@ class EventMonitor(Group, CodeRunner):
         self._enable_group_attributes()
 
     def resize(self, new_size):
+        self.variables['N'].set_value(new_size)
         for variable in self.record_variables:
             self.variables[variable].resize(new_size)
-
-    def __len__(self):
-        return self.N
 
     def reinit(self):
         '''

--- a/brian2/monitors/statemonitor.py
+++ b/brian2/monitors/statemonitor.py
@@ -220,9 +220,8 @@ class StateMonitor(Group, CodeRunner):
 
         self.variables.add_dynamic_array('t', size=0, unit=second,
                                          constant=False, constant_size=False)
-        self.variables.add_attribute_variable('N', unit=Unit(1),
-                                              dtype=np.int32,
-                                              obj=self, attribute='_N')
+        self.variables.add_array('N', unit=Unit(1), dtype=np.int32,
+                                 size=1, scalar=True, read_only=True)
         self.variables.add_array('_indices', size=len(self.record),
                                  unit=Unit(1), dtype=self.record.dtype,
                                  constant=True, read_only=True,
@@ -263,14 +262,8 @@ class StateMonitor(Group, CodeRunner):
         self.template_kwds = {'_recorded_variables': self.recorded_variables}
         self._enable_group_attributes()
 
-    @property
-    def _N(self):
-        return self.variables['t'].get_value().shape[0]
-
-    def __len__(self):
-        return self._N
-
     def resize(self, new_size):
+        self.variables['N'].set_value(new_size)
         self.variables['t'].resize(new_size)
 
         for var in self.recorded_variables.values():

--- a/brian2/synapses/cspikequeue.cpp
+++ b/brian2/synapses/cspikequeue.cpp
@@ -38,6 +38,15 @@ public:
         scalar_delay = 0;
     };
 
+    ~CSpikeQueue()
+    {
+        if (delays)
+        {
+            delete[] delays;
+            delays = NULL;
+        }
+    }
+
     void prepare(scalar *real_delays, unsigned int n_delays,
                  int32_t *sources, unsigned int n_synapses,
                  double _dt)

--- a/brian2/synapses/synapses.py
+++ b/brian2/synapses/synapses.py
@@ -668,7 +668,7 @@ class Synapses(Group):
         self._registered_variables = set()
 
         for varname, var in self.variables.iteritems():
-            if isinstance(var, DynamicArrayVariable):
+            if isinstance(var, DynamicArrayVariable) and var.owner.name == self.name:
                 # Register the array with the `SynapticItemMapping` object so
                 # it gets automatically resized
                 self.register_variable(var)

--- a/brian2/synapses/synapses.py
+++ b/brian2/synapses/synapses.py
@@ -6,7 +6,7 @@ import collections
 from collections import defaultdict
 import weakref
 import re
-from numbers import Number
+import numbers
 
 import numpy as np
 
@@ -1108,7 +1108,7 @@ class Synapses(Group):
                              'string, is %s instead.') % type(pre_or_cond))
 
     def _resize(self, number):
-        if not isinstance(number, int):
+        if not isinstance(number, numbers.Integral):
             raise TypeError(('Expected an integer number got {} '
                              'instead').format(type(number)))
         if number < self._N:

--- a/brian2/synapses/synapses.py
+++ b/brian2/synapses/synapses.py
@@ -109,13 +109,8 @@ class SynapticPathway(CodeRunner, Group):
         Whether this object should react to pre- or postsynaptic spikes
     objname : str, optional
         The name to use for the object, will be appendend to the name of
-        `synapses` to create a name in the sense of `Nameable`. The `synapses`
-        object should allow access to this object via
-        ``synapses.getattr(objname)``. It has to use the actual `objname`
-        attribute instead of relying on the provided argument, since the name
-        may have changed to become unique. If ``None`` is provided (the
-        default), ``prepost+'*'`` will be used (see `Nameable` for an
-        explanation of the wildcard operator).
+        `synapses` to create a name in the sense of `Nameable`. If ``None``
+        is provided (the default), ``prepost`` will be used.
     delay : `Quantity`, optional
         A scalar delay (same delay for all synapses) for this pathway. If
         not given, delays are expected to vary between synapses.
@@ -141,7 +136,7 @@ class SynapticPathway(CodeRunner, Group):
         self.synapses = weakref.proxy(synapses)
 
         if objname is None:
-            objname = prepost + '*'
+            objname = prepost
 
         CodeRunner.__init__(self, synapses,
                             'synapses',

--- a/brian2/synapses/synapses.py
+++ b/brian2/synapses/synapses.py
@@ -209,9 +209,6 @@ class SynapticPathway(CodeRunner, Group):
         # Enable access to the delay attribute via the specifier
         self._enable_group_attributes()
 
-    def __len__(self):
-        return self.N_
-
     @device_override('synaptic_pathway_update_abstract_code')
     def update_abstract_code(self, run_namespace=None, level=0):
         if self.synapses.event_driven is not None:
@@ -791,9 +788,6 @@ class Synapses(Group):
         if not connect is False:
             self.connect(connect, level=1)
 
-    def __len__(self):
-        return len(self.variables['_synaptic_pre'].get_value())
-
     def __getitem__(self, item):
         indices = self.indices[item]
         return SynapticSubgroup(self, indices)
@@ -908,8 +902,9 @@ class Synapses(Group):
                                      '_synaptic_post')
 
         # Add the standard variables
-        self.variables.add_attribute_variable('N', Unit(1), self, '_N',
-                                              constant=True)
+        self.variables.add_array('N', unit=Unit(1), dtype=np.int32,
+                                 size=1, scalar=True, constant=True,
+                                 read_only=True)
 
         for eq in equations.itervalues():
             dtype = get_dtype(eq, user_dtype)

--- a/brian2/synapses/synapses.py
+++ b/brian2/synapses/synapses.py
@@ -1125,6 +1125,7 @@ class Synapses(Group):
             variable.resize(number)
 
         self._N = number
+        self.variables['N'].set_value(number)
 
     def register_variable(self, variable):
         '''

--- a/brian2/synapses/synapses.py
+++ b/brian2/synapses/synapses.py
@@ -162,6 +162,12 @@ class SynapticPathway(CodeRunner, Group):
                                               scalar=False)
         self.variables.add_reference(self.eventspace_name, self.source)
         self.variables.add_reference('N', synapses)
+        if prepost == 'pre':
+            self.variables.add_reference('_n_sources', synapses, 'N_pre')
+            self.variables.add_reference('_n_targets', synapses, 'N_post')
+        else:
+            self.variables.add_reference('_n_sources', synapses, 'N_post')
+            self.variables.add_reference('_n_targets', synapses, 'N_pre')
         if delay is None:  # variable delays
             self.variables.add_dynamic_array('delay', unit=second,
                                              size=synapses._N, constant=True,

--- a/brian2/synapses/synapses.py
+++ b/brian2/synapses/synapses.py
@@ -999,9 +999,12 @@ class Synapses(Group):
             try:
                 self.variables.add_reference(name + '_post', self.target, name,
                                              index=index)
-                # Also add all the post variables without a suffix
-                self.variables.add_reference(name, self.target, name,
-                                             index=index)
+                # Also add all the post variables without a suffix, but only if
+                # it does not have a post or pre suffix in the target group
+                # (which could happen when connecting to synapses)
+                if not name.endswith('_post') or name.endswith('pre'):
+                    self.variables.add_reference(name, self.target, name,
+                                                 index=index)
             except TypeError:
                 logger.debug(('Cannot include a reference to {var} in '
                               '{synapses}, {var} uses a non-standard indexing '


### PR DESCRIPTION
This is quite a big change, necessary for the astrocyte project where we need `Synapses` that target other `Synapses`. There are a few minor tweaks and additions but the two main changes are the following:
* The variable `N` is now no longer an `AttributeVariable` that gets the length of the group via Python (or the `Synapses` class in the C++ standalone code) but instead either a constant or a scalar `ArrayVariable` (for synapses). In runtime code, it can still be simply accessed as `N`, as the value of constant scalar arrays is passed in the namespace. In standalone, two templates contain an `{% if ... %}` to generate the correct code depending on whether `N` is a constant or an array.
* The variables `N_incoming` and `N_outgoing` were previously set in Python code, they are now set in the `synapses_create` template. This is potentially redundant for multiple `Synapses.connect` calls, but the overhead should not be noticeable (and multiple connect calls are not that common, anyway).

With these changes the C++ `Synapses` class in C++ standalone became obsolete, so I removed it.