### PR TITLE
[MRG] Use compiler settings for maximal speed by default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -112,12 +112,12 @@ install:
        conda install --yes --quiet anaconda-client conda-build jinja2 pip setuptools;
     fi
   - if [[ $MINIMAL_VERSIONS == 'yes' ]]; then
-    conda create -n travis_conda --yes pip python=$PYTHON numpy==1.8.2 scipy==0.13.3 nose sphinx ipython sympy==0.7.6 jinja2==2.7 pyparsing setuptools coverage;
+    conda create -n travis_conda --yes --quiet pip python=$PYTHON numpy==1.8.2 scipy==0.13.3 nose sphinx ipython sympy==0.7.6 jinja2==2.7 pyparsing setuptools coverage;
     else
-    conda create -n travis_conda --yes pip python=$PYTHON numpy scipy nose sphinx ipython sympy pyparsing jinja2 setuptools coverage;
+    conda create -n travis_conda --yes --quiet pip python=$PYTHON numpy scipy nose sphinx ipython sympy pyparsing jinja2 setuptools coverage;
     fi
   - source activate travis_conda
-  - conda install -c brian-team py-cpuinfo  # install cpuinfo from our own channel
+  - conda install --yes --quiet -c brian-team py-cpuinfo  # install cpuinfo from our own channel
   - if [[ $CYTHON == 'yes' ]]; then conda install --yes cython; SETUP_ARGS=--with-cython; else SETUP_ARGS=''; fi
   - if [[ $REPORT_COVERAGE == 'yes' ]]; then pip install -q coveralls; fi
   - python setup.py install $SETUP_ARGS --fail-on-error --single-version-externally-managed --record=record.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -117,6 +117,7 @@ install:
     conda create -n travis_conda --yes pip python=$PYTHON numpy scipy nose sphinx ipython sympy pyparsing jinja2 setuptools coverage;
     fi
   - source activate travis_conda
+  - conda install -c brian-team py-cpuinfo  # install cpuinfo from our own channel
   - if [[ $CYTHON == 'yes' ]]; then conda install --yes cython; SETUP_ARGS=--with-cython; else SETUP_ARGS=''; fi
   - if [[ $REPORT_COVERAGE == 'yes' ]]; then pip install -q coveralls; fi
   - python setup.py install $SETUP_ARGS --fail-on-error --single-version-externally-managed --record=record.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -130,7 +130,7 @@ install:
 script:
 - if [[ $CONDA_BUILD == 'yes' ]]; then
     source deactivate;
-    conda build dev/conda-recipe --quiet;
+    conda build --quiet -c brian-team dev/conda-recipe;
     source activate travis_conda;
   fi
 # Don't run tests in parallel when reporting coverage

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -103,7 +103,7 @@ install:
 
   # Install the build dependencies of the project via conda
   - 'conda install --yes --quiet numpy scipy nose sphinx sympy pyparsing jinja2 ipython setuptools cython'
-  - 'conda install -c brian-team py-cpuinfo'
+  - 'conda install --yes --quiet -c brian-team py-cpuinfo'
 
 build: false  # Not a C# project, build stuff at the test step instead.
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -125,7 +125,7 @@ after_test:
           %CMD_IN_ENV% python setup.py bdist_wininst &&
           deactivate &&
           %CMD_IN_ENV% conda install --yes --quiet conda-build anaconda-client pip &&
-          %CMD_IN_ENV% conda build dev\conda-recipe --quiet &&
+          %CMD_IN_ENV% conda build --quiet -c brian-team dev\conda-recipe &&
           %CMD_IN_ENV% python dev\continuous-integration\move-conda-package.py dev\conda-recipe
      )'
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -103,7 +103,7 @@ install:
 
   # Install the build dependencies of the project via conda
   - 'conda install --yes --quiet numpy scipy nose sphinx sympy pyparsing jinja2 ipython setuptools cython'
-  - 'pip install py-cpuinfo'
+  - 'conda install -c brian-team py-cpuinfo'
 
 build: false  # Not a C# project, build stuff at the test step instead.
 

--- a/brian2/__init__.py
+++ b/brian2/__init__.py
@@ -38,6 +38,12 @@ except ImportError as ex:
     sys.stderr.write('Importing Jinja2 failed: %s\n' % ex)
     missing.append('jinja2')
 
+try:
+    import cpuinfo
+except ImportError as ex:
+    sys.stderr.write('Importing cpuinfo failed: %s\n' % ex)
+    missing.append('py-cpuinfo')
+
 if len(missing):
     raise ImportError('Some required dependencies are missing:\n' + ', '.join(missing))
 

