### PR TITLE
[MRG] Raise error for multiple stateless functions call in an expression

### DIFF
--- a/brian2/codegen/translation.py
+++ b/brian2/codegen/translation.py
@@ -28,7 +28,8 @@ from brian2.utils.stringtools import (deindent, strip_empty_lines,
 from brian2.utils.topsort import topsort
 from brian2.units.fundamentalunits import Unit
 from brian2.parsing.statements import parse_statement
-from brian2.parsing.sympytools import str_to_sympy, sympy_to_str
+from brian2.parsing.sympytools import (str_to_sympy, sympy_to_str,
+                                       check_expression_for_multiple_stateful_functions)
 
 from .statements import Statement
 from .optimisation import optimise_statements
@@ -230,7 +231,7 @@ def make_statements(code, variables, dtype, optimise=True):
                                                 dtype=dtype, scalar=is_scalar)
                     variables[var] = new_var
             elif not variables[var].is_boolean:
-                sympy_expr = str_to_sympy(expr)
+                sympy_expr = str_to_sympy(expr, variables)
                 sympy_var = sympy.Symbol(var, real=True)
                 try:
                     collected = sympy.collect(sympy_expr, sympy_var,

--- a/brian2/equations/codestrings.py
+++ b/brian2/equations/codestrings.py
@@ -85,13 +85,11 @@ class Expression(CodeString):
 
         if code is None:
             code = sympy_to_str(sympy_expression)
-        if sympy_expression is None:
-            sympy_expression = str_to_sympy(code)
-
+        else:
+            # Just try to convert it to a sympy expression to get syntax errors
+            # for incorrect expressions
+            str_to_sympy(code)
         super(Expression, self).__init__(code=code)
-
-        # : The expression as a sympy object
-        self.sympy_expr = sympy_expression
 
     stochastic_variables = property(lambda self: set([variable for variable in self.identifiers
                                                       if variable =='xi' or variable.startswith('xi_')]),
@@ -132,8 +130,8 @@ class Expression(CodeString):
                               for variable in stochastic_variables]
 
         # Note that collect only works properly if the expression is expanded
-        collected = self.sympy_expr.expand().collect(stochastic_symbols,
-                                                     evaluate=False)
+        collected = str_to_sympy(self.code).expand().collect(stochastic_symbols,
+                                                             evaluate=False)
 
         f_expr = None
         stochastic_expressions = {}
@@ -164,4 +162,4 @@ class Expression(CodeString):
         if cycle:
             raise AssertionError('Cyclical call of CodeString._repr_pretty')
         # Make use of sympy's pretty printing
-        p.pretty(self.sympy_expr)
+        p.pretty(str_to_sympy(self.code))

--- a/brian2/groups/neurongroup.py
+++ b/brian2/groups/neurongroup.py
@@ -156,7 +156,7 @@ class StateUpdater(CodeRunner):
                                                                    self.method_choice)
         user_code = '\n'.join(['{var} = {expr}'.format(var=var, expr=expr)
                                for var, expr in
-                               self.group.equations.substituted_expressions])
+                               self.group.equations.get_substituted_expressions(variables)])
         self.user_code = user_code
 
 

--- a/brian2/parsing/sympytools.py
+++ b/brian2/parsing/sympytools.py
@@ -1,15 +1,37 @@
 '''
 Utility functions for parsing expressions and statements.
 '''
+import re
+from collections import Counter
+
 import sympy
 from sympy.printing.precedence import precedence
 from sympy.printing.str import StrPrinter
 
-from brian2.core.functions import DEFAULT_FUNCTIONS, DEFAULT_CONSTANTS, log10
+from brian2.core.functions import (DEFAULT_FUNCTIONS, DEFAULT_CONSTANTS, log10,
+                                   Function)
 from brian2.parsing.rendering import SympyNodeRenderer
 
 
