### PR TITLE
[MRG] Fix Python spike queue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -65,9 +65,7 @@ matrix:
     - python: "2.7"
       env: PYTHON="2.7" STANDALONE=no CYTHON=no MINIMAL_VERSIONS=no REPORT_COVERAGE=no ARCHITECTURE="x86_64"
       os: linux
-    - python: "2.7"
-      env: PYTHON="2.7" STANDALONE=yes CYTHON=no MINIMAL_VERSIONS=no REPORT_COVERAGE=no ARCHITECTURE="x86_64"
-      os: linux
+
 
 # Use miniconda to install binary versions of numpy etc. from continuum
 # analytic's repository. Follows an approach described by Dan Blanchard:

--- a/.travis.yml
+++ b/.travis.yml
@@ -65,6 +65,9 @@ matrix:
     - python: "2.7"
       env: PYTHON="2.7" STANDALONE=no CYTHON=no MINIMAL_VERSIONS=no REPORT_COVERAGE=no ARCHITECTURE="x86_64"
       os: linux
+    - python: "3.4"
+      env: PYTHON="3.4" STANDALONE=no CYTHON=no MINIMAL_VERSIONS=no REPORT_COVERAGE=no ARCHITECTURE="x86_64"
+      os: linux
 
 
 # Use miniconda to install binary versions of numpy etc. from continuum

--- a/.travis.yml
+++ b/.travis.yml
@@ -65,7 +65,9 @@ matrix:
     - python: "2.7"
       env: PYTHON="2.7" STANDALONE=no CYTHON=no MINIMAL_VERSIONS=no REPORT_COVERAGE=no ARCHITECTURE="x86_64"
       os: linux
-
+    - python: "2.7"
+      env: PYTHON="2.7" STANDALONE=yes CYTHON=no MINIMAL_VERSIONS=no REPORT_COVERAGE=no ARCHITECTURE="x86_64"
+      os: linux
 
 # Use miniconda to install binary versions of numpy etc. from continuum
 # analytic's repository. Follows an approach described by Dan Blanchard:

--- a/brian2/devices/cpp_standalone/templates/summed_variable.cpp
+++ b/brian2/devices/cpp_standalone/templates/summed_variable.cpp
@@ -18,13 +18,14 @@
     const int _vectorisation_idx = -1;
     {{scalar_code|autoindent}}
 
