### PR TITLE
[MRG] Add `mole` (and `umole` etc.) to the list of units imported by default

### DIFF
--- a/brian2/units/__init__.py
+++ b/brian2/units/__init__.py
@@ -13,6 +13,8 @@ from .allunits import (
                        cmetre, cmeter, # quite commonly used
                        psecond, nsecond, usecond, msecond, second,
                        ksecond, Msecond, Gsecond, Tsecond,
+                       pmole, nmole, umole, mmole, mole,
+                       kmole, Mmole, Gmole, Tmole,
                        # derived units
                        pcoulomb, ncoulomb, ucoulomb, mcoulomb, coulomb,
                        kcoulomb, Mcoulomb, Gcoulomb, Tcoulomb,
@@ -57,6 +59,8 @@ __all__ = ['pamp', 'namp', 'uamp', 'mamp', 'amp',
            'cmetre', 'cmeter',
            'psecond', 'nsecond', 'usecond', 'msecond', 'second',
            'ksecond', 'Msecond', 'Gsecond', 'Tsecond',
+           'pmole', 'nmole', 'umole', 'mmole', 'mole',
+           'kmole', 'Mmole', 'Gmole', 'Tmole',
            # derived units
            'pcoulomb', 'ncoulomb', 'ucoulomb', 'mcoulomb', 'coulomb',
            'kcoulomb', 'Mcoulomb', 'Gcoulomb', 'Tcoulomb',

--- a/docs_sphinx/user/units.rst
+++ b/docs_sphinx/user/units.rst
@@ -3,9 +3,9 @@ Physical units
 
 Brian includes a system for defining physical units. These are defined by
 their standard SI unit names: amp,
-kilogram, second, metre/meter and the derived units coulomb, farad, gram/gramme,
-hertz, joule, pascal, ohm,  siemens, volt, watt, together with prefixed
-versions (e.g. ``msiemens = 0.001*siemens``) using the prefixes
+kilogram, second, metre/meter, mole and the derived units coulomb, farad,
+gram/gramme, hertz, joule, pascal, ohm,  siemens, volt, watt, together with
+prefixed versions (e.g. ``msiemens = 0.001*siemens``) using the prefixes
 p, n, u, m, k, M, G, T (two exceptions: kilogram is not imported with any
 prefixes, metre and meter are additionaly defined with the "centi" prefix,
 i.e. cmetre/cmeter). In addition a couple of useful standard abbreviations like
@@ -87,10 +87,10 @@ versions by appending a number. For example, the units "msiemens", "siemens2",
 
 A better choice is normally to do an ``from brian2.units import *`` or import
 everything ``from brian2 import *``, this imports only the base units amp,
-kilogram, second, metre/meter and the derived units coulomb, farad, gram/gramme,
-hertz, joule, pascal, ohm,  siemens, volt, watt, together with the prefixes
-p, n, u, m, k, M, G, T (two exceptions: kilogram is not imported with any
-prefixes, metre and meter are additionaly defined with the "centi" prefix,
+kilogram, second, metre/meter, mole and the derived units coulomb, farad,
+gram/gramme, hertz, joule, pascal, ohm,  siemens, volt, watt, together with the
+prefixes p, n, u, m, k, M, G, T (two exceptions: kilogram is not imported with
+any prefixes, metre and meter are additionaly defined with the "centi" prefix,
 i.e. cmetre/cmeter).
 
 In addition a couple of useful standard abbreviations like


### PR DESCRIPTION
Small change, but `mole` etc. is quite often used for concentration of ions in complex models, importing it explicitly is kind of annoying.