### PR TITLE
[MRG] Fixes for OpenMP

### DIFF
--- a/brian2/devices/cpp_standalone/templates/spatialstateupdate.cpp
+++ b/brian2/devices/cpp_standalone/templates/spatialstateupdate.cpp
@@ -11,8 +11,6 @@
 {% extends 'common_group.cpp' %}
 {% block maincode %}
 
-	double ai,bi,_m;
-
     int _vectorisation_idx = 1;
 
 	//// MAIN CODE ////////////
@@ -30,9 +28,10 @@
 		{{gtot_all}}[_idx] = _gtot;
         {{I0_all}}[_idx] = _I0;
     }
-
-    double *c = (double *)malloc(N * sizeof(double));
     {{ openmp_pragma('parallel') }}
+    {
+    double ai, bi, _m;
+    double *c = (double *)malloc(N * sizeof(double));
     {{ openmp_pragma('sections') }}
     {
     {
@@ -104,10 +103,10 @@
 	}
 	for(int i=N-2;i>=0;i--)
 		{{u_minus}}[i]={{u_minus}}[i] - c[i]*{{u_minus}}[i+1];
-	}
-    }
-
+	}  // (OpenMP section)
+    }  // (OpenMP sections)
     free(c);
+    }  // (OpenMP parallel)
 
     // Prepare matrix for solving the linear system
     for (int _j=0; _j<_num_B - 1; _j++)

--- a/brian2/synapses/cspikequeue.cpp
+++ b/brian2/synapses/cspikequeue.cpp
@@ -80,15 +80,15 @@ public:
         synapses.clear();
         synapses.resize(source_end - source_start);
 
-        for (unsigned int i=0; i<n_synapses; i++)
-        {
-            if (i == 0 || !scalar_delay)
-            {
+        // Note that n_synapses and n_delays do not have to be identical
+        // (homogeneous delays are stored as a single scalar), we therefore
+        // use two independent loops to initialize the delays and the synapses
+        // array
+        for (int i=0; i<n_delays; i++)
                 //round to nearest int
                 delays[i] =  (int)(real_delays[i] / _dt + 0.5);
-            }
+        for (int i=0; i<n_synapses; i++)
             synapses[sources[i] - source_start].push_back(i + openmp_padding);
-        }
 
         dt = _dt;
     }

--- a/brian2/tests/__init__.py
+++ b/brian2/tests/__init__.py
@@ -177,6 +177,7 @@ def run(codegen_targets=None, long_tests=False, test_codegen_independent=True,
             if test_openmp and test_standalone == 'cpp_standalone':
                 # Run all the standalone compatible tests again with 4 threads
                 prefs.devices.cpp_standalone.openmp_threads = 4
+                prefs._backup()
                 sys.stderr.write('Running standalone-compatible standard tests with OpenMP\n')
                 exclude_str = ',!long' if not long_tests else ''
                 argv = ['nosetests', dirname,
@@ -190,6 +191,7 @@ def run(codegen_targets=None, long_tests=False, test_codegen_independent=True,
                         '--exe']
                 success.append(nose.run(argv=argv))
                 prefs.devices.cpp_standalone.openmp_threads = 0
+                prefs._backup()
 
             set_device(previous_device)
 

--- a/brian2/tests/test_spatialneuron.py
+++ b/brian2/tests/test_spatialneuron.py
@@ -177,7 +177,7 @@ def test_infinitecable():
     theory = theory*1*nA*0.02*ms
     assert_allclose(v[t>0.5*ms],theory[t>0.5*ms],rtol=0.01) # 1% error tolerance (not exact because not infinite cable)
 
-@attr('long', 'standalone-compatible')
+@attr('standalone-compatible')
 @with_setup(teardown=restore_device)
 def test_finitecable():
     '''
@@ -218,7 +218,7 @@ def test_finitecable():
     theory = EL+ra*neuron.I[0]*cosh((length-x)/la)/sinh(length/la)
     assert_allclose(v-EL, theory-EL, rtol=0.01)
 
-@attr('long', 'standalone-compatible')
+@attr('standalone-compatible')
 @with_setup(teardown=restore_device)
 def test_rallpack1():
     '''
@@ -439,7 +439,7 @@ def test_rallpack3():
     assert 100*max_rel_x < 0.5
 
 
-@attr('long', 'standalone-compatible')
+@attr('standalone-compatible')
 @with_setup(teardown=restore_device)
 def test_rall():
     '''


### PR DESCRIPTION
This fixes #568, but I also realized two more issues along the road:
* The standalone-compatible tests that were supposed to run with OpenMP were actually not running with it (except for the first one)...
* Fixing the above revealed memory errors in some tests which had a single synapse

I also removed the long attribute from three multicompartmental neuron tests that aren't that time-consuming (they would have caught #568).