### PR TITLE
[MRG] Rename SpatialNeuron variables

### DIFF
--- a/brian2/codegen/runtime/cython_rt/templates/spatialneuron_prepare.pyx
+++ b/brian2/codegen/runtime/cython_rt/templates/spatialneuron_prepare.pyx
@@ -2,10 +2,10 @@
 
 {% block maincode %}
     {# USES_VARIABLES { N, _invr, Ri, Cm, dt, area, diameter, length,
-                        ab_star0, ab_star1, ab_star2,
-                        ab_plus0, ab_plus1, ab_plus2,
-                        ab_minus0, ab_minus1, ab_minus2,
-                        _starts, _ends, _invr0, _invrn, b_plus, b_minus } #}
+                        _ab_star0, _ab_star1, _ab_star2,
+                        _a_plus0, _a_plus1, _a_plus2,
+                        _a_minus0, _a_minus1, _a_minus2,
+                        _starts, _ends, _invr0, _invrn, _b_plus, _b_minus } #}
     cdef int _i
     cdef int _counter
     cdef int _first
@@ -34,19 +34,19 @@
     # The particular solution
     # a[i,j]=ab[u+i-j,j]   --  u is the number of upper diagonals = 1
     for _i in range(N):
-        {{ab_star1}}[_i] = (-({{Cm}}[_i] / {{dt}}) - {{_invr}}[_i] / {{area}}[_i])
+        {{_ab_star1}}[_i] = (-({{Cm}}[_i] / {{dt}}) - {{_invr}}[_i] / {{area}}[_i])
     for _i in range(1, N):
-        {{ab_star0}}[_i] = {{_invr}}[_i] / {{area}}[_i-1]
-        {{ab_star2}}[_i-1] = {{_invr}}[_i] / {{area}}[_i]
-        {{ab_star1}}[_i-1] -= {{_invr}}[_i] / {{area}}[_i-1]
+        {{_ab_star0}}[_i] = {{_invr}}[_i] / {{area}}[_i-1]
+        {{_ab_star2}}[_i-1] = {{_invr}}[_i] / {{area}}[_i]
+        {{_ab_star1}}[_i-1] -= {{_invr}}[_i] / {{area}}[_i-1]
     for _i in range(N):
         # Homogeneous solutions
-        {{ab_plus0}}[_i] = {{ab_star0}}[_i]
-        {{ab_minus0}}[_i] = {{ab_star0}}[_i]
-        {{ab_plus1}}[_i] = {{ab_star1}}[_i]
-        {{ab_minus1}}[_i] = {{ab_star1}}[_i]
-        {{ab_plus2}}[_i] = {{ab_star2}}[_i]
-        {{ab_minus2}}[_i] = {{ab_star2}}[_i]
+        {{_a_plus0}}[_i] = {{_ab_star0}}[_i]
+        {{_a_minus0}}[_i] = {{_ab_star0}}[_i]
+        {{_a_plus1}}[_i] = {{_ab_star1}}[_i]
+        {{_a_minus1}}[_i] = {{_ab_star1}}[_i]
+        {{_a_plus2}}[_i] = {{_ab_star2}}[_i]
+        {{_a_minus2}}[_i] = {{_ab_star2}}[_i]
 
     # Set the boundary conditions
     for _counter in range(_num{{_starts}}):
@@ -60,14 +60,14 @@
         {{_invr0}}[_counter] = __invr0
         {{_invrn}}[_counter] = __invrn
         # Correction for boundary conditions
-        {{ab_star1}}[_first] -= (__invr0 / {{area}}[_first])
-        {{ab_star1}}[_last] -= (__invrn / {{area}}[_last])
-        {{ab_plus1}}[_first] -= (__invr0 / {{area}}[_first])
-        {{ab_plus1}}[_last] -= (__invrn / {{area}}[_last])
-        {{ab_minus1}}[_first] -= (__invr0 / {{area}}[_first])
-        {{ab_minus1}}[_last] -= (__invrn / {{area}}[_last])
+        {{_ab_star1}}[_first] -= (__invr0 / {{area}}[_first])
+        {{_ab_star1}}[_last] -= (__invrn / {{area}}[_last])
+        {{_a_plus1}}[_first] -= (__invr0 / {{area}}[_first])
+        {{_a_plus1}}[_last] -= (__invrn / {{area}}[_last])
+        {{_a_minus1}}[_first] -= (__invr0 / {{area}}[_first])
+        {{_a_minus1}}[_last] -= (__invrn / {{area}}[_last])
         # RHS for homogeneous solutions
-        {{b_plus}}[_last] = -(__invrn / {{area}}[_last])
-        {{b_minus}}[_first] = -(__invr0 / {{area}}[_first])
+        {{_b_plus}}[_last] = -(__invrn / {{area}}[_last])
+        {{_b_minus}}[_first] = -(__invr0 / {{area}}[_first])
 
 {% endblock %}

