### PR TITLE
[MRG] Fixes for numpy 0.10

### DIFF
--- a/brian2/groups/group.py
+++ b/brian2/groups/group.py
@@ -197,7 +197,7 @@ class Indexing(object):
             raise IndexError(('Can only interpret 1-d indices, '
                               'got %d dimensions.') % len(item))
         else:
-            if item is None or item == 'True':
+            if item is None or (isinstance(item, basestring) and item == 'True'):
                 item = slice(None)
             if isinstance(item, slice):
                 if index_var == '0':

--- a/brian2/synapses/synapses.py
+++ b/brian2/synapses/synapses.py
@@ -454,7 +454,7 @@ class SynapticIndexing(object):
         (including arrays and slices), a single index or a string.
 
         '''
-        if index is None or index == 'True':
+        if index is None or (isinstance(index, basestring) and index == 'True'):
             index = slice(None)
 
         if (not isinstance(index, (tuple, basestring)) and

--- a/brian2/tests/test_monitor.py
+++ b/brian2/tests/test_monitor.py
@@ -331,7 +331,7 @@ def test_state_monitor_indexing():
     assert_array_equal(mon[[5, 7]].v, mon.v[[0, 2]])
     assert_array_equal(mon[np.array([5, 7])].v, mon.v[[0, 2]])
 
-    assert_allclose(mon.t[1:], [defaultclock.dt])
+    assert_allclose(mon.t[1:], Quantity([defaultclock.dt]))
 
     assert_raises(IndexError, lambda: mon[8])
     assert_raises(TypeError, lambda: mon['string'])

--- a/brian2/tests/test_morphology.py
+++ b/brian2/tests/test_morphology.py
@@ -32,7 +32,7 @@ def test_subgroup():
     assert_allclose(morpho.LL[1.5*um].distance,12*um)
     assert_allclose(morpho.LL[5*um].distance,15*um)
     # Getting a segment
-    assert_allclose(morpho.L[3*um:5.1*um].distance,[3*um,4*um,5*um])
+    assert_allclose(morpho.L[3*um:5.1*um].distance, [3, 4, 5]*um)
     # Indices cannot be obtained at this stage
     assert_raises(AttributeError,lambda :morpho.L.indices[:])
     # Compress the morphology and get absolute compartment indices

--- a/brian2/tests/test_spatialneuron.py
+++ b/brian2/tests/test_spatialneuron.py
@@ -33,21 +33,21 @@ def test_construction():
     neuron = SpatialNeuron(morphology=morpho, model=eqs, Cm=1 * uF / cm ** 2, Ri=100 * ohm * cm)
     # Test initialization of values
     neuron.LL.v = EL
-    assert_allclose(neuron.L.main.v,0)
-    assert_allclose(neuron.LL.v,EL)
+    assert_allclose(neuron.L.main.v, 0)
+    assert_allclose(neuron.LL.v, EL)
     neuron.LL[2*um:3.1*um].v = 0*mV
-    assert_allclose(neuron.LL.v,[EL,0,0,EL,EL])
-    assert_allclose(neuron.Cm,1 * uF / cm ** 2)
+    assert_allclose(neuron.LL.v, Quantity([EL, 0*mV, 0*mV, EL, EL]))
+    assert_allclose(neuron.Cm, 1 * uF / cm ** 2)
 
     # Test morphological variables
-    assert_allclose(neuron.main.x,morpho.x)
-    assert_allclose(neuron.L.main.x,morpho.L.x)
-    assert_allclose(neuron.LL.main.x,morpho.LL.x)
-    assert_allclose(neuron.right.main.x,morpho.right.x)
-    assert_allclose(neuron.L.main.distance,morpho.L.distance)
-    assert_allclose(neuron.L.main.diameter,morpho.L.diameter)
-    assert_allclose(neuron.L.main.area,morpho.L.area)
-    assert_allclose(neuron.L.main.length,morpho.L.length)
+    assert_allclose(neuron.main.x_, morpho.x)
+    assert_allclose(neuron.L.main.x_, morpho.L.x)
+    assert_allclose(neuron.LL.main.x_, morpho.LL.x)
+    assert_allclose(neuron.right.main.x_, morpho.right.x)
+    assert_allclose(neuron.L.main.distance_, morpho.L.distance)
+    assert_allclose(neuron.L.main.diameter_, morpho.L.diameter)
+    assert_allclose(neuron.L.main.area_, morpho.L.area)
+    assert_allclose(neuron.L.main.length_, morpho.L.length)
 
     # Check basic consistency of the flattened representation
     assert len(np.unique(neuron.diffusion_state_updater._morph_i[:])) == len(neuron.diffusion_state_updater._morph_i)
@@ -99,21 +99,21 @@ def test_construction_coordinates():
 
     # Test initialization of values
     neuron.LL.v = EL
-    assert_allclose(neuron.L.main.v,0)
-    assert_allclose(neuron.LL.v,EL)
+    assert_allclose(neuron.L.main.v, 0)
+    assert_allclose(neuron.LL.v, EL)
     neuron.LL[2*um:3.1*um].v = 0*mV
-    assert_allclose(neuron.LL.v,[EL,0,0,EL,EL])
-    assert_allclose(neuron.Cm,1 * uF / cm ** 2)
+    assert_allclose(neuron.LL.v, Quantity([EL, 0*mV, 0*mV, EL, EL]))
+    assert_allclose(neuron.Cm, 1 * uF / cm ** 2)
 
     # Test morphological variables
-    assert_allclose(neuron.main.x,morpho.x)
-    assert_allclose(neuron.L.main.x,morpho.L.x)
-    assert_allclose(neuron.LL.main.x,morpho.LL.x)
-    assert_allclose(neuron.right.main.x,morpho.right.x)
-    assert_allclose(neuron.L.main.distance,morpho.L.distance)
-    assert_allclose(neuron.L.main.diameter,morpho.L.diameter)
-    assert_allclose(neuron.L.main.area,morpho.L.area)
-    assert_allclose(neuron.L.main.length,morpho.L.length)
+    assert_allclose(neuron.main.x_, morpho.x)
+    assert_allclose(neuron.L.main.x_, morpho.L.x)
+    assert_allclose(neuron.LL.main.x_, morpho.LL.x)
+    assert_allclose(neuron.right.main.x_, morpho.right.x)
+    assert_allclose(neuron.L.main.distance_, morpho.L.distance)
+    assert_allclose(neuron.L.main.diameter_, morpho.L.diameter)
+    assert_allclose(neuron.L.main.area_, morpho.L.area)
+    assert_allclose(neuron.L.main.length_, morpho.L.length)
 
     # Check basic consistency of the flattened representation
     assert len(np.unique(neuron.diffusion_state_updater._morph_i[:])) == len(neuron.diffusion_state_updater._morph_i)

--- a/brian2/tests/test_subgroup.py
+++ b/brian2/tests/test_subgroup.py
@@ -31,9 +31,9 @@ def test_state_variables():
     assert_allclose(SG.v,
                     np.array([-80, -80, -80, -80, -80])*mV)
     assert_allclose(G.v_,
-                    np.array([0, 0, 0, 0, -80, -80, -80, -80, -80, 0])*mV)
+                    np.array([0, 0, 0, 0, -80, -80, -80, -80, -80, 0]*mV))
     assert_allclose(SG.v_,
-                    np.array([-80, -80, -80, -80, -80])*mV)
+                    np.array([-80, -80, -80, -80, -80]*mV))
     # You should also be able to set variables with a string
     SG.v = 'v + i*mV'
     assert_allclose(SG.v[0], -80*mV)

--- a/brian2/tests/test_units.py
+++ b/brian2/tests/test_units.py
@@ -893,6 +893,17 @@ def test_arange_linspace():
     assert_quantity(brian2.arange(1*mV, 5*mV, 1*mV), float(mV)*np.arange(1, 5, 1), mV)
     assert_quantity(brian2.linspace(1*mV, 2*mV), float(mV)*np.linspace(1, 2), mV)
 
+    # Check errors for arange with incorrect numbers of arguments/duplicate arguments
+    assert_raises(TypeError, lambda: brian2.arange())
+    assert_raises(TypeError, lambda: brian2.arange(0, 5, 1, 0))
+    assert_raises(TypeError, lambda: brian2.arange(0, stop=1))
+    assert_raises(TypeError, lambda: brian2.arange(0, 5, stop=1))
+    assert_raises(TypeError, lambda: brian2.arange(0, 5, start=1))
+    assert_raises(TypeError, lambda: brian2.arange(0, 5, 1, start=1))
+    assert_raises(TypeError, lambda: brian2.arange(0, 5, 1, stop=2))
+    assert_raises(TypeError, lambda: brian2.arange(0, 5, 1, step=2))
+
+
 @attr('codegen-independent')
 def test_list():
     '''

