### PR TITLE
[MRG] Store state to disk

### DIFF
--- a/brian2/core/magic.py
+++ b/brian2/core/magic.py
@@ -231,20 +231,20 @@ class MagicNetwork(Network):
         Network.run(self, duration, report=report, report_period=report_period,
                     namespace=namespace, profile=profile, level=level+1)
 
-    def store(self, name='default', level=0):
+    def store(self, name='default', filename=None, level=0):
         '''
         See `Network.store`.
         '''
         self._update_magic_objects(level=level+1)
-        super(MagicNetwork, self).store(name=name)
+        super(MagicNetwork, self).store(name=name, filename=filename)
         self.objects[:] = []
 
-    def restore(self, name='default', level=0):
+    def restore(self, name='default', filename=None, level=0):
         '''
         See `Network.store`.
         '''
         self._update_magic_objects(level=level+1)
-        super(MagicNetwork, self).restore(name=name)
+        super(MagicNetwork, self).restore(name=name, filename=filename)
         self.objects[:] = []
 
     def get_states(self, units=True, format='dict', subexpressions=False,
@@ -393,7 +393,7 @@ def reinit():
     '''
     magic_network.reinit()
 
-def store(name='default'):
+def store(name='default', filename=None):
     '''
     Store the state of the network and all included objects.
 
@@ -401,11 +401,18 @@ def store(name='default'):
     ----------
     name : str, optional
         A name for the snapshot, if not specified uses ``'default'``.
+    filename : str, optional
+        A filename where the state should be stored. If not specified, the
+        state will be stored in memory.
+
+    See Also
+    --------
+    Network.store
     '''
-    magic_network.store(name=name, level=1)
+    magic_network.store(name=name, filename=filename, level=1)
 
 
-def restore(name='default'):
+def restore(name='default', filename=None):
     '''
     Restore the state of the network and all included objects.
 
@@ -414,8 +421,17 @@ def restore(name='default'):
     name : str, optional
         The name of the snapshot to restore, if not specified uses
         ``'default'``.
+    filename : str, optional
+        The name of the file from where the state should be restored. If
+        not specified, it is expected that the state exist in memory
+        (i.e. `Network.store` was previously called without the ``filename``
+        argument).
+
+    See Also
+    --------
+    Network.restore
     '''
-    magic_network.restore(name=name, level=1)
+    magic_network.restore(name=name, filename=filename, level=1)
 
 
 def stop():

--- a/brian2/core/network.py
+++ b/brian2/core/network.py
@@ -7,10 +7,11 @@ Preferences
 .. document_brian_prefs:: core.network
 
 '''
-
+import os
 import sys
 import time
 from collections import defaultdict, Sequence, Counter
+import cPickle as pickle
 
 from brian2.utils.logger import get_logger
 from brian2.core.names import Nameable
@@ -201,9 +202,6 @@ class Network(Nameable):
         for obj in objs:
             self.add(obj)
 
-        #: Stored time for the store/restore mechanism
-        self._stored_t = {}
-
         #: Stored state of objects (store/restore)
         self._stored_state = {}
 
@@ -347,15 +345,18 @@ class Network(Nameable):
         for obj in self.objects:
             if hasattr(obj, '_full_state'):
                 state[obj.name] = obj._full_state()
+        clocks = set([obj.clock for obj in self.objects])
+        for clock in clocks:
+            state[clock.name] = clock._full_state()
         # Store the time as "0_t" -- this name is guaranteed not to clash with
         # the name of an object as names are not allowed to start with a digit
         state['0_t'] = self.t_
         return state
 
     @device_override('network_store')
-    def store(self, name='default'):
+    def store(self, name='default', filename=None):
         '''
-        store(name='default')
+        store(name='default', filename=None)
 
         Store the state of the network and all included objects.
 
@@ -363,19 +364,47 @@ class Network(Nameable):
         ----------
         name : str, optional
             A name for the snapshot, if not specified uses ``'default'``.
+        filename : str, optional
+            A filename where the state should be stored. If not specified, the
+            state will be stored in memory.
 
+        Notes
+        -----
+        The state stored to disk can be restored with the `Network.restore`
+        function. Note that it will only restore the *internal state* of all
+        the objects (including undelivered spikes) -- the objects have to
+        exist already and they need to have the same name as when they were
+        stored. Equations, thresholds, etc. are *not* stored -- this is
+        therefore not a general mechanism for object serialization. Also, the
+        format of the file is not guaranteed to work across platforms or
+        versions. If you are interested in storing the state of a network for
+        documentation or analysis purposes use `Network.get_states` instead.
         '''
         clocks = [obj.clock for obj in self.objects]
         # Make sure that all clocks are up to date
         for clock in clocks:
             clock._set_t_update_dt(target_t=self.t)
 
-        self._stored_state[name] = self._full_state()
+        state = self._full_state()
+        if filename is None:
+            self._stored_state[name] = state
+        else:
+            # A single file can contain several states, so we'll read in the
+            # existing file first if it exists
+            if os.path.exists(filename):
+                with open(filename, 'rb') as f:
+                    store_state = pickle.load(f)
+            else:
+                store_state = {}
+            store_state[name] = state
+
+            with open(filename, 'wb') as f:
+                pickle.dump(store_state, f, protocol=pickle.HIGHEST_PROTOCOL)
 
     @device_override('network_restore')
-    def restore(self, name='default'):
+    def restore(self, name='default', filename=None):
         '''
-        restore(name='default')
+        restore(name='default', filename=None)
 
         Retore the state of the network and all included objects.
 
@@ -384,13 +413,24 @@ class Network(Nameable):
         name : str, optional
             The name of the snapshot to restore, if not specified uses
             ``'default'``.
-
+        filename : str, optional
+            The name of the file from where the state should be restored. If
+            not specified, it is expected that the state exist in memory
+            (i.e. `Network.store` was previously called without the ``filename``
+            argument).
         '''
-        state = self._stored_state[name]
+        if filename is None:
+            state = self._stored_state[name]
+        else:
+            with open(filename, 'rb') as f:
+                state = pickle.load(f)[name]
         self.t_ = state.pop('0_t')
+        clocks = set([obj.clock for obj in self.objects])
         for obj in self.objects:
             if obj.name in state:
                 obj._restore_from_full_state(state[obj.name])
+        for clock in clocks:
+            clock._restore_from_full_state(state[clock.name])
 
     def get_states(self, units=True, format='dict',
                    subexpressions=False, read_only_variables=True, level=0):

--- a/brian2/groups/group.py
+++ b/brian2/groups/group.py
@@ -519,29 +519,19 @@ class VariableOwner(Nameable):
         for key, value in values.iteritems():
             self.state(key, use_units=units, level=level+1)[:] = value
 
-    def _store(self, name='default'):
-        logger.debug('Storing state at for object %s' % self.name)
+    def _full_state(self):
         state = {}
         for var in self.variables.itervalues():
             if isinstance(var, ArrayVariable):
                 state[var] = (var.get_value().copy(), var.size)
-        self._stored_states[name] = state
-        for obj in self._contained_objects:
-            if hasattr(obj, '_store'):
-                obj._store(name)
 
-    def _restore(self, name='default'):
-        logger.debug('Restoring state at for object %s' % self.name)
-        if not name in self._stored_states:
-            raise ValueError(('No state with name "%s" to restore -- '
-                              'did you call store()?') % name)
-        for var, (values, size) in self._stored_states[name].iteritems():
+        return state
+
+    def _restore_from_full_state(self, state):
+        for var, (values, size) in state.iteritems():
             if isinstance(var, DynamicArrayVariable):
                 var.resize(size)
             var.set_value(values)
-        for obj in self._contained_objects:
-            if hasattr(obj, '_restore'):
-                obj._restore(name)
 
     def _check_expression_scalar(self, expr, varname, level=0,
                                  run_namespace=None):

--- a/brian2/groups/group.py
+++ b/brian2/groups/group.py
@@ -287,8 +287,6 @@ class VariableOwner(Nameable):
             self.indices = IndexWrapper(self)
         if not hasattr(self, '_stored_states'):
             self._stored_states = {}
-        if not hasattr(self, '_stored_clocks'):
-            self._stored_clocks = {}
         self._group_attribute_access_active = True
 
     def state(self, name, use_units=True, level=0):
@@ -528,7 +526,6 @@ class VariableOwner(Nameable):
             if isinstance(var, ArrayVariable):
                 state[var] = (var.get_value().copy(), var.size)
         self._stored_states[name] = state
-        self._stored_clocks[name] = (self.clock.t_, self.clock.dt_)
         for obj in self._contained_objects:
             if hasattr(obj, '_store'):
                 obj._store(name)
@@ -542,9 +539,6 @@ class VariableOwner(Nameable):
             if isinstance(var, DynamicArrayVariable):
                 var.resize(size)
             var.set_value(values)
-        t, dt = self._stored_clocks[name]
-        self.clock.dt_ = dt
-        self.clock._set_t_update_dt(target_t=t*second)
         for obj in self._contained_objects:
             if hasattr(obj, '_restore'):
                 obj._restore(name)

--- a/brian2/groups/group.py
+++ b/brian2/groups/group.py
@@ -522,13 +522,16 @@ class VariableOwner(Nameable):
     def _full_state(self):
         state = {}
         for var in self.variables.itervalues():
+            if var.owner is None or var.owner.name != self.name:
+                continue  # we only store the state of our own variables
             if isinstance(var, ArrayVariable):
-                state[var] = (var.get_value().copy(), var.size)
+                state[var.name] = (var.get_value().copy(), var.size)
 
         return state
 
     def _restore_from_full_state(self, state):
-        for var, (values, size) in state.iteritems():
+        for var_name, (values, size) in state.iteritems():
+            var = self.variables[var_name]
             if isinstance(var, DynamicArrayVariable):
                 var.resize(size)
             var.set_value(values)

--- a/brian2/input/spikegeneratorgroup.py
+++ b/brian2/input/spikegeneratorgroup.py
@@ -126,7 +126,7 @@ class SpikeGeneratorGroup(Group, CodeRunner, SpikeSource):
                                          constant_size=True)
         self.variables.add_array('_spikespace', size=N+1, unit=Unit(1),
                                  dtype=np.int32)
