### PR TITLE
[MRG] Make clip not use fused types (fixes #609)

### DIFF
--- a/brian2/codegen/generators/cython_generator.py
+++ b/brian2/codegen/generators/cython_generator.py
@@ -355,12 +355,7 @@ DEFAULT_FUNCTIONS['sign'].implementations.add_implementation(CythonCodeGenerator
                                                              name='_sign')
 
 clip_code = '''
-ctypedef fused _float_or_double:
-    float
-    double
-
-cdef _float_or_double clip(_float_or_double x, _float_or_double low,
-                           _float_or_double high):
+cdef double clip(double x, double low, double high):
     if x<low:
         return low
     if x>high:


### PR DESCRIPTION
For some reason this code wasn't working, but we never actually use floats anywhere so for the moment it's fine to just have doubles I think.

Tiny change ready to merge as soon as tests pass I think.