### PR TITLE
[MRG] Faster `before_run`

### DIFF
--- a/brian2/codegen/codeobject.py
+++ b/brian2/codegen/codeobject.py
@@ -255,18 +255,6 @@ def create_runner_codeobj(group, code, template_name,
     else:
         override_conditional_write = set(override_conditional_write)
 
-    if check_units:
-        for c in code.values():
-            # This is the first time that the code is parsed, catch errors
-            try:
-                check_code_units(c, group,
-                                 additional_variables=additional_variables,
-                                 level=level+1,
-                                 run_namespace=run_namespace)
-            except (SyntaxError, KeyError, ValueError) as ex:
-                error_msg = _error_msg(c, name)
-                raise ValueError(error_msg + str(ex))
-
     if codeobj_class is None:
         codeobj_class = device.code_object_class(group.codeobj_class)
     else:
@@ -326,6 +314,15 @@ def create_runner_codeobj(group, code, template_name,
                                        additional_variables=additional_variables,
                                        run_namespace=run_namespace,
                                        level=level+1))
+
+    if check_units:
+        for c in code.values():
+            # This is the first time that the code is parsed, catch errors
+            try:
+                check_units_statements(c, variables)
+            except (SyntaxError, KeyError, ValueError) as ex:
+                error_msg = _error_msg(c, name)
+                raise ValueError(error_msg + str(ex))
 
     all_variable_indices = copy.copy(group.variables.indices)
     if additional_variables is not None:

--- a/brian2/codegen/generators/base.py
+++ b/brian2/codegen/generators/base.py
@@ -2,6 +2,7 @@
 Base class for generating code in different programming languages, gives the
 methods which should be overridden to implement a new language.
 '''
+from brian2.core.preferences import prefs
 from brian2.core.variables import ArrayVariable
 from brian2.utils.stringtools import get_identifiers
 from brian2.utils.logger import get_logger
@@ -214,9 +215,11 @@ class CodeGenerator(object):
         scalar_statements = {}
         vector_statements = {}
         for ac_name, ac_code in code.iteritems():
-            scalar_statements[ac_name], vector_statements[ac_name] = make_statements(ac_code,
-                                                                                     self.variables,
-                                                                                     dtype)
+            statements = make_statements(ac_code,
+                                         self.variables,
+                                         dtype,
+                                         loop_invariant_optimisations=prefs.codegen.loop_invariant_optimisations)
+            scalar_statements[ac_name], vector_statements[ac_name] = statements
         for vs in vector_statements.itervalues():
             # Check that the statements are meaningful independent on the order of
             # execution (e.g. for synapses)

--- a/brian2/core/base.py
+++ b/brian2/core/base.py
@@ -66,6 +66,7 @@ class BrianObject(Nameable):
                                                                                          funcname=funcname,
                                                                                          line=line)
                 creation_stack.append(s)
+        creation_stack = [''] + creation_stack
         #: A string indicating where this object was created (traceback with any parts of Brian code removed)
         self._creation_stack = ('Object was created here (most recent call only, full details in '
                                 'debug log):\n'+creation_stack[-1])
@@ -159,7 +160,7 @@ class BrianObject(Nameable):
         else:
             self._dependencies.add(obj.id)
 
-    def before_run(self, run_namespace=None, level=0):
+    def before_run(self, run_namespace):
         '''
         Optional method to prepare the object before a run.
 

--- a/brian2/core/variables.py
+++ b/brian2/core/variables.py
@@ -1328,7 +1328,7 @@ class VariableView(object):
                 # This will fail for subexpressions that refer to external
                 # parameters
                 values = repr(self[:])
-            except ValueError:
+            except KeyError:
                 values = ('[Subexpression refers to external parameters. Use '
                           '"group.{var}[:]"]').format(var=self.variable.name)
 

--- a/brian2/core/variables.py
+++ b/brian2/core/variables.py
@@ -1003,12 +1003,7 @@ class VariableView(object):
         abstract_code = self.name + ' = ' + code
         variables = Variables(None)
         variables.add_auxiliary_variable('_cond', unit=Unit(1), dtype=np.bool)
-        from brian2.codegen.codeobject import (create_runner_codeobj,
-                                               check_code_units)
-        check_code_units(abstract_code_cond, self.group,
-                         additional_variables=variables,
-                         level=level+2,
-                         run_namespace=run_namespace)
+        from brian2.codegen.codeobject import create_runner_codeobj
         # TODO: Have an additional argument to avoid going through the index
         # array for situations where iterate_all could be used
         from brian2.devices.device import get_default_codeobject_class
@@ -1059,12 +1054,7 @@ class VariableView(object):
 
         abstract_code = '_variable = ' + self.name + '\n'
         abstract_code += '_cond = ' + code