-        self.variables.add_array('_lastindex', size=1, values=1, unit=Unit(1),
+        self.variables.add_array('_lastindex', size=1, values=0, unit=Unit(1),
                                  dtype=np.int32, read_only=True, scalar=True)
         self.variables.create_clock_variables(self._clock)
 
@@ -187,8 +187,6 @@ class SpikeGeneratorGroup(Group, CodeRunner, SpikeSource):
                                                                self.name))
             self._previous_dt = dt
             self._spikes_changed = False
-
-            self.variables['_lastindex'].set_value(0)
 
         super(SpikeGeneratorGroup, self).before_run(run_namespace=run_namespace,
                                                     level=level+1)

--- a/brian2/synapses/cspikequeue.cpp
+++ b/brian2/synapses/cspikequeue.cpp
@@ -24,8 +24,6 @@ public:
     unsigned int openmp_padding;
     vector< vector<int> > synapses;
     // data structures for the store/restore mechanism
-    map<string, vector< vector<int32_t> > > _stored_queue;
-    map<string, unsigned int> _stored_offset;
 
     CSpikeQueue(int _source_start, int _source_end)
         : source_start(_source_start), source_end(_source_end)
@@ -93,25 +91,28 @@ public:
         dt = _dt;
     }
 
-    void store(const string name)
+    pair <unsigned int, vector< vector<int32_t> > > _full_state()
     {
-        _stored_queue[name].clear();
-        _stored_queue[name].resize(queue.size());
-        for (int i=0; i<queue.size(); i++)
-            _stored_queue[name][i] = queue[i];
-        _stored_offset[name] = offset;
+        pair <unsigned int, vector< vector<int32_t> > > state(offset, queue);
+        return state;
     }
 