-def str_to_sympy(expr):
+def check_expression_for_multiple_stateful_functions(expr, variables):
+    identifiers = re.findall('\w+', expr)
+    identifier_count = Counter(identifiers)
+    for identifier, count in identifier_count.iteritems():
+        if isinstance(variables.get(identifier, None), Function):
+            if not variables[identifier].stateless and count > 1:
+                raise NotImplementedError(('The expression "{expr}" contains '
+                                           'more than one call of {func}, this '
+                                           'is currently not supported since '
+                                           '{func} is a stateful function and '
+                                           'its multiple calls might be '
+                                           'treated incorrectly (e.g.'
+                                           '"rand() - rand()" could be '
+                                           ' simplified to '
+                                           '"0.0").').format(expr=expr,
+                                                             func=identifier))
+
+
+def str_to_sympy(expr, variables=None):
     '''
     Parses a string into a sympy expression. There are two reasons for not
     using `sympify` directly: 1) sympify does a ``from sympy import *``,
@@ -24,7 +46,10 @@ def str_to_sympy(expr):
     Parameters
     ----------
     expr : str
-        The string expression to parse..
+        The string expression to parse.
+    variables : dict, optional
+        Dictionary mapping variable/function names in the expr to their
+        respective `Variable`/`Function` objects.
     
     Returns
     -------
@@ -44,6 +69,9 @@ def str_to_sympy(expr):
     names are wrapped in `Symbol(...)` or `Function(...)`. The resulting string
     is then evaluated in the `from sympy import *` namespace.
     '''
+    if variables is None:
+        variables = {}
+    check_expression_for_multiple_stateful_functions(expr, variables)
     namespace = {}
     exec 'from sympy import *' in namespace
     # also add the log10 function to the namespace

