### PR TITLE
[MRG] Weave fixes

### DIFF
--- a/brian2/codegen/generators/cython_generator.py
+++ b/brian2/codegen/generators/cython_generator.py
@@ -272,13 +272,12 @@ class CythonCodeGenerator(CodeGenerator):
 ################################################################################
 # Functions that exist under the same name in C++
 for func in ['sin', 'cos', 'tan', 'sinh', 'cosh', 'tanh', 'exp', 'log',
-             'log10', 'sqrt', 'ceil', 'floor']:
+             'log10', 'sqrt', 'ceil', 'floor', 'abs']:
     DEFAULT_FUNCTIONS[func].implementations.add_implementation(CythonCodeGenerator,
                                                                code=None)
 
 # Functions that need a name translation
-for func, func_cpp in [('arcsin', 'asin'), ('arccos', 'acos'), ('arctan', 'atan'),
-                       ('abs', 'fabs')]:
+for func, func_cpp in [('arcsin', 'asin'), ('arccos', 'acos'), ('arctan', 'atan')]:
     DEFAULT_FUNCTIONS[func].implementations.add_implementation(CythonCodeGenerator,
                                                                code=None,
                                                                name=func_cpp)

--- a/brian2/codegen/runtime/cython_rt/templates/common.pyx
+++ b/brian2/codegen/runtime/cython_rt/templates/common.pyx
@@ -5,9 +5,12 @@
 
 import numpy as _numpy
 cimport numpy as _numpy
-from libc.math cimport sin, cos, tan, sinh, cosh, tanh, exp, log, log10, sqrt, abs, asin, acos, atan, fabs, fmod, floor, ceil
+from libc.math cimport sin, cos, tan, sinh, cosh, tanh, exp, log, log10, sqrt, asin, acos, atan, fmod, floor, ceil
 cdef extern from "math.h":
     double M_PI
+# Import the two versions of std::abs
+from libc.stdlib cimport abs  # For integers
+from libc.math cimport abs  # For floating point values
 from libcpp cimport bool
 
 cdef extern from "stdint_compat.h":

--- a/brian2/codegen/runtime/cython_rt/templates/spatialstateupdate.pyx
+++ b/brian2/codegen/runtime/cython_rt/templates/spatialstateupdate.pyx
@@ -126,11 +126,11 @@
     for _i in range(_n_segments):
         # find pivot element
         i_pivot = _i
-        pivot_magnitude = fabs({{_P}}[_i*_n_segments + _i])
+        pivot_magnitude = abs({{_P}}[_i*_n_segments + _i])
         for _j in range(_i+1, _n_segments):
-            if fabs({{_P}}[_j*_n_segments + _i]) > pivot_magnitude:
+            if abs({{_P}}[_j*_n_segments + _i]) > pivot_magnitude:
                 i_pivot = _j
-                pivot_magnitude = fabs({{_P}}[_j*_n_segments + _i])
+                pivot_magnitude = abs({{_P}}[_j*_n_segments + _i])
 
         if pivot_magnitude == 0.:
             raise ValueError('Matrix is singular')

--- a/brian2/codegen/runtime/cython_rt/templates/spikegenerator.pyx
+++ b/brian2/codegen/runtime/cython_rt/templates/spikegenerator.pyx
@@ -13,7 +13,8 @@
     cdef double _spike_time
 
     # We need some precomputed values that will be used during looping
-    not_end_period  = abs(padding_after) > ( {{dt}} - epsilon) and abs(padding_after) < (_the_period - epsilon)
+    cdef bool not_end_period  = abs(padding_after) > ( {{dt}} - epsilon) and abs(padding_after) < (_the_period - epsilon)
+    cdef bool test
 
     for _idx in range({{_lastindex}}, _num{{spike_time}}):
         _spike_time = {{spike_time}}[_idx]