-    void restore(const string name)
+    void _clear()
     {
-        size_t size = _stored_queue[name].size();
+    }
+
+    void _restore_from_full_state(const pair <unsigned int, vector< vector<int32_t> > > state)
+    {
+        unsigned int stored_offset = state.first;
+        vector< vector<int32_t> > stored_queue = state.second;
+        size_t size = stored_queue.size();
         queue.clear();
         if (size == 0)  // the queue did not exist at the time of the store call
             size = 1;
         queue.resize(size);
-        for (int i=0; i<_stored_queue[name].size(); i++)
-            queue[i] = _stored_queue[name][i];
-        offset = _stored_offset[name];
+        for (int i=0; i<stored_queue.size(); i++)
+            queue[i] = stored_queue[i];
+        offset = stored_offset;
     }
 
     void expand(unsigned int newsize)

--- a/brian2/synapses/spikequeue.py
+++ b/brian2/synapses/spikequeue.py
@@ -195,7 +195,7 @@ class SpikeQueue(object):
             self.n[row_idx] += 1
 
     def _full_state(self):
-        return self._extract_spikes()
+        return (self._dt, self._extract_spikes(), self.X.shape)
 
     def _restore_from_full_state(self, state):
         if state is None:
@@ -203,8 +203,15 @@ class SpikeQueue(object):
             # before the `SpikeQueue` was created. In that case, delete all spikes in
             # the queue
             self._store_spikes(np.empty((0, 2)))