-        from brian2.codegen.codeobject import (create_runner_codeobj,
-                                               check_code_units)
-        check_code_units(abstract_code, self.group,
-                         additional_variables=variables,
-                         level=level+2,
-                         run_namespace=run_namespace)
+        from brian2.codegen.codeobject import create_runner_codeobj
         from brian2.devices.device import get_default_codeobject_class
         codeobj = create_runner_codeobj(self.group,
                                         abstract_code,

--- a/brian2/devices/cpp_standalone/device.py
+++ b/brian2/devices/cpp_standalone/device.py
@@ -17,6 +17,7 @@ from brian2.codegen.cpp_prefs import get_compiler_and_args
 from brian2.core.network import Network
 from brian2.devices.device import Device, all_devices, get_device, set_device
 from brian2.core.variables import *
+from brian2.core.namespace import get_local_namespace
 from brian2.parsing.rendering import CPPNodeRenderer
 from brian2.synapses.synapses import Synapses
 from brian2.core.preferences import prefs, BrianPreference
@@ -929,9 +930,11 @@ class CPPStandaloneDevice(Device):
         for clock in net._clocks:
             clock.set_interval(net.t, t_end)
 
-        # We have to use +2 for the level argument here, since this function is
-        # called through the device_override mechanism
-        net.before_run(namespace, level=level+2)
+        # Get the local namespace
+        if namespace is None:
+            namespace = get_local_namespace(level=level+2)
+
+        net.before_run(namespace)
 
         self.clocks.update(net._clocks)
         net.t_ = float(t_end)

--- a/brian2/equations/unitcheck.py
+++ b/brian2/equations/unitcheck.py
@@ -64,6 +64,7 @@ def check_units_statements(code, variables):
     DimensionMismatchError
         If an unit mismatch occurs during the evaluation.
     '''
+    variables = dict(variables)
     # Avoid a circular import
     from brian2.codegen.translation import analyse_identifiers
     known = set(variables.keys())

--- a/brian2/groups/group.py
+++ b/brian2/groups/group.py
@@ -22,7 +22,7 @@ from brian2.core.namespace import (get_local_namespace,
                                    DEFAULT_FUNCTIONS,
                                    DEFAULT_UNITS,
                                    DEFAULT_CONSTANTS)
-from brian2.codegen.codeobject import create_runner_codeobj, check_code_units
+from brian2.codegen.codeobject import create_runner_codeobj
 from brian2.equations.equations import BOOLEAN, INTEGER, FLOAT
 from brian2.units.fundamentalunits import (fail_for_dimension_mismatch, Unit,
                                            get_unit, DIMENSIONLESS)
@@ -251,9 +251,6 @@ class IndexWrapper(object):
                                              dtype=np.bool)
 
             abstract_code = '_cond = ' + item
-            check_code_units(abstract_code, self.group,
-                             additional_variables=variables,
-                             level=1)
             from brian2.devices.device import get_default_codeobject_class
             codeobj = create_runner_codeobj(self.group,
                                             abstract_code,

--- a/brian2/groups/neurongroup.py
+++ b/brian2/groups/neurongroup.py
@@ -93,22 +93,7 @@ class StateUpdater(CodeRunner):
                             name=group.name + '_stateupdater*',
                             check_units=False)
 
-        # Don't do the check here for now since we don't have all the
-        # information about functions yet
-        # self.method = StateUpdateMethod.determine_stateupdater(self.group.equations,
-        #                                                        self.group.variables,
-        #                                                        method)
-
-        # Generate the refractory code to catch errors in the refractoriness
-        # formulation. However, do not fail on KeyErrors since the
-        # refractoriness might refer to variables that don't exist yet
-        try:
-            self._get_refractory_code(run_namespace=None, level=1)
-        except KeyError as ex:
-            logger.debug('Namespace not complete (yet), ignoring: %s ' % str(ex),
-                         'StateUpdater')
-
-    def _get_refractory_code(self, run_namespace, level=0):
+    def _get_refractory_code(self, run_namespace):
         ref = self.group._refractory
         if ref is False:
             # No refractoriness
@@ -125,8 +110,7 @@ class StateUpdater(CodeRunner):
             identifiers = get_identifiers(ref)
             variables = self.group.resolve_all(identifiers,
                                                identifiers,
-                                               run_namespace=run_namespace,
-                                               level=level+1)
+                                               run_namespace=run_namespace)
             unit = parse_expression_unit(str(ref), variables)
             if have_same_dimensions(unit, second):
                 abstract_code = 'not_refractory = (t - lastspike) > %s\n' % ref
@@ -147,11 +131,10 @@ class StateUpdater(CodeRunner):
                                  '"%s" has units %s instead') % (ref, unit))
         return abstract_code
 
-    def update_abstract_code(self, run_namespace=None, level=0):
+    def update_abstract_code(self, run_namespace):
 
         # Update the not_refractory variable for the refractory period mechanism
-        self.abstract_code = self._get_refractory_code(run_namespace=run_namespace,
-                                                       level=level+1)
+        self.abstract_code = self._get_refractory_code(run_namespace=run_namespace)
 
         # Get the names used in the refractory code
         _, used_known, unknown = analyse_identifiers(self.abstract_code, self.group.variables,
@@ -166,7 +149,7 @@ class StateUpdater(CodeRunner):
                                            # for the user here, warnings will
                                            # be raised in create_runner_codeobj
                                            set(),
-                                           run_namespace=run_namespace, level=level+1)
+                                           run_namespace=run_namespace)
 
         # Since we did not necessarily no all the functions at creation time,
         # we might want to reconsider our numerical integration method
@@ -210,15 +193,7 @@ class Thresholder(CodeRunner):
                             needed_variables=needed_variables,
                             template_kwds=template_kwds)
 
-        # Check the abstract code for unit mismatches (only works if the
-        # namespace is already complete)
-        try:
-            self.update_abstract_code(level=1)
-            check_code_units(self.abstract_code, self.group)
-        except KeyError:
-            pass
-
-    def update_abstract_code(self, run_namespace=None, level=0):
+    def update_abstract_code(self, run_namespace):
         code = self.group.events[self.event]
         # Raise a useful error message when the user used a Brian1 syntax
         if not isinstance(code, basestring):
@@ -241,8 +216,7 @@ class Thresholder(CodeRunner):
         identifiers = get_identifiers(code)
         variables = self.group.resolve_all(identifiers,
                                            identifiers,
-                                           run_namespace=run_namespace,
-                                           level=level+1)
+                                           run_namespace=run_namespace)
         if not is_boolean_expression(code, variables):
             raise TypeError(('Threshold condition "%s" is not a boolean '
                              'expression') % code)
@@ -277,15 +251,7 @@ class Resetter(CodeRunner):
                             needed_variables=needed_variables,
                             template_kwds=template_kwds)
 
-        # Check the abstract code for unit mismatches (only works if the
-        # namespace is already complete)
-        try:
-            self.update_abstract_code(level=1)
-            check_code_units(self.abstract_code, self.group)
-        except KeyError:
-            pass
-
-    def update_abstract_code(self, run_namespace=None, level=0):
+    def update_abstract_code(self, run_namespace):
         code = self.group.event_codes[self.event]
         # Raise a useful error message when the user used a Brian1 syntax
         if not isinstance(code, basestring):
@@ -775,10 +741,9 @@ class NeuronGroup(Group, SpikeSource):
                                                'to non-shared variable %s.')
                                               % (eq.varname, identifier))
 
-    def before_run(self, run_namespace=None, level=0):
+    def before_run(self, run_namespace=None):
         # Check units
-        self.equations.check_units(self, run_namespace=run_namespace,
-                                   level=level+1)
+        self.equations.check_units(self, run_namespace=run_namespace)
 
     def _repr_html_(self):
         text = [r'NeuronGroup "%s" with %d neurons.<br>' % (self.name, self._N)]

--- a/brian2/groups/neurongroup.py
+++ b/brian2/groups/neurongroup.py
@@ -151,12 +151,9 @@ class StateUpdater(CodeRunner):
                                            set(),
                                            run_namespace=run_namespace)
 
-        # Since we did not necessarily no all the functions at creation time,
-        # we might want to reconsider our numerical integration method
-        self.method = StateUpdateMethod.determine_stateupdater(self.group.equations,
-                                                               variables,
-                                                               self.method_choice)
-        self.abstract_code += self.method(self.group.equations, variables)
+        self.abstract_code += StateUpdateMethod.apply_stateupdater(self.group.equations,
+                                                                   variables,
+                                                                   self.method_choice)
         user_code = '\n'.join(['{var} = {expr}'.format(var=var, expr=expr)
                                for var, expr in
                                self.group.equations.substituted_expressions])

--- a/brian2/input/poissoninput.py
+++ b/brian2/input/poissoninput.py
@@ -95,11 +95,10 @@ class PoissonInput(CodeRunner):
         self.variables = Variables(self)
         self.variables._add_variable(binomial_sampling.name, binomial_sampling)
 
-    def before_run(self, run_namespace=None, level=0):
+    def before_run(self, run_namespace):
         print self._group.dt_, self._stored_dt
         if self._group.dt_ != self._stored_dt:
             raise NotImplementedError('The dt used for simulating %s changed '
                                       'after the PoissonInput source was '
                                       'created.' % self.group.name)
-        CodeRunner.before_run(self, run_namespace=run_namespace,
-                              level=level+1)
+        CodeRunner.before_run(self, run_namespace=run_namespace)

--- a/brian2/input/spikegeneratorgroup.py
+++ b/brian2/input/spikegeneratorgroup.py
@@ -151,7 +151,7 @@ class SpikeGeneratorGroup(Group, CodeRunner, SpikeSource):
 
         self.variables['period'].set_value(period)
 
-    def before_run(self, run_namespace=None, level=0):
+    def before_run(self, run_namespace):
         # Do some checks on the period vs. dt
         dt = self.dt_[:]  # make a copy
         period = self.period_
@@ -188,8 +188,7 @@ class SpikeGeneratorGroup(Group, CodeRunner, SpikeSource):
             self._previous_dt = dt
             self._spikes_changed = False
 
-        super(SpikeGeneratorGroup, self).before_run(run_namespace=run_namespace,
-                                                    level=level+1)
+        super(SpikeGeneratorGroup, self).before_run(run_namespace=run_namespace)
 
     @check_units(indices=1, times=second, period=second)
     def set_spikes(self, indices, times, period=1e100*second, sorted=False):

--- a/brian2/spatialneuron/spatialneuron.py
+++ b/brian2/spatialneuron/spatialneuron.py
@@ -402,7 +402,7 @@ class SpatialStateUpdater(CodeRunner, Group):
         self._ends = self._temp_ends
         self._prepare_codeobj = None
 
-    def before_run(self, run_namespace=None, level=0):
+    def before_run(self, run_namespace):
         # execute code to initalize the data structures
         if self._prepare_codeobj is None:
             self._prepare_codeobj = create_runner_codeobj(self.group,
@@ -411,8 +411,7 @@ class SpatialStateUpdater(CodeRunner, Group):
                                                           name=self.name+'_spatialneuron_prepare',
                                                           check_units=False,
                                                           additional_variables=self.variables,
-                                                          run_namespace=run_namespace,
-                                                          level=level+1)
+                                                          run_namespace=run_namespace)
         self._prepare_codeobj()
         # Raise a warning if the slow pure numpy version is used
         # For simplicity, we check which CodeObject class the _prepare_codeobj
@@ -428,7 +427,7 @@ class SpatialStateUpdater(CodeRunner, Group):
                              'switch to a different code generation target '
                              '(e.g. weave or cython) or install scipy.'),
                             once=True)
-        CodeRunner.before_run(self, run_namespace, level=level + 1)
+        CodeRunner.before_run(self, run_namespace)
 
     def _pre_calc_iteration(self, morphology, counter=0):
         self._temp_morph_i[counter] = morphology.index + 1

--- a/brian2/stateupdaters/exact.py
+++ b/brian2/stateupdaters/exact.py
@@ -238,7 +238,12 @@ class LinearStateUpdater(StateUpdateMethod):
 
         # Solve the system
         dt = Symbol('dt', real=True, positive=True)
-        A = (matrix * dt).exp()
+        try:
+            A = (matrix * dt).exp()
+        except NotImplementedError:
+            raise UnsupportedEquationsException('Cannot solve the given '
+                                                'equations with this '
+                                                'stateupdater.')
         if simplify:
             A.simplify()
         C = sp.ImmutableMatrix([A.dot(b)]) - b

--- a/brian2/stateupdaters/exact.py
+++ b/brian2/stateupdaters/exact.py
@@ -8,7 +8,8 @@ import sympy as sp
 
 from brian2.parsing.sympytools import sympy_to_str
 from brian2.utils.logger import get_logger
-from brian2.stateupdaters.base import StateUpdateMethod
+from brian2.stateupdaters.base import (StateUpdateMethod,
+                                       UnsupportedEquationsException)
 
 __all__ = ['linear', 'independent']
 
@@ -54,9 +55,12 @@ def get_linear_system(eqs):
             one_pattern = factor_wildcard*symbol + constant_wildcard
             matches = current_s_expr.match(one_pattern)
             if matches is None:
-                raise ValueError(('The expression "%s", defining the variable %s, '
-                                 'could not be separated into linear components') %
-                                 (expr, name))
+                raise UnsupportedEquationsException(('The expression "%s", '
+                                                     'defining the variable '
+                                                     '%s, could not be '
+                                                     'separated into linear '
+                                                     'components.') %
+                                                    (expr, name))
 
             coefficients[row_idx, col_idx] = matches[factor_wildcard]
             current_s_expr = matches[constant_wildcard]
@@ -74,8 +78,7 @@ class IndependentStateUpdater(StateUpdateMethod):
     solved by sympy.
     '''
     def can_integrate(self, equations, variables):
-        if equations.is_stochastic:
-            return False
+
 
         # Not very efficient but guaranteed to give the correct answer:
         # Just try to apply the integration method
@@ -89,11 +92,12 @@ class IndependentStateUpdater(StateUpdateMethod):
         return True
 
     def __call__(self, equations, variables=None):
+        if equations.is_stochastic:
+            raise UnsupportedEquationsException('Cannot solve stochastic '
+                                                'equations with this state '
+                                                'updater')
         if variables is None:
             variables = {}
-
-        if equations.is_stochastic:
-            raise ValueError('Cannot solve stochastic equations with this state updater')
 
         diff_eqs = equations.substituted_expressions
 
@@ -124,18 +128,16 @@ class IndependentStateUpdater(StateUpdateMethod):
                 general_solution = sp.dsolve(diff_eq, f(t), simplify=False)
             # Check whether this is an explicit solution
             if not getattr(general_solution, 'lhs', None) == f(t):
-                raise ValueError('Cannot explicitly solve: ' + str(diff_eq))
-            # seems to happen sometimes in sympy 0.7.5
-            if getattr(general_solution, 'rhs', None) == sp.nan:
-                raise ValueError('Cannot explicitly solve: ' + str(diff_eq))
+                raise UnsupportedEquationsException('Cannot explicitly solve: '
+                                                    + str(diff_eq))
             # Solve for C1 (assuming "var" as the initial value and "t0" as time)
             if general_solution.has(Symbol('C1')):
                 if general_solution.has(Symbol('C2')):
-                    raise ValueError('Too many constants in solution: %s' % str(general_solution))
+                    raise UnsupportedEquationsException('Too many constants in solution: %s' % str(general_solution))
                 constant_solution = sp.solve(general_solution, Symbol('C1'))
                 if len(constant_solution) != 1:
-                    raise ValueError(("Couldn't solve for the constant "
-                                      "C1 in : %s ") % str(general_solution))
+                    raise UnsupportedEquationsException(("Couldn't solve for the constant "
+                                                         "C1 in : %s ") % str(general_solution))
                 constant = constant_solution[0].subs(t, t0).subs(f(t0), var)
                 solution = general_solution.rhs.subs('C1', constant)
             else:
@@ -162,9 +164,11 @@ def _check_for_locally_constant(expression, variables, dt_value, t_symbol):
             func_name = str(expression.func)
             if not (func_name in variables and
                         variables[func_name].is_locally_constant(dt_value)):
-                raise ValueError(('t is used in a context where we cannot'
-                                  'guarantee that it can be considered '
-                                  'locally constant.'))
+                raise UnsupportedEquationsException(('t is used in a context '
+                                                     'where we cannot '
+                                                     'guarantee that it can be '
+                                                     'considered locally '
+                                                     'constant.'))
         else:
             _check_for_locally_constant(arg, variables, dt_value, t_symbol)
 
@@ -193,7 +197,10 @@ class LinearStateUpdater(StateUpdateMethod):
         return True
 
     def __call__(self, equations, variables=None, simplify=True):
-
+        if equations.is_stochastic:
+            raise UnsupportedEquationsException('Cannot solve stochastic '
+                                                'equations with this state '
+                                                'updater.')
         if variables is None:
             variables = {}
 
@@ -223,6 +230,10 @@ class LinearStateUpdater(StateUpdateMethod):
 
         symbols = [Symbol(variable, real=True) for variable in varnames]
         solution = sp.solve_linear_system(matrix.row_join(constants), *symbols)
+        if solution is None or set(symbols) != set(solution.keys()):
+            raise UnsupportedEquationsException('Cannot solve the given '
+                                                'equations with this '
+                                                'stateupdater.')
         b = sp.ImmutableMatrix([solution[symbol] for symbol in symbols]).transpose()
 
         # Solve the system
@@ -235,13 +246,7 @@ class LinearStateUpdater(StateUpdateMethod):
         # The use of .as_mutable() here is a workaround for a
         # ``Transpose object does not have
         updates = A * _S + C.transpose()
-        try:
-            # In sympy 0.7.3, we have to explicitly convert it to a single matrix
-            # In sympy 0.7.2, it is already a matrix (which doesn't have an
-            # is_explicit method)
-            updates = updates.as_explicit()
-        except AttributeError:
-            pass
+        updates = updates.as_explicit()
 
         # The solution contains _S[0, 0], _S[1, 0] etc. for the state variables,
         # replace them with the state variable names 

--- a/brian2/stateupdaters/explicit.py
+++ b/brian2/stateupdaters/explicit.py
@@ -11,8 +11,7 @@ from pyparsing import (Literal, Group, Word, ZeroOrMore, Suppress, restOfLine,
                        ParseException)
 
 from brian2.parsing.sympytools import str_to_sympy, sympy_to_str
-
-from .base import StateUpdateMethod
+from .base import StateUpdateMethod, UnsupportedEquationsException
 
 __all__ = ['milstein', 'heun', 'euler', 'rk2', 'rk4', 'ExplicitStateUpdater']
 
@@ -265,21 +264,7 @@ class ExplicitStateUpdater(StateUpdateMethod):
             else:
                 raise AssertionError('Unknown element name: %s' %
                                      element.getName())
-    
-    def can_integrate(self, equations, variables):
-        # Non-stochastic numerical integrators should work for all equations,
-        # except for stochastic equations
-        if equations.is_stochastic:
-            if self.stochastic is None:
-                return False
-            if (self.stochastic != 'multiplicative' and
-                        equations.stochastic_type == 'multiplicative'):
-                return False
 
-        if self.custom_check and not self.custom_check(equations, variables):
-            return False
-        else:
-            return True
     
     def __repr__(self):
         # recreate a description string
@@ -592,7 +577,22 @@ class ExplicitStateUpdater(StateUpdateMethod):
         _v = 0.166666666666667*__k_1_v + 0.333333333333333*__k_2_v + 0.333333333333333*__k_3_v + 0.166666666666667*__k_4_v + v
         v = _v
         '''
-        
+        # Non-stochastic numerical integrators should work for all equations,
+        # except for stochastic equations
+        if eqs.is_stochastic:
+            if self.stochastic is None:
+                raise UnsupportedEquationsException('Cannot integrate '
+                                                    'stochastic equations with '
+                                                    'this state updater.')
+            if (self.stochastic != 'multiplicative' and
+                        eqs.stochastic_type == 'multiplicative'):
+                raise UnsupportedEquationsException('Cannot integrate '
+                                                    'equations with '
+                                                    'multiplicative noise with '
+                                                    'this state updater.')
+
+        if self.custom_check:
+            self.custom_check(eqs, variables)
         # The final list of statements
         statements = []
 
@@ -677,21 +677,33 @@ def diagonal_noise(equations, variables):
     '''
     Checks whether we deal with diagonal noise, i.e. one independent noise
     variable per variable.
+
+    Raises
+    ------
+    UnsupportedEquationsException
+        If the noise is not diagonal.
     '''
     if not equations.is_stochastic:
-        return True
+        return
 
     stochastic_vars = []
     for _, expr in equations.substituted_expressions:
         expr_stochastic_vars = expr.stochastic_variables
         if len(expr_stochastic_vars) > 1:
             # More than one stochastic variable --> no diagonal noise
-            return False
+            raise UnsupportedEquationsException('Cannot integrate stochastic '
+                                                'equations with non-diagonal '
+                                                'noise with this state '
+                                                'updater.')
         stochastic_vars.extend(expr_stochastic_vars)
 
     # If there's no stochastic variable is used in more than one equation, we
     # have diagonal noise
-    return len(stochastic_vars) == len(set(stochastic_vars))
+    if len(stochastic_vars) != len(set(stochastic_vars)):
+        raise UnsupportedEquationsException('Cannot integrate stochastic '
+                                            'equations with non-diagonal '
+                                            'noise with this state '
+                                            'updater.')
 
 #: Derivative-free Milstein method
 milstein = ExplicitStateUpdater('''

--- a/brian2/stateupdaters/exponential_euler.py
+++ b/brian2/stateupdaters/exponential_euler.py
@@ -2,7 +2,7 @@ import sympy as sp
 
 from brian2.parsing.sympytools import sympy_to_str
 
-from .base import StateUpdateMethod
+from .base import StateUpdateMethod, UnsupportedEquationsException
 
 __all__ = ['exponential_euler']
 
@@ -87,7 +87,18 @@ class ExponentialEulerStateUpdater(StateUpdateMethod):
         return True
     
     def __call__(self, equations, variables=None):
-        system = get_conditionally_linear_system(equations)
+        if equations.is_stochastic:
+            raise UnsupportedEquationsException('Cannot solve stochastic '
+                                                'equations with this state '
+                                                'updater.')
+
+        # Try whether the equations are conditionally linear
+        try:
+            system = get_conditionally_linear_system(equations)
+        except ValueError:
+            raise UnsupportedEquationsException('Can only solve conditionally '
+                                                'linear systems with this '
+                                                'state updater.')
         
         code = []
         for var, (A, B) in system.iteritems():

--- a/brian2/synapses/synapses.py
+++ b/brian2/synapses/synapses.py
@@ -240,7 +240,7 @@ class SynapticPathway(CodeRunner, Group):
         self.abstract_code += 'lastupdate = t\n'
 
     @device_override('synaptic_pathway_before_run')
-    def before_run(self, run_namespace=None, level=0):
+    def before_run(self, run_namespace):
         # execute code to initalize the spike queue
         if self._initialise_queue_codeobj is None:
             self._initialise_queue_codeobj = create_runner_codeobj(self,
@@ -249,10 +249,9 @@ class SynapticPathway(CodeRunner, Group):
                                                                    name=self.name+'_initialise_queue',
                                                                    check_units=False,
                                                                    additional_variables=self.variables,
-                                                                   run_namespace=run_namespace,
-                                                                   level=level+2)
+                                                                   run_namespace=run_namespace)
         self._initialise_queue_codeobj()
