### PR TITLE
[MRG] Build devices by default at the first `run` call

### DIFF
--- a/brian2/devices/cpp_standalone/device.py
+++ b/brian2/devices/cpp_standalone/device.py
@@ -139,11 +139,6 @@ class CPPStandaloneDevice(Device):
         self.build_on_run = build_on_run
         self.build_options = build_options
 
-    def activate(self, build_on_run, **kwargs):
-        super(CPPStandaloneDevice, self).activate(build_on_run=build_on_run)
-        self.build_on_run = build_on_run
-        self.build_options = dict(kwargs)
-
     def freeze(self, code, ns):
         # this is a bit of a hack, it should be passed to the template somehow
         for k, v in ns.items():

--- a/brian2/devices/cpp_standalone/device.py
+++ b/brian2/devices/cpp_standalone/device.py
@@ -16,7 +16,7 @@ from cpuinfo import cpuinfo
 
 from brian2.codegen.cpp_prefs import get_compiler_and_args
 from brian2.core.network import Network
-from brian2.devices.device import Device, all_devices, temporarily_switch_device, reset_device
+from brian2.devices.device import Device, all_devices, set_device, reset_device
 from brian2.core.variables import *
 from brian2.core.namespace import get_local_namespace
 from brian2.parsing.rendering import CPPNodeRenderer
@@ -426,7 +426,7 @@ class CPPStandaloneDevice(Device):
                                       'simulation has been run.')
         # Temporarily switch to the runtime device to evaluate the subexpression
         # (based on the values stored on disk)
-        temporarily_switch_device('runtime')
+        set_device('runtime')
         result = VariableView.get_subexpression_with_index_array(variableview, item,
                                                                  level=level+2,
                                                                  run_namespace=run_namespace)

--- a/brian2/tests/__init__.py
+++ b/brian2/tests/__init__.py
@@ -3,7 +3,7 @@ import sys
 from StringIO import StringIO
 
 from brian2.core.preferences import prefs
-from brian2.devices.device import all_devices, temporarily_switch_device, reset_device
+from brian2.devices.device import all_devices, set_device, reset_device
 
 try:
     import nose
