### PR TITLE
[MRG] More fixes for numpy 0.10

### DIFF
--- a/brian2/__init__.py
+++ b/brian2/__init__.py
@@ -5,10 +5,11 @@ Brian 2.0
 # working weave/Cython on Windows with the Python for C++ compiler
 import setuptools as _setuptools
 
-# Hack to fix problem in numpy 1.10
+# Hack to fix a problem with weave on Windows, introduced in numpy 1.10
 try:
     import numpy.distutils.msvccompiler as _msvccompiler
-    _msvccompiler.MSVCCompiler.compiler_cxx = 'cl.exe'
+    if not hasattr(_msvccompiler.MSVCCompiler, 'compiler_cxx'):
+        _msvccompiler.MSVCCompiler.compiler_cxx = 'cl.exe'
 except ImportError:
     pass
 

--- a/brian2/__init__.py
+++ b/brian2/__init__.py
@@ -5,6 +5,13 @@ Brian 2.0
 # working weave/Cython on Windows with the Python for C++ compiler
 import setuptools as _setuptools
 
+# Hack to fix problem in numpy 1.10
+try:
+    import numpy.distutils.msvccompiler as _msvccompiler
+    _msvccompiler.MSVCCompiler.compiler_cxx = 'cl.exe'
+except ImportError:
+    pass
+
 # Check basic dependencies
 import sys
 from distutils.version import LooseVersion

--- a/brian2/codegen/generators/cython_generator.py
+++ b/brian2/codegen/generators/cython_generator.py
@@ -44,6 +44,13 @@ class CythonNodeRenderer(NodeRenderer):
         return {'True': '1',
                 'False': '0'}.get(node.id, node.id)
 
+    def render_BinOp(self, node):
+        if node.op.__class__.__name__=='Mod':
+            return '((({left})%({right}))+({right}))%({right})'.format(left=self.render_node(node.left),
+                                                                       right=self.render_node(node.right))
+        else:
+            return super(CythonNodeRenderer, self).render_BinOp(node)
+
 
 class CythonCodeGenerator(CodeGenerator):
     '''

--- a/brian2/codegen/runtime/cython_rt/extension_manager.py
+++ b/brian2/codegen/runtime/cython_rt/extension_manager.py
@@ -50,6 +50,8 @@ class CythonExtensionManager(object):
                          compiler=None,
                          ):
 
+        self._simplify_paths()
+
         if Cython is None:
             raise ImportError('Cython is not available')
 
@@ -206,8 +208,25 @@ class CythonExtensionManager(object):
         self._code_cache[key] = module
         return module
         #self._import_all(module)
-        
+
+    def _simplify_paths(self):
+        if 'lib' in os.environ:
+            os.environ['lib'] = simplify_path_env_var(os.environ['lib'])
+        if 'include' in os.environ:
+            os.environ['include'] = simplify_path_env_var(os.environ['include'])
+
 cython_extension_manager = CythonExtensionManager()
+
+
+def simplify_path_env_var(path):
+    allpaths = path.split(os.pathsep)
+    knownpaths = set()
+    uniquepaths = []
+    for p in allpaths:
+        if p not in knownpaths:
+            knownpaths.add(p)
+            uniquepaths.append(p)
+    return os.pathsep.join(uniquepaths)
 
 
 if __name__=='__main__':

--- a/brian2/codegen/runtime/cython_rt/templates/common.pyx
+++ b/brian2/codegen/runtime/cython_rt/templates/common.pyx
@@ -1,6 +1,6 @@
 #cython: boundscheck=False
 #cython: wraparound=False
-#cython: cdivision=False
+#cython: cdivision=True
 #cython: infer_types=True
 
 import numpy as _numpy

--- a/brian2/tests/test_complex_examples.py
+++ b/brian2/tests/test_complex_examples.py
@@ -16,8 +16,8 @@ def test_cuba():
 
     eqs = '''
     dv/dt  = (ge+gi-(v-El))/taum : volt (unless refractory)