-    {{ openmp_pragma('parallel-static') }}
+    {# The following could be parallelized with OpenMP, but this needs some care
+       to not write concurrently to the same post-synaptic variable. A general
+       critical block around the write slows things down too much, though. #}
     for(int _idx=0; _idx<_num_synaptic_post; _idx++)
     {
         // vector code
         const int _vectorisation_idx = _idx;
         {{vector_code|autoindent}}
-        {{ openmp_pragma('atomic') }}
         {{_target_var_array}}[{{_synaptic_post}}[_idx]] += _synaptic_var;
     }
 {% endblock %}

--- a/brian2/devices/cpp_standalone/templates/summed_variable.cpp
+++ b/brian2/devices/cpp_standalone/templates/summed_variable.cpp
@@ -4,12 +4,10 @@
     {# USES_VARIABLES { _synaptic_post, _synaptic_pre, N_post } #}
     {% set _target_var_array = get_array_name(_target_var) %}
     //// MAIN CODE ////////////
-    // Set all the target variable values to zero
-    std::vector<{{c_data_type(_target_var.dtype)}}> _local_sum;
     {# This enables summed variables for connections to a synapse #}
     const int _N_post = {{constant_or_scalar('N_post', variables['N_post'])}};
-    _local_sum.resize(_N_post, 0);
 
+    // Set all the target variable values to zero
     {{ openmp_pragma('parallel-static') }}
     for (int _target_idx=0; _target_idx<_N_post; _target_idx++)
     {
@@ -26,13 +24,7 @@
         // vector code
         const int _vectorisation_idx = _idx;
         {{vector_code|autoindent}}
-        _local_sum[{{_synaptic_post}}[_idx]] += _synaptic_var;
-    }
-
-    {{ openmp_pragma('parallel-static') }}
-    for (int _target_idx=0; _target_idx<_N_post; _target_idx++)
-    {
         {{ openmp_pragma('atomic') }}
-        {{_target_var_array}}[_target_idx] += _local_sum[_target_idx];
+        {{_target_var_array}}[{{_synaptic_post}}[_idx]] += _synaptic_var;
     }
 {% endblock %}

--- a/brian2/tests/test_synapses.py
+++ b/brian2/tests/test_synapses.py
@@ -550,6 +550,7 @@ def test_invalid_custom_event():
     assert_raises(ValueError, lambda: Synapses(group2, group2, pre='v+=1',
                                                on_event='custom'))
 
+@with_setup(teardown=restore_device)
 def test_transmission():
     default_dt = defaultclock.dt
     delays = [[0, 0, 0, 0] * ms,
@@ -570,12 +571,46 @@ def test_transmission():
         S = Synapses(source, target, pre='v+=1.1', connect='i==j')
         S.delay = delay
         net = Network(S, source, target, source_mon, target_mon)
-        net.run(100*ms+default_dt+max(delay), report='text')
+        net.run(50*ms+default_dt+max(delay))
         # All spikes should trigger spikes in the receiving neurons with
         # the respective delay ( + one dt)
         for d in xrange(len(delay)):
             assert_allclose(source_mon.t[source_mon.i==d],
                             target_mon.t[target_mon.i==d] - default_dt - delay[d])
+
+@attr('standalone-compatible')
+@with_setup(teardown=restore_device)
+def test_transmission_all_to_one_heterogeneous_delays():
+    source = SpikeGeneratorGroup(6,
+                                 [0, 1, 4, 5, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5],
+                                 [0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2]*defaultclock.dt)
+    target = NeuronGroup(1, 'v:1')
+    synapses = Synapses(source, target, pre='v_post += (i_pre+1)', connect=True)
+    synapses.delay = [0, 0, 0, 1, 2, 1] * defaultclock.dt
+
+    mon = StateMonitor(target, 'v', record=True, when='end')
+    run(4*defaultclock.dt)
+    assert mon[0].v[0] == 3
+    assert mon[0].v[1] == 12
+    assert mon[0].v[2] == 33
+    assert mon[0].v[3] == 48
+
+@attr('standalone-compatible')
+@with_setup(teardown=restore_device)
+def test_transmission_one_to_all_heterogeneous_delays():
+    source = SpikeGeneratorGroup(1, [0, 0], [0, 2]*defaultclock.dt)
+    target = NeuronGroup(6, 'v:integer')
+    synapses = Synapses(source, target, pre='v_post += (i_pre+1)', connect=True)
+    synapses.delay = [0, 0, 1, 3, 2, 1] * defaultclock.dt
+
+    mon = StateMonitor(target, 'v', record=True, when='end')
+    run(4*defaultclock.dt)
+    assert_equal(mon[0].v, [1, 1, 2, 2])
+    assert_equal(mon[1].v, [1, 1, 2, 2])
+    assert_equal(mon[2].v, [0, 1, 1, 2])
+    assert_equal(mon[3].v, [0, 0, 0, 1])
+    assert_equal(mon[4].v, [0, 0, 1, 1])
+    assert_equal(mon[5].v, [0, 1, 1, 2])
 
 @attr('standalone-compatible')
 @with_setup(teardown=restore_device)
@@ -1257,6 +1292,8 @@ if __name__ == '__main__':
     test_transmission_custom_event()
     test_invalid_custom_event()
     test_transmission()
+    test_transmission_all_to_one_heterogeneous_delays()
+    test_transmission_one_to_all_heterogeneous_delays()
     test_transmission_scalar_delay()
     test_transmission_scalar_delay_different_clocks()
     test_clocks()


### PR DESCRIPTION
I did not look into the issue in detail yet, but this branch includes an extended `test_transmission` test that fails with the Python spike queue.
(BTW: This test only tests transmission with one-to-one synapses, we should at least have tests for many-to-one and one-to-many connections as well).