### PR TITLE
[MRG] Make examples run under Python3

### DIFF
--- a/dev/tools/run_examples.py
+++ b/dev/tools/run_examples.py
@@ -45,7 +45,7 @@ try:
     prefs.codegen.target = '{target}'
     # add the files directory to the path so that it can do relative imports
     sys.path.append(os.path.dirname(os.path.realpath(r'{fname}')))
-    execfile(r'{fname}')
+    exec(compile(open(r'{fname}', "rb").read(), r'{fname}', 'exec'))
     if '{target}'=='numpy':
         for fignum in _mpl.pyplot.get_fignums():
             fname = r'{fname}'
@@ -53,12 +53,12 @@ try:
             fname = fname.replace('/', '.').replace('\\\\', '.')
             fname = fname.replace('.py', '.%d.png' % fignum)
             fname = '../../docs_sphinx/resources/examples_images/'+fname
-            print fname
+            print(fname)
             ensure_directory_of_file(fname)
             _mpl.pyplot.figure(fignum).savefig(fname)
-except Exception, ex:
+except Exception as ex:
     traceback.print_exc(file=sys.stdout)
-    f = open(r'{tempfname}', 'w')
+    f = open(r'{tempfname}', 'wb')
     pickle.dump(ex, f, -1)
     f.close()
 """.format(fname=self.filename,
@@ -79,7 +79,7 @@ except Exception, ex:
 
         # Re-raise any exception that occured
         if os.path.exists(tempfilename):
-            f = open(tempfilename, 'r')
+            f = open(tempfilename, 'rb')
             ex = pickle.load(f)
             self.successful = False
             raise ex

--- a/examples/adaptive_threshold.py
+++ b/examples/adaptive_threshold.py
@@ -24,7 +24,6 @@ Mvt = StateMonitor(IF, 'vt', record=True)
 # Record the value of v when the threshold is crossed
 M_crossings = SpikeMonitor(IF, variables='v')
 run(2*second, report='text')
-# print M_crossings.codeobj.code
 
 subplot(1, 2, 1)
 plot(Mv.t / ms, Mv[0].v / mV)

--- a/examples/advanced/stochastic_odes.py
+++ b/examples/advanced/stochastic_odes.py
@@ -59,7 +59,7 @@ rows = floor(sqrt(len(dts)))
 cols = ceil(1.0 * len(dts) / rows)
 errors = dict([(method, zeros(len(dts))) for method in methods])
 for dt_idx, dt in enumerate(dts):
-    print 'dt: ', dt
+    print('dt:', dt)
     trajectories = {}
     # Test the numerical methods
     for method in methods:

--- a/examples/advanced/stochastic_odes.py
+++ b/examples/advanced/stochastic_odes.py
@@ -59,7 +59,7 @@ rows = floor(sqrt(len(dts)))
 cols = ceil(1.0 * len(dts) / rows)
 errors = dict([(method, zeros(len(dts))) for method in methods])
 for dt_idx, dt in enumerate(dts):
-    print('dt:', dt)
+    print('dt: %s' % dt)
     trajectories = {}
     # Test the numerical methods
     for method in methods:

--- a/examples/compartmental/cylinder.py
+++ b/examples/compartmental/cylinder.py
@@ -25,7 +25,7 @@ neuron = SpatialNeuron(morphology=morpho, model=eqs, Cm=Cm, Ri=Ri)
 neuron.v = EL
 
 la = neuron.space_constant[0]
-print "Electrotonic length", la
+print("Electrotonic length", la)
 
 neuron.I[0] = 0.02*nA # injecting at the left end
 run(100*ms, report='text')

--- a/examples/compartmental/cylinder.py
+++ b/examples/compartmental/cylinder.py
@@ -25,7 +25,7 @@ neuron = SpatialNeuron(morphology=morpho, model=eqs, Cm=Cm, Ri=Ri)
 neuron.v = EL
 
 la = neuron.space_constant[0]
-print("Electrotonic length", la)
+print("Electrotonic length: %s" % la)
 
 neuron.I[0] = 0.02*nA # injecting at the left end
 run(100*ms, report='text')

--- a/examples/compartmental/hh_with_spikes.py
+++ b/examples/compartmental/hh_with_spikes.py
@@ -55,7 +55,7 @@ run(50*ms, report='text')
 # Calculation of velocity
 slope, intercept, r_value, p_value, std_err = stats.linregress(spikes.t/second,
                                                 neuron.distance[spikes.i]/meter)
-print("Velocity = ", slope, "m/s")
+print("Velocity = %.2f m/s" % slope)
 
 subplot(211)
 for i in range(10):

--- a/examples/compartmental/hh_with_spikes.py
+++ b/examples/compartmental/hh_with_spikes.py
@@ -55,7 +55,7 @@ run(50*ms, report='text')
 # Calculation of velocity
 slope, intercept, r_value, p_value, std_err = stats.linregress(spikes.t/second,
                                                 neuron.distance[spikes.i]/meter)
-print "Velocity = ", slope, "m/s"
+print("Velocity = ", slope, "m/s")
 
 subplot(211)
 for i in range(10):

--- a/examples/compartmental/hodgkin_huxley_1952.py
+++ b/examples/compartmental/hodgkin_huxley_1952.py
@@ -46,7 +46,7 @@ neuron.I[0] = 1*uA  # current injection at one end
 run(3*ms)
 neuron.I = 0*amp
 run(100*ms, report='text')
-for i in xrange(75, 125, 1):
+for i in range(75, 125, 1):
     plot(cumsum(neuron.length)/cm, i+(1./60)*M.v[:, i*5]/mV, 'k')
 yticks([])
 ylabel('Time [major] v (mV) [minor]')

--- a/examples/compartmental/infinite_cable.py
+++ b/examples/compartmental/infinite_cable.py
@@ -24,9 +24,9 @@ neuron = SpatialNeuron(morphology=morpho, model=eqs, Cm=Cm, Ri=Ri)
 neuron.v = EL
 
 taum = Cm  /gL  # membrane time constant
-print "Time constant", taum
+print("Time constant", taum)
 la = neuron.space_constant[0]
-print "Characteristic length", la
+print("Characteristic length", la)
 
 # Monitors
 mon = StateMonitor(neuron, 'v', record=range(0, N/2, 20))

--- a/examples/compartmental/infinite_cable.py
+++ b/examples/compartmental/infinite_cable.py
@@ -29,9 +29,9 @@ la = neuron.space_constant[0]
 print("Characteristic length", la)
 
 # Monitors
-mon = StateMonitor(neuron, 'v', record=range(0, N/2, 20))
+mon = StateMonitor(neuron, 'v', record=range(0, N//2, 20))
 
-neuron.I[len(neuron) / 2] = 1*nA  # injecting in the middle
+neuron.I[len(neuron) // 2] = 1*nA  # injecting in the middle
 run(0.02*ms)
 neuron.I = 0*amp
 run(10*ms, report='text')
@@ -39,7 +39,7 @@ run(10*ms, report='text')
 t = mon.t
 plot(t/ms, mon.v.T/mV, 'k')
 # Theory (incorrect near cable ends)
-for i in range(0, len(neuron)/2, 20):
+for i in range(0, len(neuron)//2, 20):
     x = (len(neuron)/2 - i) * morpho.length[0]*meter
     theory = (1/(la*Cm*pi*diameter) * sqrt(taum / (4*pi*(t + defaultclock.dt))) *
               exp(-(t+defaultclock.dt)/taum -

--- a/examples/compartmental/infinite_cable.py
+++ b/examples/compartmental/infinite_cable.py
@@ -24,9 +24,9 @@ neuron = SpatialNeuron(morphology=morpho, model=eqs, Cm=Cm, Ri=Ri)
 neuron.v = EL
 
 taum = Cm  /gL  # membrane time constant
-print("Time constant", taum)
+print("Time constant: %s" % taum)
 la = neuron.space_constant[0]
-print("Characteristic length", la)
+print("Characteristic length: %s" % la)
 
 # Monitors
 mon = StateMonitor(neuron, 'v', record=range(0, N//2, 20))

--- a/examples/compartmental/morphotest.py
+++ b/examples/compartmental/morphotest.py
@@ -17,7 +17,7 @@ neuron = SpatialNeuron(morphology=morpho, model=eqs,
                        Cm=1*uF/cm**2, Ri=100*ohm*cm)
 neuron.v = arange(0, 13)*volt
 
-print neuron.v
-print neuron.L.v
-print neuron.LL.v
-print neuron.L.main.v
+print(neuron.v)
+print(neuron.L.v)
+print(neuron.LL.v)
+print(neuron.L.main.v)

--- a/examples/frompapers/Brette_2012/Fig1.py
+++ b/examples/frompapers/Brette_2012/Fig1.py
@@ -31,7 +31,7 @@ neuron = SpatialNeuron(morphology=morpho, model=eqs, Cm=Cm, Ri=Ri)
 compartment = morpho.axon[location]
 neuron.v = EL
 neuron.gclamp[0] = gL*500
-neuron.gNa[compartment] = gNa/neuron.area[compartment]
+neuron.gNa[compartment] = gNa_0/neuron.area[compartment]
 
 # Monitors
 mon = StateMonitor(neuron, ['v', 'vc', 'm'], record=True)

--- a/examples/frompapers/Brette_2012/Fig3AB.py
+++ b/examples/frompapers/Brette_2012/Fig3AB.py
@@ -31,7 +31,7 @@ neuron = SpatialNeuron(morphology=morpho, model=eqs, Cm=Cm, Ri=Ri,
 
 compartment = morpho.axon[location]
 neuron.v = EL
-neuron.gNa[compartment] = gNa/neuron.area[compartment]
+neuron.gNa[compartment] = gNa_0/neuron.area[compartment]
 M = StateMonitor(neuron, ['v', 'm'], record=True)
 
 run(20*ms, report='text')

--- a/examples/frompapers/Brette_2012/Fig3CF.py
+++ b/examples/frompapers/Brette_2012/Fig3CF.py
@@ -36,8 +36,8 @@ neuron = SpatialNeuron(morphology=morpho, model=eqs, Cm=Cm, Ri=Ri,
 compartment16 = morpho.axon[location16]
 compartment12 = morpho.axon[location12]
 neuron.v = EL
-neuron.gNa[compartment16] = gNa/neuron.area[compartment16]
-neuron.gNa2[compartment12] = 20*gNa/neuron.area[compartment12]
+neuron.gNa[compartment16] = gNa_0/neuron.area[compartment16]
+neuron.gNa2[compartment12] = 20*gNa_0/neuron.area[compartment12]
 # Monitors
 M = StateMonitor(neuron, ['v', 'm', 'm2'], record=True)
 

--- a/examples/frompapers/Brette_2012/Fig4.py
+++ b/examples/frompapers/Brette_2012/Fig4.py
@@ -47,7 +47,7 @@ else:
     profile = ones(len(compartments))
 profile = profile / sum(profile)  # normalization
 
-neuron.gNa[compartments] = gNa * profile / neuron.area[compartments]
+neuron.gNa[compartments] = gNa_0 * profile / neuron.area[compartments]
 
 # Monitors
 mon = StateMonitor(neuron, 'v', record=True)

--- a/examples/frompapers/Brette_2012/Fig5A.py
+++ b/examples/frompapers/Brette_2012/Fig5A.py
@@ -40,7 +40,7 @@ neuron = SpatialNeuron(morphology=morpho, model=eqs, Cm=Cm, Ri=Ri,
                        refractory=5*ms)
 neuron.v = EL
 neuron.gLx[0] = gL
-neuron.gNa[compartment] = gNa / neuron.area[compartment]
+neuron.gNa[compartment] = gNa_0 / neuron.area[compartment]
 
 # Reset the entire neuron when there is a spike
 reset = Synapses(neuron, neuron, pre='v = EL')

--- a/examples/frompapers/Brette_2012/params.py
+++ b/examples/frompapers/Brette_2012/params.py
@@ -14,5 +14,5 @@ Ri = 150*ohm*cm
 ENa = 60*mV
 ka = 6*mV
 va = -40*mV
-gNa = gL * 2*S
+gNa_0 = gL * 2*S
 taum = 0.1*ms

--- a/examples/frompapers/Clopath_et_al_2010_no_homeostasis.py
+++ b/examples/frompapers/Clopath_et_al_2010_no_homeostasis.py
@@ -123,7 +123,7 @@ for jj, rate in enumerate(rate_array):
 
     # Calculate interval between pairs
     pair_interval = 1./rate - 10*ms
-    print('Starting simulations for '+str(rate))
+    print('Starting simulations for %s' % rate)
 
     # Initial values
     Nrns.v = V_rest
@@ -142,7 +142,7 @@ for jj, rate in enumerate(rate_array):
         Nrns.v[1] = V_thresh + 1*mV
         # run
         run(pair_interval)
-        print('Pair '+str(ii+1)+' out of '+str(reps))
+        print('Pair %d out of %d' % (ii+1, reps))
 
     #store weight changes
     weight_result[0, jj] = 100.*Syn.w_ampa[0]/init_weight

--- a/examples/frompapers/Sturzl_et_al_2000.py
+++ b/examples/frompapers/Sturzl_et_al_2000.py
@@ -23,13 +23,13 @@ gamma = (22.5 + 45 * arange(8)) * degree  # leg angle
 delay = R / vr * (1 - cos(phi - gamma))   # wave delay
 
 # Wave (vector w)
-t = arange(int(duration / defaultclock.dt) + 1) * defaultclock.dt
+time = arange(int(duration / defaultclock.dt) + 1) * defaultclock.dt
 Dtot = 0.
 w = 0.
 for f in arange(150, 451)*Hz:
     D = exp(-(f/Hz - 300) ** 2 / (2 * (50 ** 2)))
     rand_angle = 2 * pi * rand()
-    w += 100 * D * cos(2 * pi * f * t + rand_angle)
+    w += 100 * D * cos(2 * pi * f * time + rand_angle)
     Dtot += D
 w = .01 * w / Dtot
 

--- a/examples/frompapers/Sturzl_et_al_2000.py
+++ b/examples/frompapers/Sturzl_et_al_2000.py
@@ -68,7 +68,7 @@ run(duration, report='text')
 
 nspikes = spikes.count
 x = sum(nspikes * exp(gamma * 1j))
-print("Angle (deg):", arctan(imag(x) / real(x)) / degree)
+print("Angle (deg): %.2f" % (arctan(imag(x) / real(x)) / degree))
 polar(concatenate((gamma, [gamma[0] + 2 * pi])),
       concatenate((nspikes, [nspikes[0]])) / duration / Hz)
 show()

--- a/examples/frompapers/Sturzl_et_al_2000.py
+++ b/examples/frompapers/Sturzl_et_al_2000.py
@@ -68,7 +68,7 @@ run(duration, report='text')
 
 nspikes = spikes.count
 x = sum(nspikes * exp(gamma * 1j))
-print "Angle (deg):", arctan(imag(x) / real(x)) / degree
+print("Angle (deg):", arctan(imag(x) / real(x)) / degree)
 polar(concatenate((gamma, [gamma[0] + 2 * pi])),
       concatenate((nspikes, [nspikes[0]])) / duration / Hz)
 show()

--- a/examples/frompapers/kremer_et_al_2011_barrel_cortex.py
+++ b/examples/frompapers/kremer_et_al_2011_barrel_cortex.py
@@ -112,7 +112,7 @@ layer23inh.x = 'i % (barrelarraysize*M23inh) * (1.0/M23inh)'
 layer23inh.y = 'i / (barrelarraysize*M23inh) * (1.0/M23inh)'
 layer23inh.barrel_idx = 'floor(x) + floor(y)*barrelarraysize'
 
-print "Building synapses, please wait..."
+print("Building synapses, please wait...")
 # Feedforward connections (plastic)
 feedforward = Synapses(layer4, layer23exc,
                        model='''w:volt
@@ -130,7 +130,7 @@ feedforward.connect('(barrel_x_pre + barrelarraysize*barrel_y_pre) == barrel_idx
                     p=0.5)
 feedforward.w = EPSC*.5
 
-print 'excitatory lateral'
+print('excitatory lateral')
 # Excitatory lateral connections
 recurrent_exc = Synapses(layer23exc, layer23, model='w:volt', pre='ge+=w',
                          name='recurrent_exc')
@@ -143,20 +143,20 @@ recurrent_exc.w['j>=Nbarrels*N23exc'] = EPSC
 
 
 # Inhibitory lateral connections
-print 'inhibitory lateral'
+print('inhibitory lateral')
 recurrent_inh = Synapses(layer23inh, layer23exc, pre='gi+=IPSC',
                          name='recurrent_inh')
 recurrent_inh.connect('True',  # excitatory->inhibitory
                       p='exp(-.5*(((x_pre-x_post)/.2)**2+((y_pre-y_post)/.2)**2))')
 
 if not standalone:
-    print 'Total number of connections'
-    print 'feedforward:', len(feedforward)
-    print 'recurrent exc:', len(recurrent_exc)
-    print 'recurrent inh:', len(recurrent_inh)
+    print('Total number of connections')
+    print('feedforward:', len(feedforward))
+    print('recurrent exc:', len(recurrent_exc))
+    print('recurrent inh:', len(recurrent_inh))
 
     t2 = time.time()
-    print "Construction time: %.1fs" % (t2 - t1)
+    print("Construction time: %.1fs" % (t2 - t1))
 
 run(5*second, report='text')
 device.build(directory='barrelcortex', compile=True, run=True)

--- a/examples/frompapers/kremer_et_al_2011_barrel_cortex.py
+++ b/examples/frompapers/kremer_et_al_2011_barrel_cortex.py
@@ -151,9 +151,9 @@ recurrent_inh.connect('True',  # excitatory->inhibitory
 
 if not standalone:
     print('Total number of connections')
-    print('feedforward:', len(feedforward))
-    print('recurrent exc:', len(recurrent_exc))
-    print('recurrent inh:', len(recurrent_inh))
+    print('feedforward: %d' % len(feedforward))
+    print('recurrent exc: %d' % len(recurrent_exc))
+    print('recurrent inh: %d' % len(recurrent_inh))
 
     t2 = time.time()
     print("Construction time: %.1fs" % (t2 - t1))

--- a/examples/synapses/jeffress.py
+++ b/examples/synapses/jeffress.py
@@ -17,7 +17,7 @@ sound = TimedArray(10 * randn(50000), dt=defaultclock.dt) # white noise
 sound_speed = 300*metre/second
 interaural_distance = 20*cm # big head!
 max_delay = interaural_distance / sound_speed
-print "Maximum interaural delay:", max_delay
+print("Maximum interaural delay:", max_delay)
 angular_speed = 2 * pi / second # 1 turn/second
 tau_ear = 1*ms
 sigma_ear = .1

--- a/examples/synapses/jeffress.py
+++ b/examples/synapses/jeffress.py
@@ -17,7 +17,7 @@ sound = TimedArray(10 * randn(50000), dt=defaultclock.dt) # white noise
 sound_speed = 300*metre/second
 interaural_distance = 20*cm # big head!
 max_delay = interaural_distance / sound_speed
-print("Maximum interaural delay:", max_delay)
+print("Maximum interaural delay: %s" % max_delay)
 angular_speed = 2 * pi / second # 1 turn/second
 tau_ear = 1*ms
 sigma_ear = .1


### PR DESCRIPTION
Not much to review here, I just noticed that the `run_examples` script did not work under Python 3, and the same was true for a few individual examples. Since Python 3 is becoming more popular now and we never said that the examples should be run with Python 2, this needed fixing.