-    dge/dt = -ge/taue : volt (unless refractory)
-    dgi/dt = -gi/taui : volt (unless refractory)
+    dge/dt = -ge/taue : volt
+    dgi/dt = -gi/taui : volt
     '''
 
     P = NeuronGroup(4000, eqs, threshold='v>Vt', reset='v = Vr', refractory=5*ms)

--- a/brian2/tests/test_complex_examples.py
+++ b/brian2/tests/test_complex_examples.py
@@ -4,7 +4,7 @@ from nose.plugins.attrib import attr
 from brian2 import *
 from brian2.devices.device import restore_device
 
-@attr('codegen-independent', 'standalone-compatible')
+@attr('standalone-compatible')
 @with_setup(teardown=restore_device)
 def test_cuba():
     taum = 20*ms

--- a/brian2/tests/test_functions.py
+++ b/brian2/tests/test_functions.py
@@ -519,26 +519,25 @@ def test_binomial():
 
 if __name__ == '__main__':
     from brian2 import prefs
-    #prefs.codegen.target = 'numpy'
-    set_device('cpp_standalone')
+    # prefs.codegen.target = 'numpy'
     import time
     for f in [
-            # test_constants_sympy,
-            # test_constants_values,
-            # test_math_functions,
-            # test_bool_to_int,
+            test_constants_sympy,
+            test_constants_values,
+            test_math_functions,
+            test_bool_to_int,
             test_user_defined_function,
-            # test_user_defined_function_units,
-            # test_simple_user_defined_function,
-            # test_manual_user_defined_function,
-            # test_manual_user_defined_function_weave,
-            # test_user_defined_function_discarding_units,
-            # test_user_defined_function_discarding_units_2,
-            # test_function_implementation_container,
-            # test_function_dependencies_numpy,
-            # test_function_dependencies_weave,
-            # test_function_dependencies_cython,
-            # test_binomial
+            test_user_defined_function_units,
+            test_simple_user_defined_function,
+            test_manual_user_defined_function,
+            test_manual_user_defined_function_weave,
+            test_user_defined_function_discarding_units,
+            test_user_defined_function_discarding_units_2,
+            test_function_implementation_container,
+            test_function_dependencies_numpy,
+            test_function_dependencies_weave,
+            test_function_dependencies_cython,
+            test_binomial
             ]:
         try:
             start = time.time()

--- a/brian2/tests/test_neurongroup.py
+++ b/brian2/tests/test_neurongroup.py
@@ -19,6 +19,7 @@ from brian2.synapses.synapses import Synapses
 from brian2.monitors.statemonitor import StateMonitor
 from brian2.units.fundamentalunits import (DimensionMismatchError,
                                            have_same_dimensions)
+from brian2.units.unitsafefunctions import linspace
 from brian2.units.allunits import second, volt
 from brian2.units.stdunits import ms, mV, Hz
 from brian2.utils.logger import catch_logs
@@ -187,7 +188,7 @@ def test_linked_variable_correct():
     '''
     tau = 10*ms
     G1 = NeuronGroup(10, 'dv/dt = -v / tau : volt')
-    G1.v = np.linspace(0*mV, 20*mV, 10)
+    G1.v = linspace(0*mV, 20*mV, 10)
     G2 = NeuronGroup(10, 'v : volt (linked)')
     G2.v = linked_var(G1.v)
     mon1 = StateMonitor(G1, 'v', record=True)

--- a/examples/CUBA.py
+++ b/examples/CUBA.py
@@ -25,8 +25,8 @@ El = -49*mV
 
 eqs = '''
 dv/dt  = (ge+gi-(v-El))/taum : volt (unless refractory)
-dge/dt = -ge/taue : volt (unless refractory)
-dgi/dt = -gi/taui : volt (unless refractory)
+dge/dt = -ge/taue : volt
+dgi/dt = -gi/taui : volt
 '''
 
 P = NeuronGroup(4000, eqs, threshold='v>Vt', reset='v = Vr', refractory=5*ms)


### PR DESCRIPTION
The previous merge left one test failure unfixed, this should now work (tests are now using numpy 0.10 on our test servers as well). I also fixed a warning in the Python spike queue.

There's one more issue, though. After removing the `codegen-independent` label from `test_cuda`, this now fails on Cython. The reason is a division by zero (that also raises a warning on numpy). I think this problem appears only now because the CUDA example can now use the exact integration and boolean variables are taken into account for the loop-invariant constants. The problem arises for the conductances `ge` and `gi` during the refractory period:
```Python
   # ...
    _lio_const_5 = (dt * (taue - taum)) * _int(0.0)
    _lio_const_6 = ((dt * (taue - taum)) * _int(1.0)) - ((dt * (taue - taum)) * _int(0.0))
   # ...
        _ge = (((((- ge) * taue) * taum) * (_lio_const_1 + (_lio_const_2 * _int(not_refractory)))) * (_lio_const_3 + (_lio_const_4 * _int(not_refractory)))) / (_lio_const_5 + (_lio_const_6 * _int(not_refractory)))
```
When `not_refractory` is `False`, then `int(not_refractory)` is 0 and therefore the whole divisor is zero (`_lio_const_5` is always zero). It does not matter in the end, since we don't write back the values during the refractory period, but we'll still get the error/warning. Is there a reason we have the division checks switched on for Cython, actually? The documentation says that it has an "up to 35% speed penalty" and given that there's no check with weave, this should probably simply switched off? This still leaves us with a warning in numpy, though.