@@ -198,8 +198,8 @@ def run(codegen_targets=None, long_tests=False, test_codegen_independent=True,
 
         if test_standalone:
             from brian2.devices.device import get_device, set_device
-            temporarily_switch_device(test_standalone, directory=None,  # use temp directory
-                                      with_output=False)
+            set_device(test_standalone, directory=None,  # use temp directory
+                       with_output=False)
             sys.stderr.write('Testing standalone device "%s"\n' % test_standalone)
             sys.stderr.write('Running standalone-compatible standard tests\n')
             exclude_str = ',!long' if not long_tests else ''

--- a/brian2/tests/__init__.py
+++ b/brian2/tests/__init__.py
@@ -3,7 +3,7 @@ import sys
 from StringIO import StringIO
 
 from brian2.core.preferences import prefs
-from brian2.devices.device import all_devices
+from brian2.devices.device import all_devices, temporarily_switch_device, reset_device
 
 try:
     import nose
@@ -198,8 +198,8 @@ def run(codegen_targets=None, long_tests=False, test_codegen_independent=True,
 
         if test_standalone:
             from brian2.devices.device import get_device, set_device
-            previous_device = get_device()
-            set_device(test_standalone + '_simple')
+            temporarily_switch_device(test_standalone, directory=None,  # use temp directory
+                                      with_output=False)
             sys.stderr.write('Testing standalone device "%s"\n' % test_standalone)
             sys.stderr.write('Running standalone-compatible standard tests\n')
             exclude_str = ',!long' if not long_tests else ''
@@ -237,7 +237,7 @@ def run(codegen_targets=None, long_tests=False, test_codegen_independent=True,
                 prefs.devices.cpp_standalone.openmp_threads = 0
                 prefs._backup()
 
-            set_device(previous_device)
+            reset_device()
 
             sys.stderr.write('Running standalone-specific tests\n')
             exclude_openmp = ',!openmp' if not test_openmp else ''

--- a/brian2/tests/features/base.py
+++ b/brian2/tests/features/base.py
@@ -204,7 +204,7 @@ class CPPStandaloneConfiguration(Configuration):
     name = 'C++ standalone'
     def before_run(self):
         brian2.prefs.reset_to_defaults()
-        brian2.set_device('cpp_standalone')
+        brian2.set_device('cpp_standalone', build_on_run=False)
         
     def after_run(self):
         if os.path.exists('cpp_standalone'):
@@ -216,7 +216,7 @@ class CPPStandaloneConfigurationOpenMP(Configuration):
     name = 'C++ standalone (OpenMP)'
     def before_run(self):
         brian2.prefs.reset_to_defaults()
-        brian2.set_device('cpp_standalone')
+        brian2.set_device('cpp_standalone', build_on_run=False)
         brian2.prefs.devices.cpp_standalone.openmp_threads = 4
         
     def after_run(self):

--- a/brian2/tests/test_complex_examples.py
+++ b/brian2/tests/test_complex_examples.py
@@ -2,10 +2,10 @@ from nose import with_setup
 from nose.plugins.attrib import attr
 
 from brian2 import *
-from brian2.devices.device import restore_device
+from brian2.devices.device import reinit_devices
 
 @attr('standalone-compatible')
-@with_setup(teardown=restore_device)
+@with_setup(teardown=reinit_devices)
 def test_cuba():
     taum = 20*ms
     taue = 5*ms

--- a/brian2/tests/test_cpp_standalone.py
+++ b/brian2/tests/test_cpp_standalone.py
@@ -5,12 +5,12 @@ from nose.plugins.attrib import attr
 from numpy.testing.utils import assert_allclose, assert_equal, assert_raises
 
 from brian2 import *
-from brian2.devices.device import restore_device, temporarily_switch_device, reset_device
+from brian2.devices.device import reinit_devices, set_device, reset_device
 
 @attr('cpp_standalone', 'standalone-only')
-@with_setup(teardown=restore_device)
+@with_setup(teardown=reinit_devices)
 def test_cpp_standalone(with_output=False):
-    temporarily_switch_device('cpp_standalone', build_on_run=False)
+    set_device('cpp_standalone', build_on_run=False)
     ##### Define the model
     tau = 1*ms
     eqs = '''
@@ -49,9 +49,9 @@ def test_cpp_standalone(with_output=False):
     reset_device()
 
 @attr('cpp_standalone', 'standalone-only')
-@with_setup(teardown=restore_device)
+@with_setup(teardown=reinit_devices)
 def test_dt_changes_between_runs_standalone(with_output=False):
-    temporarily_switch_device('cpp_standalone', build_on_run=False)
+    set_device('cpp_standalone', build_on_run=False)
     defaultclock.dt = 0.1*ms
     G = NeuronGroup(1, 'v:1')
     mon = StateMonitor(G, 'v', record=True)
@@ -71,9 +71,9 @@ def test_dt_changes_between_runs_standalone(with_output=False):
     reset_device()
 
 @attr('cpp_standalone', 'standalone-only')
-@with_setup(teardown=restore_device)
+@with_setup(teardown=reinit_devices)
 def test_multiple_connects(with_output=False):
-    temporarily_switch_device('cpp_standalone', build_on_run=False)
+    set_device('cpp_standalone', build_on_run=False)
     G = NeuronGroup(10, 'v:1')
     S = Synapses(G, G, 'w:1')
     S.connect([0], [0])
@@ -88,9 +88,9 @@ def test_multiple_connects(with_output=False):
     reset_device()
 
 @attr('cpp_standalone', 'standalone-only')
-@with_setup(teardown=restore_device)
+@with_setup(teardown=reinit_devices)
 def test_storing_loading(with_output=False):
-    temporarily_switch_device('cpp_standalone', build_on_run=False)
+    set_device('cpp_standalone', build_on_run=False)
     G = NeuronGroup(10, '''v : volt
                            x : 1
                            n : integer
@@ -127,7 +127,7 @@ def test_storing_loading(with_output=False):
     reset_device()
 
 @attr('cpp_standalone', 'standalone-only', 'openmp')
-@with_setup(teardown=restore_device)
+@with_setup(teardown=reinit_devices)
 def test_openmp_consistency(with_output=False):
     previous_device = get_device()
     n_cells    = 100
@@ -171,7 +171,7 @@ def test_openmp_consistency(with_output=False):
         set_device(devicename, build_on_run=False, with_output=False)
         Synapses.__instances__().clear()
         if devicename=='cpp_standalone':
-            restore_device()
+            reinit_devices()
         prefs.devices.cpp_standalone.openmp_threads = n_threads
         P    = NeuronGroup(n_cells, model=eqs, threshold='v>Vt', reset='v=Vr', refractory=5 * ms)
         Q    = SpikeGeneratorGroup(n_cells, sources, times)
@@ -226,9 +226,9 @@ def test_openmp_consistency(with_output=False):
     reset_device(previous_device)
 
 @attr('cpp_standalone', 'standalone-only')
-@with_setup(teardown=restore_device)
+@with_setup(teardown=reinit_devices)
 def test_timedarray(with_output=True):
-    temporarily_switch_device('cpp_standalone', build_on_run=False)
+    set_device('cpp_standalone', build_on_run=False)
 
     defaultclock.dt = 0.1*ms
     ta1d = TimedArray(np.arange(10)*volt, dt=1*ms)
@@ -259,9 +259,9 @@ def test_timedarray(with_output=True):
     reset_device()
 
 @attr('cpp_standalone', 'standalone-only')
-@with_setup(teardown=restore_device)
+@with_setup(teardown=reinit_devices)
 def test_duplicate_names_across_nets(with_output=True):
-    temporarily_switch_device('cpp_standalone', build_on_run=False)
+    set_device('cpp_standalone', build_on_run=False)
     # In standalone mode, names have to be globally unique, not just unique
     # per network
     obj1 = BrianObject(name='name1')
@@ -277,11 +277,11 @@ def test_duplicate_names_across_nets(with_output=True):
     reset_device()
 
 @attr('cpp_standalone', 'standalone-only', 'openmp')
-@with_setup(teardown=restore_device)
+@with_setup(teardown=reinit_devices)
 def test_openmp_scalar_writes(with_output=False):
     # Test that writing to a scalar variable only is done once in an OpenMP
     # setting (see github issue #551)
-    temporarily_switch_device('cpp_standalone', build_on_run=False)
+    set_device('cpp_standalone', build_on_run=False)
     prefs.devices.cpp_standalone.openmp_threads = 4
     G = NeuronGroup(10, 's : 1 (shared)')
     G.run_regularly('s += 1')
@@ -296,9 +296,9 @@ def test_openmp_scalar_writes(with_output=False):
     reset_device()
 
 @attr('cpp_standalone', 'standalone-only')
-@with_setup(teardown=restore_device)
+@with_setup(teardown=reinit_devices)
 def test_time_after_run(with_output=False):
-    temporarily_switch_device('cpp_standalone', build_on_run=False)
+    set_device('cpp_standalone', build_on_run=False)
     # Check that the clock and network time after a run is correct, even if we
     # have not actually run the code yet (via build)
     G = NeuronGroup(10, 'dv/dt = -v/(10*ms) : 1')
@@ -328,10 +328,10 @@ def test_time_after_run(with_output=False):
     reset_device()
 
 @attr('cpp_standalone', 'standalone-only')
-@with_setup(teardown=restore_device)
+@with_setup(teardown=reinit_devices)
 def test_array_cache(with_output=False):
     # Check that variables are only accessible from Python when they should be
-    temporarily_switch_device('cpp_standalone', build_on_run=False)
+    set_device('cpp_standalone', build_on_run=False)
     G = NeuronGroup(10, '''dv/dt = -v / (10*ms) : 1
                            w : 1
                            x : 1
@@ -414,4 +414,4 @@ if __name__=='__main__':
              test_array_cache
              ]:
         t(with_output=True)
-        restore_device()
+        reinit_devices()

--- a/brian2/tests/test_cpp_standalone.py
+++ b/brian2/tests/test_cpp_standalone.py
@@ -5,13 +5,12 @@ from nose.plugins.attrib import attr
 from numpy.testing.utils import assert_allclose, assert_equal, assert_raises
 
 from brian2 import *
-from brian2.devices.device import restore_device
+from brian2.devices.device import restore_device, temporarily_switch_device, reset_device
 
 @attr('cpp_standalone', 'standalone-only')
 @with_setup(teardown=restore_device)
 def test_cpp_standalone(with_output=False):
-    previous_device = get_device()
-    set_device('cpp_standalone')
+    temporarily_switch_device('cpp_standalone', build_on_run=False)
     ##### Define the model
     tau = 1*ms
     eqs = '''
@@ -47,13 +46,12 @@ def test_cpp_standalone(with_output=False):
     assert len(M.t) == len(M.i)
     assert M.t[0] == 0.
     assert M.t[-1] == 100*ms - defaultclock.dt
-    set_device(previous_device)
+    reset_device()
 
 @attr('cpp_standalone', 'standalone-only')
 @with_setup(teardown=restore_device)
 def test_dt_changes_between_runs_standalone(with_output=False):
-    previous_device = get_device()
-    set_device('cpp_standalone')
+    temporarily_switch_device('cpp_standalone', build_on_run=False)
     defaultclock.dt = 0.1*ms
     G = NeuronGroup(1, 'v:1')
     mon = StateMonitor(G, 'v', record=True)
@@ -70,12 +68,12 @@ def test_dt_changes_between_runs_standalone(with_output=False):
     assert len(mon.t[:]) == 5 + 1 + 5
     assert_allclose(mon.t[:],
                     [0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 1., 1.1, 1.2, 1.3, 1.4]*ms)
+    reset_device()
 
 @attr('cpp_standalone', 'standalone-only')
 @with_setup(teardown=restore_device)
 def test_multiple_connects(with_output=False):
-    previous_device = get_device()
-    set_device('cpp_standalone')
+    temporarily_switch_device('cpp_standalone', build_on_run=False)
     G = NeuronGroup(10, 'v:1')
     S = Synapses(G, G, 'w:1')
     S.connect([0], [0])
@@ -87,13 +85,12 @@ def test_multiple_connects(with_output=False):
     device.build(directory=tempdir, compile=True, run=True,
                  with_output=True)
     assert len(S) == 2 and len(S.w[:]) == 2
-    set_device(previous_device)
+    reset_device()
 
 @attr('cpp_standalone', 'standalone-only')
 @with_setup(teardown=restore_device)
 def test_storing_loading(with_output=False):
-    previous_device = get_device()
-    set_device('cpp_standalone')
+    temporarily_switch_device('cpp_standalone', build_on_run=False)
     G = NeuronGroup(10, '''v : volt
                            x : 1
                            n : integer
@@ -127,7 +124,7 @@ def test_storing_loading(with_output=False):
     assert_allclose(S.n_syn[:], n)
     assert_allclose(G.b[:], b)
     assert_allclose(S.b_syn[:], b)
-    set_device(previous_device)
+    reset_device()
 
 @attr('cpp_standalone', 'standalone-only', 'openmp')
 @with_setup(teardown=restore_device)
@@ -171,10 +168,10 @@ def test_openmp_consistency(with_output=False):
                                     (2, 'cpp_standalone'),
                                     (3, 'cpp_standalone'),
                                     (4, 'cpp_standalone')]:
-        set_device(devicename)
+        set_device(devicename, build_on_run=False, with_output=False)
         Synapses.__instances__().clear()
         if devicename=='cpp_standalone':
-            device.reinit()
+            restore_device()
         prefs.devices.cpp_standalone.openmp_threads = n_threads
         P    = NeuronGroup(n_cells, model=eqs, threshold='v>Vt', reset='v=Vr', refractory=5 * ms)
         Q    = SpikeGeneratorGroup(n_cells, sources, times)
@@ -226,13 +223,12 @@ def test_openmp_consistency(with_output=False):
         assert_allclose(results[key1]['v'], results[key2]['v'])
         assert_allclose(results[key1]['r'], results[key2]['r'])
         assert_allclose(results[key1]['s'], results[key2]['s'])
-    set_device(previous_device)
+    reset_device(previous_device)
 
 @attr('cpp_standalone', 'standalone-only')
 @with_setup(teardown=restore_device)
 def test_timedarray(with_output=True):
-    previous_device = get_device()
-    set_device('cpp_standalone')
+    temporarily_switch_device('cpp_standalone', build_on_run=False)
 
     defaultclock.dt = 0.1*ms
     ta1d = TimedArray(np.arange(10)*volt, dt=1*ms)
@@ -260,13 +256,12 @@ def test_timedarray(with_output=True):
     # only NaN
     assert_equal(mon[3].y[:], np.nan)
 
-    set_device(previous_device)
+    reset_device()
 
 @attr('cpp_standalone', 'standalone-only')
 @with_setup(teardown=restore_device)
 def test_duplicate_names_across_nets(with_output=True):
-    previous_device = get_device()
-    set_device('cpp_standalone')
+    temporarily_switch_device('cpp_standalone', build_on_run=False)
     # In standalone mode, names have to be globally unique, not just unique
     # per network
     obj1 = BrianObject(name='name1')
@@ -279,15 +274,14 @@ def test_duplicate_names_across_nets(with_output=True):
     net2.run(0*ms)
     assert_raises(ValueError, lambda: device.build())
 
-    set_device(previous_device)
+    reset_device()
 
 @attr('cpp_standalone', 'standalone-only', 'openmp')
 @with_setup(teardown=restore_device)
 def test_openmp_scalar_writes(with_output=False):
     # Test that writing to a scalar variable only is done once in an OpenMP
     # setting (see github issue #551)
-    previous_device = get_device()
-    set_device('cpp_standalone')
+    temporarily_switch_device('cpp_standalone', build_on_run=False)
     prefs.devices.cpp_standalone.openmp_threads = 4
     G = NeuronGroup(10, 's : 1 (shared)')
     G.run_regularly('s += 1')
@@ -299,13 +293,12 @@ def test_openmp_scalar_writes(with_output=False):
                  with_output=with_output)
     assert_equal(G.s[:], 1.0)
 
-    set_device(previous_device)
+    reset_device()
 
 @attr('cpp_standalone', 'standalone-only')
 @with_setup(teardown=restore_device)
 def test_time_after_run(with_output=False):
-    previous_device = get_device()
-    set_device('cpp_standalone')
+    temporarily_switch_device('cpp_standalone', build_on_run=False)
     # Check that the clock and network time after a run is correct, even if we
     # have not actually run the code yet (via build)
     G = NeuronGroup(10, 'dv/dt = -v/(10*ms) : 1')
@@ -332,14 +325,13 @@ def test_time_after_run(with_output=False):
     assert_allclose(G.t, 20.*ms)
     assert_allclose(net.t, 20.*ms)
 
-    set_device(previous_device)
+    reset_device()
 
 @attr('cpp_standalone', 'standalone-only')
 @with_setup(teardown=restore_device)
 def test_array_cache(with_output=False):
     # Check that variables are only accessible from Python when they should be
-    previous_device = get_device()
-    set_device('cpp_standalone')
+    temporarily_switch_device('cpp_standalone', build_on_run=False)
     G = NeuronGroup(10, '''dv/dt = -v / (10*ms) : 1
                            w : 1
                            x : 1
@@ -403,7 +395,7 @@ def test_array_cache(with_output=False):
     assert_allclose(G.i, np.arange(10))
     assert_allclose(S.weight, 7)
 
-    set_device(previous_device)
+    reset_device()
 
 
 if __name__=='__main__':

--- a/brian2/tests/test_devices.py
+++ b/brian2/tests/test_devices.py
@@ -45,7 +45,7 @@ def test_set_reset_device_implicit():
 
 @attr('codegen-independent')
 def test_set_reset_device_explicit():
-
+    original_device = get_device()
     test_device1 = ATestDevice()
     all_devices['test1'] = test_device1
     test_device2 = ATestDevice()
@@ -65,6 +65,7 @@ def test_set_reset_device_explicit():
     del all_devices['test1']
     del all_devices['test2']
     del all_devices['test3']
+    reset_device(original_device)
 
 if __name__ == '__main__':
     test_set_reset_device_implicit()

--- a/brian2/tests/test_devices.py
+++ b/brian2/tests/test_devices.py
@@ -1,0 +1,71 @@
+from nose.plugins.attrib import attr
+
+from brian2.devices.device import (Device, all_devices, set_device, get_device,
+                                   reset_device, runtime_device, previous_devices)
+
+class ATestDevice(Device):
+    def activate(self, build_on_run, **kwargs):
+        super(ATestDevice, self).activate(build_on_run, **kwargs)
+        self.build_on_run = build_on_run
+        self._options = kwargs
+    # These functions are needed during the setup of the defaultclock
+    def add_array(self, var):
+        pass
+    def init_with_zeros(self, var, dtype):
+        pass
+    def fill_with_array(self, var, arr):
+        pass
+
+@attr('codegen-independent')
+def test_set_reset_device_implicit():
+
+    test_device1 = ATestDevice()
+    all_devices['test1'] = test_device1
+    test_device2 = ATestDevice()
+    all_devices['test2'] = test_device2
+
+    set_device('test1', build_on_run=False, my_opt=1)
+    set_device('test2', build_on_run=True, my_opt=2)
+    assert get_device() is test_device2
+    assert get_device()._options['my_opt'] == 2
+    assert get_device().build_on_run
+
+    reset_device()
+    assert get_device() is test_device1
+    assert get_device()._options['my_opt'] == 1
+    assert not get_device().build_on_run
+
+    reset_device()
+    assert get_device() is runtime_device
+
+    reset_device()  # If there is no previous device, will reset to runtime device
+    assert get_device() is runtime_device
+    del all_devices['test1']
+    del all_devices['test2']
+
+@attr('codegen-independent')
+def test_set_reset_device_explicit():
+
+    test_device1 = ATestDevice()
+    all_devices['test1'] = test_device1
+    test_device2 = ATestDevice()
+    all_devices['test2'] = test_device2
+    test_device3 = ATestDevice()
+    all_devices['test3'] = test_device3
+
+    set_device('test1', build_on_run=False, my_opt=1)
+    set_device('test2', build_on_run=True, my_opt=2)
+    set_device('test3', build_on_run=False, my_opt=3)
+
+    reset_device('test1')  # Directly jump back to the first device
+    assert get_device() is test_device1
+    assert get_device()._options['my_opt'] == 1
+    assert not get_device().build_on_run
+
+    del all_devices['test1']
+    del all_devices['test2']
+    del all_devices['test3']
+
+if __name__ == '__main__':
+    test_set_reset_device_implicit()
+    test_set_reset_device_explicit()

--- a/brian2/tests/test_functions.py
+++ b/brian2/tests/test_functions.py
@@ -5,7 +5,7 @@ from numpy.testing import assert_equal, assert_raises, assert_allclose
 from brian2 import *
 from brian2.parsing.sympytools import str_to_sympy, sympy_to_str
 from brian2.utils.logger import catch_logs
-from brian2.devices.device import restore_device
+from brian2.devices.device import reinit_devices
 
 @attr('codegen-independent')
 def test_constants_sympy():
@@ -91,7 +91,7 @@ def test_math_functions():
                             err_msg='Function %s did not return the correct values' % func.__name__)
 
 @attr('standalone-compatible')
-@with_setup(teardown=restore_device)
+@with_setup(teardown=reinit_devices)
 def test_bool_to_int():
     # Test that boolean expressions and variables are correctly converted into
     # integers
@@ -109,7 +109,7 @@ def test_bool_to_int():
     assert_equal(s_mon.intexpr2.flatten(), [1, 0])
 
 @attr('standalone-compatible')
-@with_setup(teardown=restore_device)
+@with_setup(teardown=reinit_devices)
 def test_user_defined_function():
     @implementation('cpp',"""
                 inline double usersin(double x)
@@ -137,7 +137,7 @@ def test_user_defined_function():
     assert_equal(np.sin(test_array), mon.func_.flatten())
 
 
-@with_setup(teardown=restore_device)
+@with_setup(teardown=reinit_devices)
 def test_user_defined_function_units():
     '''
     Test the preparation of functions for use in code with check_units.
@@ -506,7 +506,7 @@ def test_function_dependencies_numpy():
     assert_allclose(G.v_[:], 84*0.001)
 
 @attr('standalone-compatible')
-@with_setup(teardown=restore_device)
+@with_setup(teardown=reinit_devices)
 def test_binomial():
     binomial_f_approximated = BinomialFunction(100, 0.1, approximate=True)
     binomial_f = BinomialFunction(100, 0.1, approximate=False)

--- a/brian2/tests/test_monitor.py
+++ b/brian2/tests/test_monitor.py
@@ -6,12 +6,12 @@ from nose import with_setup
 from nose.plugins.attrib import attr
 
 from brian2 import *
-from brian2.devices.device import restore_device, temporarily_switch_device, reset_device
+from brian2.devices.device import reinit_devices, set_device, reset_device
 from brian2.utils.logger import catch_logs
 
 
 @attr('standalone-compatible')
-@with_setup(teardown=restore_device)
+@with_setup(teardown=reinit_devices)
 def test_spike_monitor():
     G = NeuronGroup(3, '''dv/dt = rate : 1
                           rate: Hz''', threshold='v>1', reset='v=0')
@@ -52,7 +52,7 @@ def test_spike_monitor():
 
 
 @attr('standalone-compatible')
-@with_setup(teardown=restore_device)
+@with_setup(teardown=reinit_devices)
 def test_spike_monitor_variables():
     G = NeuronGroup(3, '''dv/dt = rate : 1
                           rate : Hz
@@ -81,7 +81,7 @@ def test_spike_monitor_variables():
     assert_array_equal(mon2.prev_spikes[mon2.i == 2], np.arange(10)+1)
 
 @attr('standalone-compatible')
-@with_setup(teardown=restore_device)
+@with_setup(teardown=reinit_devices)
 def test_spike_monitor_get_states():
     G = NeuronGroup(3, '''dv/dt = rate : 1
                           rate : Hz
@@ -103,7 +103,7 @@ def test_spike_monitor_get_states():
 
 
 @attr('standalone-compatible')
-@with_setup(teardown=restore_device)
+@with_setup(teardown=reinit_devices)
 def test_event_monitor():
     G = NeuronGroup(3, '''dv/dt = rate : 1
                           rate: Hz''', events={'my_event': 'v>1'})
@@ -143,7 +143,7 @@ def test_event_monitor():
 
 
 @attr('standalone-compatible')
-@with_setup(teardown=restore_device)
+@with_setup(teardown=reinit_devices)
 def test_event_monitor_no_record():
     # Check that you can switch off recording spike times/indices
     G = NeuronGroup(3, '''dv/dt = rate : 1
@@ -197,7 +197,7 @@ def test_synapses_state_monitor():
     assert_allclose(synapse_mon2.w[1], 1*nS)
 
 @attr('standalone-compatible')
-@with_setup(teardown=restore_device)
+@with_setup(teardown=reinit_devices)
 def test_state_monitor():
     # Unique name to get the warning even for repeated runs of the test
     unique_name = 'neurongroup_' + str(uuid.uuid4()).replace('-', '_')
@@ -276,7 +276,7 @@ def test_state_monitor():
     assert_allclose(synapse_mon.w[:], np.tile(S.j[:]*nS,
                                               (synapse_mon.w[:].shape[1], 1)).T)
 
-@with_setup(teardown=restore_device)
+@with_setup(teardown=reinit_devices)
 def test_state_monitor_record_single_timestep():
     G = NeuronGroup(1, 'dv/dt = -v/(5*ms) : 1')
     G.v = 1
@@ -295,9 +295,9 @@ def test_state_monitor_record_single_timestep():
 
 
 @attr('cpp_standalone', 'standalone-only')
-@with_setup(teardown=restore_device)
+@with_setup(teardown=reinit_devices)
 def test_state_monitor_record_single_timestep_cpp_standalone():
-    temporarily_switch_device('cpp_standalone', build_on_run=False)
+    set_device('cpp_standalone', build_on_run=False)
     G = NeuronGroup(1, 'dv/dt = -v/(5*ms) : 1')
     G.v = 1
     mon = StateMonitor(G, 'v', record=True)
@@ -314,7 +314,7 @@ def test_state_monitor_record_single_timestep_cpp_standalone():
     reset_device()
 
 @attr('standalone-compatible')
-@with_setup(teardown=restore_device)
+@with_setup(teardown=reinit_devices)
 def test_state_monitor_indexing():
     # Check indexing semantics
     G = NeuronGroup(10, 'v:volt')
@@ -342,7 +342,7 @@ def test_state_monitor_indexing():
     assert_raises(TypeError, lambda: mon[[5.0, 6.0]])
 
 @attr('standalone-compatible')
-@with_setup(teardown=restore_device)
+@with_setup(teardown=reinit_devices)
 def test_state_monitor_get_states():
     G = NeuronGroup(2, '''dv/dt = -v / (10*ms) : 1
                           f = clip(v, 0.1, 0.9) : 1
@@ -361,7 +361,7 @@ def test_state_monitor_get_states():
     assert_array_equal(all_states['N'], mon.N)
 
 @attr('standalone-compatible')
-@with_setup(teardown=restore_device)
+@with_setup(teardown=reinit_devices)
 def test_state_monitor_resize():
     # Test for issue #518 (weave/cython did not resize the Variable object)
     G = NeuronGroup(2, 'v : 1')
@@ -379,7 +379,7 @@ def test_state_monitor_resize():
     assert mon.variables['v'].size == (10, 2)
 
 @attr('standalone-compatible')
-@with_setup(teardown=restore_device)
+@with_setup(teardown=reinit_devices)
 def test_rate_monitor_1():
     G = NeuronGroup(5, 'v : 1', threshold='v>1') # no reset
     G.v = 1.1 # All neurons spike every time step
@@ -392,7 +392,7 @@ def test_rate_monitor_1():
     assert_allclose(rate_mon.rate_, np.asarray(np.ones(10) / defaultclock.dt))
 
 @attr('standalone-compatible')
-@with_setup(teardown=restore_device)
+@with_setup(teardown=reinit_devices)
 def test_rate_monitor_2():
     G = NeuronGroup(10, 'v : 1', threshold='v>1') # no reset
     G.v['i<5'] = 1.1  # Half of the neurons fire every time step
@@ -403,7 +403,7 @@ def test_rate_monitor_2():
     assert_allclose(rate_mon.rate_, 0.5 *np.asarray(np.ones(10) / defaultclock.dt))
 
 @attr('standalone-compatible')
-@with_setup(teardown=restore_device)
+@with_setup(teardown=reinit_devices)
 def test_rate_monitor_get_states():
     G = NeuronGroup(5, 'v : 1', threshold='v>1') # no reset
     G.v = 1.1 # All neurons spike every time step
@@ -417,7 +417,7 @@ def test_rate_monitor_get_states():
 
 
 @attr('standalone-compatible')
-@with_setup(teardown=restore_device)
+@with_setup(teardown=reinit_devices)
 def test_rate_monitor_subgroups():
     old_dt = defaultclock.dt
     defaultclock.dt = 0.01*ms

--- a/brian2/tests/test_network.py
+++ b/brian2/tests/test_network.py
@@ -18,7 +18,7 @@ from brian2 import (Clock, Network, ms, second, BrianObject, defaultclock,
                     PopulationRateMonitor, MagicNetwork, magic_network,
                     PoissonGroup, Hz, collect, store, restore, BrianLogger,
                     start_scope, prefs, profiling_summary, Quantity)
-from brian2.devices.device import restore_device, Device, all_devices, set_device, get_device
+from brian2.devices.device import restore_device, Device, all_devices, set_device, get_device, reset_device
 from brian2.utils.logger import catch_logs
 
 @attr('codegen-independent')
@@ -251,7 +251,7 @@ def test_schedule_warning():
     with catch_logs() as l:
         net.run(0*ms)
         assert len(l) == 1 and l[0][1].endswith('schedule_conflict')
-    set_device(previous_device)
+    reset_device(previous_device)
 
 
 class Preparer(BrianObject):

--- a/brian2/tests/test_network.py
+++ b/brian2/tests/test_network.py
@@ -18,7 +18,7 @@ from brian2 import (Clock, Network, ms, second, BrianObject, defaultclock,
                     PopulationRateMonitor, MagicNetwork, magic_network,
                     PoissonGroup, Hz, collect, store, restore, BrianLogger,
                     start_scope, prefs, profiling_summary, Quantity)
-from brian2.devices.device import restore_device, Device, all_devices, set_device, get_device, reset_device
+from brian2.devices.device import reinit_devices, Device, all_devices, set_device, get_device, reset_device
 from brian2.utils.logger import catch_logs
 
 @attr('codegen-independent')
@@ -205,7 +205,7 @@ def test_network_incorrect_schedule():
     assert_raises(ValueError, setattr, net, 'schedule', ['before_start', 'start'])
 
 @attr('codegen-independent')
-@with_setup(teardown=restore_device)
+@with_setup(teardown=reinit_devices)
 def test_schedule_warning():
     previous_device = get_device()
     from uuid import uuid4

--- a/brian2/tests/test_neurongroup.py
+++ b/brian2/tests/test_neurongroup.py
@@ -10,7 +10,7 @@ from brian2.core.variables import linked_var
 from brian2.core.network import Network
 from brian2.core.preferences import prefs
 from brian2.core.clocks import defaultclock
-from brian2.devices.device import restore_device
+from brian2.devices.device import reinit_devices
 from brian2.equations.equations import Equations
 from brian2.groups.group import get_dtype
 from brian2.groups.neurongroup import NeuronGroup
@@ -122,7 +122,7 @@ def test_variableview_calculations():
 
 
 @attr('standalone-compatible')
-@with_setup(teardown=restore_device)
+@with_setup(teardown=reinit_devices)
 def test_stochastic_variable():
     '''
     Test that a NeuronGroup with a stochastic variable can be simulated. Only
@@ -133,7 +133,7 @@ def test_stochastic_variable():
     run(defaultclock.dt)
 
 @attr('standalone-compatible')
-@with_setup(teardown=restore_device)
+@with_setup(teardown=reinit_devices)
 def test_stochastic_variable_multiplicative():
     '''
     Test that a NeuronGroup with multiplicative noise can be simulated. Only
@@ -165,7 +165,7 @@ def test_scalar_variable():
     net.run(defaultclock.dt)
 
 @attr('standalone-compatible')
-@with_setup(teardown=restore_device)
+@with_setup(teardown=reinit_devices)
 def test_referred_scalar_variable():
     '''
     Test the correct handling of referred scalar variables in subexpressions
@@ -181,7 +181,7 @@ def test_referred_scalar_variable():
     assert_allclose(G2.out[:], np.arange(10)+1)
 
 @attr('standalone-compatible')
-@with_setup(teardown=restore_device)
+@with_setup(teardown=reinit_devices)
 def test_linked_variable_correct():
     '''
     Test correct uses of linked variables.
@@ -223,7 +223,7 @@ def test_linked_variable_incorrect():
     assert_raises(TypeError, lambda: setattr(G3, 'not_linked', linked_var(G1.x)))
 
 @attr('standalone-compatible')
-@with_setup(teardown=restore_device)
+@with_setup(teardown=reinit_devices)
 def test_linked_variable_scalar():
     '''
     Test linked variable from a size 1 group.
@@ -371,7 +371,7 @@ def test_linked_subgroup2():
     assert_equal(G3.y[:], (np.arange(5)+3).repeat(2)*0.1)
 
 @attr('standalone-compatible')
-@with_setup(teardown=restore_device)
+@with_setup(teardown=reinit_devices)
 def test_linked_subexpression():
     '''
     Test a subexpression referring to a linked variable.
@@ -392,7 +392,7 @@ def test_linked_subexpression():
     assert all((all(mon[i+5].I == mon[5].I) for i in xrange(5)))
 
 @attr('standalone-compatible')
-@with_setup(teardown=restore_device)
+@with_setup(teardown=reinit_devices)
 def test_linked_subexpression_2():
     '''
     Test a linked variable referring to a subexpression without indices
@@ -412,7 +412,7 @@ def test_linked_subexpression_2():
     assert all(mon[1].I_l == mon1[1].I)
 
 @attr('standalone-compatible')
-@with_setup(teardown=restore_device)
+@with_setup(teardown=reinit_devices)
 def test_linked_subexpression_3():
     '''
     Test a linked variable referring to a subexpression with indices
@@ -493,7 +493,7 @@ def test_linked_synapses():
     assert_raises(NotImplementedError, lambda: setattr(G2, 'x', linked_var(S, 'w')))
 
 @attr('standalone-compatible')
-@with_setup(teardown=restore_device)
+@with_setup(teardown=reinit_devices)
 def test_linked_var_in_reset():
     G1 = NeuronGroup(3, 'x:1')
     G2 = NeuronGroup(3, '''x_linked : 1 (linked)
@@ -507,7 +507,7 @@ def test_linked_var_in_reset():
     assert_equal(G1.x[:], [0, 1, 0])
 
 @attr('standalone-compatible')
-@with_setup(teardown=restore_device)
+@with_setup(teardown=reinit_devices)
 def test_linked_var_in_reset_size_1():
     G1 = NeuronGroup(1, 'x:1')
     G2 = NeuronGroup(1, '''x_linked : 1 (linked)
@@ -636,7 +636,7 @@ def test_namespace_warnings():
         assert len(l) == 0, 'got %s as warnings' % str(l)
 
 @attr('standalone-compatible')
-@with_setup(teardown=restore_device)
+@with_setup(teardown=reinit_devices)
 def test_threshold_reset():
     '''
     Test that threshold and reset work in the expected way.

--- a/brian2/tests/test_poissongroup.py
+++ b/brian2/tests/test_poissongroup.py
@@ -3,11 +3,11 @@ from nose import with_setup
 from nose.plugins.attrib import attr
 
 from brian2 import *
-from brian2.devices.device import restore_device
+from brian2.devices.device import reinit_devices
 
 
 @attr('standalone-compatible')
-@with_setup(teardown=restore_device)
+@with_setup(teardown=reinit_devices)
 def test_single_rates():
     # Specifying single rates
     P0 = PoissonGroup(10, 0*Hz)
@@ -23,7 +23,7 @@ def test_single_rates():
     assert_equal(spikes_Pfull.count, 2 * np.ones(len(P0)))
 
 @attr('standalone-compatible')
-@with_setup(teardown=restore_device)
+@with_setup(teardown=reinit_devices)
 def test_rate_arrays():
     P = PoissonGroup(2, np.array([0, 1./defaultclock.dt])*Hz)
     spikes = SpikeMonitor(P)
@@ -32,7 +32,7 @@ def test_rate_arrays():
     assert_equal(spikes.count, np.array([0, 2]))
 
 @attr('standalone-compatible')
-@with_setup(teardown=restore_device)
+@with_setup(teardown=reinit_devices)
 def test_propagation():
     # Using a PoissonGroup as a source for Synapses should work as expected
     P = PoissonGroup(2, np.array([0, 1./defaultclock.dt])*Hz)

--- a/brian2/tests/test_poissoninput.py
+++ b/brian2/tests/test_poissoninput.py
@@ -3,10 +3,10 @@ from nose import with_setup
 from nose.plugins.attrib import attr
 
 from brian2 import *
-from brian2.devices.device import restore_device
+from brian2.devices.device import reinit_devices
 
 @attr('standalone-compatible')
-@with_setup(teardown=restore_device)
+@with_setup(teardown=reinit_devices)
 def test_poissoninput():
     # Test extreme cases and do a very basic test of an intermediate case, we
     # don't want tests to be stochastic
@@ -62,5 +62,5 @@ def test_poissoninput_errors():
 
 if __name__ == '__main__':
     # test_poissoninput()
-    # restore_device()
+    # reinit_devices()
     test_poissoninput_errors()

--- a/brian2/tests/test_refractory.py
+++ b/brian2/tests/test_refractory.py
@@ -4,7 +4,7 @@ from numpy.testing.utils import assert_equal, assert_allclose, assert_raises
 
 from brian2 import *
 from brian2.equations.refractory import add_refractoriness
-from brian2.devices.device import restore_device
+from brian2.devices.device import reinit_devices
 
 
 @attr('codegen-independent')
@@ -21,7 +21,7 @@ def test_add_refractoriness():
     assert 'lastspike' in eqs
 
 @attr('standalone-compatible')
-@with_setup(teardown=restore_device)
+@with_setup(teardown=reinit_devices)
 def test_refractoriness_basic():
     G = NeuronGroup(1, '''
                        dv/dt = 100*Hz : 1 (unless refractory)
@@ -46,14 +46,14 @@ def test_refractoriness_basic():
 
 
 @attr('standalone-compatible')
-@with_setup(teardown=restore_device)
+@with_setup(teardown=reinit_devices)
 def test_refractoriness_variables():
     # Try a string evaluating to a quantity an an explicit boolean
     # condition -- all should do the same thing
     for ref_time in ['5*ms', '(t-lastspike) <= 5*ms',
                      'time_since_spike <= 5*ms', 'ref_subexpression',
                      '(t-lastspike) <= ref', 'ref', 'ref_no_unit*ms']:
-        restore_device()
+        reinit_devices()
         G = NeuronGroup(1, '''
                         dv/dt = 100*Hz : 1 (unless refractory)
                         dw/dt = 100*Hz : 1
@@ -85,7 +85,7 @@ def test_refractoriness_variables():
             raise AssertionError('Assertion failed when using %r as refractory argument:\n%s' % (ref_time, ex))
 
 @attr('standalone-compatible')
-@with_setup(teardown=restore_device)
+@with_setup(teardown=reinit_devices)
 def test_refractoriness_threshold_basic():
     G = NeuronGroup(1, '''
     dv/dt = 200*Hz : 1
@@ -99,13 +99,13 @@ def test_refractoriness_threshold_basic():
 
 
 @attr('standalone-compatible')
-@with_setup(teardown=restore_device)
+@with_setup(teardown=reinit_devices)
 def test_refractoriness_threshold():
     # Try a quantity, a string evaluating to a quantity an an explicit boolean
     # condition -- all should do the same thing
     for ref_time in [10*ms, '10*ms', '(t-lastspike) <= 10*ms',
                      '(t-lastspike) <= ref', 'ref', 'ref_no_unit*ms']:
-        restore_device()
+        reinit_devices()
         G = NeuronGroup(1, '''
                         dv/dt = 200*Hz : 1
                         ref : second
@@ -145,7 +145,7 @@ def test_conditional_write_set():
     assert G.variables['w'].conditional_write is None
 
 @attr('standalone-compatible')
-@with_setup(teardown=restore_device)
+@with_setup(teardown=reinit_devices)
 def test_conditional_write_behaviour():
     H = NeuronGroup(1, 'v:1', threshold='v>-1')
 

--- a/brian2/tests/test_refractory.py
+++ b/brian2/tests/test_refractory.py
@@ -53,7 +53,7 @@ def test_refractoriness_variables():
     for ref_time in ['5*ms', '(t-lastspike) <= 5*ms',
                      'time_since_spike <= 5*ms', 'ref_subexpression',
                      '(t-lastspike) <= ref', 'ref', 'ref_no_unit*ms']:
-        device.reinit()
+        restore_device()
         G = NeuronGroup(1, '''
                         dv/dt = 100*Hz : 1 (unless refractory)
                         dw/dt = 100*Hz : 1
@@ -105,7 +105,7 @@ def test_refractoriness_threshold():
     # condition -- all should do the same thing
     for ref_time in [10*ms, '10*ms', '(t-lastspike) <= 10*ms',
                      '(t-lastspike) <= ref', 'ref', 'ref_no_unit*ms']:
-        device.reinit()
+        restore_device()
         G = NeuronGroup(1, '''
                         dv/dt = 200*Hz : 1
                         ref : second

--- a/brian2/tests/test_spatialneuron.py
+++ b/brian2/tests/test_spatialneuron.py
@@ -4,10 +4,10 @@ from numpy.testing.utils import assert_equal, assert_allclose, assert_raises
 from nose import with_setup
 from nose.plugins.attrib import attr
 from brian2 import *
-from brian2.devices.device import restore_device
+from brian2.devices.device import reinit_devices
 
 @attr('codegen-independent')
-@with_setup(teardown=restore_device)
+@with_setup(teardown=reinit_devices)
 def test_construction():
     BrianLogger.suppress_name('resolution_conflict')
     morpho = Soma(diameter=30*um)
@@ -68,7 +68,7 @@ def test_construction():
 
 
 @attr('codegen-independent')
-@with_setup(teardown=restore_device)
+@with_setup(teardown=reinit_devices)
 def test_construction_coordinates():
     # Same as test_construction, but uses coordinates instead of lengths to
     # set up everything
@@ -134,7 +134,7 @@ def test_construction_coordinates():
 
 
 @attr('long')
-@with_setup(teardown=restore_device)
+@with_setup(teardown=reinit_devices)
 def test_infinitecable():
     '''
     Test simulation of an infinite cable vs. theory for current pulse (Green function)
@@ -178,7 +178,7 @@ def test_infinitecable():
     assert_allclose(v[t>0.5*ms],theory[t>0.5*ms],rtol=0.01) # 1% error tolerance (not exact because not infinite cable)
 
 @attr('standalone-compatible')
-@with_setup(teardown=restore_device)
+@with_setup(teardown=reinit_devices)
 def test_finitecable():
     '''
     Test simulation of short cylinder vs. theory for constant current.
@@ -219,7 +219,7 @@ def test_finitecable():
     assert_allclose(v-EL, theory-EL, rtol=0.01)
 
 @attr('standalone-compatible')
-@with_setup(teardown=restore_device)
+@with_setup(teardown=reinit_devices)
 def test_rallpack1():
     '''
     Rallpack 1
@@ -279,7 +279,7 @@ def test_rallpack1():
 
 
 @attr('long', 'standalone-compatible')
-@with_setup(teardown=restore_device)
+@with_setup(teardown=reinit_devices)
 def test_rallpack2():
     '''
     Rallpack 2
@@ -359,7 +359,7 @@ def test_rallpack2():
 
 
 @attr('long', 'standalone-compatible')
-@with_setup(teardown=restore_device)
+@with_setup(teardown=reinit_devices)
 def test_rallpack3():
     '''
     Rallpack 3
@@ -440,7 +440,7 @@ def test_rallpack3():
 
 
 @attr('standalone-compatible')
-@with_setup(teardown=restore_device)
+@with_setup(teardown=reinit_devices)
 def test_rall():
     '''
     Test simulation of a cylinder plus two branches, with diameters according to Rall's formula

--- a/brian2/tests/test_spikegenerator.py
+++ b/brian2/tests/test_spikegenerator.py
@@ -10,7 +10,7 @@ from numpy.testing.utils import assert_raises, assert_equal, assert_allclose
 
 from brian2 import *
 from brian2.devices.cpp_standalone import cpp_standalone_device
-from brian2.devices.device import restore_device
+from brian2.devices.device import restore_device, temporarily_switch_device, reset_device
 
 @attr('standalone-compatible')
 @with_setup(teardown=restore_device)
@@ -294,8 +294,7 @@ def test_spikegenerator_standalone(with_output=False):
     '''
     Basic test for `SpikeGeneratorGroup` in standalone.
     '''
-    previous_device = get_device()
-    set_device('cpp_standalone')
+    temporarily_switch_device('cpp_standalone', build_on_run=False)
     indices = np.array([3, 2, 1, 1, 2, 3, 3, 2, 1])
     times   = np.array([1, 4, 4, 3, 2, 4, 2, 3, 2]) * ms
     SG = SpikeGeneratorGroup(5, indices, times)
@@ -309,7 +308,7 @@ def test_spikegenerator_standalone(with_output=False):
 
     _compare_spikes(5, indices, times, s_mon)
 
-    set_device(previous_device)
+    reset_device()
 
 
 @attr('cpp_standalone', 'standalone-only')
@@ -318,8 +317,7 @@ def test_spikegenerator_standalone_change_spikes(with_output=False):
     '''
     Basic test for `SpikeGeneratorGroup`.
     '''
-    previous_device = get_device()
-    set_device('cpp_standalone')
+    temporarily_switch_device('cpp_standalone', build_on_run=False)
     indices1 = np.array([3, 2, 1, 1, 2, 3, 3, 2, 1])
     times1   = np.array([1, 4, 4, 3, 2, 4, 2, 3, 2]) * ms
     SG = SpikeGeneratorGroup(5, indices1, times1)
@@ -348,7 +346,7 @@ def test_spikegenerator_standalone_change_spikes(with_output=False):
     _compare_spikes(5, indices2, times2, s_mon, start_time=5*ms, end_time=10*ms)
     _compare_spikes(5, indices3, times3, s_mon, start_time=10*ms)
 
-    set_device(previous_device)
+    reset_device()
 
 
 @attr('cpp_standalone', 'standalone-only')
@@ -357,8 +355,7 @@ def test_spikegenerator_standalone_change_period(with_output=False):
     '''
     Basic test for `SpikeGeneratorGroup`.
     '''
-    previous_device = get_device()
-    set_device('cpp_standalone')
+    temporarily_switch_device('cpp_standalone', build_on_run=False)
     indices1 = np.array([3, 2, 1, 1, 2, 3, 3, 2, 1])
     times1   = np.array([1, 4, 4, 3, 2, 4, 2, 3, 2]) * ms
     SG = SpikeGeneratorGroup(5, indices1, times1, period=5*ms)
@@ -382,7 +379,7 @@ def test_spikegenerator_standalone_change_period(with_output=False):
                     s_mon, end_time=10*ms)
     _compare_spikes(5, indices2, times2, s_mon, start_time=10*ms)
 
-    set_device(previous_device)
+    reset_device()
 
 
 if __name__ == '__main__':

--- a/brian2/tests/test_spikegenerator.py
+++ b/brian2/tests/test_spikegenerator.py
@@ -10,10 +10,10 @@ from numpy.testing.utils import assert_raises, assert_equal, assert_allclose
 
 from brian2 import *
 from brian2.devices.cpp_standalone import cpp_standalone_device
-from brian2.devices.device import restore_device, temporarily_switch_device, reset_device
+from brian2.devices.device import reinit_devices, set_device, reset_device
 
 @attr('standalone-compatible')
-@with_setup(teardown=restore_device)
+@with_setup(teardown=reinit_devices)
 def test_spikegenerator_connected():
     '''
     Test that `SpikeGeneratorGroup` connects properly.
@@ -38,7 +38,7 @@ def test_spikegenerator_connected():
     assert all(mon[1].v[(mon.t>=4*ms)] == 2)
 
 @attr('standalone-compatible')
-@with_setup(teardown=restore_device)
+@with_setup(teardown=reinit_devices)
 def test_spikegenerator_basic():
     '''
     Basic test for `SpikeGeneratorGroup`.
@@ -54,7 +54,7 @@ def test_spikegenerator_basic():
         assert generator_spikes == recorded_spikes
 
 @attr('standalone-compatible')
-@with_setup(teardown=restore_device)
+@with_setup(teardown=reinit_devices)
 def test_spikegenerator_basic_sorted():
     '''
     Basic test for `SpikeGeneratorGroup` with already sorted spike events.
@@ -70,7 +70,7 @@ def test_spikegenerator_basic_sorted():
         assert generator_spikes == recorded_spikes
 
 @attr('standalone-compatible')
-@with_setup(teardown=restore_device)
+@with_setup(teardown=reinit_devices)
 def test_spikegenerator_period():
     '''
     Basic test for `SpikeGeneratorGroup`.
@@ -87,7 +87,7 @@ def test_spikegenerator_period():
         assert generator_spikes == recorded_spikes
 
 
-@with_setup(teardown=restore_device)
+@with_setup(teardown=reinit_devices)
 def test_spikegenerator_period_repeat():
     '''
     Basic test for `SpikeGeneratorGroup`.
@@ -203,7 +203,7 @@ def test_spikegenerator_incorrect_period():
     net = Network(SG)
     assert_raises(ValueError, lambda: net.run(0*ms))
 
-@with_setup(teardown=restore_device)
+@with_setup(teardown=reinit_devices)
 def test_spikegenerator_rounding():
     # all spikes should fall into the first time bin
     indices = np.arange(100)
@@ -230,7 +230,7 @@ def test_spikegenerator_rounding():
     assert_equal(mon[0].count, np.ones(10000))
 
 @attr('standalone-compatible', 'long')
-@with_setup(teardown=restore_device)
+@with_setup(teardown=reinit_devices)
 def test_spikegenerator_rounding_long():
     # all spikes should fall in separate bins
     dt = 0.1*ms
@@ -247,7 +247,7 @@ def test_spikegenerator_rounding_long():
     assert all(np.diff(mon[0].count[:]) == 1)
 
 @attr('standalone-compatible', 'long')
-@with_setup(teardown=restore_device)
+@with_setup(teardown=reinit_devices)
 def test_spikegenerator_rounding_period():
     # all spikes should fall in separate bins
     dt = 0.1*ms
@@ -289,12 +289,12 @@ def test_spikegenerator_multiple_spikes_per_bin():
 
 
 @attr('cpp_standalone', 'standalone-only')
-@with_setup(teardown=restore_device)
+@with_setup(teardown=reinit_devices)
 def test_spikegenerator_standalone(with_output=False):
     '''
     Basic test for `SpikeGeneratorGroup` in standalone.
     '''
-    temporarily_switch_device('cpp_standalone', build_on_run=False)
+    set_device('cpp_standalone', build_on_run=False)
     indices = np.array([3, 2, 1, 1, 2, 3, 3, 2, 1])
     times   = np.array([1, 4, 4, 3, 2, 4, 2, 3, 2]) * ms
     SG = SpikeGeneratorGroup(5, indices, times)
@@ -312,12 +312,12 @@ def test_spikegenerator_standalone(with_output=False):
 
 
 @attr('cpp_standalone', 'standalone-only')
-@with_setup(teardown=restore_device)
+@with_setup(teardown=reinit_devices)
 def test_spikegenerator_standalone_change_spikes(with_output=False):
     '''
     Basic test for `SpikeGeneratorGroup`.
     '''
-    temporarily_switch_device('cpp_standalone', build_on_run=False)
+    set_device('cpp_standalone', build_on_run=False)
     indices1 = np.array([3, 2, 1, 1, 2, 3, 3, 2, 1])
     times1   = np.array([1, 4, 4, 3, 2, 4, 2, 3, 2]) * ms
     SG = SpikeGeneratorGroup(5, indices1, times1)
@@ -350,12 +350,12 @@ def test_spikegenerator_standalone_change_spikes(with_output=False):
 
 
 @attr('cpp_standalone', 'standalone-only')
-@with_setup(teardown=restore_device)
+@with_setup(teardown=reinit_devices)
 def test_spikegenerator_standalone_change_period(with_output=False):
     '''
     Basic test for `SpikeGeneratorGroup`.
     '''
-    temporarily_switch_device('cpp_standalone', build_on_run=False)
+    set_device('cpp_standalone', build_on_run=False)
     indices1 = np.array([3, 2, 1, 1, 2, 3, 3, 2, 1])
     times1   = np.array([1, 4, 4, 3, 2, 4, 2, 3, 2]) * ms
     SG = SpikeGeneratorGroup(5, indices1, times1, period=5*ms)
@@ -407,6 +407,6 @@ if __name__ == '__main__':
                 test_spikegenerator_standalone_change_period
              ]:
         t(with_output=True)
-        restore_device()
+        reinit_devices()
 
     print 'Tests took', time.time()-start

--- a/brian2/tests/test_stateupdaters.py
+++ b/brian2/tests/test_stateupdaters.py
@@ -8,7 +8,7 @@ from nose import with_setup
 from brian2 import *
 from brian2.utils.logger import catch_logs
 from brian2.core.variables import ArrayVariable, Variable, Constant
-from brian2.devices.device import restore_device
+from brian2.devices.device import reinit_devices
 from brian2.stateupdaters.base import UnsupportedEquationsException
 
 @attr('codegen-independent')
@@ -501,7 +501,7 @@ def test_determination():
         assert "'heun'" in logs[0][2]
 
 @attr('standalone-compatible')
-@with_setup(teardown=restore_device)
+@with_setup(teardown=reinit_devices)
 def test_subexpressions_basic():
     '''
     Make sure that the integration of a (non-stochastic) differential equation

--- a/brian2/tests/test_subgroup.py
+++ b/brian2/tests/test_subgroup.py
@@ -4,7 +4,7 @@ from numpy.testing.utils import assert_raises, assert_equal, assert_allclose
 
 from brian2 import *
 from brian2.utils.logger import catch_logs
-from brian2.devices.device import restore_device
+from brian2.devices.device import reinit_devices
 
 @attr('codegen-independent')
 def test_str_repr():
@@ -57,7 +57,7 @@ def test_state_variables():
     assert_equal(G.v[SG], SG.v[:])
 
 @attr('standalone-compatible')
-@with_setup(teardown=restore_device)
+@with_setup(teardown=reinit_devices)
 def test_state_variables_simple():
     G = NeuronGroup(10, '''a : 1
                            b : 1
@@ -123,7 +123,7 @@ def test_state_variables_group_as_index_problematic():
                         for entry in l])
 
 @attr('standalone-compatible')
-@with_setup(teardown=restore_device)
+@with_setup(teardown=reinit_devices)
 def test_state_monitor():
     G = NeuronGroup(10, 'v : volt')
     G.v = np.arange(10) * volt
@@ -345,7 +345,7 @@ def test_subexpression_no_references():
     assert_equal(S3.x[:], np.arange(5)*2+1)
 
 @attr('standalone-compatible')
-@with_setup(teardown=restore_device)
+@with_setup(teardown=reinit_devices)
 def test_synaptic_propagation():
     G1 = NeuronGroup(10, 'v:1', threshold='v>1', reset='v=0')
     G1.v['i%2==1'] = 1.1 # odd numbers should spike
@@ -361,7 +361,7 @@ def test_synaptic_propagation():
     assert_equal(np.asarray(G2.v).flatten(), expected)
 
 @attr('standalone-compatible')
-@with_setup(teardown=restore_device)
+@with_setup(teardown=reinit_devices)
 def test_synaptic_propagation_2():
     # This tests for the bug in github issue #461
     source = NeuronGroup(100, '', threshold='True')
@@ -372,7 +372,7 @@ def test_synaptic_propagation_2():
     assert target.v[0] == 1.0
 
 @attr('standalone-compatible')
-@with_setup(teardown=restore_device)
+@with_setup(teardown=reinit_devices)
 def test_spike_monitor():
     G = NeuronGroup(10, 'v:1', threshold='v>1', reset='v=0')
     G.v[0] = 1.1
@@ -414,7 +414,7 @@ def test_no_reference_1():
     assert_equal(G[:5].v[:], G.v[:5])
 
 @attr('standalone-compatible')
-@with_setup(teardown=restore_device)
+@with_setup(teardown=reinit_devices)
 def test_no_reference_2():
     '''
     Using subgroups without keeping an explicit reference. Monitors
@@ -431,7 +431,7 @@ def test_no_reference_2():
     assert_equal(rate_mon.rate[:], np.array([0.5, 0])/defaultclock.dt)
 
 @attr('standalone-compatible')
-@with_setup(teardown=restore_device)
+@with_setup(teardown=reinit_devices)
 def test_no_reference_3():
     '''
     Using subgroups without keeping an explicit reference. Monitors
@@ -443,7 +443,7 @@ def test_no_reference_3():
     assert_equal(G.v[:], np.array([0, 1]))
 
 @attr('standalone-compatible')
-@with_setup(teardown=restore_device)
+@with_setup(teardown=reinit_devices)
 def test_no_reference_4():
     '''
     Using subgroups without keeping an explicit reference. Synapses

--- a/brian2/tests/test_synapses.py
+++ b/brian2/tests/test_synapses.py
@@ -12,7 +12,7 @@ from brian2.core.variables import variables_by_owner, ArrayVariable
 from brian2.core.functions import DEFAULT_FUNCTIONS
 from brian2.utils.logger import catch_logs
 from brian2.utils.stringtools import get_identifiers, word_substitute, indent, deindent
-from brian2.devices.device import restore_device, all_devices, get_device
+from brian2.devices.device import restore_device, all_devices, get_device, temporarily_switch_device, reset_device
 from brian2.codegen.permutation_analysis import check_for_order_independence, OrderDependenceError
 
 
@@ -146,8 +146,7 @@ def test_connection_arrays():
 @attr('cpp_standalone', 'standalone-only')
 @with_setup(teardown=restore_device)
 def test_connection_array_standalone():
-    previous_device = get_device()
-    set_device('cpp_standalone')
+    temporarily_switch_device('cpp_standalone', build_on_run=False)
     # use a clock with 1s timesteps to avoid rounding issues
     G1 = SpikeGeneratorGroup(4, np.array([0, 1, 2, 3]),
                              [0, 1, 2, 3]*second, dt=1*second)
@@ -168,7 +167,7 @@ def test_connection_array_standalone():
                          [0, 0, 0, 1, 1],
                          [0, 0, 0, 0, 0]], dtype=np.float64)
     assert_equal(mon.v, expected)
-    set_device(previous_device)
+    reset_device()
 
 
 def test_connection_string_deterministic_basic():

--- a/brian2/tests/test_thresholder.py
+++ b/brian2/tests/test_thresholder.py
@@ -3,10 +3,10 @@ from nose.plugins.attrib import attr
 from numpy.testing import assert_equal
 
 from brian2 import *
-from brian2.devices.device import restore_device
+from brian2.devices.device import reinit_devices
 
 @attr('standalone-compatible')
-@with_setup(teardown=restore_device)
+@with_setup(teardown=reinit_devices)
 def test_simple_threshold():
     G = NeuronGroup(4, 'v : 1', threshold='v > 1')
     G.v = [1.5, 0, 3, -1]
@@ -15,7 +15,7 @@ def test_simple_threshold():
     assert_equal(s_mon.count, np.array([1, 0, 1, 0]))
 
 @attr('standalone-compatible')
-@with_setup(teardown=restore_device)
+@with_setup(teardown=reinit_devices)
 def test_scalar_threshold():
     c = 2
     G = NeuronGroup(4, '', threshold='c > 1')

--- a/brian2/tests/test_timedarray.py
+++ b/brian2/tests/test_timedarray.py
@@ -4,7 +4,7 @@ from nose import with_setup
 from nose.plugins.attrib import attr
 
 from brian2 import *
-from brian2.devices.device import restore_device
+from brian2.devices.device import reinit_devices
 
 @attr('codegen-independent')
 def test_timedarray_direct_use():
@@ -27,7 +27,7 @@ def test_timedarray_direct_use():
     assert_equal(ta2d(15*ms, [0, 1, 2]), [9, 10, 11]*amp)
 
 @attr('standalone-compatible')
-@with_setup(teardown=restore_device)
+@with_setup(teardown=reinit_devices)
 def test_timedarray_semantics():
     # Make sure that timed arrays are interpreted as specifying the values
     # between t and t+dt (not between t-dt/2 and t+dt/2 as in Brian1)
@@ -39,7 +39,7 @@ def test_timedarray_semantics():
     assert_equal(mon[0].value, ta(mon.t))
 
 @attr('standalone-compatible')
-@with_setup(teardown=restore_device)
+@with_setup(teardown=reinit_devices)
 def test_timedarray_no_units():
     ta = TimedArray(np.arange(10), dt=0.1*ms)
     G = NeuronGroup(1, 'value = ta(t) + 1: 1', dt=0.1*ms)
@@ -48,7 +48,7 @@ def test_timedarray_no_units():
     assert_equal(mon[0].value_, np.clip(np.arange(len(mon[0].t)), 0, 9) + 1)
 
 @attr('standalone-compatible')
-@with_setup(teardown=restore_device)
+@with_setup(teardown=reinit_devices)
 def test_timedarray_with_units():
     ta = TimedArray(np.arange(10)*amp, dt=0.1*ms)
     G = NeuronGroup(1, 'value = ta(t) + 2*nA: amp', dt=0.1*ms)
@@ -57,7 +57,7 @@ def test_timedarray_with_units():
     assert_equal(mon[0].value, np.clip(np.arange(len(mon[0].t)), 0, 9)*amp + 2*nA)
 
 @attr('standalone-compatible')
-@with_setup(teardown=restore_device)
+@with_setup(teardown=reinit_devices)
 def test_timedarray_2d():
     # 4 time steps, 3 neurons
     ta2d = TimedArray(np.arange(12).reshape(4, 3), dt=0.1*ms)
@@ -69,7 +69,7 @@ def test_timedarray_2d():
     assert_equal(mon[2].value_, np.array([2, 5, 8, 11, 11]) + 1)
 
 @attr('standalone-compatible')
-@with_setup(teardown=restore_device)
+@with_setup(teardown=reinit_devices)
 def test_timedarray_no_upsampling():
     # Test a TimedArray where no upsampling is necessary because the monitor's
     # dt is bigger than the TimedArray's
@@ -80,7 +80,7 @@ def test_timedarray_no_upsampling():
     assert_equal(mon[0].value, [0, 9, 9])
 
 #@attr('standalone-compatible')  # see FIXME comment below
-@with_setup(teardown=restore_device)
+@with_setup(teardown=reinit_devices)
 def test_long_timedarray():
     '''
     Use a very long timedarray (with a big dt), where the upsampling can lead

--- a/docs_sphinx/user/devices.rst
+++ b/docs_sphinx/user/devices.rst
@@ -12,19 +12,36 @@ propagation rules (such as STDP).
 C++ standalone
 --------------
 
-To use the C++ standalone mode, make the following changes to your script:
+To use the C++ standalone mode, you only have to make very small changes to your script. The exact change depends on
+whether your script has only a single `run` (or `Network.run`) call, or several of them:
 
-1. At the beginning of the script, i.e. after the import statements, add::
+Single run call
+~~~~~~~~~~~~~~~
+At the beginning of the script, i.e. after the import statements, add::
 
     set_device('cpp_standalone')
 
-2. After ``run(duration)`` in your script, add::
+The `CPPStandaloneDevice.build` function will be automatically called with default arguments right after the `run`
+call. If you need non-standard arguments then you can specify them as part of the `set_device` call::
+
+    set_device('cpp_standalone', directory='my_directory', debug=True)
+
+Multiple run call
+~~~~~~~~~~~~~~~~~
+At the beginning of the script, i.e. after the import statements, add::
+
+    set_device('cpp_standalone', build_on_run=False)
+
+After the last `run` call, call `device.build` explicitly::
 
     device.build(directory='output', compile=True, run=True, debug=False)
 
-The `~CPPStandaloneDevice.build` function has several arguments to specify the output directory, whether or not to compile and run
-the project after creating it (using ``gcc``) and whether or not to compile it with debugging support or not.
+The `~CPPStandaloneDevice.build` function has several arguments to specify the output directory, whether or not to
+compile and run the project after creating it (using ``gcc``) and whether or not to compile it with debugging support
+or not.
 
+Limitations
+~~~~~~~~~~~
 Not all features of Brian will work with C++ standalone, in particular Python based network operations and
 some array based syntax such as ``S.w[0, :] = ...`` will not work. If possible, rewrite these using string
 based syntax and they should work. Also note that since the Python code actually runs as normal, code that does
@@ -44,7 +61,10 @@ C++ source code and modifying it, or by inserting code directly into the main lo
     cout << "Testing direct insertion of code." << endl;
     ''')
 
-After a simulation has been run (using the ``run`` keyword in the `Device.build` call), state variables and
+Variables
+~~~~~~~~~
+After a simulation has been run (after the `run` call if `set_device` has been called with ``build_on_run`` set to
+``True`` or after the `Device.build` call with ``run`` set to ``True``), state variables and
 monitored variables can be accessed using standard syntax, with a few exceptions (e.g. string expressions for indexing).
 
 .. _openmp:


### PR DESCRIPTION
This fixes #512: `set_device` now has a `build_on_run` argument which defaults to `True` and the overwritten `network_run` function in the standalone device now calls `build` directly if it has not been set to `False`. For quite a few scripts, this now means that a single `set_device('cpp_standalone')` line is enough to switch to the standalone device. All other arguments that `set_device` gets will be stored in `Device.build_options` and will be propagated to `Device.build` when it is automatically called (so you can do something like `set_device('cpp_standalone', directory='my_dir', debug=True)`.

For testing, this also means that the `standalone-compatible` tests now no longer use a "simple" device (`CPPStandaloneSimpleDevice` does not exist anymore), but instead use this mechanism. For this to work, the device also has to support the new feature that you can set `directory=None` and it will create a temporary directory for the build. I also added a new function `reset_device`, which can be used without argument to reset to the previously used device. This is nice for testing and avoids explicitly storing `previous_device = get_device()` in the tests.
I tried to document everything a bit, from my side this is good to go.