-        CodeRunner.before_run(self, run_namespace, level=level+2)
+        CodeRunner.before_run(self, run_namespace)
 
         # we insert rather than replace because CodeRunner puts a CodeObject in updaters already
         if self._pushspikes_codeobj is None:
@@ -273,8 +272,7 @@ class SynapticPathway(CodeRunner, Group):
                                                              additional_variables=self.variables,
                                                              needed_variables=needed_variables,
                                                              template_kwds=template_kwds,
-                                                             run_namespace=run_namespace,
-                                                             level=level+2)
+                                                             run_namespace=run_namespace)
 
         self._code_objects.insert(0, weakref.proxy(self._pushspikes_codeobj))
 
@@ -829,9 +827,9 @@ class Synapses(Group):
         indices = self.indices[item]
         return SynapticSubgroup(self, indices)
 
-    def before_run(self, run_namespace=None, level=0):
+    def before_run(self, run_namespace):
         self.state('lastupdate')[:] = 't'
-        super(Synapses, self).before_run(run_namespace, level=level+1)
+        super(Synapses, self).before_run(run_namespace)
 
     def _add_updater(self, code, prepost, objname=None, delay=None,
                      event='spike'):

--- a/brian2/synapses/synapses.py
+++ b/brian2/synapses/synapses.py
@@ -49,19 +49,11 @@ class StateUpdater(CodeRunner):
                             order=order,
                             name=group.name + '_stateupdater',
                             check_units=False)
