### PR TITLE
[MRG] Customise Cython cache dir (fixes #599)

### DIFF
--- a/brian2/codegen/runtime/cython_rt/cython_rt.py
+++ b/brian2/codegen/runtime/cython_rt/cython_rt.py
@@ -32,7 +32,17 @@ prefs.register_preferences(
         Whether to use a lock file to prevent simultaneous write access
         to cython .pyx and .so files.
         '''
-        )
+        ),
+    cache_dir = BrianPreference(
+        default=None,
+        validator=lambda x: x is None or isinstance(x, basestring),
+        docs='''
+        Location of the cache directory for Cython files. By default,
+        will be stored in a ``brian_extensions`` subdirectory
+        where Cython inline stores its temporary files
+        (the result of ``get_cython_cache_dir()``).
+        '''
+        ),
     )
 
 

--- a/brian2/codegen/runtime/cython_rt/extension_manager.py
+++ b/brian2/codegen/runtime/cython_rt/extension_manager.py
@@ -26,6 +26,7 @@ try:
     import Cython
     import Cython.Compiler as Cython_Compiler
     import Cython.Build as Cython_Build
+    from Cython.Utils import get_cython_cache_dir
 except ImportError:
     Cython = None
 
@@ -60,7 +61,11 @@ class CythonExtensionManager(object):
 
         code = deindent(code)
 
-        lib_dir = os.path.expanduser('~/.brian/cython_extensions')
+        lib_dir = prefs.codegen.runtime.cython.cache_dir
+        if lib_dir is None:
+            lib_dir = os.path.join(get_cython_cache_dir(), 'brian_extensions')
+        if '~' in lib_dir:
+            lib_dir = os.path.expanduser(lib_dir)
         try:
             os.makedirs(lib_dir)
         except OSError:

--- a/brian2/codegen/runtime/cython_rt/extension_manager.py
+++ b/brian2/codegen/runtime/cython_rt/extension_manager.py
@@ -70,7 +70,8 @@ class CythonExtensionManager(object):
             os.makedirs(lib_dir)
         except OSError:
             if not os.path.exists(lib_dir):
-                raise
+                raise IOError("Couldn't create Cython cache directory '%s', try setting the "
+                              "cache directly with prefs.codegen.runtime.cython.cache_dir." % lib_dir)
 
         key = code, sys.version_info, sys.executable, Cython.__version__
             


### PR DESCRIPTION
Changed it so that by default it uses the same cache directory that Cython's inline uses, but you can override with your own preference.