--- a/brian2/tests/test_units.py
+++ b/brian2/tests/test_units.py
@@ -524,7 +524,12 @@ def test_inplace_operations():
     for inplace_op in [q.__iadd__, q.__isub__, q.__imul__,
                        q.__idiv__, q.__itruediv__, q.__ifloordiv__,
                        q.__imod__, q.__ipow__]:
-        assert inplace_op('string') == NotImplemented
+        try:
+            result = inplace_op('string')
+            # if it doesn't fail with an error, it should return NotImplemented
+            assert result == NotImplemented
+        except TypeError:
+            pass  # raised on numpy >= 0.10
     
     # make sure that inplace operations do not work on units/dimensions at all
     for inplace_op in [volt.__iadd__, volt.__isub__, volt.__imul__,
@@ -849,9 +854,17 @@ def test_numpy_functions_logical():
                 # two arguments
                 result_units = eval('np.%s(value1, value2)' % ufunc)        
                 result_array = eval('np.%s(np.array(value1), np.array(value2))' % ufunc)
-                # assert that comparing to a string results in "NotImplemented"
-                assert eval('np.%s(value1, "a string")' % ufunc) == NotImplemented
-                assert eval('np.%s("a string", value1)' % ufunc) == NotImplemented
+                # assert that comparing to a string results in "NotImplemented" or an error
+                try:
+                    result = eval('np.%s(value1, "a string")' % ufunc)
+                    assert result == NotImplemented
+                except TypeError:
+                    pass  # raised on numpy >= 0.10
+                try:
+                    result = eval('np.%s("a string", value1)' % ufunc)
+                    assert result == NotImplemented
+                except TypeError:
+                    pass  # raised on numpy >= 0.10
             assert not isinstance(result_units, Quantity)
             assert_equal(result_units, result_array)
 

--- a/brian2/units/unitsafefunctions.py
+++ b/brian2/units/unitsafefunctions.py
@@ -3,6 +3,7 @@ Unit-aware replacements for numpy functions.
 """
 from functools import wraps
 
+import pkg_resources
 import numpy as np
 
 from .fundamentalunits import (Quantity, wrap_function_dimensionless,
@@ -139,9 +140,15 @@ def linspace(start, stop, num=50, endpoint=True, retstep=False, dtype=None):
                                                'same units.'),
                                 start=start, stop=stop)
     dim = getattr(start, 'dim', DIMENSIONLESS)
-    return Quantity(np.linspace(np.asarray(start), np.asarray(stop), num=num,
-                    endpoint=endpoint, retstep=retstep, dtype=None),
-                    dim=dim, copy=False)
+    if pkg_resources.parse_version(np.__version__) < pkg_resources.parse_version('1.9.0'):
+        if dtype is not None:
+            raise TypeError('The "dtype" argument needs numpy >= 1.9.0')
+        result = np.linspace(np.asarray(start), np.asarray(stop), num=num,
+                             endpoint=endpoint, retstep=retstep)
+    else:
+        result = np.linspace(np.asarray(start), np.asarray(stop), num=num,
+                             endpoint=endpoint, retstep=retstep, dtype=dtype)
+    return Quantity(result, dim=dim, copy=False)
 
 
 # these functions discard subclass info -- maybe a bug in numpy?

--- a/brian2/units/unitsafefunctions.py
+++ b/brian2/units/unitsafefunctions.py
@@ -94,19 +94,19 @@ def arange(*args, **kwargs):
     step = kwargs.pop('step', 1)
     stop = kwargs.pop('stop', None)
     if len(args) == 1:
-        if stop != None:
+        if stop is not None:
             raise TypeError('Duplicate definition of "stop"')
         stop = args[0]
     elif len(args) == 2:
         if start != 0:
             raise TypeError('Duplicate definition of "start"')
-        if stop != None:
+        if stop is not None:
             raise TypeError('Duplicate definition of "stop"')
         start, stop = args
     elif len(args) == 3:
         if start != 0:
             raise TypeError('Duplicate definition of "start"')
-        if stop != None:
+        if stop is not None:
             raise TypeError('Duplicate definition of "stop"')
         if step != 1:
             raise TypeError('Duplicate definition of "step"')


### PR DESCRIPTION
This should fix brian2 for use with the latest numpy release. Note that the test servers are not yet using numpy 0.10 because packages depending on numpy (scipy mostly, I think) are not updated yet on conda. I think this should change in the next days, though.

The test suite showed quite a number of errors with numpy 0.10, luckily most of them were problems in the test suite, brian itself should work mostly fine (except for `linspace`, see below). Most important changes:
* `assert_allclose` removed units in previous numpy versions, so some tests were sloppy about them (also, you cannot compare e.g. `np.arange(3)*mV` to `[0*mV, 1*mV, 2*mV]`, you'll have to use `[0, 1, 2]*mV` or `Quantity([0*mv, 1*mV, 2*mV])` for the latter).
* comparing `x == 'string'` raises a warning if `x` is a numpy array, I changed it into `(isinstance(x, basestring) and x == 'string')`
* Some ufuncs now raise a `TypeError` when used with illegal types instead of returning `NotImplemented`

The only major change that touches the main code is that `linspace(0*mV, 10*mV, 10)` worked "by accident" in previous numpy versions, we did not explicitly provide a unit-aware implementation. I think it can be useful, so I added explicit support for it and `arange` (i.e. you can do `arange(0*mV, 10*mV, 1*mV)` instead of `arange(0, 10, 10)*mV`).

 Good to merge from my side (note that tests on appveyor seem to get stuck or time out recently, we might have to re-launch them).