-
-        self.method = StateUpdateMethod.determine_stateupdater(self.group.equations,
-                                                               self.group.variables,
-                                                               method)
     
     def update_abstract_code(self, run_namespace=None, level=0):
-        
-        self.method = StateUpdateMethod.determine_stateupdater(self.group.equations,
-                                                               self.group.variables,
-                                                               self.method_choice)
-        
-        self.abstract_code = self.method(self.group.equations,
-                                         self.group.variables)
+        self.abstract_code = StateUpdateMethod.apply_stateupdater(self.group.equations,
+                                                                  self.group.variables,
+                                                                  self.method_choice)
 
 
 class SummedVariableUpdater(CodeRunner):

--- a/brian2/tests/test_namespaces.py
+++ b/brian2/tests/test_namespaces.py
@@ -123,16 +123,15 @@ def test_warning():
 
 @attr('codegen-independent')
 def test_warning_internal_variables():
-    N = 5
     group1 = SimpleGroup(namespace=None,
                          variables={'N': Constant('N', Unit(1), 5)})
     group2 = SimpleGroup(namespace=None,
                          variables={'N': Constant('N', Unit(1), 7)})
     with catch_logs() as l:
-        group1.resolve_all(['N'])  # should not raise a warning
+        group1.resolve_all(['N'], run_namespace={'N': 5})  # should not raise a warning
         assert len(l) == 0, 'got warnings: %s' % str(l)
     with catch_logs() as l:
-        group2.resolve_all(['N'])  # should raise a warning
+        group2.resolve_all(['N'], run_namespace={'N': 5})  # should raise a warning
         assert len(l) == 1, 'got warnings: %s' % str(l)
         assert l[0][1].endswith('.resolution_conflict')
 

--- a/brian2/tests/test_neurongroup.py
+++ b/brian2/tests/test_neurongroup.py
@@ -14,7 +14,7 @@ from brian2.devices.device import restore_device
 from brian2.equations.equations import Equations
 from brian2.groups.group import get_dtype
 from brian2.groups.neurongroup import NeuronGroup
-from brian2.core.magic import run, collect
+from brian2.core.magic import run
 from brian2.synapses.synapses import Synapses
 from brian2.monitors.statemonitor import StateMonitor
 from brian2.units.fundamentalunits import (DimensionMismatchError,
@@ -667,14 +667,14 @@ def test_unit_errors_threshold_reset():
     # Unit error in threshold
     group = NeuronGroup(1, 'dv/dt = -v/(10*ms) : 1', threshold='v > -20*mV')
     assert_raises(DimensionMismatchError,
-                  lambda: Network(collect(level=3)).run(0*ms))
+                  lambda: Network(group).run(0*ms))
 
     # Unit error in reset
     group = NeuronGroup(1, 'dv/dt = -v/(10*ms) : 1',
                         threshold='True',
                         reset='v = -65*mV')
     assert_raises(DimensionMismatchError,
-                  lambda: Network(collect(level=3)).run(0*ms))
+                  lambda: Network(group).run(0*ms))
 
     # More complicated unit reset with an intermediate variable
     # This should pass