--- a/brian2/codegen/runtime/cython_rt/templates/spatialstateupdate.pyx
+++ b/brian2/codegen/runtime/cython_rt/templates/spatialstateupdate.pyx
@@ -1,9 +1,9 @@
 {# USES_VARIABLES { Cm, dt, v, N,
-                  ab_star0, ab_star1, ab_star2, b_plus,
-                  ab_plus0, ab_plus1, ab_plus2, b_minus,
-                  ab_minus0, ab_minus1, ab_minus2, v_star, u_plus, u_minus,
-                  gtot_all, I0_all,
-                  c1, c2, c3,
+                  _ab_star0, _ab_star1, _ab_star2, _b_plus,
+                  _a_plus0, _a_plus1, _a_plus2, _b_minus,
+                  _a_minus0, _a_minus1, _a_minus2, _v_star, _u_plus, _u_minus,
+                  _gtot_all, _I0_all,
+                  _c1, _c2, _c3,
                   _P_diag, _P_parent, _P_children,
                   _B, _morph_parent_i, _starts, _ends,
                   _morph_children, _morph_children_num, _morph_idxchild,
@@ -39,80 +39,80 @@
         _vectorisation_idx = _idx
 
         {{vector_code|autoindent}}
-        {{gtot_all}}[_idx] = _gtot
-        {{I0_all}}[_idx] = _I0
+        {{_gtot_all}}[_idx] = _gtot
+        {{_I0_all}}[_idx] = _I0
 
     # STEP 2: for each branch: solve three tridiagonal systems
 
-    # system 2a: solve for v_star
+    # system 2a: solve for _v_star
     for _i in range(0, _num{{_B}} - 1):
         # first and last index of the i-th branch
         _j_start = {{_starts}}[_i]
         _j_end = {{_ends}}[_i]
 
-        # upper triangularization of tridiagonal system for v_star
+        # upper triangularization of tridiagonal system for _v_star
         for _j in range(_j_start, _j_end+1):
-            {{v_star}}[_j]=-({{Cm}}[_j]/{{dt}}*{{v}}[_j])-{{I0_all}}[_j] # RHS -> v_star (solution)
-            bi={{ab_star1}}[_j]-{{gtot_all}}[_j] # main diagonal
+            {{_v_star}}[_j]=-({{Cm}}[_j]/{{dt}}*{{v}}[_j])-{{_I0_all}}[_j] # RHS -> _v_star (solution)
+            bi={{_ab_star1}}[_j]-{{_gtot_all}}[_j] # main diagonal
             if _j < N-1:
-                {{c1}}[_j]={{ab_star0}}[_j+1] # superdiagonal
+                {{_c1}}[_j]={{_ab_star0}}[_j+1] # superdiagonal
             if _j > 0:
-                ai={{ab_star2}}[_j-1] # subdiagonal
-                _m=1.0/(bi-ai*{{c1}}[_j-1])
-                {{c1}}[_j]={{c1}}[_j]*_m
-                {{v_star}}[_j]=({{v_star}}[_j] - ai*{{v_star}}[_j-1])*_m
+                ai={{_ab_star2}}[_j-1] # subdiagonal
+                _m=1.0/(bi-ai*{{_c1}}[_j-1])
+                {{_c1}}[_j]={{_c1}}[_j]*_m
+                {{_v_star}}[_j]=({{_v_star}}[_j] - ai*{{_v_star}}[_j-1])*_m
             else:
-                {{c1}}[0]={{c1}}[0]/bi
-                {{v_star}}[0]={{v_star}}[0]/bi
-        # backwards substitution of the upper triangularized system for v_star
+                {{_c1}}[0]={{_c1}}[0]/bi
+                {{_v_star}}[0]={{_v_star}}[0]/bi
+        # backwards substitution of the upper triangularized system for _v_star
         for _j in range(_j_end-1, _j_start-1, -1):
-            {{v_star}}[_j]={{v_star}}[_j] - {{c1}}[_j]*{{v_star}}[_j+1]
+            {{_v_star}}[_j]={{_v_star}}[_j] - {{_c1}}[_j]*{{_v_star}}[_j+1]
 
     for _i in range(0, _num{{_B}} - 1):
         # first and last index of the i-th branch
         _j_start = {{_starts}}[_i]
         _j_end = {{_ends}}[_i]
 
-        # upper triangularization of tridiagonal system for u_plus
+        # upper triangularization of tridiagonal system for _u_plus
         for _j in range(_j_start, _j_end + 1):
-            {{u_plus}}[_j]={{b_plus}}[_j] # RHS -> u_plus (solution)
-            bi={{ab_plus1}}[_j]-{{gtot_all}}[_j] # main diagonal
+            {{_u_plus}}[_j]={{_b_plus}}[_j] # RHS -> _u_plus (solution)
+            bi={{_a_plus1}}[_j]-{{_gtot_all}}[_j] # main diagonal
             if _j < N-1:
-                {{c2}}[_j]={{ab_plus0}}[_j+1] # superdiagonal
+                {{_c2}}[_j]={{_a_plus0}}[_j+1] # superdiagonal
             if _j > 0:
-                ai={{ab_plus2}}[_j-1] # subdiagonal
-                _m=1.0/(bi-ai*{{c2}}[_j-1])
-                {{c2}}[_j]={{c2}}[_j]*_m
-                {{u_plus}}[_j]=({{u_plus}}[_j] - ai*{{u_plus}}[_j-1])*_m
+                ai={{_a_plus2}}[_j-1] # subdiagonal
+                _m=1.0/(bi-ai*{{_c2}}[_j-1])
+                {{_c2}}[_j]={{_c2}}[_j]*_m
+                {{_u_plus}}[_j]=({{_u_plus}}[_j] - ai*{{_u_plus}}[_j-1])*_m
             else:
-                {{c2}}[0]={{c2}}[0]/bi
-                {{u_plus}}[0]={{u_plus}}[0]/bi
-        # backwards substitution of the upper triangularized system for u_plus
+                {{_c2}}[0]={{_c2}}[0]/bi
+                {{_u_plus}}[0]={{_u_plus}}[0]/bi
+        # backwards substitution of the upper triangularized system for _u_plus
         for _j in range(_j_end-1, _j_start-1, -1):
-            {{u_plus}}[_j]={{u_plus}}[_j] - {{c2}}[_j]*{{u_plus}}[_j+1]
+            {{_u_plus}}[_j]={{_u_plus}}[_j] - {{_c2}}[_j]*{{_u_plus}}[_j+1]
 
     for _i in range(0, _num{{_B}} - 1):
         # first and last index of the i-th branch
         _j_start = {{_starts}}[_i]
         _j_end = {{_ends}}[_i]
 
-        # upper triangularization of tridiagonal system for u_minus
+        # upper triangularization of tridiagonal system for _u_minus
         for _j in range(_j_start, _j_end + 1):
-            {{u_minus}}[_j]={{b_minus}}[_j] # RHS -> u_minus (solution)
-            bi={{ab_minus1}}[_j]-{{gtot_all}}[_j] # main diagonal
+            {{_u_minus}}[_j]={{_b_minus}}[_j] # RHS -> _u_minus (solution)
+            bi={{_a_minus1}}[_j]-{{_gtot_all}}[_j] # main diagonal
             if _j < N-1:
-                {{c3}}[_j]={{ab_minus0}}[_j+1] # superdiagonal
+                {{_c3}}[_j]={{_a_minus0}}[_j+1] # superdiagonal
             if _j > 0:
-                ai={{ab_minus2}}[_j-1] # subdiagonal
-                _m=1.0/(bi-ai*{{c3}}[_j-1])
-                {{c3}}[_j]={{c3}}[_j]*_m
-                {{u_minus}}[_j]=({{u_minus}}[_j] - ai*{{u_minus}}[_j-1])*_m
+                ai={{_a_minus2}}[_j-1] # subdiagonal
+                _m=1.0/(bi-ai*{{_c3}}[_j-1])
+                {{_c3}}[_j]={{_c3}}[_j]*_m
+                {{_u_minus}}[_j]=({{_u_minus}}[_j] - ai*{{_u_minus}}[_j-1])*_m
             else:
-                {{c3}}[0]={{c3}}[0]/bi
-                {{u_minus}}[0]={{u_minus}}[0]/bi
-        # backwards substitution of the upper triangularized system for u_minus
+                {{_c3}}[0]={{_c3}}[0]/bi
+                {{_u_minus}}[0]={{_u_minus}}[0]/bi
+        # backwards substitution of the upper triangularized system for _u_minus
         for _j in range(_j_end-1, _j_start-1, -1):
-            {{u_minus}}[_j]={{u_minus}}[_j] - {{c3}}[_j]*{{u_minus}}[_j+1]
+            {{_u_minus}}[_j]={{_u_minus}}[_j] - {{_c3}}[_j]*{{_u_minus}}[_j+1]
 
     # STEP 3: solve the coupling system
 
@@ -135,24 +135,24 @@
 
         # Towards parent
         if _i == 0: # first branch, sealed end
-            {{_P_diag}}[0] = {{u_minus}}[_first] - 1
-            {{_P_children}}[0 + 0] = {{u_plus}}[_first]
+            {{_P_diag}}[0] = {{_u_minus}}[_first] - 1
+            {{_P_children}}[0 + 0] = {{_u_plus}}[_first]
 
             # RHS
-            {{_B}}[0] = -{{v_star}}[_first]
+            {{_B}}[0] = -{{_v_star}}[_first]
         else:
-            {{_P_diag}}[_i_parent] += (1 - {{u_minus}}[_first]) * _this_invr0
-            {{_P_children}}[_i_parent * children_rowlength + _i_childind] = -{{u_plus}}[_first] * _this_invr0
+            {{_P_diag}}[_i_parent] += (1 - {{_u_minus}}[_first]) * _this_invr0
+            {{_P_children}}[_i_parent * children_rowlength + _i_childind] = -{{_u_plus}}[_first] * _this_invr0
 
             # RHS
-            {{_B}}[_i_parent] += {{v_star}}[_first] * _this_invr0
+            {{_B}}[_i_parent] += {{_v_star}}[_first] * _this_invr0
 
         # Towards children
-        {{_P_diag}}[_i+1] = (1 - {{u_plus}}[_last]) * _this_invrn
-        {{_P_parent}}[_i] = -{{u_minus}}[_last] * _this_invrn
+        {{_P_diag}}[_i+1] = (1 - {{_u_plus}}[_last]) * _this_invrn
+        {{_P_parent}}[_i] = -{{_u_minus}}[_last] * _this_invrn
 
         # RHS
-        {{_B}}[_i+1] = {{v_star}}[_last] * _this_invrn
+        {{_B}}[_i+1] = {{_v_star}}[_last] * _this_invrn
 
     # STEP 3b: solve the linear system (the result will be stored in the former rhs _B in the end)
     # use efficient O(n) solution of the sparse linear system (structure-specific Gaussian elemination)
@@ -190,8 +190,8 @@
         _j_end = {{_ends}}[_i]
         for _j in range(_j_start, _j_end + 1):
             if _j < _num{{v}}:  # don't go beyond the last element
-                {{v}}[_j] = ({{v_star}}[_j] + {{_B}}[_i_parent] * {{u_minus}}[_j]
-                                            + {{_B}}[_i+1] * {{u_plus}}[_j])
+                {{v}}[_j] = ({{_v_star}}[_j] + {{_B}}[_i_parent] * {{_u_minus}}[_j]
+                                            + {{_B}}[_i+1] * {{_u_plus}}[_j])
 
 
 

--- a/brian2/codegen/runtime/cython_rt/templates/spatialstateupdate.pyx
+++ b/brian2/codegen/runtime/cython_rt/templates/spatialstateupdate.pyx
@@ -18,16 +18,16 @@
     cdef int _k
     cdef int _j_start
     cdef int _j_end
-    cdef double ai
-    cdef double bi
+    cdef double _ai
+    cdef double _bi
     cdef double _m
     cdef int _i_parent
     cdef int _i_childind
     cdef int _first
     cdef int _last
-    cdef int num_children
-    cdef double subfac
-    cdef int children_rowlength
+    cdef int _num_children
+    cdef double _subfac
+    cdef int _children_rowlength
 
     # MAIN CODE
     _vectorisation_idx = 1
@@ -53,17 +53,17 @@
         # upper triangularization of tridiagonal system for _v_star
         for _j in range(_j_start, _j_end+1):
             {{_v_star}}[_j]=-({{Cm}}[_j]/{{dt}}*{{v}}[_j])-{{_I0_all}}[_j] # RHS -> _v_star (solution)
-            bi={{_ab_star1}}[_j]-{{_gtot_all}}[_j] # main diagonal
+            _bi={{_ab_star1}}[_j]-{{_gtot_all}}[_j] # main diagonal
             if _j < N-1:
                 {{_c1}}[_j]={{_ab_star0}}[_j+1] # superdiagonal
             if _j > 0:
-                ai={{_ab_star2}}[_j-1] # subdiagonal
-                _m=1.0/(bi-ai*{{_c1}}[_j-1])
+                _ai={{_ab_star2}}[_j-1] # subdiagonal
+                _m=1.0/(_bi-_ai*{{_c1}}[_j-1])
                 {{_c1}}[_j]={{_c1}}[_j]*_m
-                {{_v_star}}[_j]=({{_v_star}}[_j] - ai*{{_v_star}}[_j-1])*_m
+                {{_v_star}}[_j]=({{_v_star}}[_j] - _ai*{{_v_star}}[_j-1])*_m
             else:
-                {{_c1}}[0]={{_c1}}[0]/bi
-                {{_v_star}}[0]={{_v_star}}[0]/bi
+                {{_c1}}[0]={{_c1}}[0]/_bi
+                {{_v_star}}[0]={{_v_star}}[0]/_bi
         # backwards substitution of the upper triangularized system for _v_star
         for _j in range(_j_end-1, _j_start-1, -1):
             {{_v_star}}[_j]={{_v_star}}[_j] - {{_c1}}[_j]*{{_v_star}}[_j+1]
@@ -76,17 +76,17 @@
         # upper triangularization of tridiagonal system for _u_plus
         for _j in range(_j_start, _j_end + 1):
             {{_u_plus}}[_j]={{_b_plus}}[_j] # RHS -> _u_plus (solution)
-            bi={{_a_plus1}}[_j]-{{_gtot_all}}[_j] # main diagonal
+            _bi={{_a_plus1}}[_j]-{{_gtot_all}}[_j] # main diagonal
             if _j < N-1:
                 {{_c2}}[_j]={{_a_plus0}}[_j+1] # superdiagonal
             if _j > 0:
-                ai={{_a_plus2}}[_j-1] # subdiagonal
-                _m=1.0/(bi-ai*{{_c2}}[_j-1])
+                _ai={{_a_plus2}}[_j-1] # subdiagonal
+                _m=1.0/(_bi-_ai*{{_c2}}[_j-1])
                 {{_c2}}[_j]={{_c2}}[_j]*_m
-                {{_u_plus}}[_j]=({{_u_plus}}[_j] - ai*{{_u_plus}}[_j-1])*_m
+                {{_u_plus}}[_j]=({{_u_plus}}[_j] - _ai*{{_u_plus}}[_j-1])*_m
             else:
-                {{_c2}}[0]={{_c2}}[0]/bi
-                {{_u_plus}}[0]={{_u_plus}}[0]/bi
+                {{_c2}}[0]={{_c2}}[0]/_bi
+                {{_u_plus}}[0]={{_u_plus}}[0]/_bi
         # backwards substitution of the upper triangularized system for _u_plus
         for _j in range(_j_end-1, _j_start-1, -1):
             {{_u_plus}}[_j]={{_u_plus}}[_j] - {{_c2}}[_j]*{{_u_plus}}[_j+1]
@@ -99,17 +99,17 @@
         # upper triangularization of tridiagonal system for _u_minus
         for _j in range(_j_start, _j_end + 1):
             {{_u_minus}}[_j]={{_b_minus}}[_j] # RHS -> _u_minus (solution)
-            bi={{_a_minus1}}[_j]-{{_gtot_all}}[_j] # main diagonal
+            _bi={{_a_minus1}}[_j]-{{_gtot_all}}[_j] # main diagonal
             if _j < N-1:
                 {{_c3}}[_j]={{_a_minus0}}[_j+1] # superdiagonal
             if _j > 0:
-                ai={{_a_minus2}}[_j-1] # subdiagonal
-                _m=1.0/(bi-ai*{{_c3}}[_j-1])
+                _ai={{_a_minus2}}[_j-1] # subdiagonal
+                _m=1.0/(_bi-_ai*{{_c3}}[_j-1])
                 {{_c3}}[_j]={{_c3}}[_j]*_m
-                {{_u_minus}}[_j]=({{_u_minus}}[_j] - ai*{{_u_minus}}[_j-1])*_m
+                {{_u_minus}}[_j]=({{_u_minus}}[_j] - _ai*{{_u_minus}}[_j-1])*_m
             else:
-                {{_c3}}[0]={{_c3}}[0]/bi
-                {{_u_minus}}[0]={{_u_minus}}[0]/bi
+                {{_c3}}[0]={{_c3}}[0]/_bi
+                {{_u_minus}}[0]={{_u_minus}}[0]/_bi
         # backwards substitution of the upper triangularized system for _u_minus
         for _j in range(_j_end-1, _j_start-1, -1):
             {{_u_minus}}[_j]={{_u_minus}}[_j] - {{_c3}}[_j]*{{_u_minus}}[_j+1]
@@ -117,7 +117,7 @@
     # STEP 3: solve the coupling system
 
     # indexing for _P_children which contains the elements above the diagonal of the coupling matrix _P
-    children_rowlength = _num{{_morph_children}}/_num{{_morph_children_num}}
+    _children_rowlength = _num{{_morph_children}}/_num{{_morph_children_num}}
 
     # STEP 3a: construct the coupling system with matrix _P in sparse form. s.t.
     # _P_diag contains the diagonal elements
@@ -142,7 +142,7 @@
             {{_B}}[0] = -{{_v_star}}[_first]
         else:
             {{_P_diag}}[_i_parent] += (1 - {{_u_minus}}[_first]) * _this_invr0
-            {{_P_children}}[_i_parent * children_rowlength + _i_childind] = -{{_u_plus}}[_first] * _this_invr0
+            {{_P_children}}[_i_parent * _children_rowlength + _i_childind] = -{{_u_plus}}[_first] * _this_invr0
 
             # RHS
             {{_B}}[_i_parent] += {{_v_star}}[_first] * _this_invr0
@@ -159,21 +159,21 @@
 
     # part 1: lower triangularization
     for _i in range(_num{{_B}}-1, -1, -1):
-        num_children = {{_morph_children_num}}[_i]
+        _num_children = {{_morph_children_num}}[_i]
 
         # for every child eliminate the corresponding matrix element of row i
-        for _k in range(0, num_children):
-            _j = {{_morph_children}}[_i * children_rowlength + _k] # child index
+        for _k in range(0, _num_children):
+            _j = {{_morph_children}}[_i * _children_rowlength + _k] # child index
 
-            # subtracting subfac times the j-th from the i-th row
-            subfac = {{_P_children}}[_i * children_rowlength + _k] / {{_P_diag}}[_j] # element i,j appears only here
+            # subtracting _subfac times the j-th from the i-th row
+            _subfac = {{_P_children}}[_i * _children_rowlength + _k] / {{_P_diag}}[_j] # element i,j appears only here
 
             # the following commented (superdiagonal) element is not used in the following anymore since
             # it is 0 by definition of (lower) triangularization we keep it here for algorithmic clarity
-            #{{_P_children}}[_i * children_rowlength +_k] = {{_P_children}}[_i * children_rowlength + _k]  - subfac * {{_P_diag}}[_j] # = 0
+            #{{_P_children}}[_i * _children_rowlength +_k] = {{_P_children}}[_i * _children_rowlength + _k]  - _subfac * {{_P_diag}}[_j] # = 0
 
-            {{_P_diag}}[_i] = {{_P_diag}}[_i]  - subfac * {{_P_parent}}[_j-1] # note: element j,i is only used here
-            {{_B}}[_i] = {{_B}}[_i] - subfac * {{_B}}[_j]
+            {{_P_diag}}[_i] = {{_P_diag}}[_i]  - _subfac * {{_P_parent}}[_j-1] # note: element j,i is only used here
+            {{_B}}[_i] = {{_B}}[_i] - _subfac * {{_B}}[_j]
 
     # part 2: forwards substitution
     {{_B}}[0] = {{_B}}[0] / {{_P_diag}}[0] # the first branch does not have a parent

--- a/brian2/codegen/runtime/numpy_rt/templates/spatialneuron_prepare.py_
+++ b/brian2/codegen/runtime/numpy_rt/templates/spatialneuron_prepare.py_
@@ -1,8 +1,8 @@
 {# USES_VARIABLES { _invr, Ri, Cm, dt, area, diameter, length,
-                    ab_star0, ab_star1, ab_star2,
-                    ab_plus0, ab_plus1, ab_plus2,
-                    ab_minus0, ab_minus1, ab_minus2,
-                    _starts, _ends, _invr0, _invrn, b_plus, b_minus } #}
+                    _ab_star0, _ab_star1, _ab_star2,
+                    _a_plus0, _a_plus1, _a_plus2,
+                    _a_minus0, _a_minus1, _a_minus2,
+                    _starts, _ends, _invr0, _invrn, _b_plus, _b_minus } #}
 import numpy as _numpy
 from numpy import pi
 
@@ -24,17 +24,17 @@ for _first in {{_starts}}:
 # The particular solution
 '''a[i,j]=ab[u+i-j,j]'''  # u is the number of upper diagonals = 1
 
-{{ab_star0}}[1:] = {{_invr}}[1:] / {{area}}[:-1]
-{{ab_star2}}[:-1] = {{_invr}}[1:] / {{area}}[1:]
-{{ab_star1}}[:] = (-({{Cm}} / {{dt}}) - {{_invr}} / {{area}})
-{{ab_star1}}[:-1] -= {{_invr}}[1:] / {{area}}[:-1]
+{{_ab_star0}}[1:] = {{_invr}}[1:] / {{area}}[:-1]
+{{_ab_star2}}[:-1] = {{_invr}}[1:] / {{area}}[1:]
+{{_ab_star1}}[:] = (-({{Cm}} / {{dt}}) - {{_invr}} / {{area}})
+{{_ab_star1}}[:-1] -= {{_invr}}[1:] / {{area}}[:-1]
 # Homogeneous solutions
