### PR TITLE
[MRG] Check that source/target indicies provided to `Synapses.connect` lie within the correct range

### DIFF
--- a/brian2/synapses/synapses.py
+++ b/brian2/synapses/synapses.py
@@ -1156,6 +1156,18 @@ class Synapses(Group):
 
             sources = np.atleast_1d(sources).astype(np.int32)
             targets = np.atleast_1d(targets).astype(np.int32)
+
+            # Check whether the values in sources/targets make sense
+            error_message = ('The given {source_or_target} indices contain '
+                             'values outside of the range [0, {max_value}] '
+                             'allowed for the {source_or_target} group '
+                             '"{group_name}"')
+            for indices, source_or_target, group in [(sources, 'source', self.source),
+                                                     (targets, 'target', self.target)]:
+                if np.max(indices) >= len(group) or np.min(indices) < 0:
+                    raise IndexError(error_message.format(source_or_target=source_or_target,
+                                                          max_value=len(group)-1,
+                                                          group_name=group.name))
             n = np.atleast_1d(n)
             p = np.atleast_1d(p)
 

--- a/brian2/tests/test_synapses.py
+++ b/brian2/tests/test_synapses.py
@@ -117,6 +117,10 @@ def test_connection_arrays():
     assert_raises(ValueError, lambda: S.connect([1, 2, 3], [1, 2]))
     assert_raises(ValueError, lambda: S.connect(np.ones((3, 3), dtype=np.int32),
                                                 np.ones((3, 1), dtype=np.int32)))
+    assert_raises(IndexError, lambda: S.connect([41, 42], [0, 1]))  # source index > max
+    assert_raises(IndexError, lambda: S.connect([0, 1], [16, 17]))  # target index > max
+    assert_raises(IndexError, lambda: S.connect([0, -1], [0, 1]))  # source index < 0
+    assert_raises(IndexError, lambda: S.connect([0, 1], [0, -1]))  # target index < 0
     assert_raises(ValueError, lambda: S.connect('i==j',
                                                 post=np.arange(10)))
     assert_raises(TypeError, lambda: S.connect('i==j',


### PR DESCRIPTION
Fixes #548