### PR TITLE
[MRG] Unit performance improvements

### DIFF
--- a/brian2/tests/test_units.py
+++ b/brian2/tests/test_units.py
@@ -130,11 +130,10 @@ def test_get_dimensions():
     assert is_scalar_type(np.float32(5.0))
     assert is_scalar_type(np.float64(5.0))
     assert_raises(TypeError, lambda: get_dimensions('a string'))
-    
     # wrong number of indices
-    assert_raises(ValueError, lambda: get_or_create_dimension([1, 2, 3, 4, 5, 6]))
+    assert_raises(TypeError, lambda: get_or_create_dimension([1, 2, 3, 4, 5, 6]))
     # not a sequence
-    assert_raises(ValueError, lambda: get_or_create_dimension(42))
+    assert_raises(TypeError, lambda: get_or_create_dimension(42))
 
 
 @attr('codegen-independent')

--- a/brian2/tests/test_units.py
+++ b/brian2/tests/test_units.py
@@ -1004,11 +1004,19 @@ def test_fail_for_dimension_mismatch():
     Test the fail_for_dimension_mismatch function.
     '''
     # examples that should not raise an error
-    fail_for_dimension_mismatch(3)
-    fail_for_dimension_mismatch(3 * volt/volt)
-    fail_for_dimension_mismatch(3 * volt/volt, 7)
-    fail_for_dimension_mismatch(3 * volt, 5 * volt)
-    
+    dim1, dim2 = fail_for_dimension_mismatch(3)
+    assert dim1 is DIMENSIONLESS
+    assert dim2 is DIMENSIONLESS
+    dim1, dim2 = fail_for_dimension_mismatch(3 * volt/volt)
+    assert dim1 is DIMENSIONLESS
+    assert dim2 is DIMENSIONLESS
+    dim1, dim2 = fail_for_dimension_mismatch(3 * volt/volt, 7)
+    assert dim1 is DIMENSIONLESS
+    assert dim2 is DIMENSIONLESS
+    dim1, dim2 = fail_for_dimension_mismatch(3 * volt, 5 * volt)
+    assert dim1 is volt.dim
+    assert dim2 is volt.dim
+
     # examples that should raise an error
     assert_raises(DimensionMismatchError, lambda: fail_for_dimension_mismatch(6 * volt))
     assert_raises(DimensionMismatchError, lambda: fail_for_dimension_mismatch(6 * volt, 5 * second))    

--- a/brian2/tests/test_units.py
+++ b/brian2/tests/test_units.py
@@ -102,11 +102,7 @@ def test_construction():
     assert_raises(TypeError, lambda: Quantity(['some', 'nonsense']))
     assert_raises(DimensionMismatchError, lambda: Quantity([500 * ms,
                                                             1 * volt]))
-    assert_raises(DimensionMismatchError, lambda: Quantity([500 * ms],
-                                                           dim=volt.dim))
-    q = Quantity.with_dimensions(np.array([0.5, 1]), second=1)
-    assert_raises(DimensionMismatchError, lambda: Quantity(q, dim=volt.dim))
-    
+
 
 @attr('codegen-independent')
 def test_get_dimensions():

--- a/brian2/units/fundamentalunits.py
+++ b/brian2/units/fundamentalunits.py
@@ -510,11 +510,13 @@ def get_or_create_dimension(*args, **kwds):
     e.g. length, metre, and m all refer to the same thing here.
     """
     if len(args):
-        if isinstance(args[0], collections.Sequence) and len(args[0]) == 7:
-            # initialisation by list
-            dims = args[0]
-        else:
-            raise ValueError('Need a sequence of exactly 7 items')
+        # initialisation by list
+        dims = args[0]
+        try:
+            if len(dims) != 7:
+                raise TypeError()
+        except TypeError:
+            raise TypeError('Need a sequence of exactly 7 items')
     else:
         # initialisation by keywords
         dims = [0, 0, 0, 0, 0, 0, 0]
@@ -577,6 +579,7 @@ class DimensionMismatchError(Exception):
                             for d in self.dims]))
         return s + ').'
 
+
 def is_scalar_type(obj):
     """
     Tells you if the object is a 1d number type.
@@ -592,10 +595,10 @@ def is_scalar_type(obj):
         ``True`` if `obj` is a scalar that can be interpreted as a
         dimensionless `Quantity`.
     """
-    if isinstance(obj, np.number) or isinstance(obj, np.ndarray):
-        return np.isscalar(obj) or np.ndim(obj) == 0
-    else:
-        return isinstance(obj, numbers.Number)
+    try:
+        return obj.ndim == 0
+    except AttributeError:
+        return np.isscalar(obj) and not isinstance(obj, basestring)
 
 
 def get_dimensions(obj):

--- a/brian2/units/fundamentalunits.py
+++ b/brian2/units/fundamentalunits.py
@@ -1334,21 +1334,23 @@ class Quantity(np.ndarray, object):
         not like a numpy array scalar, preventing weird effects when a reference
         to the same value was stored in another variable. See github issue #469.
         '''