--- a/brian2/codegen/runtime/weave_rt/templates/group_get_indices.cpp
+++ b/brian2/codegen/runtime/weave_rt/templates/group_get_indices.cpp
@@ -2,18 +2,22 @@
 {# USES_VARIABLES { N, _indices } #}
 {% block maincode %}
     //// MAIN CODE ////////////
+    // This allows everything to work correctly for synapses where N is not a
+    // constant
+    const int _N = {{constant_or_scalar('N', variables['N'])}};
+
     {%set c_type = c_data_type(variables['_indices'].dtype) %}
     {%set numpy_dtype = dtype(variables['_indices'].dtype).char %}
     {%set numpy_type_int = dtype(variables['_indices'].dtype).num %}
     // {{c_type}} {{numpy_dtype}} {{numpy_type_int}}
     int _cpp_numelements = 0;
     // Container for all the potential values
-    {{c_type}}* _elements = ({{c_type}}*)malloc(sizeof({{c_type}}) * N);
+    {{c_type}}* _elements = ({{c_type}}*)malloc(sizeof({{c_type}}) * _N);
 
     // scalar code
     const int _vectorisation_idx = 1;
     {{scalar_code|autoindent}}
-    for(int _idx=0; _idx<N; _idx++)
+    for(int _idx=0; _idx<_N; _idx++)
     {
         // vector code
         const int _vectorisation_idx = _idx;

--- a/brian2/codegen/runtime/weave_rt/templates/group_variable_get_conditional.cpp
+++ b/brian2/codegen/runtime/weave_rt/templates/group_variable_get_conditional.cpp
@@ -3,19 +3,23 @@
 
 {% block maincode %}
     //// MAIN CODE ////////////
+    // This allows everything to work correctly for synapses where N is not a
+    // constant
+    const int _N = {{constant_or_scalar('N', variables['N'])}};
+
     {%set c_type = c_data_type(variables['_variable'].dtype) %}
     {%set numpy_dtype = dtype(variables['_variable'].dtype).char %}
     {%set numpy_type_int = dtype(variables['_variable'].dtype).num %}
     // {{c_type}} {{numpy_dtype}} {{numpy_type_int}}
     int _cpp_numelements = 0;
     // Container for all the potential values
-    {{c_type}}* _elements = ({{c_type}}*)malloc(sizeof({{c_type}}) * N);
+    {{c_type}}* _elements = ({{c_type}}*)malloc(sizeof({{c_type}}) * _N);
 
     // scalar code
 	const int _vectorisation_idx = 1;
 	{{scalar_code|autoindent}}
 
-    for(int _idx=0; _idx<N; _idx++)
+    for(int _idx=0; _idx<_N; _idx++)
     {
         // vector code
         const int _vectorisation_idx = _idx;

--- a/brian2/codegen/runtime/weave_rt/templates/group_variable_set_conditional.cpp
+++ b/brian2/codegen/runtime/weave_rt/templates/group_variable_set_conditional.cpp
@@ -8,6 +8,9 @@
 	{{ common.insert_lines('HASH DEFINES', hashdefine_lines) }}
 	{{ common.insert_lines('POINTERS', pointers_lines) }}
 	//// MAIN CODE ////////////
+    // This allows everything to work correctly for synapses where N is not a
+    // constant
+    const int _N = {{constant_or_scalar('N', variables['N'])}};
 	// scalar code
 	const int _vectorisation_idx = 1;
 	{# Note that the scalar_code['statement'] will not write to any scalar
@@ -17,7 +20,7 @@
 	{{scalar_code['condition']|autoindent}}
 	{{scalar_code['statement']|autoindent}}
 
-	for(int _idx=0; _idx<N; _idx++)
+	for(int _idx=0; _idx<_N; _idx++)
 	{
 	    const int _vectorisation_idx = _idx;
 	    {{ common.insert_lines('CONDITION', vector_code['condition']) }}

--- a/brian2/codegen/runtime/weave_rt/templates/stateupdate.cpp
+++ b/brian2/codegen/runtime/weave_rt/templates/stateupdate.cpp
@@ -5,11 +5,14 @@
 {% block maincode %}
 	//// MAIN CODE ////////////
 
+    // This allows everything to work correctly for synapses where N is not a
+    // constant
+    const int _N = {{constant_or_scalar('N', variables['N'])}};
 	// scalar code
 	const int _vectorisation_idx = 1;
 	{{scalar_code|autoindent}}
 
-	for(int _idx=0; _idx<N; _idx++)
+	for(int _idx=0; _idx<_N; _idx++)
 	{
 	    // vector code
 		const int _vectorisation_idx = _idx;

--- a/brian2/tests/__init__.py
+++ b/brian2/tests/__init__.py
@@ -135,6 +135,9 @@ def run(codegen_targets=None, long_tests=False, test_codegen_independent=True,
         for target in codegen_targets:
             sys.stderr.write('Running tests for target %s:\n' % target)
             prefs.codegen.target = target
+            # Also set the target for string-expressions -- otherwise we'd only
+            # ever test numpy for those
+            prefs.codegen.string_expression_target = target
             prefs._backup()
             exclude_str = "!standalone-only,!codegen-independent"
             if not long_tests:
@@ -154,6 +157,7 @@ def run(codegen_targets=None, long_tests=False, test_codegen_independent=True,
             if target in test_in_parallel:
                 argv.extend(multiprocess_arguments)
             success.append(nose.run(argv=argv))
+
         if test_standalone:
             from brian2.devices.device import get_device, set_device
             previous_device = get_device()

--- a/brian2/tests/test_synapses.py
+++ b/brian2/tests/test_synapses.py
@@ -1175,6 +1175,17 @@ def test_vectorisation_STDP_like():
 
 @attr('standalone-compatible')
 @with_setup(teardown=restore_device)
+def test_synaptic_equations():
+    # Check that integration works for synaptic equations
+    G = NeuronGroup(10, '')
+    tau = 10*ms
+    S = Synapses(G, G, 'dw/dt = -w / tau : 1', connect='i==j')
+    S.w = 'i'
+    run(10*ms)
+    assert_allclose(S.w[:], np.arange(10) * np.exp(-1))
+
+@attr('standalone-compatible')
+@with_setup(teardown=restore_device)
 def test_synapses_to_synapses():
     source = SpikeGeneratorGroup(3, [0, 1, 2], [0, 0, 0]*ms, period=2*ms)
     modulator = SpikeGeneratorGroup(3, [0, 2], [1, 3]*ms)
@@ -1310,6 +1321,7 @@ if __name__ == '__main__':
     test_permutation_analysis()
     test_vectorisation()
     test_vectorisation_STDP_like()
+    test_synaptic_equations()
     test_synapses_to_synapses()
     test_synapses_to_synapses_summed_variable()
     test_ufunc_at_vectorisation()

--- a/dev/conda-recipe/meta.yaml
+++ b/dev/conda-recipe/meta.yaml
@@ -20,6 +20,7 @@ requirements:
     - sympy >=0.7.6
     - pyparsing
     - scipy >=0.13.3 # [py2k]
+    - bsddb # [py2k and not win]
     - cython >=0.18
     - jinja2 >=2.7
     - setuptools >=6.0


### PR DESCRIPTION
I noticed that there were a few bugs which even made some examples no longer work with weave (all related to getting rid of `AttributeVariable` for `N`). None of these problems were caught by the test suite, mostly because they were in the templates that are used for expressions such as `G.v['i%2 == 0'] = -70*mV` and by default we execute them in numpy, since the compilation often takes longer than running the code in such simple cases. Now when the tests are run, also these simple statements are using the tested code generation target. I also added one small test and included `bsddb` in the run-time dependencies for the conda package which should make the issue with inefficient weave under anaconda go away (#577).

Nothing too spectacular in this branch, ready to merge from my side.