@@ -696,7 +696,7 @@ def test_unit_errors_threshold_reset():
                         reset='''temp_var = -65*mV
                                  v = temp_var''')
     assert_raises(DimensionMismatchError,
-                  lambda: Network(collect(level=3)).run(0*ms))
+                  lambda: Network(group).run(0*ms))
 
     # Resets with an in-place modification
     # This should work
@@ -710,7 +710,7 @@ def test_unit_errors_threshold_reset():
                         threshold='False',
                         reset='''v -= 60*mV''')
     assert_raises(DimensionMismatchError,
-              lambda: Network(collect(level=3)).run(0*ms))
+              lambda: Network(group).run(0*ms))
 
 @attr('codegen-independent')
 def test_syntax_errors():
@@ -724,13 +724,13 @@ def test_syntax_errors():
     # Syntax error in threshold
     group = NeuronGroup(1, 'dv/dt = 5*Hz : 1',
                         threshold='>1')
-    assert_raises(Exception, lambda: Network(collect(level=3)).run(0*ms))
+    assert_raises(Exception, lambda: Network(group).run(0*ms))
 
     # Syntax error in reset
     group = NeuronGroup(1, 'dv/dt = 5*Hz : 1',
                         threshold='True',
                         reset='0')
-    assert_raises(Exception, lambda: Network(collect(level=3)).run(0*ms))
+    assert_raises(Exception, lambda: Network(group).run(0*ms))
 
 @attr('codegen-independent')
 def test_custom_events():
@@ -771,7 +771,7 @@ def test_incorrect_custom_event_definition():
                                                   events={'spike': 'False'}))
     # not a threshold
     G = NeuronGroup(1, '', events={'my_event': 10*mV})
-    assert_raises(TypeError, lambda: Network(collect(level=3)).run(0*ms))
+    assert_raises(TypeError, lambda: Network(G).run(0*ms))
     # schedule for a non-existing event
     G = NeuronGroup(1, '', threshold='False', events={'my_event': 'True'})
     assert_raises(ValueError, lambda: G.set_event_schedule('another_event'))

--- a/brian2/tests/test_neurongroup.py
+++ b/brian2/tests/test_neurongroup.py
@@ -1027,8 +1027,8 @@ def test_subexpression_with_constant():
         assert len(G.I) == 1
 
         # These will not work
-        assert_raises(ValueError, lambda: np.array(G.I))
-        assert_raises(ValueError, lambda: np.mean(G.I))
+        assert_raises(KeyError, lambda: np.array(G.I))
+        assert_raises(KeyError, lambda: np.mean(G.I))
         # But these should
         assert_equal(np.array(G.I[:]), G.I[:])
         assert np.mean(G.I[:]) == 2

--- a/brian2/tests/test_neurongroup.py
+++ b/brian2/tests/test_neurongroup.py
@@ -14,7 +14,7 @@ from brian2.devices.device import restore_device
 from brian2.equations.equations import Equations
 from brian2.groups.group import get_dtype
 from brian2.groups.neurongroup import NeuronGroup
