### PR TITLE
[MRG] Fix various inefficiencies

### DIFF
--- a/brian2/codegen/codeobject.py
+++ b/brian2/codegen/codeobject.py
@@ -260,7 +260,7 @@ def create_runner_codeobj(group, code, template_name,
     else:
         codeobj_class = device.code_object_class(codeobj_class)
 
-    template = getattr(codeobj_class.templater, template_name, None)
+    template = getattr(codeobj_class.templater, template_name)
     template_variables = getattr(template, 'variables', None)
 
     all_variables = dict(group.variables)

--- a/brian2/codegen/generators/base.py
+++ b/brian2/codegen/generators/base.py
@@ -2,8 +2,8 @@
 Base class for generating code in different programming languages, gives the
 methods which should be overridden to implement a new language.
 '''
-from brian2.core.preferences import prefs
 from brian2.core.variables import ArrayVariable
+from brian2.core.functions import Function
 from brian2.utils.stringtools import get_identifiers
 from brian2.utils.logger import get_logger
 from brian2.codegen.translation import make_statements
@@ -37,6 +37,13 @@ class CodeGenerator(object):
         self.device = get_device()
         self.variables = variables
         self.variable_indices = variable_indices
+        self.func_name_replacements = {}
+        for varname, var in variables.iteritems():
+            if isinstance(var, Function):
+                if codeobj_class in var.implementations:
+                    impl_name = var.implementations[codeobj_class].name
+                    if impl_name is not None:
+                        self.func_name_replacements[varname] = impl_name
         self.iterate_all = iterate_all
         self.codeobj_class = codeobj_class
         self.owner = owner

--- a/brian2/codegen/generators/cpp_generator.py
+++ b/brian2/codegen/generators/cpp_generator.py
@@ -158,11 +158,7 @@ class CPPCodeGenerator(CodeGenerator):
             return device.get_array_name(var, access_data=False)
 
     def translate_expression(self, expr):
-        for varname, var in self.variables.iteritems():
-            if isinstance(var, Function):
-                impl_name = var.implementations[self.codeobj_class].name
-                if impl_name is not None:
-                    expr = word_substitute(expr, {varname: impl_name})
+        expr = word_substitute(expr, self.func_name_replacements)
         return CPPNodeRenderer().render_expr(expr).strip()
 
     def translate_statement(self, statement):

--- a/brian2/codegen/generators/cython_generator.py
+++ b/brian2/codegen/generators/cython_generator.py
@@ -61,12 +61,7 @@ class CythonCodeGenerator(CodeGenerator):
     class_name = 'cython'
 
     def translate_expression(self, expr):
-        # numpy version
-        for varname, var in self.variables.iteritems():
-            if isinstance(var, Function):
-                impl_name = var.implementations[self.codeobj_class].name
-                if impl_name is not None:
-                    expr = word_substitute(expr, {varname: impl_name})
+        expr = word_substitute(expr, self.func_name_replacements)
         return CythonNodeRenderer().render_expr(expr, self.variables).strip()
 
     def translate_statement(self, statement):

--- a/brian2/codegen/generators/numpy_generator.py
+++ b/brian2/codegen/generators/numpy_generator.py
@@ -31,11 +31,7 @@ class NumpyCodeGenerator(CodeGenerator):
     _use_ufunc_at_vectorisation = True # allow this to be off for testing only
 
     def translate_expression(self, expr):
-        for varname, var in self.variables.iteritems():
-            if isinstance(var, Function):
-                impl_name = var.implementations[self.codeobj_class].name
-                if impl_name is not None:
-                    expr = word_substitute(expr, {varname: impl_name})
+        expr = word_substitute(expr, self.func_name_replacements)
         return NumpyNodeRenderer().render_expr(expr, self.variables).strip()
 
     def translate_statement(self, statement):

--- a/brian2/codegen/runtime/cython_rt/cython_rt.py
+++ b/brian2/codegen/runtime/cython_rt/cython_rt.py
@@ -39,7 +39,7 @@ class CythonCodeObject(NumpyCodeObject):
     '''
     Execute code using Cython.
     '''
-    templater = Templater('brian2.codegen.runtime.cython_rt',
+    templater = Templater('brian2.codegen.runtime.cython_rt', '.pyx',
                           env_globals={'cpp_dtype': get_cpp_dtype,
                                        'numpy_dtype': get_numpy_dtype,
                                        'dtype': numpy.dtype})

--- a/brian2/codegen/runtime/numpy_rt/numpy_rt.py
+++ b/brian2/codegen/runtime/numpy_rt/numpy_rt.py
@@ -35,7 +35,7 @@ class NumpyCodeObject(CodeObject):
     
     Default for Brian because it works on all platforms.
     '''
-    templater = Templater('brian2.codegen.runtime.numpy_rt')
+    templater = Templater('brian2.codegen.runtime.numpy_rt', '.py_')
     generator_class = NumpyCodeGenerator
     class_name = 'numpy'
 

--- a/brian2/codegen/runtime/numpy_rt/templates/spikemonitor.py_
+++ b/brian2/codegen/runtime/numpy_rt/templates/spikemonitor.py_
@@ -4,21 +4,24 @@ import numpy as _numpy
 {#  Get the name of the array that stores these events (e.g. the spikespace array) #}
 {% set _eventspace = get_array_name(eventspace_variable) %}
 
-_events = {{_eventspace}}[:{{_eventspace}}[-1]]
-# Take subgroups into account
-_events = _events[(_events >= _source_start) & (_events < _source_stop)]
-_n_events = len(_events)
-_vectorisation_idx = 1
-{{scalar_code|autoindent}}
+_n_events = {{_eventspace}}[-1]
 if _n_events > 0:
-    _curlen = {{N}}
-    _newlen = _curlen + _n_events
-    _owner.resize(_newlen)
-    _vectorisation_idx = _n_events
-    _idx = _events
-    {{vector_code|autoindent}}
-    {% for varname, var in record_variables.items() %}
-    {% set dynamic_varname = get_array_name(var, access_data=False) %}
-    {{dynamic_varname}}[_curlen:_newlen] = _to_record_{{varname}}
-    {% endfor %}
-    {{count}}[_events - _source_start] += 1
+    _events = {{_eventspace}}[:_n_events]
+    # Take subgroups into account
+    if _source_start!=0 or _source_stop!={{N}}:
+        _events = _events[(_events >= _source_start) & (_events < _source_stop)]
+    _n_events = len(_events)
+    if _n_events > 0:
+        _vectorisation_idx = 1
+        {{scalar_code|autoindent}}
+        _curlen = {{N}}
+        _newlen = _curlen + _n_events
+        _owner.resize(_newlen)
+        _vectorisation_idx = _n_events
+        _idx = _events
+        {{vector_code|autoindent}}
+        {% for varname, var in record_variables.items() %}
+        {% set dynamic_varname = get_array_name(var, access_data=False) %}
+        {{dynamic_varname}}[_curlen:_newlen] = _to_record_{{varname}}
+        {% endfor %}
+        {{count}}[_events - _source_start] += 1

--- a/brian2/codegen/runtime/weave_rt/weave_rt.py
+++ b/brian2/codegen/runtime/weave_rt/weave_rt.py
@@ -67,7 +67,7 @@ class WeaveCodeObject(CodeObject):
     object with two macros defined, ``main`` (for the main loop code) and
     ``support_code`` for any support code (e.g. function definitions).
     '''
-    templater = Templater('brian2.codegen.runtime.weave_rt',
+    templater = Templater('brian2.codegen.runtime.weave_rt', '.cpp',
                           env_globals={'c_data_type': weave_data_type,
                                        'dtype': numpy.dtype,
                                        'constant_or_scalar': constant_or_scalar})

--- a/brian2/core/clocks.py
+++ b/brian2/core/clocks.py
@@ -142,25 +142,6 @@ class Clock(VariableOwner):
         else:
             self._i_end = np.uint64(np.ceil(end/self.dt_))
 
-    def tick(self):
-        '''
-        Advance the clock by a single time step
-        '''
-        timestep_array = self.variables['timestep'].get_value()
-        # We can assume the runtime device here, standalone will provide it's
-        # own mechanism for advancing the clock. Therefore, we don't have to
-        # update the variable in the general way but just work directly with
-        # the underlying array
-        timestep_array[0] += 1
-        self.variables['t'].get_value()[0] = timestep_array[0] * self.variables['dt'].get_value()[0]
-
-    @property
-    def running(self):
-        '''
-        A ``bool`` to indicate whether the current simulation is running.
-        '''
-        return self.timestep < self._i_end
-
     epsilon = 1e-14
 
 

--- a/brian2/core/network.py
+++ b/brian2/core/network.py
@@ -18,7 +18,7 @@ from brian2.core.names import Nameable
 from brian2.core.base import BrianObject, brian_object_exception
 from brian2.core.clocks import Clock
 from brian2.devices.device import device
-from brian2.units.fundamentalunits import check_units
+from brian2.units.fundamentalunits import check_units, Quantity
 from brian2.units.allunits import second, msecond 
 from brian2.core.preferences import prefs, BrianPreference
 from brian2.core.namespace import get_local_namespace
@@ -210,7 +210,7 @@ class Network(Nameable):
 
         self._schedule = None
      
-    t = property(fget=lambda self: self.t_*second,
+    t = property(fget=lambda self: Quantity(self.t_, dim=second.dim, copy=False),
                  doc='''
                      Current simulation time in seconds (`Quantity`)
                      ''')
@@ -714,13 +714,12 @@ class Network(Nameable):
                 obj.after_run()
         
     def _nextclocks(self):
-        # Getting Clock.t_ is relatively expensive since it involves a
-        # multiplication therefore we extract it only once
-        clocks_times = [(clock, clock.t_) for clock in self._clocks]
+        clocks_times = [(c, self._clock_variables[c][1][0])
+                        for c in self._clocks]
         minclock, min_time = min(clocks_times, key=lambda k: k[1])
         curclocks = set(clock for clock, time in clocks_times if
                         (time == min_time or
-                         abs(time - min_time)<Clock.epsilon))
+                         abs(time - min_time) < Clock.epsilon))
         return minclock, curclocks
 
     @device_override('network_run')
@@ -768,6 +767,12 @@ class Network(Nameable):
         global `stop` function.
         '''
         self._clocks = set([obj.clock for obj in self.objects])
+        # We get direct references to the underlying variables for all clocks
+        # to avoid expensive access during the run loop
+        self._clock_variables = {c : (c.variables['timestep'].get_value(),
+                                      c.variables['t'].get_value(),
+                                      c.variables['dt'].get_value())
+                                 for c in self._clocks}
         t_start = self.t
         t_end = self.t+duration
         for clock in self._clocks:
@@ -807,9 +812,12 @@ class Network(Nameable):
         profiling_info = defaultdict(float)
 
         start_time = time.time()
-        while clock.running and not self._stopped and not Network._globally_stopped:
+        timestep, _, _ = self._clock_variables[clock]
+        running = timestep[0] < clock._i_end
+        while running and not self._stopped and not Network._globally_stopped:
+            timestep, t, dt = self._clock_variables[clock]
             # update the network time to this clocks time
-            self.t_ = clock.t_
+            self.t_ = t
             if report is not None:
                 current = time.time()
                 if current > next_report_time:
@@ -829,7 +837,10 @@ class Network(Nameable):
 
             # tick the clock forward one time step
             for c in curclocks:
-                c.tick()
+                timestep, t, dt = self._clock_variables[c]
+                timestep[0] += 1
+                t[0] = timestep[0] * dt[0]
+
             # find the next clocks to be updated. The < operator for Clock
             # determines that the first clock to be updated should be the one
             # with the smallest t value, unless there are several with the 
@@ -838,6 +849,9 @@ class Network(Nameable):
 
             if device._maximum_run_time is not None and time.time()-start_time>float(device._maximum_run_time):
                 self._stopped = True
+            else:
+                timestep, _, _ = self._clock_variables[clock]
+                running = timestep < clock._i_end
 
         if self._stopped or Network._globally_stopped:
             self.t_ = clock.t_

--- a/brian2/devices/cpp_standalone/codeobject.py
+++ b/brian2/devices/cpp_standalone/codeobject.py
@@ -89,7 +89,7 @@ class CPPStandaloneCodeObject(CodeObject):
     object with two macros defined, ``main`` (for the main loop code) and
     ``support_code`` for any support code (e.g. function definitions).
     '''
-    templater = Templater('brian2.devices.cpp_standalone',
+    templater = Templater('brian2.devices.cpp_standalone', '.cpp',
                           env_globals={'c_data_type': c_data_type,
                                        'openmp_pragma': openmp_pragma,
                                        'constant_or_scalar': constant_or_scalar})

--- a/brian2/groups/group.py
+++ b/brian2/groups/group.py
@@ -25,10 +25,10 @@ from brian2.core.namespace import (get_local_namespace,
                                    DEFAULT_UNITS,
                                    DEFAULT_CONSTANTS)
 from brian2.codegen.codeobject import create_runner_codeobj
+from brian2.codegen.generators.numpy_generator import NumpyCodeGenerator
 from brian2.equations.equations import BOOLEAN, INTEGER, FLOAT
 from brian2.units.fundamentalunits import (fail_for_dimension_mismatch, Unit,
                                            get_unit, DIMENSIONLESS)
-from brian2.units.allunits import second
 from brian2.utils.logger import get_logger
 from brian2.utils.stringtools import get_identifiers, SpellChecker
 

--- a/brian2/groups/neurongroup.py
+++ b/brian2/groups/neurongroup.py
@@ -449,14 +449,6 @@ class NeuronGroup(Group, SpikeSource):
         if reset is not None:
             self.run_on_event('spike', reset, when='resets')
 
-        # We try to run a before_run already now. This might fail because of an
-        # incomplete namespace but if the namespace is already complete we
-        # can spot unit errors in the equation already here.
-        try:
-            self.before_run(None)
-        except KeyError:
-            pass
-
         #: Performs numerical integration step
         self.state_updater = StateUpdater(self, method)
 

--- a/brian2/stateupdaters/exact.py
+++ b/brian2/stateupdaters/exact.py
@@ -215,11 +215,10 @@ class LinearStateUpdater(StateUpdateMethod):
                                                 'equations with this '
                                                 'stateupdater.')
         if simplify:
-            A.simplify()
+            A = A.applyfunc(lambda x:
+                            sp.factor_terms(sp.cancel(sp.signsimp(x))))
         C = sp.ImmutableMatrix([A.dot(b)]) - b
         _S = sp.MatrixSymbol('_S', len(varnames), 1)
-        # The use of .as_mutable() here is a workaround for a
-        # ``Transpose object does not have
         updates = A * _S + C.transpose()
         updates = updates.as_explicit()
 

--- a/brian2/tests/test_clocks.py
+++ b/brian2/tests/test_clocks.py
@@ -5,13 +5,11 @@ from nose.plugins.attrib import attr
 
 @attr('codegen-independent')
 @with_setup(teardown=restore_initial_state)
-def test_clocks():
+def test_clock_attributes():
     clock = Clock(dt=1*ms)
     assert_array_equal(clock.t, 0*second)
     assert_array_equal(clock.timestep, 0)
-    clock.tick()
-    assert_array_equal(clock.t, 1*ms)
-    assert_array_equal(clock.timestep, 1)
+    assert_array_equal(clock.dt, 1*ms)
 
 @attr('codegen-independent')
 @with_setup(teardown=restore_initial_state)

--- a/brian2/tests/test_functions.py
+++ b/brian2/tests/test_functions.py
@@ -231,16 +231,22 @@ def test_manual_user_defined_function():
     assert foo(1*volt, 2*volt) == 6*volt
 
     # Incorrect argument units
-    assert_raises(DimensionMismatchError, lambda: NeuronGroup(1, '''
+    group = NeuronGroup(1, '''
                        dv/dt = foo(x, y)/ms : volt
                        x : 1
-                       y : 1''', namespace={'foo': foo}))
+                       y : 1''')
+    net = Network(group)
+    assert_raises(DimensionMismatchError,
+                  lambda: net.run(0*ms, namespace={ 'foo': foo}))
 
     # Incorrect output unit
-    assert_raises(DimensionMismatchError, lambda: NeuronGroup(1, '''
+    group = NeuronGroup(1, '''
                        dv/dt = foo(x, y)/ms : 1
                        x : volt
-                       y : volt''', namespace={'foo': foo}))
+                       y : volt''')
+    net = Network(group)
+    assert_raises(DimensionMismatchError,
+                  lambda: net.run(0*ms, namespace={'foo': foo}))
 
     G = NeuronGroup(1, '''
                        func = foo(x, y) : volt