-        # try:
-        #     other = Quantity(other)
-        # except TypeError:
-        #     return NotImplemented
+        other_dim = None
 
         if fail_for_mismatch:
             if inplace:
                 message = ('Cannot calculate ... %s {value}, units do not '
                            'match') % operator_str
-                fail_for_dimension_mismatch(self, other, message, value=other)
+                _, other_dim = fail_for_dimension_mismatch(self, other,
+                                                           message, value=other)
             else:
                 message = ('Cannot calculate {value1} %s {value2}, units do not '
                            'match') % operator_str
-                fail_for_dimension_mismatch(self, other, message,
-                                            value1=self, value2=other)
+                _, other_dim = fail_for_dimension_mismatch(self, other, message,
+                                                           value1=self,
+                                                           value2=other)
+
+        if other_dim is None:
+            other_dim = get_dimensions(other)
 
         if inplace:
             if self.shape == ():
@@ -1356,10 +1358,9 @@ class Quantity(np.ndarray, object):
             else:
                 self_value = self
             operation(self_value, other)
-            self_value.dim = dim_operation(self.dim, get_dimensions(other))
+            self_value.dim = dim_operation(self.dim, other_dim)
             return self_value
         else:
-            other_dim = get_dimensions(other)
             newdims = dim_operation(self.dim, other_dim)
             self_arr = np.array(self, copy=False)
             other_arr = np.array(other, copy=False)

