### PR TITLE
[MRG] Resize variables correctly in `StateMonitor`

### DIFF
--- a/brian2/codegen/runtime/cython_rt/templates/statemonitor.pyx
+++ b/brian2/codegen/runtime/cython_rt/templates/statemonitor.pyx
@@ -9,7 +9,7 @@
     cdef int _new_len = _curlen + 1
 
     # Resize the recorded times
-    {{_dynamic_t}}.resize(_new_len)
+    _var_t.resize(_new_len)
     {{_dynamic_t}}[_new_len-1] = _clock_t
 
     # scalar code
@@ -23,7 +23,7 @@
     {% set np_type = numpy_dtype(variables[varname].dtype) %}
     # Resize the recorded variable "{{varname}}" and get the (potentially
     # changed) reference to the underlying data
-    {{get_array_name(var, access_data=False)}}.resize_along_first((_new_len, _num{{_indices}}))
+    _var_{{varname}}.resize((_new_len, _num{{_indices}}))
     cdef {{c_type}}[:, :] _record_data_{{varname}} = {{get_array_name(var, access_data=False)}}.data.view(_numpy.{{np_type}})
     for _i in range(_num{{_indices}}):
         # vector code

--- a/brian2/codegen/runtime/weave_rt/templates/statemonitor.cpp
+++ b/brian2/codegen/runtime/weave_rt/templates/statemonitor.cpp
@@ -9,7 +9,7 @@
 
     // Resize the recorded times and get the (potentially changed) reference to
     // the underlying data
-    PyObject_CallMethod({{_dynamic_t}}, "resize", "i", _new_len);
+    PyObject_CallMethod(_var_t, "resize", "i", _new_len);
     double *_t_data = (double*)(((PyArrayObject*)(PyObject*){{_dynamic_t}}.attr("data"))->data);
     _t_data[_new_len - 1] = _clock_t;
 
@@ -23,7 +23,7 @@
     {
         // Resize the recorded variable "{{varname}}" and get the (potentially
         // changed) reference to the underlying data
-        PyObject_CallMethod({{get_array_name(var, access_data=False)}}, "resize_along_first", "((ii))", _new_len, _num_indices);
+        PyObject_CallMethod(_var_{{varname}}, "resize", "((ii))", _new_len, _num_indices);
         PyArrayObject *_record_data = (((PyArrayObject*)(PyObject*){{get_array_name(var, access_data=False)}}.attr("data")));
         const npy_intp* _record_strides = _record_data->strides;
         for (int _i = 0; _i < _num_indices; _i++)

--- a/brian2/devices/cpp_standalone/device.py
+++ b/brian2/devices/cpp_standalone/device.py
@@ -384,17 +384,20 @@ class CPPStandaloneDevice(Device):
                 # other dimension has size 0 at the beginning
                 if isinstance(var.size, tuple) and len(var.size) == 2:
                     if var.size[0] * var.size[1] == len(data):
-                        return data.reshape(var.size)
+                        size = var.size
                     elif var.size[0] == 0:
-                        return data.reshape((-1, var.size[1]))
+                        size = (len(data)/var.size[1], var.size[1])
                     elif var.size[0] == 0:
-                        return data.reshape((var.size[1], -1))
+                        size = (var.size[0], len(data)/var.size[0])
                     else:
                         raise IndexError(('Do not now how to deal with 2d '
                                           'array of size %s, the array on disk '
                                           'has length %d') % (str(var.size),
                                                               len(data)))
 
+                    var.size = size
+                    return data.reshape(var.size)
+                var.size = len(data)
                 return data
             raise NotImplementedError('Cannot retrieve the values of state '
                                       'variables in standalone code before the '

--- a/brian2/devices/cpp_standalone/templates/statemonitor.cpp
+++ b/brian2/devices/cpp_standalone/templates/statemonitor.cpp
@@ -17,8 +17,8 @@
     {% endfor %}
 
     // scalar code
-	const int _vectorisation_idx = -1;
-	{{scalar_code|autoindent}}
+    const int _vectorisation_idx = -1;
+    {{scalar_code|autoindent}}
 
     {{ openmp_pragma('static') }}
     for (int _i = 0; _i < _num_indices; _i++)

--- a/brian2/tests/test_monitor.py
+++ b/brian2/tests/test_monitor.py
@@ -363,7 +363,14 @@ def test_state_monitor_resize():
     mon = StateMonitor(G, 'v', record=True)
     defaultclock.dt = 0.1*ms
     run(1*ms)
+    # On standalone, the size information of the variables is only updated
+    # after the variable has been accessed, so we can not only check the size
+    # information of the variables object
+    assert len(mon.t) == 10
+    assert mon.v.shape == (2, 10)
     assert mon.variables['t'].size == 10
+    # Note that the internally stored variable has the transposed shape of the
+    # variable that is visible to the user
     assert mon.variables['v'].size == (10, 2)
 
 @attr('standalone-compatible')

--- a/brian2/tests/test_monitor.py
+++ b/brian2/tests/test_monitor.py
@@ -357,6 +357,17 @@ def test_state_monitor_get_states():
 
 @attr('standalone-compatible')
 @with_setup(teardown=restore_device)
+def test_state_monitor_resize():
+    # Test for issue #518 (weave/cython did not resize the Variable object)
+    G = NeuronGroup(2, 'v : 1')
+    mon = StateMonitor(G, 'v', record=True)
+    defaultclock.dt = 0.1*ms
+    run(1*ms)
+    assert mon.variables['t'].size == 10
+    assert mon.variables['v'].size == (10, 2)
+
+@attr('standalone-compatible')
+@with_setup(teardown=restore_device)
 def test_rate_monitor():
     G = NeuronGroup(5, 'v : 1', threshold='v>1') # no reset
     G.v = 1.1 # All neurons spike every time step
@@ -420,6 +431,7 @@ if __name__ == '__main__':
     test_state_monitor_record_single_timestep_cpp_standalone()
     test_state_monitor_get_states()
     test_state_monitor_indexing()
+    test_state_monitor_resize()
     test_rate_monitor()
     test_rate_monitor_get_states()
     test_rate_monitor_subgroups()


### PR DESCRIPTION
This uses the `Variable` object itself to resize the dynamic array in state monitor. This is slightly slower than using `DynamicArray.resize` but it will update the `Variable.size` attribute as well, which is important, especially for the `store`/`restore` mechanism (which was broken for Cython and weave).

Fixes #518