### PR TITLE
[MRG] Don't check all objects in the local namespace for their type

### DIFF
--- a/brian2/core/namespace.py
+++ b/brian2/core/namespace.py
@@ -41,20 +41,13 @@ def get_local_namespace(level):
         The locals and globals at the given depth of the stack frame.
     '''
     # Get the locals and globals from the stack frame
-    namespace = dict()
     frame = inspect.stack()[level + 1][0]
-    for k, v in itertools.chain(frame.f_globals.iteritems(),
-                                frame.f_locals.iteritems()):
-        # We are only interested in numbers and functions, not in
-        # everything else (classes, modules, etc.)
-        if (((isinstance(v, (numbers.Number, np.ndarray, np.number, Function))) or
-            (inspect.isfunction(v) and
-                 hasattr(v, '_arg_units') and
-                 hasattr(v, '_return_unit'))) and
-                not k.startswith('_')):
-            namespace[k] = v
-    del frame
-    return namespace
+    # We return the full stack here, even if it contains a lot of stuff we are
+    # not interested in -- it is cheaper to later raise an error when we find
+    # a specific object with an incorrect type instead of going through this big
+    # list now to check the types of all objects
+    return dict(itertools.chain(frame.f_globals.iteritems(),
+                                frame.f_locals.iteritems()))
 
 
 def _get_default_unit_namespace():

--- a/brian2/groups/group.py
+++ b/brian2/groups/group.py
@@ -8,6 +8,8 @@ objects such as `NeuronGroup` or `StateMonitor` but not `Clock`, and finally
 import collections
 from collections import OrderedDict
 import weakref
+import numbers
+import inspect
 
 import numpy as np
 
@@ -761,7 +763,17 @@ class Group(VariableOwner, BrianObject):
 
         for description, namespace in namespaces.iteritems():
             if identifier in namespace:
-                matches.append((description, namespace[identifier]))
+                match = namespace[identifier]
+                if ((isinstance(match, (numbers.Number,
+                                         np.ndarray,
+                                         np.number,
+                                         Function,
+                                         Variable))) or
+                         (inspect.isfunction(match) and
+                              hasattr(match, '_arg_units') and
+                              hasattr(match, '_return_unit'))
+                    ):
+                    matches.append((description, match))
 
         if len(matches) == 0:
             # No match at all

--- a/brian2/tests/test_functions.py
+++ b/brian2/tests/test_functions.py
@@ -166,7 +166,7 @@ def test_user_defined_function_units():
                   lambda: setattr(G, 'c', 'one_arg_missing(a, b, t)'))
     assert_raises(ValueError,
                   lambda: setattr(G, 'c', 'no_result_unit(a, b, t)'))
-    assert_raises(ValueError,
+    assert_raises(KeyError,
                   lambda: setattr(G, 'c', 'nothing_specified(a, b, t)'))
     assert_raises(DimensionMismatchError,
                   lambda: setattr(G, 'a', 'all_specified(a, b, t)'))


### PR DESCRIPTION
I mentioned this in #593 but forgot to actually change this. We are currently checking all of the objects in the local namespace for their type, and only include the objects we are generally interested in (numbers, functions, ...) in the namespace dictionary that we pass on. This is quite expensive, since the full local namespace can be big. With the small change here, we instead pass the full local namespace down to the resolve method and only do the type checks for names we are actually interested in.
This reduces the time that `before_run` takes by a very small amount for e.g. the CUBA example, but it can have a significant effect for scripts that make a use of string expressions a lot.