+            self._dt = None
         else:
-            self._store_spikes(state)
+            self._dt, spikes, X_shape = state
+            # Restore the previous shape
+            n_steps, max_events = X_shape
+            self.X = np.zeros((n_steps, max_events), dtype=self.dtype)
+            self.X_flat = self.X.reshape(n_steps*max_events,)
+            self.n = np.zeros(n_steps, dtype=int)
+            self._store_spikes(spikes)
 
     ################################ SPIKE QUEUE DATASTRUCTURE ################
     def advance(self):

--- a/brian2/synapses/spikequeue.py
+++ b/brian2/synapses/spikequeue.py
@@ -214,17 +214,17 @@ class SpikeQueue(object):
             self.X[row_idx, self.n[row_idx]] = target
             self.n[row_idx] += 1
 
-    def _store(self, name='default'):
-        self._stored_spikes[name] = self._extract_spikes()
+    def _full_state(self):
+        return self._extract_spikes()
 
-    def _restore(self, name='default'):
-        if name in self._stored_spikes:
-            self._store_spikes(self._stored_spikes[name])
-        else:
-            # It is possible that _store was called in `SynapticPathway`, before
-            # the `SpikeQueue` was created. In that case, delete all spikes in
+    def _restore_from_full_state(self, state):
+        if state is None:
+            # It is possible that _full_state was called in `SynapticPathway`,
+            # before the `SpikeQueue` was created. In that case, delete all spikes in
             # the queue
             self._store_spikes(np.empty((0, 2)))
+        else:
+            self._store_spikes(state)
 
     ################################ SPIKE QUEUE DATASTRUCTURE ################
     def advance(self):

--- a/brian2/synapses/synapses.py
+++ b/brian2/synapses/synapses.py
@@ -305,15 +305,19 @@ class SynapticPathway(CodeRunner, Group):
                                             synapses=self.synapses.name),
                         'synapses_dt_mismatch', once=True)
 
-    def _store(self, name='default'):
-        super(SynapticPathway, self)._store(name=name)
+    def _full_state(self):
+        state = super(SynapticPathway, self)._full_state()
         if self.queue is not None:
-            self.queue._store(name)
+            state['_spikequeue'] = self.queue._full_state()
+        else:
+            state['_spikequeue'] = None
+        return state
 
-    def _restore(self, name='default'):
-        super(SynapticPathway, self)._restore(name=name)
+    def _restore_from_full_state(self, state):
+        queue_state = state.pop('_spikequeue', None)
+        super(SynapticPathway, self)._restore_from_full_state(state)
         if self.queue is not None:
-            self.queue._restore(name)
+            self.queue._restore_from_full_state(queue_state)
 
     def push_spikes(self):
         # Push new events (e.g. spikes) into the queue

--- a/brian2/synapses/synapses.py
+++ b/brian2/synapses/synapses.py
@@ -316,8 +316,9 @@ class SynapticPathway(CodeRunner, Group):
     def _restore_from_full_state(self, state):
         queue_state = state.pop('_spikequeue', None)
         super(SynapticPathway, self)._restore_from_full_state(state)
-        if self.queue is not None:
-            self.queue._restore_from_full_state(queue_state)
+        if self.queue is None:
+            self.queue = get_device().spike_queue(self.source.start, self.source.stop)
+        self.queue._restore_from_full_state(queue_state)
 
     def push_spikes(self):
         # Push new events (e.g. spikes) into the queue

--- a/brian2/tests/test_network.py
+++ b/brian2/tests/test_network.py
@@ -869,6 +869,28 @@ def test_store_restore_to_file_new_objects():
     except OSError:
         pass
 
+
+@attr('codegen-independent')
+def test_store_restore_to_file_differing_nets():
+    # Check that the store/restore mechanism is not used with differing
+    # networks
+    filename = tempfile.mktemp(suffix='state', prefix='brian_test')
+
+    source = SpikeGeneratorGroup(5, [0, 1, 2, 3, 4], [0, 1, 2, 3, 4]*ms,
+                                 name='source_1')
+    mon = SpikeMonitor(source, name='monitor')
+    net = Network(source, mon)
+    net.store(filename=filename)
+
+    source_2 = SpikeGeneratorGroup(5, [0, 1, 2, 3, 4], [0, 1, 2, 3, 4]*ms,
+                                   name='source_2')
+    mon = SpikeMonitor(source_2, name='monitor')
+    net = Network(source_2, mon)
+    assert_raises(KeyError, lambda: net.restore(filename=filename))
+
+    net = Network(source)  # Without the monitor
+    assert_raises(KeyError, lambda: net.restore(filename=filename))
+
 @attr('codegen-independent')
 @with_setup(teardown=restore_initial_state)
 def test_store_restore_magic():
@@ -1148,6 +1170,7 @@ if __name__=='__main__':
             test_store_restore,
             test_store_restore_to_file,
             test_store_restore_to_file_new_objects,
+            test_store_restore_to_file_differing_nets,
             test_store_restore_magic,
             test_store_restore_magic_to_file,
             test_defaultclock_dt_changes,

--- a/docs_sphinx/user/running.rst
+++ b/docs_sphinx/user/running.rst
@@ -219,3 +219,14 @@ Note that `Network.run`, `Network.store` and `Network.restore` (or `run`,
 `store`, `restore`) are the only way of affecting the time of the clocks. In
 contrast to Brian1, it is no longer necessary (nor possible) to directly set
 the time of the clocks or call a ``reinit`` function.
+
+The state of a network can also be stored on disk with the optional ``filename``
+argument of `Network.store`/`store`. This way, you can run the initial part of
+a simulation once, store it to disk, and then continue from this state later.
+Note that the `store`/`restore` mechanism does not re-create the network as
+such, you still need to construct all the `NeuronGroup`, `Synapses`,
+`StateMonitor`, ... objects, restoring will only restore all the state variable
+values (membrane potential, conductances, synaptic connections/weights/delays,
+...). This restoration does however restore the internal state of the objects
+as well, e.g. spikes that have not been delivered yet because of synaptic
+delays will be delivered correctly.


### PR DESCRIPTION
There's still a bit of documentation and testing missing, but the basic functionality is there. The `store/restore` mechanism now takes an optional `filename` argument, allowing you to store the state to disk instead of to memory. It internally uses a `_full_state` method that returns a dictionary of the values of all the state variables of the object (for `SynapticPathway`, it also contains a representation of the internal state of the spike queue). There is some redundancy with the `get_state` method here, but I'd prefer them to stay separate, the `get_state` method is something for the user which focuses on usability instead of completeness. 

The spike queue part is not quite working yet but the current test does not catch it.