--- a/brian2/spatialneuron/spatialneuron.py
+++ b/brian2/spatialneuron/spatialneuron.py
@@ -2,11 +2,9 @@
 Compartmental models.
 This module defines the SpatialNeuron class, which defines multicompartmental models.
 '''
-from itertools import izip
 import weakref
 
 import sympy as sp
-from numpy import pi
 import numpy as np
 
 from brian2.core.variables import Variables
@@ -16,7 +14,7 @@ from brian2.groups.group import Group, CodeRunner, create_runner_codeobj
 from brian2.units.allunits import ohm, siemens, amp
 from brian2.units.fundamentalunits import Unit, fail_for_dimension_mismatch
 from brian2.units.stdunits import uF, cm
-from brian2.parsing.sympytools import sympy_to_str
+from brian2.parsing.sympytools import sympy_to_str, str_to_sympy
 from brian2.utils.logger import get_logger
 from brian2.groups.neurongroup import NeuronGroup
 from brian2.groups.subgroup import Subgroup
@@ -153,13 +151,13 @@ class SpatialNeuron(NeuronGroup):
 
         # Expand expressions in the membrane equation
         membrane_eq.type = DIFFERENTIAL_EQUATION
-        for var, expr in model._get_substituted_expressions():  # this returns substituted expressions for diff eqs
+        for var, expr in model.get_substituted_expressions():
             if var == 'Im':
                 Im_expr = expr
         membrane_eq.type = SUBEXPRESSION
 
         # Factor out the variable
-        s_expr = sp.collect(Im_expr.sympy_expr.expand(), var)
+        s_expr = sp.collect(str_to_sympy(Im_expr.code).expand(), var)
         matches = s_expr.match(pattern)
 
         if matches is None:

--- a/brian2/stateupdaters/explicit.py
+++ b/brian2/stateupdaters/explicit.py
@@ -607,6 +607,8 @@ class ExplicitStateUpdater(StateUpdateMethod):
         for stochastic_variable in stochastic_variables:
             statements.append(stochastic_variable + ' = ' + 'dt**.5 * randn()')
 
+        substituted_expressions = eqs.get_substituted_expressions(variables)
+
         # Process the intermediate statements in the stateupdater description
         for intermediate_var, intermediate_expr in self.statements:
                       
@@ -617,7 +619,7 @@ class ExplicitStateUpdater(StateUpdateMethod):
             # and g and the variable x for every equation in the model.
             # We use the model equations where the subexpressions have
             # already been substituted into the model equations.
-            for var, expr in eqs.substituted_expressions:
+            for var, expr in substituted_expressions:
                 for xi in stochastic_variables:
                     RHS = self._generate_RHS(eqs, var, eq_variables, intermediate_vars,
                                              expr, non_stochastic_expr,
@@ -633,15 +635,15 @@ class ExplicitStateUpdater(StateUpdateMethod):
         non_stochastic_expr, stochastic_expr = split_expression(self.output)
         
         # Assign a value to all the model variables described by differential
-        # equations       
-        for var, expr in eqs.substituted_expressions:
+        # equations
+        for var, expr in substituted_expressions:
             RHS = self._generate_RHS(eqs, var, eq_variables, intermediate_vars,
                                      expr, non_stochastic_expr, stochastic_expr,
                                      stochastic_variables)
             statements.append('_' + var + ' = ' + RHS)
         
         # Assign everything to the final variables
-        for var, expr in eqs.substituted_expressions:
+        for var, expr in substituted_expressions:
             statements.append(var + ' = ' + '_' + var)
 
         return '\n'.join(statements)
@@ -684,7 +686,7 @@ def diagonal_noise(equations, variables):
         return
 
     stochastic_vars = []
-    for _, expr in equations.substituted_expressions:
+    for _, expr in equations.get_substituted_expressions(variables):
         expr_stochastic_vars = expr.stochastic_variables
         if len(expr_stochastic_vars) > 1:
             # More than one stochastic variable --> no diagonal noise

--- a/brian2/tests/test_functions.py
+++ b/brian2/tests/test_functions.py
@@ -587,6 +587,19 @@ def test_declare_types():
     assert_raises(TypeError, bad_type)
 
 
+def test_multiple_stateless_function_calls():
+    # Check that expressions such as rand() + rand() (which might be incorrectly
+    # simplified to 2*rand()) raise an error
+    G = NeuronGroup(1, 'dv/dt = (rand() - rand())/second : 1')
+    net = Network(G)
+    assert_raises(NotImplementedError, lambda: net.run(0*ms))
+    G2 = NeuronGroup(1, 'v:1', threshold='v>1', reset='v=rand() - rand()')
+    net2 = Network(G2)
+    assert_raises(NotImplementedError, lambda: net2.run(0*ms))
+    G3 = NeuronGroup(1, 'v:1')
+    G3.run_regularly('v = rand() - rand()')
+    net3 = Network(G3)
+    assert_raises(NotImplementedError, lambda: net3.run(0*ms))
 
 if __name__ == '__main__':
     from brian2 import prefs
@@ -610,6 +623,7 @@ if __name__ == '__main__':
             test_function_dependencies_cython,
             test_binomial,
             test_declare_types,
+            test_multiple_stateless_function_calls,
             ]:
         try:
             start = time.time()


### PR DESCRIPTION
It is less elegant than I'd like it to be but to make sure we catch this problem everywhere where we use sympy, I had to include it in `str_to_sympy` and change this function so that it optionally takes a `variables` dictionary (so it knows which functions are stateful). In a way this makes perfect sense because an abstract code block should always be accompanied by a `variables` dictionary, otherwise it is not meaningful. There are still a few places where the function is used without this argument, though, but those are about printing (using `str_to_sympy` to then use sympy's pretty printing facilities), for parsing state updater descriptions or in one somewhat ugly case, to just find out whether there are implicitly vectorized functions (i.e. `func()` calls) in an expression.

One disadvantage of this change is that we can no longer do the conversion to sympy once for each expression when it is created (because at that time the variables are not yet known) so we do some extra work. This should not be noticeable in normal use cases, though.

Fixes #604 