-{{ab_plus0}}[:] = {{ab_star0}}
-{{ab_minus0}}[:] = {{ab_star0}}
-{{ab_plus1}}[:] = {{ab_star1}}
-{{ab_minus1}}[:] = {{ab_star1}}
-{{ab_plus2}}[:] = {{ab_star2}}
-{{ab_minus2}}[:] = {{ab_star2}}
+{{_a_plus0}}[:] = {{_ab_star0}}
+{{_a_minus0}}[:] = {{_ab_star0}}
+{{_a_plus1}}[:] = {{_ab_star1}}
+{{_a_minus1}}[:] = {{_ab_star1}}
+{{_a_plus2}}[:] = {{_ab_star2}}
+{{_a_minus2}}[:] = {{_ab_star2}}
 
 # Set the boundary conditions
 for _counter, (_first, _last) in enumerate(zip({{_starts}},
@@ -47,12 +47,12 @@ for _counter, (_first, _last) in enumerate(zip({{_starts}},
                                      {{diameter}}[_last] ** 2 /
                                      {{length}}[_last])
     # Correction for boundary conditions
-    {{ab_star1}}[_first] -= (_invr0 / {{area}}[_first])
-    {{ab_star1}}[_last] -= (_invrn / {{area}}[_last])
-    {{ab_plus1}}[_first] -= (_invr0 / {{area}}[_first])
-    {{ab_plus1}}[_last] -= (_invrn / {{area}}[_last])
-    {{ab_minus1}}[_first] -= (_invr0 / {{area}}[_first])
-    {{ab_minus1}}[_last] -= (_invrn / {{area}}[_last])
+    {{_ab_star1}}[_first] -= (_invr0 / {{area}}[_first])
+    {{_ab_star1}}[_last] -= (_invrn / {{area}}[_last])
+    {{_a_plus1}}[_first] -= (_invr0 / {{area}}[_first])
+    {{_a_plus1}}[_last] -= (_invrn / {{area}}[_last])
+    {{_a_minus1}}[_first] -= (_invr0 / {{area}}[_first])
+    {{_a_minus1}}[_last] -= (_invrn / {{area}}[_last])
     # RHS for homogeneous solutions
-    {{b_plus}}[_last] = -(_invrn / {{area}}[_last])
-    {{b_minus}}[_first] = -(_invr0 / {{area}}[_first])
+    {{_b_plus}}[_last] = -(_invrn / {{area}}[_last])
+    {{_b_minus}}[_first] = -(_invr0 / {{area}}[_first])

--- a/brian2/codegen/runtime/numpy_rt/templates/spatialstateupdate.py_
+++ b/brian2/codegen/runtime/numpy_rt/templates/spatialstateupdate.py_
@@ -28,90 +28,90 @@ _vectorisation_idx = N
 from scipy.linalg import solve_banded
 
 # Particular solution
-b=-({{Cm}}/{{dt}}*{{v}})-_I0
-ab = zeros((3,N))
-ab[0,:]={{_ab_star0}}
-ab[1,:]={{_ab_star1}}
-ab[2,:]={{_ab_star2}}
-ab[1,:]-=_gtot
-{{_v_star}}[:]=solve_banded((1,1),ab,b,overwrite_ab=True,overwrite_b=True)
+_b=-({{Cm}}/{{dt}}*{{v}})-_I0
+_ab = zeros((3,N))
+_ab[0,:] = {{_ab_star0}}
+_ab[1,:] = {{_ab_star1}}
+_ab[2,:] = {{_ab_star2}}
+_ab[1,:] -= _gtot
+{{_v_star}}[:] = solve_banded((1,1),_ab,_b,overwrite_ab=True,overwrite_b=True)
 # Homogeneous solutions
-b[:]={{_b_plus}}
-ab[0,:]={{_a_plus0}}
-ab[1,:]={{_a_plus1}}
-ab[2,:]={{_a_plus2}}
-ab[1,:]-=_gtot
-{{_u_plus}}[:]=solve_banded((1,1),ab,b,overwrite_ab=True,overwrite_b=True)
-b[:]={{_b_minus}}
-ab[0,:]={{_a_minus0}}
-ab[1,:]={{_a_minus1}}
-ab[2,:]={{_a_minus2}}
-ab[1,:]-=_gtot
-{{_u_minus}}[:]=solve_banded((1,1),ab,b,overwrite_ab=True,overwrite_b=True)
+_b[:] = {{_b_plus}}
+_ab[0,:] = {{_a_plus0}}
+_ab[1,:] = {{_a_plus1}}
+_ab[2,:] = {{_a_plus2}}
+_ab[1,:] -= _gtot
+{{_u_plus}}[:] = solve_banded((1,1),_ab,_b,overwrite_ab=True,overwrite_b=True)
+_b[:] = {{_b_minus}}
+_ab[0,:] = {{_a_minus0}}
+_ab[1,:] = {{_a_minus1}}
+_ab[2,:] = {{_a_minus2}}
+_ab[1,:] -= _gtot
+{{_u_minus}}[:] = solve_banded((1,1),_ab,_b,overwrite_ab=True,overwrite_b=True)
 {% else %}
 # Pure numpy solution, very slow because it needs forward and backward passes
 # along the array that can't be vectorized
-b = -({{Cm}} / {{dt}}*{{v}}) - _I0
+_b = -({{Cm}} / {{dt}}*{{v}}) - _I0
 
 # Tridiagonal solving
-forward = range(1, N)
-backward = range(N-2, -1, -1)
-c = zeros(N)
+_forward = range(1, N)
+_backward = range(N-2, -1, -1)
+_c = zeros(N)
 
 # Pass 1
-bi = {{_ab_star1}} - _gtot  # main diagonal
+_bi = {{_ab_star1}} - _gtot  # main diagonal
 
 # First compartment
-c[0] = {{_ab_star0}}[1] / bi[0]
-{{_v_star}}[0] = b[0] / bi[0]
+_c[0] = {{_ab_star0}}[1] / _bi[0]
+{{_v_star}}[0] = _b[0] / _bi[0]
 
 # Other compartments
-c[1:-1] = {{_ab_star0}}[2:]
-for i in forward:
-    ai = {{_ab_star2}}[i-1]  # subdiagonal
-    _m = 1.0/(bi[i]-ai*c[i-1])
-    c[i] *= _m
-    {{_v_star}}[i] = (b[i] - ai*{{_v_star}}[i-1])*_m
+_c[1:-1] = {{_ab_star0}}[2:]
+for _i in _forward:
+    _ai = {{_ab_star2}}[_i-1]  # subdiagonal
+    _m = 1.0/(_bi[_i]-_ai*_c[_i-1])
+    _c[_i] *= _m
+    {{_v_star}}[_i] = (_b[_i] - _ai*{{_v_star}}[_i-1])*_m
 
-for i in backward:
-    {{_v_star}}[i] -= c[i]*{{_v_star}}[i+1]
+for _i in _backward:
+    {{_v_star}}[_i] -= _c[_i]*{{_v_star}}[_i+1]
 
 # Pass 2
-bi = {{_a_plus1}} - _gtot  # main diagonal
+_bi = {{_a_plus1}} - _gtot  # main diagonal
 
 # First compartment
-c[0] = {{_a_plus0}}[1]/bi[0]
-{{_u_plus}}[0] = {{_b_plus}}[0]/bi[0]
+_c[0] = {{_a_plus0}}[1]/_bi[0]
+{{_u_plus}}[0] = {{_b_plus}}[0]/_bi[0]
 
 # Other compartments
-c[1:-1] = {{_a_plus0}}[2:]  # superdiagonal
+_c[1:-1] = {{_a_plus0}}[2:]  # superdiagonal
 
-for i in forward:
-    ai = {{_a_plus2}}[i-1]  # subdiagonal
-    _m = 1.0/(bi[i]-ai*c[i-1])
-    c[i] *= _m
-    {{_u_plus}}[i] = ({{_b_plus}}[i] - ai*{{_u_plus}}[i-1])*_m
+for _i in _forward:
+    _ai = {{_a_plus2}}[_i-1]  # subdiagonal
+    _m = 1.0/(_bi[_i]-_ai*_c[_i-1])
+    _c[_i] *= _m
+    {{_u_plus}}[_i] = ({{_b_plus}}[_i] - _ai*{{_u_plus}}[_i-1])*_m
 
-for i in backward:
-    {{_u_plus}}[i] -= c[i]*{{_u_plus}}[i+1]
+for _i in _backward:
+    {{_u_plus}}[_i] -= _c[_i]*{{_u_plus}}[_i+1]
 
 # Pass 3
-bi = {{_a_minus1}} - _gtot  # main diagonal
+_bi = {{_a_minus1}} - _gtot  # main diagonal
 
 # First compartment
-c[0] = {{_a_minus0}}[1]/bi[0]
-{{_u_minus}}[0] = {{_b_minus}}[0]/bi[0]
+_c[0] = {{_a_minus0}}[1]/_bi[0]
+{{_u_minus}}[0] = {{_b_minus}}[0]/_bi[0]
 
 # Other compartments
-c[1:-1] = {{_a_minus0}}[2:]  # superdiagonal
-for i in forward:
-    ai = {{_a_minus2}}[i-1]  # subdiagonal
-    _m = 1.0/(bi[i]-ai*c[i-1]);
-    c[i] *= _m
-    {{_u_minus}}[i] = ({{_b_minus}}[i] - ai*{{_u_minus}}[i-1])*_m
+_c[1:-1] = {{_a_minus0}}[2:]  # superdiagonal
+for _i in _forward:
+    _ai = {{_a_minus2}}[_i-1]  # subdiagonal
+    _m = 1.0/(_bi[_i]-_ai*_c[_i-1]);
+    _c[_i] *= _m
+    {{_u_minus}}[_i] = ({{_b_minus}}[_i] - _ai*{{_u_minus}}[_i-1])*_m
 
-for i in backward:
-    {{_u_minus}}[i] -= c[i]*{{_u_minus}}[i+1]
+for _i in _backward:
+    {{_u_minus}}[_i] -= _c[_i]*{{_u_minus}}[_i+1]
 {% endif %}
 
 # indexing for _P_children which contains the elements above the diagonal of the coupling matrix _P
@@ -159,16 +159,16 @@ _morph_children_2d = {{_morph_children}}.reshape(-1, children_rowlength)
 # part 1: lower triangularization
 
 for _i in range(len({{_B}})-1, -1, -1):
-    num_children = {{_morph_children_num}}[_i];
+    _num_children = {{_morph_children_num}}[_i];
 
-    for _k in range(num_children):
+    for _k in range(_num_children):
         _j = _morph_children_2d[_i, _k]  # child index
 
-        # subtracting subfac times the j-th from the i-th row
-        subfac = _P_children_2d[_i, _k] / {{_P_diag}}[_j]
+        # subtracting _subfac times the j-th from the _i-th row
+        _subfac = _P_children_2d[_i, _k] / {{_P_diag}}[_j]
 
-        {{_P_diag}}[_i] = {{_P_diag}}[_i]  - subfac * {{_P_parent}}[_j-1]
-        {{_B}}[_i] = {{_B}}[_i] - subfac * {{_B}}[_j]
+        {{_P_diag}}[_i] = {{_P_diag}}[_i]  - _subfac * {{_P_parent}}[_j-1]
+        {{_B}}[_i] = {{_B}}[_i] - _subfac * {{_B}}[_j]
 
 # part 2: forwards substitution
 {{_B}}[0] = {{_B}}[0] / {{_P_diag}}[0]  # the first branch does not have a parent

--- a/brian2/codegen/runtime/numpy_rt/templates/spatialstateupdate.py_
+++ b/brian2/codegen/runtime/numpy_rt/templates/spatialstateupdate.py_
@@ -1,9 +1,9 @@
 {# USES_VARIABLES { Cm, dt, v, N,
-                  ab_star0, ab_star1, ab_star2, b_plus,
-                  ab_plus0, ab_plus1, ab_plus2, b_minus,
-                  ab_minus0, ab_minus1, ab_minus2, v_star, u_plus, u_minus,
-                  gtot_all, I0_all,
-                  c1, c2, c3,
+                  _ab_star0, _ab_star1, _ab_star2, _b_plus,
+                  _a_plus0, _a_plus1, _a_plus2, _b_minus,
+                  _a_minus0, _a_minus1, _a_minus2, _v_star, _u_plus, _u_minus,
+                  _gtot_all, _I0_all, v
+                  _c1, _c2, _c3,
                   _P_diag, _P_parent, _P_children,
                   _B, _morph_parent_i, _starts, _ends,
                   _morph_children, _morph_children_num, _morph_idxchild,
@@ -30,24 +30,24 @@ from scipy.linalg import solve_banded
 # Particular solution
 b=-({{Cm}}/{{dt}}*{{v}})-_I0
 ab = zeros((3,N))
-ab[0,:]={{ab_star0}}
-ab[1,:]={{ab_star1}}
-ab[2,:]={{ab_star2}}
+ab[0,:]={{_ab_star0}}
+ab[1,:]={{_ab_star1}}
+ab[2,:]={{_ab_star2}}
 ab[1,:]-=_gtot
-{{v_star}}[:]=solve_banded((1,1),ab,b,overwrite_ab=True,overwrite_b=True)
+{{_v_star}}[:]=solve_banded((1,1),ab,b,overwrite_ab=True,overwrite_b=True)
 # Homogeneous solutions
-b[:]={{b_plus}}
-ab[0,:]={{ab_plus0}}
-ab[1,:]={{ab_plus1}}
-ab[2,:]={{ab_plus2}}
+b[:]={{_b_plus}}
+ab[0,:]={{_a_plus0}}
+ab[1,:]={{_a_plus1}}
+ab[2,:]={{_a_plus2}}
 ab[1,:]-=_gtot
-{{u_plus}}[:]=solve_banded((1,1),ab,b,overwrite_ab=True,overwrite_b=True)
-b[:]={{b_minus}}
-ab[0,:]={{ab_minus0}}
-ab[1,:]={{ab_minus1}}
-ab[2,:]={{ab_minus2}}
+{{_u_plus}}[:]=solve_banded((1,1),ab,b,overwrite_ab=True,overwrite_b=True)
+b[:]={{_b_minus}}
+ab[0,:]={{_a_minus0}}
+ab[1,:]={{_a_minus1}}
+ab[2,:]={{_a_minus2}}
 ab[1,:]-=_gtot
-{{u_minus}}[:]=solve_banded((1,1),ab,b,overwrite_ab=True,overwrite_b=True)
+{{_u_minus}}[:]=solve_banded((1,1),ab,b,overwrite_ab=True,overwrite_b=True)
 {% else %}
 # Pure numpy solution, very slow because it needs forward and backward passes
 # along the array that can't be vectorized
@@ -59,59 +59,59 @@ backward = range(N-2, -1, -1)
 c = zeros(N)
 
 # Pass 1
-bi = {{ab_star1}} - _gtot  # main diagonal
+bi = {{_ab_star1}} - _gtot  # main diagonal
 
 # First compartment
-c[0] = {{ab_star0}}[1] / bi[0]
-{{v_star}}[0] = b[0] / bi[0]
+c[0] = {{_ab_star0}}[1] / bi[0]
+{{_v_star}}[0] = b[0] / bi[0]
 
 # Other compartments
-c[1:-1] = {{ab_star0}}[2:]
+c[1:-1] = {{_ab_star0}}[2:]
 for i in forward:
-    ai = {{ab_star2}}[i-1]  # subdiagonal
+    ai = {{_ab_star2}}[i-1]  # subdiagonal
     _m = 1.0/(bi[i]-ai*c[i-1])
     c[i] *= _m
-    {{v_star}}[i] = (b[i] - ai*{{v_star}}[i-1])*_m
+    {{_v_star}}[i] = (b[i] - ai*{{_v_star}}[i-1])*_m
 
 for i in backward:
-    {{v_star}}[i] -= c[i]*{{v_star}}[i+1]
+    {{_v_star}}[i] -= c[i]*{{_v_star}}[i+1]
 
 # Pass 2
-bi = {{ab_plus1}} - _gtot  # main diagonal
+bi = {{_a_plus1}} - _gtot  # main diagonal
 
 # First compartment
-c[0] = {{ab_plus0}}[1]/bi[0]
-{{u_plus}}[0] = {{b_plus}}[0]/bi[0]
+c[0] = {{_a_plus0}}[1]/bi[0]
+{{_u_plus}}[0] = {{_b_plus}}[0]/bi[0]
 
 # Other compartments
-c[1:-1] = {{ab_plus0}}[2:]  # superdiagonal
+c[1:-1] = {{_a_plus0}}[2:]  # superdiagonal
 
 for i in forward:
-    ai = {{ab_plus2}}[i-1]  # subdiagonal
+    ai = {{_a_plus2}}[i-1]  # subdiagonal
     _m = 1.0/(bi[i]-ai*c[i-1])
     c[i] *= _m
-    {{u_plus}}[i] = ({{b_plus}}[i] - ai*{{u_plus}}[i-1])*_m
+    {{_u_plus}}[i] = ({{_b_plus}}[i] - ai*{{_u_plus}}[i-1])*_m
 
 for i in backward:
-    {{u_plus}}[i] -= c[i]*{{u_plus}}[i+1]
+    {{_u_plus}}[i] -= c[i]*{{_u_plus}}[i+1]
 
 # Pass 3
-bi = {{ab_minus1}} - _gtot  # main diagonal
+bi = {{_a_minus1}} - _gtot  # main diagonal
 
 # First compartment
-c[0] = {{ab_minus0}}[1]/bi[0]
-{{u_minus}}[0] = {{b_minus}}[0]/bi[0]
+c[0] = {{_a_minus0}}[1]/bi[0]
+{{_u_minus}}[0] = {{_b_minus}}[0]/bi[0]
 
 # Other compartments
-c[1:-1] = {{ab_minus0}}[2:]  # superdiagonal
+c[1:-1] = {{_a_minus0}}[2:]  # superdiagonal
 for i in forward:
-    ai = {{ab_minus2}}[i-1]  # subdiagonal
+    ai = {{_a_minus2}}[i-1]  # subdiagonal
     _m = 1.0/(bi[i]-ai*c[i-1]);
     c[i] *= _m
-    {{u_minus}}[i] = ({{b_minus}}[i] - ai*{{u_minus}}[i-1])*_m
+    {{_u_minus}}[i] = ({{_b_minus}}[i] - ai*{{_u_minus}}[i-1])*_m
 
 for i in backward:
-    {{u_minus}}[i] -= c[i]*{{u_minus}}[i+1]
+    {{_u_minus}}[i] -= c[i]*{{_u_minus}}[i+1]
 {% endif %}
 
 # indexing for _P_children which contains the elements above the diagonal of the coupling matrix _P
@@ -133,24 +133,24 @@ for _i, (_i_parent, _i_childind, _first, _last, _invr0, _invrn) in enumerate(zip
                                                                                  {{_invrn}})):
     # Towards parent
     if _i == 0: # first branch, sealed end
-        {{_P_diag}}[0] = {{u_minus}}[_first] - 1
-        _P_children_2d[0, 0] = {{u_plus}}[_first]
+        {{_P_diag}}[0] = {{_u_minus}}[_first] - 1
+        _P_children_2d[0, 0] = {{_u_plus}}[_first]
 
         # RHS
-        {{_B}}[0] = -{{v_star}}[_first]
+        {{_B}}[0] = -{{_v_star}}[_first]
     else:
-        {{_P_diag}}[_i_parent] += (1 - {{u_minus}}[_first]) * _invr0
-        _P_children_2d[_i_parent, _i_childind] = -{{u_plus}}[_first] * _invr0
+        {{_P_diag}}[_i_parent] += (1 - {{_u_minus}}[_first]) * _invr0
+        _P_children_2d[_i_parent, _i_childind] = -{{_u_plus}}[_first] * _invr0
 
         # RHS
-        {{_B}}[_i_parent] += {{v_star}}[_first] * _invr0
+        {{_B}}[_i_parent] += {{_v_star}}[_first] * _invr0
 
     # Towards children
-    {{_P_diag}}[_i+1] = (1 - {{u_plus}}[_last]) * _invrn
-    {{_P_parent}}[_i] = -{{u_minus}}[_last] * _invrn
+    {{_P_diag}}[_i+1] = (1 - {{_u_plus}}[_last]) * _invrn
+    {{_P_parent}}[_i] = -{{_u_minus}}[_last] * _invrn
 
     # RHS
-    {{_B}}[_i+1] = {{v_star}}[_last] * _invrn
+    {{_B}}[_i+1] = {{_v_star}}[_last] * _invrn
 
 # Solve the linear system (the result will be stored in the former rhs _B in the end)
 # use efficient O(n) solution of the sparse linear system (structure-specific Gaussian elemination)
@@ -182,9 +182,9 @@ for _i, (_B_parent, _j_start, _j_end) in enumerate(zip({{_B}}[{{_morph_parent_i}
                                                        {{_ends}})):
     _B_current = {{_B}}[_i+1]
     if _j_start == _j_end:
-        {{v}}[_j_start] = ({{v_star}}[_j_start] + _B_parent * {{u_minus}}[_j_start]
-                     + _B_current * {{u_plus}}[_j_start])
+        {{v}}[_j_start] = ({{_v_star}}[_j_start] + _B_parent * {{_u_minus}}[_j_start]
+                     + _B_current * {{_u_plus}}[_j_start])
     else:
-        {{v}}[_j_start:_j_end+1] = ({{v_star}}[_j_start:_j_end+1] + _B_parent * {{u_minus}}[_j_start:_j_end+1]
-                     + _B_current * {{u_plus}}[_j_start:_j_end+1])
+        {{v}}[_j_start:_j_end+1] = ({{_v_star}}[_j_start:_j_end+1] + _B_parent * {{_u_minus}}[_j_start:_j_end+1]
+                     + _B_current * {{_u_plus}}[_j_start:_j_end+1])
 

--- a/brian2/codegen/runtime/weave_rt/templates/spatialneuron_prepare.cpp
+++ b/brian2/codegen/runtime/weave_rt/templates/spatialneuron_prepare.cpp
@@ -1,8 +1,8 @@
 {# USES_VARIABLES { N, _invr, Ri, Cm, dt, area, diameter, length,
-                    ab_star0, ab_star1, ab_star2,
-                    ab_plus0, ab_plus1, ab_plus2,
-                    ab_minus0, ab_minus1, ab_minus2,
-                    _starts, _ends, _invr0, _invrn, b_plus, b_minus } #}
+                    _ab_star0, _ab_star1, _ab_star2,
+                    _a_plus0, _a_plus1, _a_plus2,
+                    _a_minus0, _a_minus1, _a_minus2,
+                    _starts, _ends, _invr0, _invrn, _b_plus, _b_minus } #}
 {% import 'common_macros.cpp' as common with context %}
 {% macro main() %}
     {{ common.insert_group_preamble() }}
@@ -27,22 +27,22 @@
     // The particular solution
     // a[i,j]=ab[u+i-j,j]   --  u is the number of upper diagonals = 1
     for (int _i=0; _i<N; _i++)
-        {{ab_star1}}[_i] = (-({{Cm}}[_i] / {{dt}}) - {{_invr}}[_i] / {{area}}[_i]);
+        {{_ab_star1}}[_i] = (-({{Cm}}[_i] / {{dt}}) - {{_invr}}[_i] / {{area}}[_i]);
     for (int _i=1; _i<N; _i++)
     {
-        {{ab_star0}}[_i] = {{_invr}}[_i] / {{area}}[_i-1];
-        {{ab_star2}}[_i-1] = {{_invr}}[_i] / {{area}}[_i];
-        {{ab_star1}}[_i-1] -= {{_invr}}[_i] / {{area}}[_i-1];
+        {{_ab_star0}}[_i] = {{_invr}}[_i] / {{area}}[_i-1];
+        {{_ab_star2}}[_i-1] = {{_invr}}[_i] / {{area}}[_i];
+        {{_ab_star1}}[_i-1] -= {{_invr}}[_i] / {{area}}[_i-1];
     }
     for (int _i=0; _i<N; _i++)
     {
         // Homogeneous solutions
-        {{ab_plus0}}[_i] = {{ab_star0}}[_i];
-        {{ab_minus0}}[_i] = {{ab_star0}}[_i];
-        {{ab_plus1}}[_i] = {{ab_star1}}[_i];
-        {{ab_minus1}}[_i] = {{ab_star1}}[_i];
-        {{ab_plus2}}[_i] = {{ab_star2}}[_i];
-        {{ab_minus2}}[_i] = {{ab_star2}}[_i];
+        {{_a_plus0}}[_i] = {{_ab_star0}}[_i];
+        {{_a_minus0}}[_i] = {{_ab_star0}}[_i];
+        {{_a_plus1}}[_i] = {{_ab_star1}}[_i];
+        {{_a_minus1}}[_i] = {{_ab_star1}}[_i];
+        {{_a_plus2}}[_i] = {{_ab_star2}}[_i];
+        {{_a_minus2}}[_i] = {{_ab_star2}}[_i];
     }
 
     // Set the boundary conditions
@@ -58,15 +58,15 @@
         {{_invr0}}[_counter] = _invr0;
         {{_invrn}}[_counter] = _invrn;
         // Correction for boundary conditions
-        {{ab_star1}}[_first] -= (_invr0 / {{area}}[_first]);
-        {{ab_star1}}[_last] -= (_invrn / {{area}}[_last]);
-        {{ab_plus1}}[_first] -= (_invr0 / {{area}}[_first]);
-        {{ab_plus1}}[_last] -= (_invrn / {{area}}[_last]);
-        {{ab_minus1}}[_first] -= (_invr0 / {{area}}[_first]);
-        {{ab_minus1}}[_last] -= (_invrn / {{area}}[_last]);
+        {{_ab_star1}}[_first] -= (_invr0 / {{area}}[_first]);
+        {{_ab_star1}}[_last] -= (_invrn / {{area}}[_last]);
+        {{_a_plus1}}[_first] -= (_invr0 / {{area}}[_first]);
+        {{_a_plus1}}[_last] -= (_invrn / {{area}}[_last]);
+        {{_a_minus1}}[_first] -= (_invr0 / {{area}}[_first]);
+        {{_a_minus1}}[_last] -= (_invrn / {{area}}[_last]);
         // RHS for homogeneous solutions
-        {{b_plus}}[_last] = -(_invrn / {{area}}[_last]);
-        {{b_minus}}[_first] = -(_invr0 / {{area}}[_first]);
+        {{_b_plus}}[_last] = -(_invrn / {{area}}[_last]);
+        {{_b_minus}}[_first] = -(_invr0 / {{area}}[_first]);
     }
 {% endmacro %}
 

--- a/brian2/codegen/runtime/weave_rt/templates/spatialstateupdate.cpp
+++ b/brian2/codegen/runtime/weave_rt/templates/spatialstateupdate.cpp
@@ -39,25 +39,25 @@
         const int _j_start = {{_starts}}[_i];
         const int _j_end = {{_ends}}[_i];
 
-        double ai, bi, _m; // helper variables
+        double _ai, _bi, _m; // helper variables
 
         // upper triangularization of tridiagonal system for _v_star
         for(int _j=_j_start; _j<_j_end+1; _j++)
         {
             {{_v_star}}[_j]=-({{Cm}}[_j]/{{dt}}*{{v}}[_j])-{{_I0_all}}[_j]; // RHS -> _v_star (solution)
-            bi={{_ab_star1}}[_j]-{{_gtot_all}}[_j]; // main diagonal
+            _bi={{_ab_star1}}[_j]-{{_gtot_all}}[_j]; // main diagonal
             if (_j<N-1)
                 {{_c1}}[_j]={{_ab_star0}}[_j+1]; // superdiagonal
             if (_j>0)
             {
-                ai={{_ab_star2}}[_j-1]; // subdiagonal
-                _m=1.0/(bi-ai*{{_c1}}[_j-1]);
+                _ai={{_ab_star2}}[_j-1]; // subdiagonal
+                _m=1.0/(_bi-_ai*{{_c1}}[_j-1]);
                 {{_c1}}[_j]={{_c1}}[_j]*_m;
-                {{_v_star}}[_j]=({{_v_star}}[_j] - ai*{{_v_star}}[_j-1])*_m;
+                {{_v_star}}[_j]=({{_v_star}}[_j] - _ai*{{_v_star}}[_j-1])*_m;
             } else
             {
-                {{_c1}}[0]={{_c1}}[0]/bi;
-                {{_v_star}}[0]={{_v_star}}[0]/bi;
+                {{_c1}}[0]={{_c1}}[0]/_bi;
+                {{_v_star}}[0]={{_v_star}}[0]/_bi;
             }
         }
         // backwards substitution of the upper triangularized system for _v_star
@@ -70,25 +70,25 @@
         const int _j_start = {{_starts}}[_i];
         const int _j_end = {{_ends}}[_i];
 
-        double ai, bi, _m; // helper variables
+        double _ai, _bi, _m; // helper variables
 
         // upper triangularization of tridiagonal system for _u_plus
         for(int _j=_j_start; _j<_j_end+1; _j++)
         {
             {{_u_plus}}[_j]={{_b_plus}}[_j]; // RHS -> _u_plus (solution)
-            bi={{_a_plus1}}[_j]-{{_gtot_all}}[_j]; // main diagonal
+            _bi={{_a_plus1}}[_j]-{{_gtot_all}}[_j]; // main diagonal
             if (_j<N-1)
                 {{_c2}}[_j]={{_a_plus0}}[_j+1]; // superdiagonal
             if (_j>0)
             {
-                ai={{_a_plus2}}[_j-1]; // subdiagonal
-                _m=1.0/(bi-ai*{{_c2}}[_j-1]);
+                _ai={{_a_plus2}}[_j-1]; // subdiagonal
+                _m=1.0/(_bi-_ai*{{_c2}}[_j-1]);
                 {{_c2}}[_j]={{_c2}}[_j]*_m;
-                {{_u_plus}}[_j]=({{_u_plus}}[_j] - ai*{{_u_plus}}[_j-1])*_m;
+                {{_u_plus}}[_j]=({{_u_plus}}[_j] - _ai*{{_u_plus}}[_j-1])*_m;
             } else
             {
-                {{_c2}}[0]={{_c2}}[0]/bi;
-                {{_u_plus}}[0]={{_u_plus}}[0]/bi;
+                {{_c2}}[0]={{_c2}}[0]/_bi;
+                {{_u_plus}}[0]={{_u_plus}}[0]/_bi;
             }
         }
         // backwards substitution of the upper triangularized system for _u_plus
@@ -102,25 +102,25 @@
         const int _j_start = {{_starts}}[_i];
         const int _j_end = {{_ends}}[_i];
 
-        double ai, bi, _m; // helper variables
+        double _ai, _bi, _m; // helper variables
 
         // upper triangularization of tridiagonal system for _u_minus
         for(int _j=_j_start; _j<_j_end+1; _j++)
         {
             {{_u_minus}}[_j]={{_b_minus}}[_j]; // RHS -> _u_minus (solution)
-            bi={{_a_minus1}}[_j]-{{_gtot_all}}[_j]; // main diagonal
+            _bi={{_a_minus1}}[_j]-{{_gtot_all}}[_j]; // main diagonal
             if (_j<N-1)
                 {{_c3}}[_j]={{_a_minus0}}[_j+1]; // superdiagonal
             if (_j>0)
             {
-                ai={{_a_minus2}}[_j-1]; // subdiagonal
-                _m=1.0/(bi-ai*{{_c3}}[_j-1]);
+                _ai={{_a_minus2}}[_j-1]; // subdiagonal
+                _m=1.0/(_bi-_ai*{{_c3}}[_j-1]);
                 {{_c3}}[_j]={{_c3}}[_j]*_m;
-                {{_u_minus}}[_j]=({{_u_minus}}[_j] - ai*{{_u_minus}}[_j-1])*_m;
+                {{_u_minus}}[_j]=({{_u_minus}}[_j] - _ai*{{_u_minus}}[_j-1])*_m;
             } else
             {
-                {{_c3}}[0]={{_c3}}[0]/bi;
-                {{_u_minus}}[0]={{_u_minus}}[0]/bi;
+                {{_c3}}[0]={{_c3}}[0]/_bi;
+                {{_u_minus}}[0]={{_u_minus}}[0]/_bi;
             }
         }
         // backwards substitution of the upper triangularized system for _u_minus
@@ -131,8 +131,8 @@
     // STEP 3: solve the coupling system
 
     // indexing for _P_children which contains the elements above the diagonal of the coupling matrix _P
-    const int children_rowlength = _num_morph_children/_num_morph_children_num;
-    #define IDX_C(idx_row,idx_col) children_rowlength * idx_row + idx_col
+    const int _children_rowlength = _num_morph_children/_num_morph_children_num;
+    #define _IDX_C(idx_row,idx_col) _children_rowlength * idx_row + idx_col
 
     // STEP 3a: construct the coupling system with matrix _P in sparse form. s.t.
     // _P_diag contains the diagonal elements
@@ -152,7 +152,7 @@
         if (_i == 0) // first branch, sealed end
         {
             {{_P_diag}}[0] = {{_u_minus}}[_first] - 1;
-            {{_P_children}}[IDX_C(0,0)] = {{_u_plus}}[_first];
+            {{_P_children}}[_IDX_C(0,0)] = {{_u_plus}}[_first];
 
             // RHS
             {{_B}}[0] = -{{_v_star}}[_first];
@@ -160,7 +160,7 @@
         else
         {
             {{_P_diag}}[_i_parent] += (1 - {{_u_minus}}[_first]) * _invr0;
-            {{_P_children}}[IDX_C(_i_parent, _i_childind)] = -{{_u_plus}}[_first] * _invr0;
+            {{_P_children}}[_IDX_C(_i_parent, _i_childind)] = -{{_u_plus}}[_first] * _invr0;
 
             // RHS
             {{_B}}[_i_parent] += {{_v_star}}[_first] * _invr0;
@@ -184,17 +184,17 @@
 
         // for every child eliminate the corresponding matrix element of row i
         for (int _k=0; _k<num_children; _k++) {
-            int _j = {{_morph_children}}[IDX_C(_i,_k)]; // child index
+            int _j = {{_morph_children}}[_IDX_C(_i,_k)]; // child index
 
-            // subtracting subfac times the j-th from the i-th row
-            double subfac = {{_P_children}}[IDX_C(_i,_k)] / {{_P_diag}}[_j]; // element i,j appears only here
+            // subtracting _subfac times the j-th from the i-th row
+            double _subfac = {{_P_children}}[_IDX_C(_i,_k)] / {{_P_diag}}[_j]; // element i,j appears only here
 
             // the following commented (superdiagonal) element is not used in the following anymore since
             // it is 0 by definition of (lower) triangularization; we keep it here for algorithmic clarity
-            //{{_P_children}}[IDX_C(_i,_k)] = {{_P_children}}[IDX_C(_i,_k)]  - subfac * {{_P_diag}}[_j]; // = 0;
+            //{{_P_children}}[_IDX_C(_i,_k)] = {{_P_children}}[_IDX_C(_i,_k)]  - _subfac * {{_P_diag}}[_j]; // = 0;
 
-            {{_P_diag}}[_i] = {{_P_diag}}[_i]  - subfac * {{_P_parent}}[_j-1]; // note: element j,i is only used here
-            {{_B}}[_i] = {{_B}}[_i] - subfac * {{_B}}[_j];
+            {{_P_diag}}[_i] = {{_P_diag}}[_i]  - _subfac * {{_P_parent}}[_j-1]; // note: element j,i is only used here
+            {{_B}}[_i] = {{_B}}[_i] - _subfac * {{_B}}[_j];
 
         }
     }
@@ -202,8 +202,8 @@
     // part 2: forwards substitution
     {{_B}}[0] = {{_B}}[0] / {{_P_diag}}[0]; // the first branch does not have a parent
     for (int _i=1; _i<_num_B; _i++) {
-        const int j = {{_morph_parent_i}}[_i-1]; // parent index
-        {{_B}}[_i] = {{_B}}[_i] - {{_P_parent}}[_i-1] * {{_B}}[j];
+        const int _j = {{_morph_parent_i}}[_i-1]; // parent index
+        {{_B}}[_i] = {{_B}}[_i] - {{_P_parent}}[_i-1] * {{_B}}[_j];
         {{_B}}[_i] = {{_B}}[_i] / {{_P_diag}}[_i];
 
     }

--- a/brian2/codegen/runtime/weave_rt/templates/spatialstateupdate.cpp
+++ b/brian2/codegen/runtime/weave_rt/templates/spatialstateupdate.cpp
@@ -1,11 +1,11 @@
 ////////////////////////////////////////////////////////////////////////////
 //// MAIN CODE /////////////////////////////////////////////////////////////
 {# USES_VARIABLES { Cm, dt, v, N,
-                  ab_star0, ab_star1, ab_star2, b_plus,
-                  ab_plus0, ab_plus1, ab_plus2, b_minus,
-                  ab_minus0, ab_minus1, ab_minus2, v_star, u_plus, u_minus,
-                  gtot_all, I0_all,
-                  c1, c2, c3,
+                  _ab_star0, _ab_star1, _ab_star2, _b_plus,
+                  _a_plus0, _a_plus1, _a_plus2, _b_minus,
+                  _a_minus0, _a_minus1, _a_minus2, _v_star, _u_plus, _u_minus,
+                  _gtot_all, _I0_all,
+                  _c1, _c2, _c3,
                   _P_diag, _P_parent, _P_children,
                   _B, _morph_parent_i, _starts, _ends,
                   _morph_children, _morph_children_num, _morph_idxchild,
@@ -26,13 +26,13 @@
         _vectorisation_idx = _idx;
 
         {{vector_code|autoindent}}
-        {{gtot_all}}[_idx] = _gtot;
-        {{I0_all}}[_idx] = _I0;
+        {{_gtot_all}}[_idx] = _gtot;
+        {{_I0_all}}[_idx] = _I0;
     }
 
     // STEP 2: for each branch: solve three tridiagonal systems
 
-    // system 2a: solve for v_star
+    // system 2a: solve for _v_star
     for (int _i=0; _i<_num_B - 1; _i++)
     {
         // first and last index of the i-th branch
@@ -41,28 +41,28 @@
 
         double ai, bi, _m; // helper variables
 
-        // upper triangularization of tridiagonal system for v_star
+        // upper triangularization of tridiagonal system for _v_star
         for(int _j=_j_start; _j<_j_end+1; _j++)
         {
-            {{v_star}}[_j]=-({{Cm}}[_j]/{{dt}}*{{v}}[_j])-{{I0_all}}[_j]; // RHS -> v_star (solution)
-            bi={{ab_star1}}[_j]-{{gtot_all}}[_j]; // main diagonal
+            {{_v_star}}[_j]=-({{Cm}}[_j]/{{dt}}*{{v}}[_j])-{{_I0_all}}[_j]; // RHS -> _v_star (solution)
+            bi={{_ab_star1}}[_j]-{{_gtot_all}}[_j]; // main diagonal
             if (_j<N-1)
-                {{c1}}[_j]={{ab_star0}}[_j+1]; // superdiagonal
+                {{_c1}}[_j]={{_ab_star0}}[_j+1]; // superdiagonal
             if (_j>0)
             {
-                ai={{ab_star2}}[_j-1]; // subdiagonal
-                _m=1.0/(bi-ai*{{c1}}[_j-1]);
-                {{c1}}[_j]={{c1}}[_j]*_m;
-                {{v_star}}[_j]=({{v_star}}[_j] - ai*{{v_star}}[_j-1])*_m;
+                ai={{_ab_star2}}[_j-1]; // subdiagonal
+                _m=1.0/(bi-ai*{{_c1}}[_j-1]);
+                {{_c1}}[_j]={{_c1}}[_j]*_m;
+                {{_v_star}}[_j]=({{_v_star}}[_j] - ai*{{_v_star}}[_j-1])*_m;
             } else
             {
-                {{c1}}[0]={{c1}}[0]/bi;
-                {{v_star}}[0]={{v_star}}[0]/bi;
+                {{_c1}}[0]={{_c1}}[0]/bi;
+                {{_v_star}}[0]={{_v_star}}[0]/bi;
             }
         }
-        // backwards substitution of the upper triangularized system for v_star
+        // backwards substitution of the upper triangularized system for _v_star
         for(int _j=_j_end-1; _j>=_j_start; _j--)
-            {{v_star}}[_j]={{v_star}}[_j] - {{c1}}[_j]*{{v_star}}[_j+1];
+            {{_v_star}}[_j]={{_v_star}}[_j] - {{_c1}}[_j]*{{_v_star}}[_j+1];
     }
     for (int _i=0; _i<_num_B - 1; _i++)
     {
@@ -72,28 +72,28 @@
 
         double ai, bi, _m; // helper variables
 
-        // upper triangularization of tridiagonal system for u_plus
+        // upper triangularization of tridiagonal system for _u_plus
         for(int _j=_j_start; _j<_j_end+1; _j++)
         {
-            {{u_plus}}[_j]={{b_plus}}[_j]; // RHS -> u_plus (solution)
-            bi={{ab_plus1}}[_j]-{{gtot_all}}[_j]; // main diagonal
+            {{_u_plus}}[_j]={{_b_plus}}[_j]; // RHS -> _u_plus (solution)
+            bi={{_a_plus1}}[_j]-{{_gtot_all}}[_j]; // main diagonal
             if (_j<N-1)
-                {{c2}}[_j]={{ab_plus0}}[_j+1]; // superdiagonal
+                {{_c2}}[_j]={{_a_plus0}}[_j+1]; // superdiagonal
             if (_j>0)
             {
-                ai={{ab_plus2}}[_j-1]; // subdiagonal
-                _m=1.0/(bi-ai*{{c2}}[_j-1]);
-                {{c2}}[_j]={{c2}}[_j]*_m;
-                {{u_plus}}[_j]=({{u_plus}}[_j] - ai*{{u_plus}}[_j-1])*_m;
+                ai={{_a_plus2}}[_j-1]; // subdiagonal
+                _m=1.0/(bi-ai*{{_c2}}[_j-1]);
+                {{_c2}}[_j]={{_c2}}[_j]*_m;
+                {{_u_plus}}[_j]=({{_u_plus}}[_j] - ai*{{_u_plus}}[_j-1])*_m;
             } else
             {
-                {{c2}}[0]={{c2}}[0]/bi;
-                {{u_plus}}[0]={{u_plus}}[0]/bi;
+                {{_c2}}[0]={{_c2}}[0]/bi;
+                {{_u_plus}}[0]={{_u_plus}}[0]/bi;
             }
         }
-        // backwards substitution of the upper triangularized system for u_plus
+        // backwards substitution of the upper triangularized system for _u_plus
         for(int _j=_j_end-1; _j>=_j_start; _j--)
-            {{u_plus}}[_j]={{u_plus}}[_j] - {{c2}}[_j]*{{u_plus}}[_j+1];
+            {{_u_plus}}[_j]={{_u_plus}}[_j] - {{_c2}}[_j]*{{_u_plus}}[_j+1];
     }
 
     for (int _i=0; _i<_num_B - 1; _i++)
@@ -104,28 +104,28 @@
 
         double ai, bi, _m; // helper variables
 
-        // upper triangularization of tridiagonal system for u_minus
+        // upper triangularization of tridiagonal system for _u_minus
         for(int _j=_j_start; _j<_j_end+1; _j++)
         {
-            {{u_minus}}[_j]={{b_minus}}[_j]; // RHS -> u_minus (solution)
-            bi={{ab_minus1}}[_j]-{{gtot_all}}[_j]; // main diagonal
+            {{_u_minus}}[_j]={{_b_minus}}[_j]; // RHS -> _u_minus (solution)
+            bi={{_a_minus1}}[_j]-{{_gtot_all}}[_j]; // main diagonal
             if (_j<N-1)
-                {{c3}}[_j]={{ab_minus0}}[_j+1]; // superdiagonal
+                {{_c3}}[_j]={{_a_minus0}}[_j+1]; // superdiagonal
             if (_j>0)
             {
-                ai={{ab_minus2}}[_j-1]; // subdiagonal
-                _m=1.0/(bi-ai*{{c3}}[_j-1]);
-                {{c3}}[_j]={{c3}}[_j]*_m;
-                {{u_minus}}[_j]=({{u_minus}}[_j] - ai*{{u_minus}}[_j-1])*_m;
+                ai={{_a_minus2}}[_j-1]; // subdiagonal
+                _m=1.0/(bi-ai*{{_c3}}[_j-1]);
+                {{_c3}}[_j]={{_c3}}[_j]*_m;
+                {{_u_minus}}[_j]=({{_u_minus}}[_j] - ai*{{_u_minus}}[_j-1])*_m;
             } else
             {
-                {{c3}}[0]={{c3}}[0]/bi;
-                {{u_minus}}[0]={{u_minus}}[0]/bi;
+                {{_c3}}[0]={{_c3}}[0]/bi;
+                {{_u_minus}}[0]={{_u_minus}}[0]/bi;
             }
         }
-        // backwards substitution of the upper triangularized system for u_minus
+        // backwards substitution of the upper triangularized system for _u_minus
         for(int _j=_j_end-1; _j>=_j_start; _j--)
-            {{u_minus}}[_j]={{u_minus}}[_j] - {{c3}}[_j]*{{u_minus}}[_j+1];
+            {{_u_minus}}[_j]={{_u_minus}}[_j] - {{_c3}}[_j]*{{_u_minus}}[_j+1];
     }
 
     // STEP 3: solve the coupling system
@@ -151,27 +151,27 @@
         // Towards parent
         if (_i == 0) // first branch, sealed end
         {
-            {{_P_diag}}[0] = {{u_minus}}[_first] - 1;
-            {{_P_children}}[IDX_C(0,0)] = {{u_plus}}[_first];
+            {{_P_diag}}[0] = {{_u_minus}}[_first] - 1;
+            {{_P_children}}[IDX_C(0,0)] = {{_u_plus}}[_first];
 
             // RHS
-            {{_B}}[0] = -{{v_star}}[_first];
+            {{_B}}[0] = -{{_v_star}}[_first];
         }
         else
         {
-            {{_P_diag}}[_i_parent] += (1 - {{u_minus}}[_first]) * _invr0;
-            {{_P_children}}[IDX_C(_i_parent, _i_childind)] = -{{u_plus}}[_first] * _invr0;
+            {{_P_diag}}[_i_parent] += (1 - {{_u_minus}}[_first]) * _invr0;
+            {{_P_children}}[IDX_C(_i_parent, _i_childind)] = -{{_u_plus}}[_first] * _invr0;
 
             // RHS
-            {{_B}}[_i_parent] += {{v_star}}[_first] * _invr0;
+            {{_B}}[_i_parent] += {{_v_star}}[_first] * _invr0;
         }
 
         // Towards children
-        {{_P_diag}}[_i+1] = (1 - {{u_plus}}[_last]) * _invrn;
-        {{_P_parent}}[_i] = -{{u_minus}}[_last] * _invrn;
+        {{_P_diag}}[_i+1] = (1 - {{_u_plus}}[_last]) * _invrn;
+        {{_P_parent}}[_i] = -{{_u_minus}}[_last] * _invrn;
 
         // RHS
-        {{_B}}[_i+1] = {{v_star}}[_last] * _invrn;
+        {{_B}}[_i+1] = {{_v_star}}[_last] * _invrn;
     }
 
 
@@ -217,8 +217,8 @@
         const int _j_end = {{_ends}}[_i];
         for (int _j=_j_start; _j<_j_end + 1; _j++)
             if (_j < _numv)  // don't go beyond the last element
-                {{v}}[_j] = {{v_star}}[_j] + {{_B}}[_i_parent] * {{u_minus}}[_j]
-                                           + {{_B}}[_i+1] * {{u_plus}}[_j];
+                {{v}}[_j] = {{_v_star}}[_j] + {{_B}}[_i_parent] * {{_u_minus}}[_j]
+                                           + {{_B}}[_i+1] * {{_u_plus}}[_j];
     }
 
 {% endblock %}

--- a/brian2/core/variables.py
+++ b/brian2/core/variables.py
@@ -1447,7 +1447,7 @@ class Variables(collections.Mapping):
             See `ArrayVariable`. Defaults to ``False``.
         '''
         if np.asanyarray(size).shape == ():
-            # We don't a basic Python type for the size instead of something
+            # We want a basic Python type for the size instead of something
             # like numpy.int64
             size = int(size)
         var = ArrayVariable(name=name, unit=unit, owner=self.owner,
@@ -1471,6 +1471,45 @@ class Variables(collections.Mapping):
                     raise ValueError(('Size of the provided values does not match '
                                       'size: %d != %d') % (len(values), size))
                 self.device.fill_with_array(var, values)
+
+    def add_arrays(self, names, unit, size, values=None, dtype=None,
+                  constant=False, read_only=False, scalar=False, unique=False,
+                  index=None):
+        '''
+        Adds several arrays (initialized with zeros) with the same attributes
+        (size, units, etc.).
+
+        Parameters
+        ----------
+        names : list of str
+            The names of the variable.
+        unit : `Unit`
+            The unit of the variables
+        size : int
+            The sizes of the arrays.
+        dtype : `dtype`, optional
+            The dtype used for storing the variables. If none is given, defaults
+            to `core.default_float_dtype`.
+        constant : bool, optional
+            Whether the variables' values are constant during a run.
+            Defaults to ``False``.
+        scalar : bool, optional
+            Whether these are scalar variables. Defaults to ``False``, if set to
+            ``True``, also implies that `size` equals 1.
+        read_only : bool, optional
+            Whether these are read-only variables, i.e. variables that are set
+            internally and cannot be changed by the user. Defaults
+            to ``False``.
+        index : str, optional
+            The index to use for these variables. Defaults to
+            `Variables.default_index`.
+        unique : bool, optional
+            See `ArrayVariable`. Defaults to ``False``.
+        '''
+        for name in names:
+            self.add_array(name, unit=unit, size=size, dtype=dtype,
+                           constant=constant, read_only=read_only,
+                           scalar=scalar, unique=unique, index=index)
 
     def add_dynamic_array(self, name, unit, size, values=None, dtype=None,
                           constant=False, needs_reference_update=False,

--- a/brian2/devices/cpp_standalone/templates/spatialneuron_prepare.cpp
+++ b/brian2/devices/cpp_standalone/templates/spatialneuron_prepare.cpp
@@ -1,8 +1,8 @@
 {# USES_VARIABLES { N, _invr, Ri, Cm, dt, area, diameter, length,
-                    ab_star0, ab_star1, ab_star2,
-                    ab_plus0, ab_plus1, ab_plus2,
-                    ab_minus0, ab_minus1, ab_minus2,
-                    _starts, _ends, _invr0, _invrn, b_plus, b_minus } #}
+                    _ab_star0, _ab_star1, _ab_star2,
+                    _a_plus0, _a_plus1, _a_plus2,
+                    _a_minus0, _a_minus1, _a_minus2,
+                    _starts, _ends, _invr0, _invrn, _b_plus, _b_minus } #}
 {% extends 'common_group.cpp' %}
 {% block maincode %}
     const double _Ri = {{Ri}};  // Ri is a shared variable
@@ -29,24 +29,24 @@
     // a[i,j]=ab[u+i-j,j]   --  u is the number of upper diagonals = 1
     {{ openmp_pragma('parallel-static') }}
     for (int _i=0; _i<N; _i++)
-        {{ab_star1}}[_i] = (-({{Cm}}[_i] / {{dt}}) - {{_invr}}[_i] / {{area}}[_i]);
+        {{_ab_star1}}[_i] = (-({{Cm}}[_i] / {{dt}}) - {{_invr}}[_i] / {{area}}[_i]);
     {{ openmp_pragma('parallel-static') }}
     for (int _i=1; _i<N; _i++)
     {
-        {{ab_star0}}[_i] = {{_invr}}[_i] / {{area}}[_i-1];
-        {{ab_star2}}[_i-1] = {{_invr}}[_i] / {{area}}[_i];
-        {{ab_star1}}[_i-1] -= {{_invr}}[_i] / {{area}}[_i-1];
+        {{_ab_star0}}[_i] = {{_invr}}[_i] / {{area}}[_i-1];
+        {{_ab_star2}}[_i-1] = {{_invr}}[_i] / {{area}}[_i];
+        {{_ab_star1}}[_i-1] -= {{_invr}}[_i] / {{area}}[_i-1];
     }
     {{ openmp_pragma('parallel-static') }}
     for (int _i=0; _i<N; _i++)
     {
         // Homogeneous solutions
-        {{ab_plus0}}[_i] = {{ab_star0}}[_i];
-        {{ab_minus0}}[_i] = {{ab_star0}}[_i];
-        {{ab_plus1}}[_i] = {{ab_star1}}[_i];
-        {{ab_minus1}}[_i] = {{ab_star1}}[_i];
-        {{ab_plus2}}[_i] = {{ab_star2}}[_i];
-        {{ab_minus2}}[_i] = {{ab_star2}}[_i];
+        {{_a_plus0}}[_i] = {{_ab_star0}}[_i];
+        {{_a_minus0}}[_i] = {{_ab_star0}}[_i];
+        {{_a_plus1}}[_i] = {{_ab_star1}}[_i];
+        {{_a_minus1}}[_i] = {{_ab_star1}}[_i];
+        {{_a_plus2}}[_i] = {{_ab_star2}}[_i];
+        {{_a_minus2}}[_i] = {{_ab_star2}}[_i];
     }
 
     // Set the boundary conditions
@@ -62,15 +62,15 @@
         {{_invr0}}[_counter] = _invr0;
         {{_invrn}}[_counter] = _invrn;
         // Correction for boundary conditions
-        {{ab_star1}}[_first] -= (_invr0 / {{area}}[_first]);
-        {{ab_star1}}[_last] -= (_invrn / {{area}}[_last]);
-        {{ab_plus1}}[_first] -= (_invr0 / {{area}}[_first]);
-        {{ab_plus1}}[_last] -= (_invrn / {{area}}[_last]);
-        {{ab_minus1}}[_first] -= (_invr0 / {{area}}[_first]);
-        {{ab_minus1}}[_last] -= (_invrn / {{area}}[_last]);
+        {{_ab_star1}}[_first] -= (_invr0 / {{area}}[_first]);
+        {{_ab_star1}}[_last] -= (_invrn / {{area}}[_last]);
+        {{_a_plus1}}[_first] -= (_invr0 / {{area}}[_first]);
+        {{_a_plus1}}[_last] -= (_invrn / {{area}}[_last]);
+        {{_a_minus1}}[_first] -= (_invr0 / {{area}}[_first]);
+        {{_a_minus1}}[_last] -= (_invrn / {{area}}[_last]);
         // RHS for homogeneous solutions
-        {{b_plus}}[_last] = -(_invrn / {{area}}[_last]);
-        {{b_minus}}[_first] = -(_invr0 / {{area}}[_first]);
+        {{_b_plus}}[_last] = -(_invrn / {{area}}[_last]);
+        {{_b_minus}}[_first] = -(_invr0 / {{area}}[_first]);
     }
 {% endblock %}
 

--- a/brian2/devices/cpp_standalone/templates/spatialstateupdate.cpp
+++ b/brian2/devices/cpp_standalone/templates/spatialstateupdate.cpp
@@ -2,11 +2,11 @@
 //// MAIN CODE /////////////////////////////////////////////////////////////
 
 {# USES_VARIABLES { Cm, dt, v, N,
-                  ab_star0, ab_star1, ab_star2, b_plus,
-                  ab_plus0, ab_plus1, ab_plus2, b_minus,
-                  ab_minus0, ab_minus1, ab_minus2, v_star, u_plus, u_minus,
-                  gtot_all, I0_all,
-                  c1, c2, c3,
+                  _ab_star0, _ab_star1, _ab_star2, _b_plus,
+                  _a_plus0, _a_plus1, _a_plus2, _b_minus,
+                  _a_minus0, _a_minus1, _a_minus2, _v_star, _u_plus, _u_minus,
+                  _gtot_all, _I0_all,
+                  _c1, _c2, _c3,
                   _P_diag, _P_parent, _P_children,
                   _B, _morph_parent_i, _starts, _ends,
                   _morph_children, _morph_children_num, _morph_idxchild,
@@ -37,8 +37,8 @@
         _vectorisation_idx = _idx;
 
         {{vector_code|autoindent}}
-        {{gtot_all}}[_idx] = _gtot;
-        {{I0_all}}[_idx] = _I0;
+        {{_gtot_all}}[_idx] = _gtot;
+        {{_I0_all}}[_idx] = _I0;
     }
 
     // STEP 2: for each branch: solve three tridiagonal systems
@@ -50,7 +50,7 @@
     {% endif %}
     {{ openmp_pragma('sections') }}
     {
-    // system 2a: solve for v_star
+    // system 2a: solve for _v_star
     {{ openmp_pragma('section') }}
     {
         {% if strategy == 'branches' %}
@@ -64,31 +64,31 @@
             
             double ai, bi, _m; // helper variables
 
-            // upper triangularization of tridiagonal system for v_star
+            // upper triangularization of tridiagonal system for _v_star
             for(int _j=_j_start; _j<_j_end+1; _j++)
             {
-                {{v_star}}[_j]=-({{Cm}}[_j]/{{dt}}*{{v}}[_j])-{{I0_all}}[_j]; // RHS -> v_star (solution)
-                bi={{ab_star1}}[_j]-{{gtot_all}}[_j]; // main diagonal
+                {{_v_star}}[_j]=-({{Cm}}[_j]/{{dt}}*{{v}}[_j])-{{_I0_all}}[_j]; // RHS -> _v_star (solution)
+                bi={{_ab_star1}}[_j]-{{_gtot_all}}[_j]; // main diagonal
                 if (_j<N-1)
-                    {{c1}}[_j]={{ab_star0}}[_j+1]; // superdiagonal
+                    {{_c1}}[_j]={{_ab_star0}}[_j+1]; // superdiagonal
                 if (_j>0)
                 {
-                    ai={{ab_star2}}[_j-1]; // subdiagonal
-                    _m=1.0/(bi-ai*{{c1}}[_j-1]);
-                    {{c1}}[_j]={{c1}}[_j]*_m;
-                    {{v_star}}[_j]=({{v_star}}[_j] - ai*{{v_star}}[_j-1])*_m;
+                    ai={{_ab_star2}}[_j-1]; // subdiagonal
+                    _m=1.0/(bi-ai*{{_c1}}[_j-1]);
+                    {{_c1}}[_j]={{_c1}}[_j]*_m;
+                    {{_v_star}}[_j]=({{_v_star}}[_j] - ai*{{_v_star}}[_j-1])*_m;
                 } else
                 {
-                    {{c1}}[0]={{c1}}[0]/bi;
-                    {{v_star}}[0]={{v_star}}[0]/bi;
+                    {{_c1}}[0]={{_c1}}[0]/bi;
+                    {{_v_star}}[0]={{_v_star}}[0]/bi;
                 }
             }
-            // backwards substituation of the upper triangularized system for v_star
+            // backwards substituation of the upper triangularized system for _v_star
             for(int _j=_j_end-1; _j>=_j_start; _j--)
-                {{v_star}}[_j]={{v_star}}[_j] - {{c1}}[_j]*{{v_star}}[_j+1];
+                {{_v_star}}[_j]={{_v_star}}[_j] - {{_c1}}[_j]*{{_v_star}}[_j+1];
         }
     }
-    // system 2b: solve for u_plus
+    // system 2b: solve for _u_plus
     {{ openmp_pragma('section') }}
     {
         {% if strategy == 'branches' %}
@@ -102,31 +102,31 @@
             
             double ai, bi, _m; // helper variables
 
-            // upper triangularization of tridiagonal system for u_plus
+            // upper triangularization of tridiagonal system for _u_plus
             for(int _j=_j_start; _j<_j_end+1; _j++)
             {
-                {{u_plus}}[_j]={{b_plus}}[_j]; // RHS -> u_plus (solution)
-                bi={{ab_plus1}}[_j]-{{gtot_all}}[_j]; // main diagonal
+                {{_u_plus}}[_j]={{_b_plus}}[_j]; // RHS -> _u_plus (solution)
+                bi={{_a_plus1}}[_j]-{{_gtot_all}}[_j]; // main diagonal
                 if (_j<N-1)
-                    {{c2}}[_j]={{ab_plus0}}[_j+1]; // superdiagonal
+                    {{_c2}}[_j]={{_a_plus0}}[_j+1]; // superdiagonal
                 if (_j>0)
                 {
-                    ai={{ab_plus2}}[_j-1]; // subdiagonal
-                    _m=1.0/(bi-ai*{{c2}}[_j-1]);
-                    {{c2}}[_j]={{c2}}[_j]*_m;
-                    {{u_plus}}[_j]=({{u_plus}}[_j] - ai*{{u_plus}}[_j-1])*_m;
+                    ai={{_a_plus2}}[_j-1]; // subdiagonal
+                    _m=1.0/(bi-ai*{{_c2}}[_j-1]);
+                    {{_c2}}[_j]={{_c2}}[_j]*_m;
+                    {{_u_plus}}[_j]=({{_u_plus}}[_j] - ai*{{_u_plus}}[_j-1])*_m;
                 } else
                 {
-                    {{c2}}[0]={{c2}}[0]/bi;
-                    {{u_plus}}[0]={{u_plus}}[0]/bi;
+                    {{_c2}}[0]={{_c2}}[0]/bi;
+                    {{_u_plus}}[0]={{_u_plus}}[0]/bi;
                 }
             }
-            // backwards substituation of the upper triangularized system for u_plus
+            // backwards substituation of the upper triangularized system for _u_plus
             for(int _j=_j_end-1; _j>=_j_start; _j--)
-                {{u_plus}}[_j]={{u_plus}}[_j] - {{c2}}[_j]*{{u_plus}}[_j+1];
+                {{_u_plus}}[_j]={{_u_plus}}[_j] - {{_c2}}[_j]*{{_u_plus}}[_j+1];
         }
     }
-    // system 2c: solve for u_minus
+    // system 2c: solve for _u_minus
     {{ openmp_pragma('section') }}
     {
         {% if strategy == 'branches' %}
@@ -140,28 +140,28 @@
 
             double ai, bi, _m; // helper variables
             
-            // upper triangularization of tridiagonal system for u_minus
+            // upper triangularization of tridiagonal system for _u_minus
             for(int _j=_j_start; _j<_j_end+1; _j++)
             {
-                {{u_minus}}[_j]={{b_minus}}[_j]; // RHS -> u_minus (solution)
-                bi={{ab_minus1}}[_j]-{{gtot_all}}[_j]; // main diagonal
+                {{_u_minus}}[_j]={{_b_minus}}[_j]; // RHS -> _u_minus (solution)
+                bi={{_a_minus1}}[_j]-{{_gtot_all}}[_j]; // main diagonal
                 if (_j<N-1)
-                    {{c3}}[_j]={{ab_minus0}}[_j+1]; // superdiagonal
+                    {{_c3}}[_j]={{_a_minus0}}[_j+1]; // superdiagonal
                 if (_j>0)
                 {
-                    ai={{ab_minus2}}[_j-1]; // subdiagonal
-                    _m=1.0/(bi-ai*{{c3}}[_j-1]);
-                    {{c3}}[_j]={{c3}}[_j]*_m;
-                    {{u_minus}}[_j]=({{u_minus}}[_j] - ai*{{u_minus}}[_j-1])*_m;
+                    ai={{_a_minus2}}[_j-1]; // subdiagonal
+                    _m=1.0/(bi-ai*{{_c3}}[_j-1]);
+                    {{_c3}}[_j]={{_c3}}[_j]*_m;
+                    {{_u_minus}}[_j]=({{_u_minus}}[_j] - ai*{{_u_minus}}[_j-1])*_m;
                 } else
                 {
-                    {{c3}}[0]={{c3}}[0]/bi;
-                    {{u_minus}}[0]={{u_minus}}[0]/bi;
+                    {{_c3}}[0]={{_c3}}[0]/bi;
+                    {{_u_minus}}[0]={{_u_minus}}[0]/bi;
                 }
             }
-            // backwards substituation of the upper triangularized system for u_minus
+            // backwards substituation of the upper triangularized system for _u_minus
             for(int _j=_j_end-1; _j>=_j_start; _j--)
-                {{u_minus}}[_j]={{u_minus}}[_j] - {{c3}}[_j]*{{u_minus}}[_j+1];
+                {{_u_minus}}[_j]={{_u_minus}}[_j] - {{_c3}}[_j]*{{_u_minus}}[_j+1];
         }
     } // (OpenMP section)
     } // (OpenMP sections)
@@ -194,30 +194,30 @@
         if (_i == 0) // first branch, sealed end
         {
             // sparse matrix version
-            {{_P_diag}}[0] = {{u_minus}}[_first] - 1;
-            {{_P_children}}[IDX_C(0,0)] = {{u_plus}}[_first];
+            {{_P_diag}}[0] = {{_u_minus}}[_first] - 1;
+            {{_P_children}}[IDX_C(0,0)] = {{_u_plus}}[_first];
 
             // RHS
-            {{_B}}[0] = -{{v_star}}[_first];
+            {{_B}}[0] = -{{_v_star}}[_first];
         }
         else
         {
             // sparse matrix version
-            {{_P_diag}}[_i_parent] += (1 - {{u_minus}}[_first]) * _invr0;
-            {{_P_children}}[IDX_C(_i_parent, _i_childind)] = -{{u_plus}}[_first] * _invr0;
+            {{_P_diag}}[_i_parent] += (1 - {{_u_minus}}[_first]) * _invr0;
+            {{_P_children}}[IDX_C(_i_parent, _i_childind)] = -{{_u_plus}}[_first] * _invr0;
 
             // RHS
-            {{_B}}[_i_parent] += {{v_star}}[_first] * _invr0;
+            {{_B}}[_i_parent] += {{_v_star}}[_first] * _invr0;
         }
 
         // Towards children
 
         // sparse matrix version
-        {{_P_diag}}[_i+1] = (1 - {{u_plus}}[_last]) * _invrn;
-        {{_P_parent}}[_i] = -{{u_minus}}[_last] * _invrn;
+        {{_P_diag}}[_i+1] = (1 - {{_u_plus}}[_last]) * _invrn;
+        {{_P_parent}}[_i] = -{{_u_minus}}[_last] * _invrn;
 
         // RHS
-        {{_B}}[_i+1] = {{v_star}}[_last] * _invrn;
+        {{_B}}[_i+1] = {{_v_star}}[_last] * _invrn;
     }
 
 
@@ -263,8 +263,8 @@
         const int _j_end = {{_ends}}[_i];
         for (int _j=_j_start; _j<_j_end + 1; _j++)
             if (_j < _numv)  // don't go beyond the last element
-                {{v}}[_j] = {{v_star}}[_j] + {{_B}}[_i_parent] * {{u_minus}}[_j]
-                                           + {{_B}}[_i+1] * {{u_plus}}[_j];
+                {{v}}[_j] = {{_v_star}}[_j] + {{_B}}[_i_parent] * {{_u_minus}}[_j]
+                                           + {{_B}}[_i+1] * {{_u_plus}}[_j];
     }
 
 {% endblock %}

--- a/brian2/devices/cpp_standalone/templates/spatialstateupdate.cpp
+++ b/brian2/devices/cpp_standalone/templates/spatialstateupdate.cpp
@@ -62,25 +62,25 @@
             const int _j_start = {{_starts}}[_i];
             const int _j_end = {{_ends}}[_i];
             
-            double ai, bi, _m; // helper variables
+            double _ai, _bi, _m; // helper variables
 
             // upper triangularization of tridiagonal system for _v_star
             for(int _j=_j_start; _j<_j_end+1; _j++)
             {
                 {{_v_star}}[_j]=-({{Cm}}[_j]/{{dt}}*{{v}}[_j])-{{_I0_all}}[_j]; // RHS -> _v_star (solution)
-                bi={{_ab_star1}}[_j]-{{_gtot_all}}[_j]; // main diagonal
+                _bi={{_ab_star1}}[_j]-{{_gtot_all}}[_j]; // main diagonal
                 if (_j<N-1)
                     {{_c1}}[_j]={{_ab_star0}}[_j+1]; // superdiagonal
                 if (_j>0)
                 {
-                    ai={{_ab_star2}}[_j-1]; // subdiagonal
-                    _m=1.0/(bi-ai*{{_c1}}[_j-1]);
+                    _ai={{_ab_star2}}[_j-1]; // subdiagonal
+                    _m=1.0/(_bi-_ai*{{_c1}}[_j-1]);
                     {{_c1}}[_j]={{_c1}}[_j]*_m;
-                    {{_v_star}}[_j]=({{_v_star}}[_j] - ai*{{_v_star}}[_j-1])*_m;
+                    {{_v_star}}[_j]=({{_v_star}}[_j] - _ai*{{_v_star}}[_j-1])*_m;
                 } else
                 {
-                    {{_c1}}[0]={{_c1}}[0]/bi;
-                    {{_v_star}}[0]={{_v_star}}[0]/bi;
+                    {{_c1}}[0]={{_c1}}[0]/_bi;
+                    {{_v_star}}[0]={{_v_star}}[0]/_bi;
                 }
             }
             // backwards substituation of the upper triangularized system for _v_star
@@ -100,25 +100,25 @@
             const int _j_start = {{_starts}}[_i];
             const int _j_end = {{_ends}}[_i];
             
-            double ai, bi, _m; // helper variables
+            double _ai, _bi, _m; // helper variables
 
             // upper triangularization of tridiagonal system for _u_plus
             for(int _j=_j_start; _j<_j_end+1; _j++)
             {
                 {{_u_plus}}[_j]={{_b_plus}}[_j]; // RHS -> _u_plus (solution)
-                bi={{_a_plus1}}[_j]-{{_gtot_all}}[_j]; // main diagonal
+                _bi={{_a_plus1}}[_j]-{{_gtot_all}}[_j]; // main diagonal
                 if (_j<N-1)
                     {{_c2}}[_j]={{_a_plus0}}[_j+1]; // superdiagonal
                 if (_j>0)
                 {
-                    ai={{_a_plus2}}[_j-1]; // subdiagonal
-                    _m=1.0/(bi-ai*{{_c2}}[_j-1]);
+                    _ai={{_a_plus2}}[_j-1]; // subdiagonal
+                    _m=1.0/(_bi-_ai*{{_c2}}[_j-1]);
                     {{_c2}}[_j]={{_c2}}[_j]*_m;
-                    {{_u_plus}}[_j]=({{_u_plus}}[_j] - ai*{{_u_plus}}[_j-1])*_m;
+                    {{_u_plus}}[_j]=({{_u_plus}}[_j] - _ai*{{_u_plus}}[_j-1])*_m;
                 } else
                 {
-                    {{_c2}}[0]={{_c2}}[0]/bi;
-                    {{_u_plus}}[0]={{_u_plus}}[0]/bi;
+                    {{_c2}}[0]={{_c2}}[0]/_bi;
+                    {{_u_plus}}[0]={{_u_plus}}[0]/_bi;
                 }
             }
             // backwards substituation of the upper triangularized system for _u_plus
@@ -138,25 +138,25 @@
             const int _j_start = {{_starts}}[_i];
             const int _j_end = {{_ends}}[_i];
 
-            double ai, bi, _m; // helper variables
+            double _ai, _bi, _m; // helper variables
             
             // upper triangularization of tridiagonal system for _u_minus
             for(int _j=_j_start; _j<_j_end+1; _j++)
             {
                 {{_u_minus}}[_j]={{_b_minus}}[_j]; // RHS -> _u_minus (solution)
-                bi={{_a_minus1}}[_j]-{{_gtot_all}}[_j]; // main diagonal
+                _bi={{_a_minus1}}[_j]-{{_gtot_all}}[_j]; // main diagonal
                 if (_j<N-1)
                     {{_c3}}[_j]={{_a_minus0}}[_j+1]; // superdiagonal
                 if (_j>0)
                 {
-                    ai={{_a_minus2}}[_j-1]; // subdiagonal
-                    _m=1.0/(bi-ai*{{_c3}}[_j-1]);
+                    _ai={{_a_minus2}}[_j-1]; // subdiagonal
+                    _m=1.0/(_bi-_ai*{{_c3}}[_j-1]);
                     {{_c3}}[_j]={{_c3}}[_j]*_m;
-                    {{_u_minus}}[_j]=({{_u_minus}}[_j] - ai*{{_u_minus}}[_j-1])*_m;
+                    {{_u_minus}}[_j]=({{_u_minus}}[_j] - _ai*{{_u_minus}}[_j-1])*_m;
                 } else
                 {
-                    {{_c3}}[0]={{_c3}}[0]/bi;
-                    {{_u_minus}}[0]={{_u_minus}}[0]/bi;
+                    {{_c3}}[0]={{_c3}}[0]/_bi;
+                    {{_u_minus}}[0]={{_u_minus}}[0]/_bi;
                 }
             }
             // backwards substituation of the upper triangularized system for _u_minus
@@ -173,8 +173,8 @@
     // STEP 3: solve the coupling system
 
     // indexing for _P_children which contains the elements above the diagonal of the coupling matrix _P
-    const int children_rowlength = _num_morph_children/_num_morph_children_num;
-    #define IDX_C(idx_row,idx_col) children_rowlength * idx_row + idx_col
+    const int _children_rowlength = _num_morph_children/_num_morph_children_num;
+    #define _IDX_C(idx_row,idx_col) _children_rowlength * idx_row + idx_col
 
     // STEP 3a: construct the coupling system with matrix _P in sparse form. s.t. 
     // _P_diag contains the diagonal elements
@@ -195,7 +195,7 @@
         {
             // sparse matrix version
             {{_P_diag}}[0] = {{_u_minus}}[_first] - 1;
-            {{_P_children}}[IDX_C(0,0)] = {{_u_plus}}[_first];
+            {{_P_children}}[_IDX_C(0,0)] = {{_u_plus}}[_first];
 
             // RHS
             {{_B}}[0] = -{{_v_star}}[_first];
@@ -204,7 +204,7 @@
         {
             // sparse matrix version
             {{_P_diag}}[_i_parent] += (1 - {{_u_minus}}[_first]) * _invr0;
-            {{_P_children}}[IDX_C(_i_parent, _i_childind)] = -{{_u_plus}}[_first] * _invr0;
+            {{_P_children}}[_IDX_C(_i_parent, _i_childind)] = -{{_u_plus}}[_first] * _invr0;
 
             // RHS
             {{_B}}[_i_parent] += {{_v_star}}[_first] * _invr0;
@@ -226,21 +226,21 @@
 
     // part 1: lower triangularization
     for (int _i=_num_B-1; _i>=0; _i--) {
-        const int num_children = {{_morph_children_num}}[_i];
+        const int _num_children = {{_morph_children_num}}[_i];
         
         // for every child eliminate the corresponding matrix element of row i
-        for (int _k=0; _k<num_children; _k++) {
-            int _j = {{_morph_children}}[IDX_C(_i,_k)]; // child index
+        for (int _k=0; _k<_num_children; _k++) {
+            int _j = {{_morph_children}}[_IDX_C(_i,_k)]; // child index
             
-            // subtracting subfac times the j-th from the i-th row
-            double subfac = {{_P_children}}[IDX_C(_i,_k)] / {{_P_diag}}[_j]; // element i,j appears only here
+            // subtracting _subfac times the j-th from the i-th row
+            double _subfac = {{_P_children}}[_IDX_C(_i,_k)] / {{_P_diag}}[_j]; // element i,j appears only here
 
             // the following commented (superdiagonal) element is not used in the following anymore since 
             // it is 0 by definition of (lower) triangularization; we keep it here for algorithmic clarity
-            //{{_P_children}}[IDX_C(_i,_k)] = {{_P_children}}[IDX_C(_i,_k)]  - subfac * {{_P_diag}}[_j]; // = 0;
+            //{{_P_children}}[_IDX_C(_i,_k)] = {{_P_children}}[_IDX_C(_i,_k)]  - _subfac * {{_P_diag}}[_j]; // = 0;
 
-            {{_P_diag}}[_i] = {{_P_diag}}[_i]  - subfac * {{_P_parent}}[_j-1]; // note: element j,i is only used here
-            {{_B}}[_i] = {{_B}}[_i] - subfac * {{_B}}[_j];
+            {{_P_diag}}[_i] = {{_P_diag}}[_i]  - _subfac * {{_P_parent}}[_j-1]; // note: element j,i is only used here
+            {{_B}}[_i] = {{_B}}[_i] - _subfac * {{_B}}[_j];
         
         }
     }
@@ -248,8 +248,8 @@
     // part 2: forwards substitution
     {{_B}}[0] = {{_B}}[0] / {{_P_diag}}[0]; // the first branch does not have a parent
     for (int _i=1; _i<_num_B; _i++) {
-        const int j = {{_morph_parent_i}}[_i-1]; // parent index
-        {{_B}}[_i] = {{_B}}[_i] - {{_P_parent}}[_i-1] * {{_B}}[j];
+        const int _j = {{_morph_parent_i}}[_i-1]; // parent index
+        {{_B}}[_i] = {{_B}}[_i] - {{_P_parent}}[_i-1] * {{_B}}[_j];
         {{_B}}[_i] = {{_B}}[_i] / {{_P_diag}}[_i];
         
     }

--- a/brian2/spatialneuron/spatialneuron.py
+++ b/brian2/spatialneuron/spatialneuron.py
@@ -210,21 +210,21 @@ class SpatialNeuron(NeuronGroup):
                              namespace=namespace, dtype=dtype, name=name)
         # Parameters and intermediate variables for solving the cable equations
         # Note that some of these variables could have meaningful physical
-        # units (e.g. v_star is in volt, I0_all is in amp/meter**2 etc.) but
+        # units (e.g. _v_star is in volt, _I0_all is in amp/meter**2 etc.) but
         # since these variables should never be used in user code, we don't
         # assign them any units
-        self.variables.add_arrays(['ab_star0', 'ab_star1', 'ab_star2',
-                                   'ab_minus0', 'ab_minus1', 'ab_minus2',
-                                   'ab_plus0', 'ab_plus1', 'ab_plus2',
-                                   'b_plus', 'b_minus',
-                                   'v_star', 'u_plus', 'u_minus',
+        self.variables.add_arrays(['_ab_star0', '_ab_star1', '_ab_star2',
+                                   '_a_minus0', '_a_minus1', '_a_minus2',
+                                   '_a_plus0', '_a_plus1', '_a_plus2',
+                                   '_b_plus', '_b_minus',
+                                   '_v_star', '_u_plus', '_u_minus',
                                    # The following three are for solving the
                                    # three tridiag systems in parallel
-                                   'c1', 'c2', 'c3',
+                                   '_c1', '_c2', '_c3',
                                    # The following two are only necessary for
                                    # C code where we cannot deal with scalars
                                    # and arrays interchangeably:
-                                   'I0_all', 'gtot_all'], unit=1,
+                                   '_I0_all', '_gtot_all'], unit=1,
                                   size=self.N, read_only=True)
 
         self.Cm = Cm
@@ -340,8 +340,6 @@ class SpatialStateUpdater(CodeRunner, Group):
     '''
     The `CodeRunner` that updates the state variables of a `SpatialNeuron`
     at every timestep.
-
-    TODO: all internal variables (u_minus etc) could be inserted in the SpatialNeuron.
     '''
 
     def __init__(self, group, method, clock, order=0):


### PR DESCRIPTION
Not a particularly interesting pull request... Renames all the internal variables used in the `spatialstateupdate` template so that they start with `_`. Also pulls them out of the `SpatialNeuron` equations (they are nothing the user cares about). To make this easier, introduces a new `add_arrays` method that allows to add several `ArrayVariable` objects at once.