-from brian2.core.magic import run
+from brian2.core.magic import run, collect
 from brian2.synapses.synapses import Synapses
 from brian2.monitors.statemonitor import StateMonitor
 from brian2.units.fundamentalunits import (DimensionMismatchError,
@@ -665,47 +665,52 @@ def test_unit_errors_threshold_reset():
     Test that unit errors in thresholds and resets are detected.
     '''
     # Unit error in threshold
+    group = NeuronGroup(1, 'dv/dt = -v/(10*ms) : 1', threshold='v > -20*mV')
     assert_raises(DimensionMismatchError,
-                  lambda: NeuronGroup(1, 'dv/dt = -v/(10*ms) : 1',
-                                      threshold='v > -20*mV'))
+                  lambda: Network(collect(level=3)).run(0*ms))
 
     # Unit error in reset
+    group = NeuronGroup(1, 'dv/dt = -v/(10*ms) : 1',
+                        threshold='True',
+                        reset='v = -65*mV')
     assert_raises(DimensionMismatchError,
-                  lambda: NeuronGroup(1, 'dv/dt = -v/(10*ms) : 1',
-                                      threshold='True',
-                                      reset='v = -65*mV'))
+                  lambda: Network(collect(level=3)).run(0*ms))
 
     # More complicated unit reset with an intermediate variable
     # This should pass
-    NeuronGroup(1, 'dv/dt = -v/(10*ms) : 1',
+    group = NeuronGroup(1, 'dv/dt = -v/(10*ms) : 1',
                 threshold='False',
                 reset='''temp_var = -65
                          v = temp_var''')
+    run(0*ms)
     # throw in an empty line (should still pass)
-    NeuronGroup(1, 'dv/dt = -v/(10*ms) : 1',
+    group = NeuronGroup(1, 'dv/dt = -v/(10*ms) : 1',
                 threshold='False',
                 reset='''temp_var = -65
 
                          v = temp_var''')
-
+    run(0*ms)
     # This should fail
+    group = NeuronGroup(1, 'dv/dt = -v/(10*ms) : 1',
+                        threshold='False',
+                        reset='''temp_var = -65*mV
+                                 v = temp_var''')
     assert_raises(DimensionMismatchError,
-                  lambda: NeuronGroup(1, 'dv/dt = -v/(10*ms) : 1',
-                                      threshold='False',
-                                      reset='''temp_var = -65*mV
-                                               v = temp_var'''))
+                  lambda: Network(collect(level=3)).run(0*ms))
 
     # Resets with an in-place modification
     # This should work
-    NeuronGroup(1, 'dv/dt = -v/(10*ms) : 1',
-                threshold='False',
-                reset='''v /= 2''')
+    group = NeuronGroup(1, 'dv/dt = -v/(10*ms) : 1',
+                        threshold='False',
+                        reset='''v /= 2''')
+    run(0*ms)
 
     # This should fail
+    group = NeuronGroup(1, 'dv/dt = -v/(10*ms) : 1',
+                        threshold='False',
+                        reset='''v -= 60*mV''')
     assert_raises(DimensionMismatchError,
-                  lambda: NeuronGroup(1, 'dv/dt = -v/(10*ms) : 1',
-                                      threshold='False',
-                                      reset='''v -= 60*mV'''))
+              lambda: Network(collect(level=3)).run(0*ms))
 
 @attr('codegen-independent')
 def test_syntax_errors():
@@ -717,16 +722,15 @@ def test_syntax_errors():
     # We do not specify the exact type of exception here: Python throws a
     # SyntaxError while C++ results in a ValueError
     # Syntax error in threshold
-    assert_raises(Exception,
-                  lambda: NeuronGroup(1, 'dv/dt = 5*Hz : 1',
-                                      threshold='>1'),
-                  )
+    group = NeuronGroup(1, 'dv/dt = 5*Hz : 1',
+                        threshold='>1')
+    assert_raises(Exception, lambda: Network(collect(level=3)).run(0*ms))
 
     # Syntax error in reset
-    assert_raises(Exception,
-                  lambda: NeuronGroup(1, 'dv/dt = 5*Hz : 1',
-                                      threshold='True',
-                                      reset='0'))
+    group = NeuronGroup(1, 'dv/dt = 5*Hz : 1',
+                        threshold='True',
+                        reset='0')
+    assert_raises(Exception, lambda: Network(collect(level=3)).run(0*ms))
 
 @attr('codegen-independent')
 def test_custom_events():
@@ -761,14 +765,13 @@ def test_custom_events_schedule():
 @attr('codegen-independent')
 def test_incorrect_custom_event_definition():
     # Incorrect event name
-    assert_raises(TypeError, lambda: NeuronGroup(1, '',
-                                                 events={'1event': 'True'}))
+    assert_raises(TypeError, lambda: NeuronGroup(1, '', events={'1event': 'True'}))
     # duplicate definition of 'spike' event
     assert_raises(ValueError, lambda: NeuronGroup(1, '', threshold='True',
                                                   events={'spike': 'False'}))
     # not a threshold
-    assert_raises(TypeError, lambda: NeuronGroup(1, '',
-                                                 events={'my_event': 10*mV}))
+    G = NeuronGroup(1, '', events={'my_event': 10*mV})
+    assert_raises(TypeError, lambda: Network(collect(level=3)).run(0*ms))
     # schedule for a non-existing event
     G = NeuronGroup(1, '', threshold='False', events={'my_event': 'True'})
     assert_raises(ValueError, lambda: G.set_event_schedule('another_event'))

--- a/brian2/tests/test_parsing.py
+++ b/brian2/tests/test_parsing.py
@@ -293,7 +293,7 @@ def test_parse_expression_unit():
             if name in variables:
                 all_variables[name] = variables[name]
             else:
-                all_variables[name] = group.resolve(name)
+                all_variables[name] = group._resolve(name, {})
 
         if expect is DimensionMismatchError:
             assert_raises(DimensionMismatchError, parse_expression_unit, expr,
@@ -312,7 +312,7 @@ def test_parse_expression_unit():
             if name in variables:
                 all_variables[name] = variables[name]
             else:
-                all_variables[name] = group.resolve(name)
+                all_variables[name] = group._resolve(name, {})
         assert_raises(SyntaxError, parse_expression_unit, expr, all_variables)
 
 

--- a/brian2/tests/test_refractory.py
+++ b/brian2/tests/test_refractory.py
@@ -24,11 +24,11 @@ def test_add_refractoriness():
 @with_setup(teardown=restore_device)
 def test_refractoriness_basic():
     G = NeuronGroup(1, '''
-        dv/dt = 100*Hz : 1 (unless refractory)
-        dw/dt = 100*Hz : 1
-        ''',
-                        threshold='v>1', reset='v=0;w=0',
-                        refractory=5*ms)
+                       dv/dt = 100*Hz : 1 (unless refractory)
+                       dw/dt = 100*Hz : 1
+                       ''',
+                    threshold='v>1', reset='v=0;w=0',
+                    refractory=5*ms)
     # It should take 10ms to reach the threshold, then v should stay at 0
     # for 5ms, while w continues to increase
     mon = StateMonitor(G, ['v', 'w'], record=True, when='end')
@@ -55,13 +55,13 @@ def test_refractoriness_variables():
                      '(t-lastspike) <= ref', 'ref', 'ref_no_unit*ms']:
         device.reinit()
         G = NeuronGroup(1, '''
-        dv/dt = 100*Hz : 1 (unless refractory)
-        dw/dt = 100*Hz : 1
-        ref : second
-        ref_no_unit : 1
-        time_since_spike = t - lastspike : second
-        ref_subexpression = (t - lastspike) <= ref : boolean
-        ''',
+                        dv/dt = 100*Hz : 1 (unless refractory)
+                        dw/dt = 100*Hz : 1
+                        ref : second
+                        ref_no_unit : 1
+                        time_since_spike = t - lastspike : second
+                        ref_subexpression = (t - lastspike) <= ref : boolean
+                        ''',
                         threshold='v>1', reset='v=0;w=0',
                         refractory=ref_time)
         G.ref = 5*ms
@@ -107,10 +107,10 @@ def test_refractoriness_threshold():
                      '(t-lastspike) <= ref', 'ref', 'ref_no_unit*ms']:
         device.reinit()
         G = NeuronGroup(1, '''
-        dv/dt = 200*Hz : 1
-        ref : second
-        ref_no_unit : 1
-        ''', threshold='v > 1',
+                        dv/dt = 200*Hz : 1
+                        ref : second
+                        ref_no_unit : 1
+                        ''', threshold='v > 1',
                         reset='v=0', refractory=ref_time)
         G.ref = 10*ms
         G.ref_no_unit = 10
@@ -125,12 +125,14 @@ def test_refractoriness_threshold():
 @attr('codegen-independent')
 def test_refractoriness_types():
     # make sure that using a wrong type of refractoriness does not work
