### PR TITLE
[MRG] Standalone error for manual build with `build_on_run`

### DIFF
--- a/brian2/devices/cpp_standalone/device.py
+++ b/brian2/devices/cpp_standalone/device.py
@@ -839,7 +839,7 @@ class CPPStandaloneDevice(Device):
         direct_call : bool, optional
             Whether this function was called directly. Is used internally to
             distinguish an automatic build due to the ``build_on_run`` option
-            from a manual ``device.buil`` call.
+            from a manual ``device.build`` call.
         '''
         if self.build_on_run and direct_call:
             raise RuntimeError('You used set_device with build_on_run=True '

--- a/brian2/devices/cpp_standalone/device.py
+++ b/brian2/devices/cpp_standalone/device.py
@@ -805,7 +805,7 @@ class CPPStandaloneDevice(Device):
     def build(self, directory='output',
               compile=True, run=True, debug=False, clean=True,
               with_output=True, additional_source_files=None,
-              run_args=None, **kwds):
+              run_args=None, direct_call=True, **kwds):
         '''
         Build the project
 
@@ -836,7 +836,19 @@ class CPPStandaloneDevice(Device):
             ``True``.
         additional_source_files : list of str, optional
             A list of additional ``.cpp`` files to include in the build.
+        direct_call : bool, optional
+            Whether this function was called directly. Is used internally to
+            distinguish an automatic build due to the ``build_on_run`` option
+            from a manual ``device.buil`` call.
         '''
+        if self.build_on_run and direct_call:
+            raise RuntimeError('You used set_device with build_on_run=True '
+                               '(the default option), which will automatically '
+                               'build the simulation at the first encountered '
+                               'run call - do not call device.build manually '
+                               'in this case. If you want to call it manually, '
+                               'e.g. because you have multiple run calls, use '
+                               'set_device with build_on_run=False.')
         renames = {'project_dir': 'directory',
                    'compile_project': 'compile',
                    'run_project': 'run'}
@@ -1031,7 +1043,7 @@ class CPPStandaloneDevice(Device):
                                    'build_on_run=False and an explicit '
                                    'device.build call to use multiple run '
                                    'statements with this device.')
-            self.build(**self.build_options)
+            self.build(direct_call=False, **self.build_options)
 
     def network_store(self, net, name='default'):
         raise NotImplementedError(('The store/restore mechanism is not '

--- a/brian2/tests/test_functions.py
+++ b/brian2/tests/test_functions.py
@@ -133,7 +133,6 @@ def test_user_defined_function():
     G.variable = test_array
     mon = StateMonitor(G, 'func', record=True)
     run(default_dt)
-    device.build(run=True, compile=True)
     assert_equal(np.sin(test_array), mon.func_.flatten())
 
 

--- a/examples/standalone/STDP_standalone.py
+++ b/examples/standalone/STDP_standalone.py
@@ -8,7 +8,7 @@ C++ project in the directory ``STDP_standalone``.
 '''
 from brian2 import *
 
-set_device('cpp_standalone')
+set_device('cpp_standalone', directory='STDP_standalone')
 
 N = 1000
 taum = 10*ms
@@ -50,8 +50,6 @@ s_mon = SpikeMonitor(input)
 r_mon = PopulationRateMonitor(input)
 
 run(100*second, report='text')
-device.build(directory='STDP_standalone', compile=True,
-             run=True, debug=True, with_output=False)
 
 subplot(311)
 plot(S.w / gmax, '.k')

--- a/examples/standalone/cuba_openmp.py
+++ b/examples/standalone/cuba_openmp.py
@@ -4,7 +4,7 @@ Run the ``cuba.py`` example with OpenMP threads.
 """
 from brian2 import *
 
-set_device('cpp_standalone')
+set_device('cpp_standalone', directory='CUBA')
 prefs.devices.cpp_standalone.openmp_threads = 4
 
 taum = 20*ms
@@ -35,7 +35,6 @@ Ci.connect('i>=3200', p=0.02)
 s_mon = SpikeMonitor(P)
 
 run(1 * second)
-device.build(directory='CUBA', compile=True, run=True, debug=True)
 
 plot(s_mon.t/ms, s_mon.i, '.k')
 xlabel('Time (ms)')


### PR DESCRIPTION
The reason the standalone examples were failing was that they used the new `build_on_run` mechanism (which we switched on by default) as well as an explicit `device.build` call. I fixed this (also in one test) and made `CPPStandaloneDevice.build` raise an error for this situation (which can occur when copying older examples or upgrading code to the new version) -- this should make it *much* clearer what the actual problem is.