--- a/brian2/codegen/cpp_prefs.py
+++ b/brian2/codegen/cpp_prefs.py
@@ -13,6 +13,25 @@ from brian2.core.preferences import prefs, BrianPreference
 
 __all__ = ['get_compiler_and_args']
 
+# Try to get architecture information to get the best compiler setting for
+# Windows
+msvc_arch_flag = ''
+try:
+    from cpuinfo import cpuinfo
+    res = cpuinfo.get_cpu_info()
+    # Note that this overwrites the arch_flag, i.e. only the best option will
+    # be used
+    if 'sse' in res['flags']:
+        msvc_arch_flag = '/arch:SSE'
+    if 'sse2' in res['flags']:
+        msvc_arch_flag = '/arch:SSE2'
+    if 'avx' in res['flags']:
+        msvc_arch_flag = '/arch:AVX'
+    if 'avx2' in res['flags']:
+        msvc_arch_flag = '/arch:AVX2'
+except ImportError:
+    pass
+
 # Preferences
 prefs.register_preferences(
     'codegen.cpp',
@@ -34,13 +53,13 @@ prefs.register_preferences(
         '''
         ),
     extra_compile_args_gcc=BrianPreference(
-        default=['-w', '-O3'],
+        default=['-w', '-O3', '-ffast-math', '-march=native'],
         docs='''
         Extra compile arguments to pass to GCC compiler
         '''
         ),
     extra_compile_args_msvc=BrianPreference(
-        default=['/Ox', '/EHsc', '/w'],
+        default=['/Ox', '/EHsc', '/w', '/fp:fast', msvc_arch_flag],
         docs='''
         Extra compile arguments to pass to MSVC compiler
         '''

--- a/brian2/codegen/cpp_prefs.py
+++ b/brian2/codegen/cpp_prefs.py
@@ -6,8 +6,9 @@ Preferences
 .. document_brian_prefs:: codegen.cpp
 
 '''
-
 from distutils.ccompiler import get_default_compiler
+
+from cpuinfo import cpuinfo
 
 from brian2.core.preferences import prefs, BrianPreference
 
@@ -16,21 +17,17 @@ __all__ = ['get_compiler_and_args']
 # Try to get architecture information to get the best compiler setting for
 # Windows
 msvc_arch_flag = ''
-try:
-    from cpuinfo import cpuinfo
-    res = cpuinfo.get_cpu_info()
-    # Note that this overwrites the arch_flag, i.e. only the best option will
-    # be used
-    if 'sse' in res['flags']:
-        msvc_arch_flag = '/arch:SSE'
-    if 'sse2' in res['flags']:
-        msvc_arch_flag = '/arch:SSE2'
-    if 'avx' in res['flags']:
-        msvc_arch_flag = '/arch:AVX'
-    if 'avx2' in res['flags']:
-        msvc_arch_flag = '/arch:AVX2'
-except ImportError:
-    pass
+res = cpuinfo.get_cpu_info()
+# Note that this overwrites the arch_flag, i.e. only the best option will
+# be used
+if 'sse' in res['flags']:
+    msvc_arch_flag = '/arch:SSE'
+if 'sse2' in res['flags']:
+    msvc_arch_flag = '/arch:SSE2'
+if 'avx' in res['flags']:
+    msvc_arch_flag = '/arch:AVX'
+if 'avx2' in res['flags']:
+    msvc_arch_flag = '/arch:AVX2'
 
 # Preferences
 prefs.register_preferences(

--- a/brian2/codegen/cpp_prefs.py
+++ b/brian2/codegen/cpp_prefs.py
@@ -46,7 +46,7 @@ prefs.register_preferences(
         validator=lambda v: True,
         docs='''
         Extra arguments to pass to compiler (if None, use either
-        ``extra_compile_args_gcc`` or ``extra_compile_args_msvs``).
+        ``extra_compile_args_gcc`` or ``extra_compile_args_msvc``).
         '''
         ),
     extra_compile_args_gcc=BrianPreference(
@@ -58,7 +58,8 @@ prefs.register_preferences(
     extra_compile_args_msvc=BrianPreference(
         default=['/Ox', '/EHsc', '/w', '/fp:fast', msvc_arch_flag],
         docs='''
-        Extra compile arguments to pass to MSVC compiler
+        Extra compile arguments to pass to MSVC compiler (the default
+        ``/arch:`` flag is determined based on the processor architecture)
         '''
         ),
     extra_link_args=BrianPreference(

--- a/brian2/devices/cpp_standalone/device.py
+++ b/brian2/devices/cpp_standalone/device.py
@@ -633,17 +633,8 @@ class CPPStandaloneDevice(Device):
                                                         )
         writer.write('run.*', run_tmp)
         
-    def generate_makefile(self, writer, compiler, native, compiler_flags, linker_flags, nb_threads):
+    def generate_makefile(self, writer, compiler, compiler_flags, linker_flags, nb_threads):
         if compiler=='msvc':
-            if native:
-                arch_flag = ''
-                res = cpuinfo.get_cpu_info()
-                if 'sse' in res['flags']:
-                    arch_flag = '/arch:SSE'
-                if 'sse2' in res['flags']:
-                    arch_flag = '/arch:SSE2'
-                compiler_flags += ' '+arch_flag
-            
             if nb_threads>1:
                 openmp_flag = '/openmp'
             else:
@@ -720,7 +711,7 @@ class CPPStandaloneDevice(Device):
         self.networks = networks
         self.net_synapses = synapses
     
-    def compile_source(self, directory, compiler, debug, clean, native):
+    def compile_source(self, directory, compiler, debug, clean):
         with in_directory(directory):
             if compiler == 'msvc':
                 from distutils import msvc9compiler
@@ -767,8 +758,6 @@ class CPPStandaloneDevice(Device):
                         os.system('make clean')
                     if debug:
                         x = os.system('make debug')
-                    elif native:
-                        x = os.system('make native')
                     else:
                         x = os.system('make')
                     if x!=0:
@@ -797,8 +786,7 @@ class CPPStandaloneDevice(Device):
 
     def build(self, directory='output',
               compile=True, run=True, debug=False, clean=True,
-              with_output=True, native=True,
-              additional_source_files=None,
+              with_output=True, additional_source_files=None,
               run_args=None, **kwds):
         '''
         Build the project
@@ -818,8 +806,6 @@ class CPPStandaloneDevice(Device):
         with_output : bool
             Whether or not to show the ``stdout`` of the built program when run. Output will be shown in case
             of compilation or runtime error.
-        native : bool
-            Whether or not to compile for the current machine's architecture (best for speed, but not portable)
         clean : bool
             Whether or not to clean the project before building
         additional_source_files : list of str
@@ -906,13 +892,13 @@ class CPPStandaloneDevice(Device):
 
         writer.source_files.extend(additional_source_files)
 
-        self.generate_makefile(writer, compiler, native=native,
+        self.generate_makefile(writer, compiler,
                                compiler_flags=' '.join(compiler_flags),
                                linker_flags=' '.join(linker_flags),
                                nb_threads=nb_threads)
 
         if compile:
-            self.compile_source(directory, compiler, debug, clean, native)
+            self.compile_source(directory, compiler, debug, clean)
             if run:
                 self.run(directory, with_output, run_args)
 

--- a/brian2/devices/cpp_standalone/device.py
+++ b/brian2/devices/cpp_standalone/device.py
@@ -12,6 +12,7 @@ import tempfile
 from distutils import ccompiler
 
 import numpy as np
+from cpuinfo import cpuinfo
 
 from brian2.codegen.cpp_prefs import get_compiler_and_args
 from brian2.core.network import Network
@@ -636,15 +637,11 @@ class CPPStandaloneDevice(Device):
         if compiler=='msvc':
             if native:
                 arch_flag = ''
-                try:
-                    from cpuinfo import cpuinfo
-                    res = cpuinfo.get_cpu_info()
-                    if 'sse' in res['flags']:
-                        arch_flag = '/arch:SSE'
-                    if 'sse2' in res['flags']:
-                        arch_flag = '/arch:SSE2'
-                except ImportError:
-                    logger.warn('Native flag for MSVC compiler requires installation of the py-cpuinfo module')
+                res = cpuinfo.get_cpu_info()
+                if 'sse' in res['flags']:
+                    arch_flag = '/arch:SSE'
+                if 'sse2' in res['flags']:
+                    arch_flag = '/arch:SSE2'
                 compiler_flags += ' '+arch_flag
             
             if nb_threads>1:

--- a/brian2/devices/cpp_standalone/templates/makefile
+++ b/brian2/devices/cpp_standalone/templates/makefile
@@ -16,11 +16,7 @@ debug: CFLAGS += $(DEBUG)
 debug: LFLAGS += $(DEBUG)
 debug: executable
 
-# Adds -march=native to optimisations, which only works for recent gcc versions
-native: OPTIMISATIONS += -march=native
-native: executable
-
-.PHONY: all debug native executable clean
+.PHONY: all debug executable clean
 
 executable: $(OBJS) $(DEPS)
 	$(CC) $(OBJS) -o $(PROGRAM) $(LFLAGS)

--- a/dev/conda-recipe/meta.yaml
+++ b/dev/conda-recipe/meta.yaml
@@ -13,6 +13,7 @@ requirements:
     - sympy >=0.7.6
     - pyparsing
     - jinja2 >=2.7
+    - py-cpuinfo >=0.1.6
 
   run:
     - python
@@ -24,6 +25,7 @@ requirements:
     - cython >=0.18
     - jinja2 >=2.7
     - setuptools >=6.0
+    - py-cpuinfo >=0.1.6
 
 test:
   # Python imports
@@ -63,4 +65,3 @@ about:
   home: http://www.briansimulator.org/
   license: CeCILL-2.1
   summary: 'A clock-driven simulator for spiking neural networks'
-

--- a/docs_sphinx/user/computation.rst
+++ b/docs_sphinx/user/computation.rst
@@ -20,8 +20,6 @@ that only the Python fallback is available), set the preference to ``'numpy'``,
     prefs.codegen.target = 'numpy'  # use the Python fallback
 
 See :doc:`../advanced/preferences` for different ways of setting preferences.
-If you are using a compiled language target, also see the
-`Compiler settings for maximum speed`_ section below.
 
  .. _Cython: http://cython.org/
 
@@ -48,44 +46,21 @@ The reason is that the function ``f(x)`` is a Python function and so cannot
 be called from C++ directly. To solve this problem, you need to provide an
 implementation of the function in the target language. See :doc:`functions`.
 
-Compiler settings for maximum speed
------------------------------------
+Compiler settings
+-----------------
 
-If using C++ code generation (either via weave, cython or standalone), you
-can maximise the efficiency of the generated code in various ways, described
-below. These can be set in the global preferences file as described in
-:doc:`../advanced/preferences`.
+If using C++ code generation (either via weave, cython or standalone), the
+compiler settings can make a big difference for the speed of the simulation.
+By default, Brian uses a set of compiler settings that switches on various
+optimizations and compiles for running on the same architecture where the
+code is compiled. This allows the compiler to make use of as many advanced
+instructions as possible, but reduces portability of the generated executable
+(which is not usually an issue).
 
-GCC
-~~~
-
-For the GCC compiler, the fastest options are::
-
-    codegen.cpp.extra_compile_args_gcc = ['-w', '-Ofast', '-march=native']
-    
-The ``-Ofast`` optimisation allows the compiler to disregard strict IEEE standards
-compliance. In our usage this has never been a problem, but we don't do this
-by default for safety. Note that not all versions of gcc include this switch,
-older versions might require you to write ``'-O3', '-ffast-math'``.
-
-The ``-march=native`` sets the computer architecture to be the one available
-on the machine you are compiling on. This allows the compiler to make use of
-as many advanced instructions as possible, but reduces portability of the
-generated executable (which is not usually an issue). Again, this option
-is not available on all versions of gcc so on an older version you might have
-to put your architecture in explicitly (check the gcc docs for your version).
-
-MSVC
-~~~~
-
-For the MSVC compiler, the fastest options are::
-
-    codegen.cpp.extra_compile_args_msvc = ['/Ox', '/EHsc', '/w', '/arch:AVX2', '/fp:fast']
-    
-Note that as above for ``-Ofast`` on gcc, ``/fp:fast`` will enable the
-compiler to disregard strict IEEE standards compliance, which has never
-been a problem in our usage but we leave this off by default for safety.
-
-The ``/arch:AVX2`` option may not be available on your version of MSVC and
-your computer architecture. The available options (in order from best to
-worst) are: ``AVX2``, ``AVX``, ``SSE2``, ``SSE`` and ``IA32``.
+If there are any issues with these compiler settings, for example because
+you are using an older version of the C++ compiler or because you want to
+run the generated code on a different architecture, you can change the
+settings by manually specifying the `codegen.cpp.extra_compile_args`
+preference (or by using `codegen.cpp.extra_compile_args_gcc` or
+`codegen.cpp.extra_compile_args_msvc` if you want to specify the settings
+for either compiler only).

--- a/setup.py
+++ b/setup.py
@@ -162,6 +162,7 @@ setup(name='Brian2',
                         'sympy>=0.7.6',
                         'pyparsing',
                         'jinja2>=2.7',
+                        'py-cpuinfo>=0.1.6',
                         'setuptools>=6.0'  # FIXME: setuptools>=6.0 is only needed for Windows
                        ],
       setup_requires=['numpy>=1.8.2',


### PR DESCRIPTION
I just enabled the fast compilation options in this branch, testing on Linux did not show any test failures but we don't yet have the results from appveyor. If there's no problem, then it seems we do not actually have to change anything (apart from the documentation). I included an auto-detection of the arch flag for Windows in the same way it was done in standalone when you specified `native=True`. This makes the latter obsolete, do you think this is important enough to have as a specific keyword argument to build instead of having it set simply via the compiler options? I think users will build for their own machine in 99% of the cases and if not, they probably have to set some compiler/linker settings anyway, no?