### PR TITLE
[MRG] Better error message for `StateMonitor(synapses, ..., record=True)` in standalone

### DIFF
--- a/brian2/codegen/codeobject.py
+++ b/brian2/codegen/codeobject.py
@@ -258,7 +258,13 @@ def create_runner_codeobj(group, code, template_name,
         codeobj_class = device.code_object_class(group.codeobj_class)
     else:
         codeobj_class = device.code_object_class(codeobj_class)
-    template = getattr(codeobj_class.templater, template_name)
+
+    template = getattr(codeobj_class.templater, template_name, None)
+    if template is None:
+        codeobj_class_name = codeobj_class.class_name or codeobj_class.__name__
+        raise AttributeError(('"%s" does not provide a code generation '
+                              'template "%s"') % (codeobj_class_name,
+                                                  template_name))
 
     all_variables = dict(group.variables)
     if additional_variables is not None:

--- a/docs_sphinx/user/synapses.rst
+++ b/docs_sphinx/user/synapses.rst
@@ -293,9 +293,16 @@ indices for you in this case::
 	M = StateMonitor(S,'w',record=S['i!=j'])  # all synapses excluding autapses
 	M = StateMonitor(S,'w',record=S['w>0'])  # all synapses with non-zero weights (at this time)
 
+You can also record a synaptic variable for all synapses by passing ``record=True``.
+
 The recorded traces can then be accessed in the usual way, again with the
 possibility to index the `Synapses` object::
 
 	plot(M.t / ms, M[0].w / nS)  # first synapse
 	plot(M.t / ms, M[0, :].w / nS)  # all synapses originating from neuron 0
 	plot(M.t / ms, M['w>0'].w / nS)  # all synapses with non-zero weights (at this time)
+
+Note that the use of the `Synapses` object for indexing and ``record=True`` only
+work in the default runtime modes. In standalone mode (see :doc:`devices`),
+the synapses have not yet been created at this point, so Brian cannot calculate
+the indices.

--- a/examples/synapses/nonlinear.py
+++ b/examples/synapses/nonlinear.py
@@ -11,7 +11,7 @@ c = 1 / (10*ms)
 input = NeuronGroup(2, 'dv/dt = 1/(10*ms) : 1', threshold='v>1', reset='v = 0')
 neurons = NeuronGroup(1, """dv/dt = (g-v)/(10*ms) : 1
                             g : 1""")
-S = Synapses(input,neurons,
+S = Synapses(input, neurons,
              '''# This variable could also be called g_syn to avoid confusion
                 dg_syn/dt = -a*g_syn+b*x*(1-g_syn) : 1
                 g_post = g_syn : 1 (summed)
@@ -23,7 +23,10 @@ S.connect(True)
 S.w = [1., 10.]
 input.v = [0., 0.5]
 
-M = StateMonitor(S, 'g', record=True)
+M = StateMonitor(S, 'g',
+                 # If not using standalone mode, this could also simply be
+                 # record=True
+                 record=np.arange(len(input)*len(neurons)))
 Mn = StateMonitor(neurons, 'g', record=0)
 
 run(1000*ms)


### PR DESCRIPTION
This also updates the documentation and makes another error message slightly nicer (which occurs if you do something like `StateMonitor(synapses, ..., record=synapses['i==0'])` in standalone).