--- a/brian2/units/fundamentalunits.py
+++ b/brian2/units/fundamentalunits.py
@@ -127,6 +127,13 @@ def fail_for_dimension_mismatch(obj1, obj2=None, error_message=None,
         details in ``error_messsage`` is that converting large quantity arrays
         to strings can be rather costly and we don't want to do it if no error
         occured.
+
+    Returns
+    -------
+    dim1, dim2 : `Dimension`, `Dimension`
+        The dimensions of the two arguments (so that later code does not need
+        to get the dimensions again).
+
     Raises
     ------
     DimensionMismatchError
@@ -139,7 +146,7 @@ def fail_for_dimension_mismatch(obj1, obj2=None, error_message=None,
     dimensions".
     '''
     if not unit_checking:
-        return
+        return None, None
 
     dim1 = get_dimensions(obj1)
     if obj2 is None:
@@ -157,12 +164,12 @@ def fail_for_dimension_mismatch(obj1, obj2=None, error_message=None,
         # is not allowed, though.
         if ((dim1 is DIMENSIONLESS and np.all(obj1 == 0)) or
                 (dim2 is DIMENSIONLESS and np.all(obj2 == 0))):
-            return
+            return dim1, dim2
 
         # We do another check here, this should allow Brian1 units to pass as
         # having the same dimensions as a Brian2 unit
         if dim1 == dim2:
-            return
+            return dim1, dim2
 
         if error_message is None:
             error_message = 'Dimension mismatch'
@@ -176,6 +183,8 @@ def fail_for_dimension_mismatch(obj1, obj2=None, error_message=None,
             raise DimensionMismatchError(error_message, dim1)
         else:
             raise DimensionMismatchError(error_message, dim1, dim2)
+    else:
+        return dim1, dim2
 
 
 def wrap_function_dimensionless(func):

--- a/brian2/units/fundamentalunits.py
+++ b/brian2/units/fundamentalunits.py
@@ -791,8 +791,7 @@ def quantity_with_dimensions(floatval, dims):
     --------
     get_or_create_dimensions
     '''
-    return Quantity.with_dimensions(floatval,
-                                    get_or_create_dimension(dims._dims))
+    return Quantity(floatval, get_or_create_dimension(dims._dims))
 
 
 class Quantity(np.ndarray, object):
@@ -1223,7 +1222,7 @@ class Quantity(np.ndarray, object):
                     return r[self]
                 except KeyError:
                     pass
-            return Quantity.with_dimensions(1, self.dim)
+            return Quantity(1, self.dim)
         else:
             return self._get_best_unit(standard_unit_register, user_unit_register,
                                        additional_unit_register)
@@ -1280,8 +1279,7 @@ class Quantity(np.ndarray, object):
         ''' Overwritten to assure that single elements (i.e., indexed with a
         single integer or a tuple of integers) retain their unit.
         '''
-        return Quantity.with_dimensions(np.ndarray.__getitem__(self, key),
-                                        self.dim)
+        return Quantity(np.ndarray.__getitem__(self, key), self.dim)
 
     def __getslice__(self, start, end):
         return self.__getitem__(slice(start, end))
@@ -1295,7 +1293,6 @@ class Quantity(np.ndarray, object):
         return self.__setitem__(slice(start, end), value)
 
     #### ARITHMETIC ####
-
     def _binary_operation(self, other, operation,
                           dim_operation=lambda a, b: a, fail_for_mismatch=False,
                           operator_str=None, inplace=False):
@@ -1357,10 +1354,10 @@ class Quantity(np.ndarray, object):
             return self_value
         else:
             other_dim = get_dimensions(other)
-            return Quantity.with_dimensions(operation(np.asarray(self),
-                                                      np.asarray(other)),
-                                            dim_operation(self.dim,
-                                                          other_dim))
+            return Quantity(operation(np.asarray(self),
+                                      np.asarray(other)),
+                            dim_operation(self.dim,
+                                          other_dim))
 
     def __mul__(self, other):
         return self._binary_operation(other, operator.mul, operator.mul)
@@ -1441,8 +1438,8 @@ class Quantity(np.ndarray, object):
                                                       'the exponent has to be '
                                                       'dimensionless',
                                         base=self, exponent=other)
-            return Quantity.with_dimensions(np.asarray(self)**np.asarray(other),
-                                            self.dim**np.asarray(other))
+            return Quantity(np.asarray(self)**np.asarray(other),
+                            self.dim**np.asarray(other))
         else:
             return NotImplemented
 
@@ -1450,7 +1447,7 @@ class Quantity(np.ndarray, object):
         if self.is_dimensionless:
             if isinstance(other, np.ndarray) or isinstance(other, np.ndarray):
                 new_array = np.asarray(other)**np.asarray(self)
-                return Quantity.with_dimensions(new_array, DIMENSIONLESS)
+                return Quantity(new_array, DIMENSIONLESS)
             else:
                 return NotImplemented
         else:
@@ -1476,13 +1473,13 @@ class Quantity(np.ndarray, object):
             return NotImplemented
 
     def __neg__(self):
-        return Quantity.with_dimensions(-np.asarray(self), self.dim)
+        return Quantity(-np.asarray(self), self.dim)
 
     def __pos__(self):
         return self
 
     def __abs__(self):
-        return Quantity.with_dimensions(abs(np.asarray(self)), self.dim)
+        return Quantity(abs(np.asarray(self)), self.dim)
 
     def tolist(self):
         '''
@@ -1500,7 +1497,7 @@ class Quantity(np.ndarray, object):
             '''
             # No recursion needed for single values
             if not isinstance(seq, list):
-                return Quantity.with_dimensions(seq, dim)
+                return Quantity(seq, dim)
 
             def top_replace(s):
                 '''
@@ -1508,7 +1505,7 @@ class Quantity(np.ndarray, object):
                 '''
                 for i in s:
                     if not isinstance(i, list):
-                        yield Quantity.with_dimensions(i, dim)
+                        yield Quantity(i, dim)
                     else:
                         yield type(i)(top_replace(i))
 
@@ -1639,17 +1636,17 @@ class Quantity(np.ndarray, object):
     def clip(self, a_min, a_max, *args, **kwds): # pylint: disable=C0111
         fail_for_dimension_mismatch(self, a_min, 'clip')
         fail_for_dimension_mismatch(self, a_max, 'clip')
-        return Quantity.with_dimensions(np.clip(np.asarray(self),
-                                                np.asarray(a_min),
-                                                np.asarray(a_max),
-                                                *args, **kwds),
-                                        self.dim)
+        return Quantity(np.clip(np.asarray(self),
+                                np.asarray(a_min),
+                                np.asarray(a_max),
+                                *args, **kwds),
+                        self.dim)
     clip.__doc__ = np.ndarray.clip.__doc__
 
     def dot(self, other, **kwds): # pylint: disable=C0111
-        return Quantity.with_dimensions(np.array(self).dot(np.array(other),
-                                                           **kwds),
-                                        self.dim*get_dimensions(other))
+        return Quantity(np.array(self).dot(np.array(other),
+                                           **kwds),
+                        self.dim*get_dimensions(other))
     dot.__doc__ = np.ndarray.dot.__doc__
 
     def searchsorted(self, v, **kwds): # pylint: disable=C0111
@@ -1672,7 +1669,7 @@ class Quantity(np.ndarray, object):
         # identical
         if dim_exponent.size > 1:
             dim_exponent = dim_exponent[0]
-        return Quantity.with_dimensions(np.asarray(prod_result), self.dim ** dim_exponent)
+        return Quantity(np.asarray(prod_result), self.dim ** dim_exponent)
     prod.__doc__ = np.ndarray.prod.__doc__
 
     def cumprod(self, *args, **kwds):  # pylint: disable=C0111

--- a/brian2/units/fundamentalunits.py
+++ b/brian2/units/fundamentalunits.py
@@ -891,8 +891,8 @@ class Quantity(np.ndarray, object):
         subarr = np.array(arr, dtype=dtype, copy=copy).view(cls)
 
         # We only want numerical datatypes
-        if not (np.issubdtype(subarr.dtype, np.number) or
-                np.issubdtype(subarr.dtype, np.bool_)):
+        if not np.issubclass_(np.dtype(subarr.dtype).type,
+                              (np.number, np.bool_)):
             raise TypeError('Quantities can only be created from numerical data.')
 
         # If a dimension is given, force this dimension


### PR DESCRIPTION
In general, we do not care much about the performance of `Quantity` operations, since they are not used during the actual simulation. However, the `Morphology` object does use them, and constructing/analyzing/plotting such objects can therefore benefit from performance improvements. This PR includes a few optimisations, most of them are just different ways of doing the same thing (e.g. replacing an `isinstance` test by a try/except), if I am not mistaken there's only one semantical difference: previously, calling `Quantity` with an existing quantity *and* a dimension argument would raise an error if the two were inconsistent (e.g. `Quantity(3*mV, dim=second.dim)`). Now, this will just force the dimension given as the `dim` argument. Raising an error does make more sense, I think, but I don't see any real use case where a user would do this. Small performance gains like this in `Quantity.__new__` have a lot of impact, since this function is called very often (e.g. a simple `0*mV` is more or less equivalent to `Quantity(np.array(0) * np.array(mV), dim=mV.dim)`).

Ready-to-merge if you are happy with the changes. As a practical data point for the benefits: generating random coordinates for the example morphology with ~1000 sections that we use in the "Rall" tests and for illustration in the docs takes ~18s instead of ~44s. This is still slow, but it is a somewhat extreme case in the first place.