--- a/brian2/tests/test_monitor.py
+++ b/brian2/tests/test_monitor.py
@@ -266,7 +266,11 @@ def test_state_monitor():
     assert_allclose(np.clip(multi_mon.v, 0.1, 0.9), multi_mon.f)
     assert_allclose(np.clip(multi_mon1.v, 0.1, 0.9), multi_mon1.f)
 
-    assert all(all_mon[0].not_refractory[:] == True)
+    assert all(all_mon[0].not_refractory[:] == True), ('not_refractory should '
+                                                       'be True, but got'
+                                                       '(not_refractory, v):'
+                                                       '%s ' % str((all_mon.not_refractory,
+                                                                    all_mon.v)))
 
     # Synapses
     assert_allclose(synapse_mon.w[:], np.tile(S.j[:]*nS,

--- a/brian2/tests/test_neurongroup.py
+++ b/brian2/tests/test_neurongroup.py
@@ -536,17 +536,6 @@ def test_linked_var_in_reset_incorrect():
     assert_raises(SyntaxError, lambda: net.run(0*ms))
 
 @attr('codegen-independent')
-def test_unit_errors():
-    '''
-    Test that units are checked for a complete namespace.
-    '''
-    # Unit error in model equations
-    assert_raises(DimensionMismatchError,
-                  lambda: NeuronGroup(1, 'dv/dt = -v : 1'))
-    assert_raises(DimensionMismatchError,
-                  lambda: NeuronGroup(1, 'dv/dt = -v/(10*ms) + 2*mV: 1'))
-
-@attr('codegen-independent')
 def test_incomplete_namespace():
     '''
     Test that the namespace does not have to be complete at creation time.

--- a/brian2/tests/test_templates/__init__.py
+++ b/brian2/tests/test_templates/__init__.py
@@ -5,8 +5,11 @@ from nose.plugins.attrib import attr
 
 @attr('codegen-independent')
 def test_templates():
-    T1 = Templater('brian2.tests.test_templates.fake_package_1', env_globals={'f': lambda: 'F1', 'g': lambda: 'G1'})
-    T2 = T1.derive('brian2.tests.test_templates.fake_package_2', env_globals={'f': lambda: 'F2'})
+    T1 = Templater('brian2.tests.test_templates.fake_package_1',
+                   env_globals={'f': lambda: 'F1', 'g': lambda: 'G1'},
+                   extension='.txt')
+    T2 = T1.derive('brian2.tests.test_templates.fake_package_2',
+                   env_globals={'f': lambda: 'F2'})
     ns = {}
     for i, T in enumerate([T1, T2], start=1):
         for c in ['A', 'B', 'C', 'D']:

--- a/brian2/units/fundamentalunits.py
+++ b/brian2/units/fundamentalunits.py
@@ -901,7 +901,7 @@ class Quantity(np.ndarray, object):
                                              arr.dim, dim)
         elif hasattr(arr, 'unit'):
             subarr.dim = arr.unit.dim if arr.unit is not None else None
-            if not (dim is None) and not (dim is subarr.dim):
+            if not (dim is None or subarr.dim is None) and not (dim is subarr.dim):
                 raise DimensionMismatchError('Conflicting dimension '
                                              'information between array and '
                                              'dim keyword',


### PR DESCRIPTION
Ok, this one deserves slightly more discussion. It fixes a few "low-hanging fruits" for performance, hopefully it should now compare better against Brian 1. Nothing too controversial here, the changes are:
* As mentioned previously, the way the clock was accessed in `Network.run` was far from optimal. I changed it in a way that takes some logic out of the `Clock` class and puts direct access to the variables in `Network.run`. This makes the code somewhat less readable but I think it is justified here since `Clock.running` and `Clock.tick` were only ever used from within the runtime `Network.run` function, standalone had to do something else. So not having this in `Clock` but instead in `Network.run` seems like the sensible choice, instead of having very runtime specific code in the `Clock` class.
* During import, all the templates for all code generation targets were loaded into memory, which took a significant amount of time, I changed it so that they are now loaded on demand only.
* There was one left-over call where `NeuronGroup` tried to run `before_run` in its constructor, which only worked if the namespace was already complete. In line with the changes for the state updater/thresholder/resetter in the `optimize_before_run` branch we did earlier, I removed this.
* For every expression that went through code generation, we went through the variables dictionary, noted all the name translations (e.g. `acos` to `arccos`) and replaced them in the expression. We now create a dictionary of name translations when we create the `CodeGenerator` object.
* We were still using sympy's `simplify` function, which tries out all kind of simplifications and takes quite a long time. I replaced this by a few specific simplifications that for the linear equations of the CUBA example lead to basically the same result but take much less time.

Looking at the profiling output I don't see anything obvious to improve any more. The only significant improvements that I could think of would take more thought, e.g. things that optimize the whole run loop (special case a single clock or pre-calculate a completely fixed schedule, say. `clock1, clock2, clock1, clock2, ...`, instead of checking things on a per-timestep basis, merging code objects if there is nothing in between them, etc.).

If you can't think of any more obvious inefficiencies (the synapses discussion aside), then this is ready to merge from my side.