-    assert_raises(TypeError, lambda: NeuronGroup(1, '', refractory='3*Hz'))
-    assert_raises(TypeError, lambda: NeuronGroup(1, 'ref: Hz',
-                                                 refractory='ref'))
-    assert_raises(TypeError, lambda: NeuronGroup(1, '', refractory='3'))
-    assert_raises(TypeError, lambda: NeuronGroup(1, 'ref: 1',
-                                                 refractory='ref'))
+    group = NeuronGroup(1, '', refractory='3*Hz')
+    assert_raises(TypeError, lambda: Network(collect(level=3)).run(0*ms))
+    group = NeuronGroup(1, 'ref: Hz', refractory='ref')
+    assert_raises(TypeError, lambda: Network(collect(level=3)).run(0*ms))
+    group = NeuronGroup(1, '', refractory='3')
+    assert_raises(TypeError, lambda: Network(collect(level=3)).run(0*ms))
+    group = NeuronGroup(1, 'ref: 1', refractory='ref')
+    assert_raises(TypeError, lambda: Network(collect(level=3)).run(0*ms))
 
 @attr('codegen-independent')
 def test_conditional_write_set():

--- a/brian2/tests/test_refractory.py
+++ b/brian2/tests/test_refractory.py
@@ -126,13 +126,13 @@ def test_refractoriness_threshold():
 def test_refractoriness_types():
     # make sure that using a wrong type of refractoriness does not work
     group = NeuronGroup(1, '', refractory='3*Hz')
-    assert_raises(TypeError, lambda: Network(collect(level=3)).run(0*ms))
+    assert_raises(TypeError, lambda: Network(group).run(0*ms))
     group = NeuronGroup(1, 'ref: Hz', refractory='ref')
-    assert_raises(TypeError, lambda: Network(collect(level=3)).run(0*ms))
+    assert_raises(TypeError, lambda: Network(group).run(0*ms))
     group = NeuronGroup(1, '', refractory='3')
-    assert_raises(TypeError, lambda: Network(collect(level=3)).run(0*ms))
+    assert_raises(TypeError, lambda: Network(group).run(0*ms))
     group = NeuronGroup(1, 'ref: 1', refractory='ref')
-    assert_raises(TypeError, lambda: Network(collect(level=3)).run(0*ms))
+    assert_raises(TypeError, lambda: Network(group).run(0*ms))
 
 @attr('codegen-independent')
 def test_conditional_write_set():

--- a/docs_sphinx/developer/equations_namespaces.rst
+++ b/docs_sphinx/developer/equations_namespaces.rst
@@ -31,12 +31,6 @@ group-specific namespace used for resolving names in that group. At run time,
 this namespace is combined with a "run namespace". This namespace is either
 explicitly provided to the `Network.run` method, or the implicit namespace
 consisting of the locals and globals around the point where the run function is
-called.
-
-Internally, this is realized via the ``before_run`` function. At the start of a
-run, `Network.before_run` calls `BrianObject.before_run` of every object in the
-network with a namespace argument and a level. If the namespace argument is
-given (even if it is an empty dictionary), it will be used together with any
-group-specific namespaces for resolving names. If it is not specified or
-``None``, the given level will be used to go up in the call frame and determine
-the respective locals and globals.
+called is used. This namespace is then passed down to all the objects via
+`Network.before_fun` which calls all the individual `BrianObject.before_run`
+methods with this namespace.


### PR DESCRIPTION
As we discussed, instead of implementing joblib caching (#124) I first had a look at where the preparation time is spend. In this branch, I implemented a few small uncontroversial changes (e.g. `check_code_units` was called before `create_runner_codeobj`, but the latter called `check_code_units` again), but also some bigger changes that are at least worth discussing:
1. Instead of passing down the level argument down from `before_run` all the way until when namespaces are actually resolved, we get the local namespace in the `run` method and pass this namespace down. The advantage is that we don't have to get the local namespace several times, which is relatively expensive since we have to go through a lot of objects and call `isinstance` on them to see whether we are interested in them. Actually, now that I am writing this: we should probably not filter out "uninteresting" objects beforehand, because that means we will not get a warning if we have a clash between the name of such an object (say, a string) and a variable. We could rather always transmit the full namespace and then raise an error when such an object is actually used as a variable name (or a warning for a name clash). Either way, I think the change is a good one because it makes the code simpler (less `level=level+1` or `level=level+2`) and wastes less time in the mildly expensive namespace resolution. The only disadvantage is that we can't make a difference in warning messages anymore between clashes that occur with names in the local namespace vs. clashes with names in the explicitly provided `run(..., namespace={...})` namespace. But then, I don't think this leads to any confusion.
2. We no longer try to analyse certain strings (thresholds, resets, refractory condition) at creation time (where this check would only succeed if the expressions do not use external variables that are unknown at that time). This has clearer disadvantages: we don't get error messages for incorrect syntax / unit errors, etc. at creation time but only at the time of before run. The advantages: The code is clearer (no `try/except` around some checks) and we don't do things like unit checking twice. I am not 100% sure about this one, but with the new error messages that point to the creation statement, I think this is ok. It is mostly in interactive use that this could be annoying. But then, with some refactoring that better separate the various stages of code generation, we could at least deal with syntax changes directly where they occur again.
3. Another big change: Instead of two methods, a `can_integrate` function that returns a `bool` and a `__call__` function that creates the actual abstract code, state updaters now only have a single `__call__` function that will raise an `UnsupportedEquationsException` if it cannot integrate them. The reason for this is that for the more complicated state updaters (e.g. linear), the only robust way of determining whether it can integrate given equations is by actually trying it (this is what we did in `LinearStateUpdater.can_integrate`). Therefore, we actually generated the code twice for examples like CUBA, once for checking whether we can use `linear` and once for actually using it. I don't really see a disadvantage of the new approach, it is pretty straightforward. We had a feature before where you could tell Brian to use a state updater despite its claiming not to be able to integrate the given equations which we lose now, but I don't think that had any practical use.

Now, the cumulative effect of these changes is not great, but it is something. If I do a `run(0*ms)` and remove the connection code (which otherwise dominate the total runtime), then the total run time for CUBA goes down from 4.2s to 3.4s on my machine, and from 3.9s to 3.1s for COBAHH. If I use an artificial example that makes use of code generation and namespace resolution alot like this:
```Python
G = NeuronGroup(100, 'v : 1')
for x in xrange(100):
    G.v['i == x'] = 'x'
```
then the reduction is more significant, it goes down from 6.5s to 2.3s (but of course here the state updater stuff does not play a role).

Thoughts?