### PR TITLE
[MRG] Rename the `pre` and `post` keyword arguments to `on_pre` and `on_post`

### DIFF
--- a/brian2/tests/features/speed.py
+++ b/brian2/tests/features/speed.py
@@ -114,8 +114,8 @@ class CUBAFixedConnectivity(SpeedTest):
 
         we = (60 * 0.27 / 10) * mV  # excitatory synaptic weight (voltage)
         wi = (-20 * 4.5 / 10) * mV  # inhibitory synaptic weight
-        Ce = Synapses(P, P, pre='ge += we')
-        Ci = Synapses(P, P, pre='gi += wi')
+        Ce = Synapses(P, P, on_pre='ge += we')
+        Ci = Synapses(P, P, on_pre='gi += wi')
         Ce.connect('i<Ne', p=80. / N)
         Ci.connect('i>=Ne', p=80. / N)
 
@@ -141,7 +141,7 @@ class SynapsesOnly(object):
             M = 1
         G = NeuronGroup(M, 'v:1', threshold='True')
         H = NeuronGroup(N, 'w:1')
-        S = Synapses(G, H, pre='w += 1.0')
+        S = Synapses(G, H, on_pre='w += 1.0')
         S.connect(True, p=self.p)
         #M = SpikeMonitor(G)
         self.timed_run(self.duration,

--- a/brian2/tests/features/synapses.py
+++ b/brian2/tests/features/synapses.py
@@ -21,7 +21,7 @@ class SynapsesPre(FeatureTest):
         G = NeuronGroup(10, eqs, threshold='V>1', reset='V=0')
         G.k = linspace(1, 5, len(G))
         H = NeuronGroup(10, 'V:1')
-        S = Synapses(G, H, pre='V += 1')
+        S = Synapses(G, H, on_pre='V += 1')
         S.connect(j='i')
         self.H = H
         run(101*ms)
@@ -48,7 +48,7 @@ class SynapsesPost(FeatureTest):
         G = NeuronGroup(10, eqs, threshold='V>1', reset='V=0')
         G.k = linspace(1, 5, len(G))
         H = NeuronGroup(10, 'V:1')
-        S = Synapses(H, G, post='V_pre += 1')
+        S = Synapses(H, G, on_post='V_pre += 1')
         S.connect(j='i')
         self.H = H
         run(101*ms)
@@ -118,7 +118,7 @@ class SynapsesSTDP(FeatureTest):
         
         S.w       = fac*connectivity.flatten()
 
-        T         = Synapses(Q, P, model = "w : 1", pre="g += w*mV")
+        T         = Synapses(Q, P, model = "w : 1", on_pre="g += w*mV")
         T.connect(j='i')
         T.w       = 10*fac
 

--- a/brian2/tests/test_complex_examples.py
+++ b/brian2/tests/test_complex_examples.py
@@ -27,8 +27,8 @@ def test_cuba():
 
     we = (60*0.27/10)*mV # excitatory synaptic weight (voltage)
     wi = (-20*4.5/10)*mV # inhibitory synaptic weight
-    Ce = Synapses(P, P, pre='ge += we')
-    Ci = Synapses(P, P, pre='gi += wi')
+    Ce = Synapses(P, P, on_pre='ge += we')
+    Ci = Synapses(P, P, on_pre='gi += wi')
     Ce.connect('i<3200', p=0.02)
     Ci.connect('i>=3200', p=0.02)
 

--- a/brian2/tests/test_cpp_standalone.py
+++ b/brian2/tests/test_cpp_standalone.py
@@ -28,7 +28,7 @@ def test_cpp_standalone(with_output=False):
                     name='gp')
     G.V = '-i*mV'
     M = SpikeMonitor(G)
-    S = Synapses(G, G, 'w : volt', pre='V += w')
+    S = Synapses(G, G, 'w : volt', on_pre='V += w')
     S.connect('abs(i-j)<5 and i!=j')
     S.w = 0.5*mV
     S.delay = '0*ms'
@@ -191,7 +191,7 @@ def test_openmp_consistency(with_output=False):
         
         S.w       = fac*connectivity.flatten()
 
-        T         = Synapses(Q, P, model = "w : 1", pre="g += w*mV")
+        T         = Synapses(Q, P, model = "w : 1", on_pre="g += w*mV")
         T.connect(j='i')
         T.w       = 10*fac
 
@@ -340,7 +340,7 @@ def test_array_cache(with_output=False):
                            y : 1
                            z : 1 (shared)''',
                     threshold='v>1')
-    S = Synapses(G, G, 'weight: 1', pre='w += weight')
+    S = Synapses(G, G, 'weight: 1', on_pre='w += weight')
     S.connect(p=0.2)
     S.weight = 7
     # All neurongroup values should be known

--- a/brian2/tests/test_network.py
+++ b/brian2/tests/test_network.py
@@ -602,7 +602,7 @@ def test_dependency_check():
                              StateMonitor(G, 'v', record=True),
                              SpikeMonitor(G),
                              PopulationRateMonitor(G),
-                             Synapses(G, G, pre='v+=1')
+                             Synapses(G, G, on_pre='v+=1')
                              ]
         return dependent_objects
 
@@ -760,7 +760,7 @@ def test_store_restore():
                                 rates : Hz''', threshold='v>1', reset='v=0')
     source.rates = 'i*100*Hz'
     target = NeuronGroup(10, 'v:1')
-    synapses = Synapses(source, target, model='w:1', pre='v+=w')
+    synapses = Synapses(source, target, model='w:1', on_pre='v+=w')
     synapses.connect(j='i')
     synapses.w = 'i*1.0'
     synapses.delay = 'i*ms'
@@ -797,7 +797,7 @@ def test_store_restore_to_file():
                                 rates : Hz''', threshold='v>1', reset='v=0')
     source.rates = 'i*100*Hz'
     target = NeuronGroup(10, 'v:1')
-    synapses = Synapses(source, target, model='w:1', pre='v+=w')
+    synapses = Synapses(source, target, model='w:1', on_pre='v+=w')
     synapses.connect(j='i')
     synapses.w = 'i*1.0'
     synapses.delay = 'i*ms'
@@ -847,7 +847,7 @@ def test_store_restore_to_file_new_objects():
                                      [3, 4, 1, 2, 3, 7, 5, 4, 1, 0, 5, 9, 7, 8, 9]*ms,
                                      name='source')
         target = NeuronGroup(10, 'v:1', name='target')
-        synapses = Synapses(source, target, model='w:1', pre='v+=w',
+        synapses = Synapses(source, target, model='w:1', on_pre='v+=w',
                             name='synapses')
         synapses.connect('j>=i')
         synapses.w = 'i*1.0 + j*2.0'
@@ -914,7 +914,7 @@ def test_store_restore_magic():
                                 rates : Hz''', threshold='v>1', reset='v=0')
     source.rates = 'i*100*Hz'
     target = NeuronGroup(10, 'v:1')
-    synapses = Synapses(source, target, model='w:1', pre='v+=w')
+    synapses = Synapses(source, target, model='w:1', on_pre='v+=w')
     synapses.connect(j='i')
     synapses.w = 'i*1.0'
     synapses.delay = 'i*ms'
@@ -953,7 +953,7 @@ def test_store_restore_magic_to_file():
                                 rates : Hz''', threshold='v>1', reset='v=0')
     source.rates = 'i*100*Hz'
     target = NeuronGroup(10, 'v:1')
-    synapses = Synapses(source, target, model='w:1', pre='v+=w')
+    synapses = Synapses(source, target, model='w:1', on_pre='v+=w')
     synapses.connect(j='i')
     synapses.w = 'i*1.0'
     synapses.delay = 'i*ms'

--- a/brian2/tests/test_poissongroup.py
+++ b/brian2/tests/test_poissongroup.py
@@ -37,7 +37,7 @@ def test_propagation():
     # Using a PoissonGroup as a source for Synapses should work as expected
     P = PoissonGroup(2, np.array([0, 1./defaultclock.dt])*Hz)
     G = NeuronGroup(2, 'v:1')
-    S = Synapses(P, G, pre='v+=1')
+    S = Synapses(P, G, on_pre='v+=1')
     S.connect(j='i')
     run(2*defaultclock.dt)
 
@@ -53,9 +53,9 @@ def test_poissongroup_subgroup():
     P2 = P[2:]
     P2.rates = 1./defaultclock.dt
     G = NeuronGroup(4, 'v:1')
-    S1 = Synapses(P1, G[:2], pre='v+=1')
+    S1 = Synapses(P1, G[:2], on_pre='v+=1')
     S1.connect(j='i')
-    S2 = Synapses(P2, G[2:], pre='v+=1')
+    S2 = Synapses(P2, G[2:], on_pre='v+=1')
     S2.connect(j='i')
     run(2*defaultclock.dt)
 

--- a/brian2/tests/test_refractory.py
+++ b/brian2/tests/test_refractory.py
@@ -162,10 +162,10 @@ def test_conditional_write_behaviour():
     '''
     G = NeuronGroup(1, eqs, threshold='v>1', reset=reset, refractory=1*ms)
 
-    Sx = Synapses(H, G, pre='x += dt*100*Hz')
+    Sx = Synapses(H, G, on_pre='x += dt*100*Hz')
     Sx.connect(True)
 
-    Sy = Synapses(H, G, pre='y += dt*100*Hz')
+    Sy = Synapses(H, G, on_pre='y += dt*100*Hz')
     Sy.connect(True)
 
     M = StateMonitor(G, variables=True, record=True)

--- a/brian2/tests/test_spikegenerator.py
+++ b/brian2/tests/test_spikegenerator.py
@@ -23,7 +23,7 @@ def test_spikegenerator_connected():
     indices = np.array([3, 2, 1, 1, 4, 5])
     times =   np.array([6, 5, 4, 3, 3, 1]) * ms
     SG = SpikeGeneratorGroup(10, indices, times)
-    S = Synapses(SG, G, pre='v+=1')
+    S = Synapses(SG, G, on_pre='v+=1')
     S.connect(j='i')
     run(7*ms)
     # The following neurons should not receive any spikes
@@ -222,7 +222,7 @@ def test_spikegenerator_rounding():
     SG = SpikeGeneratorGroup(1, indices, times, dt=dt)
     target = NeuronGroup(1, 'count : 1',
                          threshold='True', reset='count=0')  # set count to zero at every time step
-    syn = Synapses(SG, target, pre='count+=1')
+    syn = Synapses(SG, target, on_pre='count+=1')
     syn.connect()
     mon = StateMonitor(target, 'count', record=0, when='end')
     net = Network(SG, target, syn, mon)
@@ -241,7 +241,7 @@ def test_spikegenerator_rounding_long():
     times = np.arange(N)*dt
     SG = SpikeGeneratorGroup(1, indices, times, dt=dt)
     target = NeuronGroup(1, 'count : 1')
-    syn = Synapses(SG, target, pre='count+=1')
+    syn = Synapses(SG, target, on_pre='count+=1')
     syn.connect()
     spikes = SpikeMonitor(SG)
     mon = StateMonitor(target, 'count', record=0, when='end')
@@ -260,7 +260,7 @@ def test_spikegenerator_rounding_period():
     times = np.arange(N)*dt
     SG = SpikeGeneratorGroup(1, indices, times, dt=dt, period=N*dt)
     target = NeuronGroup(1, 'count : 1')
-    syn = Synapses(SG, target, pre='count+=1')
+    syn = Synapses(SG, target, on_pre='count+=1')
     syn.connect()
     spikes = SpikeMonitor(SG)
     mon = StateMonitor(target, 'count', record=0, when='end')

--- a/brian2/tests/test_subgroup.py
+++ b/brian2/tests/test_subgroup.py
@@ -156,21 +156,21 @@ def test_synapse_creation():
     G2.v = '10 + i'
     SG1 = G1[:5]
     SG2 = G2[10:]
-    S = Synapses(SG1, SG2, 'w:1', pre='v+=w')
+    S = Synapses(SG1, SG2, 'w:1', on_pre='v+=w')
     S.connect(i=2, j=2)  # Should correspond to (2, 12)
     S.connect('i==2 and j==5') # Should correspond to (2, 15)
 
     # connect based on pre-/postsynaptic state variables
-    S2 = Synapses(SG1, SG2, 'w:1', pre='v+=w')
+    S2 = Synapses(SG1, SG2, 'w:1', on_pre='v+=w')
     S2.connect('v_pre > 2')
 
-    S3 = Synapses(SG1, SG2, 'w:1', pre='v+=w')
+    S3 = Synapses(SG1, SG2, 'w:1', on_pre='v+=w')
     S3.connect('v_post < 25')
 
-    S4 = Synapses(SG2, SG1, 'w:1', pre='v+=w')
+    S4 = Synapses(SG2, SG1, 'w:1', on_pre='v+=w')
     S4.connect('v_post > 2')
 
-    S5 = Synapses(SG2, SG1, 'w:1', pre='v+=w')
+    S5 = Synapses(SG2, SG1, 'w:1', on_pre='v+=w')
     S5.connect('v_pre < 25')
 
     run(0*ms)  # for standalone
@@ -206,20 +206,20 @@ def test_synapse_creation_generator():
     G2.v = '10 + i'
     SG1 = G1[:5]
     SG2 = G2[10:]
-    S = Synapses(SG1, SG2, 'w:1', pre='v+=w')
+    S = Synapses(SG1, SG2, 'w:1', on_pre='v+=w')
     S.connect(j='i*2 + k for k in range(2)')  # diverging connections
 
     # connect based on pre-/postsynaptic state variables
-    S2 = Synapses(SG1, SG2, 'w:1', pre='v+=w')
+    S2 = Synapses(SG1, SG2, 'w:1', on_pre='v+=w')
     S2.connect(j='k for k in range(N_post) if v_pre > 2')
 
-    S3 = Synapses(SG1, SG2, 'w:1', pre='v+=w')
+    S3 = Synapses(SG1, SG2, 'w:1', on_pre='v+=w')
     S3.connect(j='k for k in range(N_post) if v_post < 25')
 
-    S4 = Synapses(SG2, SG1, 'w:1', pre='v+=w')
+    S4 = Synapses(SG2, SG1, 'w:1', on_pre='v+=w')
     S4.connect(j='k for k in range(N_post) if v_post > 2')
 
-    S5 = Synapses(SG2, SG1, 'w:1', pre='v+=w')
+    S5 = Synapses(SG2, SG1, 'w:1', on_pre='v+=w')
     S5.connect(j='k for k in range(N_post) if v_pre < 25')
 
     run(0*ms)  # for standalone
@@ -255,34 +255,34 @@ def test_synapse_creation_generator_multiple_synapses():
     G2.v = '10 + i'
     SG1 = G1[:5]
     SG2 = G2[10:]
-    S1 = Synapses(SG1, SG2, 'w:1', pre='v+=w')
+    S1 = Synapses(SG1, SG2, 'w:1', on_pre='v+=w')
     S1.connect(j='k for k in range(N_post)', n='i')
 
-    S2 = Synapses(SG1, SG2, 'w:1', pre='v+=w')
+    S2 = Synapses(SG1, SG2, 'w:1', on_pre='v+=w')
     S2.connect(j='k for k in range(N_post)', n='j')
 
-    S3 = Synapses(SG2, SG1, 'w:1', pre='v+=w')
+    S3 = Synapses(SG2, SG1, 'w:1', on_pre='v+=w')
     S3.connect(j='k for k in range(N_post)', n='i')
 
-    S4 = Synapses(SG2, SG1, 'w:1', pre='v+=w')
+    S4 = Synapses(SG2, SG1, 'w:1', on_pre='v+=w')
     S4.connect(j='k for k in range(N_post)', n='j')
 
-    S5 = Synapses(SG1, SG2, 'w:1', pre='v+=w')
+    S5 = Synapses(SG1, SG2, 'w:1', on_pre='v+=w')
     S5.connect(j='k for k in range(N_post)', n='i+j')
 
-    S6 = Synapses(SG2, SG1, 'w:1', pre='v+=w')
+    S6 = Synapses(SG2, SG1, 'w:1', on_pre='v+=w')
     S6.connect(j='k for k in range(N_post)', n='i+j')
 
-    S7 = Synapses(SG1, SG2, 'w:1', pre='v+=w')
+    S7 = Synapses(SG1, SG2, 'w:1', on_pre='v+=w')
     S7.connect(j='k for k in range(N_post)', n='int(v_pre>2)*2')
 
-    S8 = Synapses(SG2, SG1, 'w:1', pre='v+=w')
+    S8 = Synapses(SG2, SG1, 'w:1', on_pre='v+=w')
     S8.connect(j='k for k in range(N_post)', n='int(v_post>2)*2')
 
-    S9 = Synapses(SG1, SG2, 'w:1', pre='v+=w')
+    S9 = Synapses(SG1, SG2, 'w:1', on_pre='v+=w')
     S9.connect(j='k for k in range(N_post)', n='int(v_post>22)*2')
 
-    S10 = Synapses(SG2, SG1, 'w:1', pre='v+=w')
+    S10 = Synapses(SG2, SG1, 'w:1', on_pre='v+=w')
     S10.connect(j='k for k in range(N_post)', n='int(v_pre>22)*2')
 
     run(0*ms)  # for standalone
@@ -314,15 +314,15 @@ def test_synapse_creation_generator_complex_ranges():
     G2.v = '10 + i'
     SG1 = G1[:5]
     SG2 = G2[10:]
-    S = Synapses(SG1, SG2, 'w:1', pre='v+=w')
+    S = Synapses(SG1, SG2, 'w:1', on_pre='v+=w')
     S.connect(j='i+k for k in range(N_post-i)')  # Connect to all j>i
 
     # connect based on pre-/postsynaptic state variables
-    S2 = Synapses(SG1, SG2, 'w:1', pre='v+=w')
+    S2 = Synapses(SG1, SG2, 'w:1', on_pre='v+=w')
     S2.connect(j='k for k in range(N_post * int(v_pre > 2))')
 
     # connect based on pre-/postsynaptic state variables
-    S3 = Synapses(SG2, SG1, 'w:1', pre='v+=w')
+    S3 = Synapses(SG2, SG1, 'w:1', on_pre='v+=w')
     S3.connect(j='k for k in range(N_post * int(v_pre > 22))')
 
     run(0*ms)  # for standalone
@@ -351,10 +351,10 @@ def test_synapse_creation_generator_random():
     SG2 = G2[10:]
 
     # connect based on pre-/postsynaptic state variables
-    S2 = Synapses(SG1, SG2, 'w:1', pre='v+=w')
+    S2 = Synapses(SG1, SG2, 'w:1', on_pre='v+=w')
     S2.connect(j='k for k in sample(N_post, p=1.0*int(v_pre > 2))')
 
-    S3 = Synapses(SG2, SG1, 'w:1', pre='v+=w')
+    S3 = Synapses(SG2, SG1, 'w:1', on_pre='v+=w')
     S3.connect(j='k for k in sample(N_post, p=1.0*int(v_pre > 22))')
 
     run(0*ms)  # for standalone
@@ -372,7 +372,7 @@ def test_synapse_access():
     G2.v = 'i'
     SG1 = G1[:5]
     SG2 = G2[10:]
-    S = Synapses(SG1, SG2, 'w:1', pre='v+=w')
+    S = Synapses(SG1, SG2, 'w:1', on_pre='v+=w')
     S.connect(True)
     S.w['j == 0'] = 5
     assert all(S.w['j==0'] == 5)
@@ -540,7 +540,7 @@ def test_synaptic_propagation():
     G2 = NeuronGroup(20, 'v:1')
     SG1 = G1[1:6]
     SG2 = G2[10:]
-    S = Synapses(SG1, SG2, pre='v+=1')
+    S = Synapses(SG1, SG2, on_pre='v+=1')
     S.connect('i==j')
     run(defaultclock.dt)
     expected = np.zeros(len(G2))
@@ -556,7 +556,7 @@ def test_synaptic_propagation_2():
     source = NeuronGroup(100, '', threshold='True')
     sub_source = source[99:]
     target = NeuronGroup(1, 'v:1')
-    syn = Synapses(sub_source, target, pre='v+=1')
+    syn = Synapses(sub_source, target, on_pre='v+=1')
     syn.connect()
     run(defaultclock.dt)
     assert target.v[0] == 1.0
@@ -637,7 +637,7 @@ def test_no_reference_3():
     '''
     G = NeuronGroup(2, 'v:1', threshold='v>1', reset='v=0')
     G.v = [1.1, 0]
-    S = Synapses(G[:1], G[1:], pre='v+=1')
+    S = Synapses(G[:1], G[1:], on_pre='v+=1')
     S.connect()
     run(defaultclock.dt)
     assert_equal(G.v[:], np.array([0, 1]))
@@ -652,7 +652,7 @@ def test_no_reference_4():
     G1 = NeuronGroup(10, 'v:1', threshold='v>1', reset='v=0')
     G1.v['i%2==1'] = 1.1 # odd numbers should spike
     G2 = NeuronGroup(20, 'v:1')
-    S = Synapses(G1[1:6], G2[10:], pre='v+=1')
+    S = Synapses(G1[1:6], G2[10:], on_pre='v+=1')
     S.connect('i==j')
     run(defaultclock.dt)
     expected = np.zeros(len(G2))

--- a/brian2/tests/test_synapses.py
+++ b/brian2/tests/test_synapses.py
@@ -663,7 +663,7 @@ def test_pre_post_simple():
                      pre='pre_value +=1',
                      post='post_value +=2')
     S.connect()
-    syn_mon = StateMonitor(S, ['pre_value', 'post_value'], record=True,
+    syn_mon = StateMonitor(S, ['pre_value', 'post_value'], record=[0],
                            when='end')
     run(3*ms)
     assert_equal(syn_mon.pre_value[0][syn_mon.t < 1*ms], 0)

--- a/brian2/tests/test_synapses.py
+++ b/brian2/tests/test_synapses.py
@@ -49,16 +49,26 @@ def test_creation():
     A basic test that creating a Synapses object works.
     '''
     G = NeuronGroup(42, 'v: 1', threshold='False')
-    S = Synapses(G, G, 'w:1', pre='v+=w')
+    S = Synapses(G, G, 'w:1', on_pre='v+=w')
     # We store weakref proxys, so we can't directly compare the objects
     assert S.source.name == S.target.name == G.name
     assert len(S) == 0
-    S = Synapses(G, model='w:1', pre='v+=w')
+    S = Synapses(G, model='w:1', on_pre='v+=w')
     assert S.source.name == S.target.name == G.name
 
+
+@attr('codegen-independent')
+def test_creation_errors():
+    G = NeuronGroup(42, 'v: 1', threshold='False')
     # Check that the old Synapses(..., connect=...) syntax raises an error
-    assert_raises(TypeError, lambda: Synapses(G, G, 'w:1', pre='v+=w',
+    assert_raises(TypeError, lambda: Synapses(G, G, 'w:1', on_pre='v+=w',
                                               connect=True))
+    # Check that using pre and on_pre (resp. post/on_post) at the same time
+    # raises an error
+    assert_raises(TypeError, lambda: Synapses(G, G, 'w:1', pre='v+=w',
+                                              on_pre='v+=w', connect=True))
+    assert_raises(TypeError, lambda: Synapses(G, G, 'w:1', post='v+=w',
+                                              on_post='v+=w', connect=True))
 
 @attr('codegen-independent')
 def test_name_clashes():
@@ -84,7 +94,7 @@ def test_incoming_outgoing():
     '''
     G1 = NeuronGroup(5, 'v: 1', threshold='False')
     G2 = NeuronGroup(5, 'v: 1', threshold='False')
-    S = Synapses(G1, G2, 'w:1', pre='v+=w')
+    S = Synapses(G1, G2, 'w:1', on_pre='v+=w')
     S.connect(i=[0, 0, 0, 1, 1, 2],
               j=[0, 1, 2, 1, 2, 3])
     run(0*ms)  # to make this work for standalone
@@ -392,12 +402,12 @@ def test_connection_random_without_condition():
 
     # Use pre-/post-synaptic variables for "stochastic" connections that are
     # actually deterministic
-    S4 = Synapses(G, G2, 'w:1', pre='v+=w')
+    S4 = Synapses(G, G2, 'w:1', on_pre='v+=w')
     S4.connect(True, p='int(x_pre==2)*1.0')
 
     # Use pre-/post-synaptic variables for "stochastic" connections that are
     # actually deterministic
-    S5 = Synapses(G, G2, 'w:1', pre='v+=w')
+    S5 = Synapses(G, G2, 'w:1', on_pre='v+=w')
     S5.connect(True, p='int(x_pre==2 and y_post > 0.5)*1.0')
 
     with catch_logs() as _:  # Ignore warnings about empty synapses
@@ -600,7 +610,7 @@ def test_delay_specification():
     G = NeuronGroup(10, 'v:1', threshold='False')
 
     # Array delay
-    S = Synapses(G, G, 'w:1', pre='v+=w')
+    S = Synapses(G, G, 'w:1', on_pre='v+=w')
     S.connect('i==j')
     assert len(S.delay[:]) == len(G)
     S.delay = 'i*ms'
@@ -609,7 +619,7 @@ def test_delay_specification():
     assert_equal(S.delay[:], np.ones(len(G))*5*ms)
 
     # Scalar delay
-    S = Synapses(G, G, 'w:1', pre='v+=w', delay=5*ms)
+    S = Synapses(G, G, 'w:1', on_pre='v+=w', delay=5*ms)
     assert_equal(S.delay[:], 5*ms)
     S.connect('i==j')
     S.delay = 10*ms
@@ -619,12 +629,12 @@ def test_delay_specification():
 
     # Invalid arguments
     assert_raises(DimensionMismatchError, lambda: Synapses(G, G, 'w:1',
-                                                           pre='v+=w',
+                                                           on_pre='v+=w',
                                                            delay=5*mV))
-    assert_raises(TypeError, lambda: Synapses(G, G, 'w:1', pre='v+=w',
+    assert_raises(TypeError, lambda: Synapses(G, G, 'w:1', on_pre='v+=w',
                                               delay=object()))
     assert_raises(ValueError, lambda: Synapses(G, G, 'w:1', delay=5*ms))
-    assert_raises(ValueError, lambda: Synapses(G, G, 'w:1', pre='v+=w',
+    assert_raises(ValueError, lambda: Synapses(G, G, 'w:1', on_pre='v+=w',
                                                delay={'post': 5*ms}))
 
 @attr('codegen-independent')
@@ -632,7 +642,7 @@ def test_pre_before_post():
     # The pre pathway should be executed before the post pathway
     G = NeuronGroup(1, '''x : 1
                           y : 1''', threshold='True')
-    S = Synapses(G, G, '', pre='x=1; y=1', post='x=2')
+    S = Synapses(G, G, '', on_pre='x=1; y=1', on_post='x=2')
     S.connect()
     run(defaultclock.dt)
     # Both pathways should have been executed, but post should have overriden
@@ -640,12 +650,34 @@ def test_pre_before_post():
     assert G.x == 2
     assert G.y == 1
 
+
+@attr('standalone-compatible')
+@with_setup(teardown=reinit_devices)
+def test_pre_post_simple():
+    # Test that pre and post still work correctly
+    G1 = SpikeGeneratorGroup(1, [0], [1]*ms)
+    G2 = SpikeGeneratorGroup(1, [0], [2]*ms)
+    with catch_logs() as l:
+        S = Synapses(G1, G2, '''pre_value : 1
+                                post_value : 1''',
+                     pre='pre_value +=1',
+                     post='post_value +=2')
+    S.connect()
+    syn_mon = StateMonitor(S, ['pre_value', 'post_value'], record=True,
+                           when='end')
+    run(3*ms)
+    assert_equal(syn_mon.pre_value[0][syn_mon.t < 1*ms], 0)
+    assert_equal(syn_mon.pre_value[0][syn_mon.t >= 1*ms], 1)
+    assert_equal(syn_mon.post_value[0][syn_mon.t < 2*ms], 0)
+    assert_equal(syn_mon.post_value[0][syn_mon.t >= 2*ms], 2)
+
+
 @attr('standalone-compatible')
 @with_setup(teardown=reinit_devices)
 def test_transmission_simple():
     source = SpikeGeneratorGroup(2, [0, 1], [2, 1] * ms)
     target = NeuronGroup(2, 'v : 1')
-    syn = Synapses(source, target, pre='v += 1')
+    syn = Synapses(source, target, on_pre='v += 1')
     syn.connect(j='i')
     mon = StateMonitor(target, 'v', record=True, when='end')
     run(2.5*ms)
@@ -660,7 +692,7 @@ def test_transmission_custom_event():
     source = NeuronGroup(2, '',
                          events={'custom': 't>=(2-i)*ms and t<(2-i)*ms + dt'})
     target = NeuronGroup(2, 'v : 1')
-    syn = Synapses(source, target, pre='v += 1',
+    syn = Synapses(source, target, on_pre='v += 1',
                    on_event='custom')
     syn.connect(j='i')
     mon = StateMonitor(target, 'v', record=True, when='end')
@@ -675,9 +707,9 @@ def test_invalid_custom_event():
     group1 = NeuronGroup(2, 'v : 1',
                          events={'custom': 't>=(2-i)*ms and t<(2-i)*ms + dt'})
     group2 = NeuronGroup(2, 'v : 1', threshold='v>1')
-    assert_raises(ValueError, lambda: Synapses(group1, group1, pre='v+=1',
+    assert_raises(ValueError, lambda: Synapses(group1, group1, on_pre='v+=1',
                                                on_event='spike'))
-    assert_raises(ValueError, lambda: Synapses(group2, group2, pre='v+=1',
+    assert_raises(ValueError, lambda: Synapses(group2, group2, on_pre='v+=1',
                                                on_event='custom'))
 
 @with_setup(teardown=reinit_devices)
@@ -698,7 +730,7 @@ def test_transmission():
         source_mon = SpikeMonitor(source)
         target_mon = SpikeMonitor(target)
 
-        S = Synapses(source, target, pre='v+=1.1')
+        S = Synapses(source, target, on_pre='v+=1.1')
         S.connect(j='i')
         S.delay = delay
         net = Network(S, source, target, source_mon, target_mon)
@@ -717,7 +749,7 @@ def test_transmission_all_to_one_heterogeneous_delays():
                                  [0, 1, 4, 5, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5],
                                  [0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2]*defaultclock.dt)
     target = NeuronGroup(1, 'v:1')
-    synapses = Synapses(source, target, pre='v_post += (i_pre+1)')
+    synapses = Synapses(source, target, on_pre='v_post += (i_pre+1)')
     synapses.connect()
     synapses.delay = [0, 0, 0, 1, 2, 1] * defaultclock.dt
 
@@ -734,7 +766,7 @@ def test_transmission_all_to_one_heterogeneous_delays():
 def test_transmission_one_to_all_heterogeneous_delays():
     source = SpikeGeneratorGroup(1, [0, 0], [0, 2]*defaultclock.dt)
     target = NeuronGroup(6, 'v:integer')
-    synapses = Synapses(source, target, pre='v_post += (i_pre+1)')
+    synapses = Synapses(source, target, on_pre='v_post += (i_pre+1)')
     synapses.connect()
     synapses.delay = [0, 0, 1, 3, 2, 1] * defaultclock.dt
 
@@ -753,7 +785,7 @@ def test_transmission_one_to_all_heterogeneous_delays():
 def test_transmission_scalar_delay():
     inp = SpikeGeneratorGroup(2, [0, 1], [0, 1]*ms)
     target = NeuronGroup(2, 'v:1')
-    S = Synapses(inp, target, pre='v+=1', delay=0.5*ms)
+    S = Synapses(inp, target, on_pre='v+=1', delay=0.5*ms)
     S.connect(j='i')
     mon = StateMonitor(target, 'v', record=True, when='end')
     run(2*ms)
@@ -772,7 +804,7 @@ def test_transmission_scalar_delay_different_clocks():
                               # get a 'fresh' warning
                               name='sg_%d' % uuid.uuid4())
     target = NeuronGroup(2, 'v:1', dt=0.1*ms)
-    S = Synapses(inp, target, pre='v+=1', delay=0.5*ms)
+    S = Synapses(inp, target, on_pre='v+=1', delay=0.5*ms)
     S.connect(j='i')
     mon = StateMonitor(target, 'v', record=True, when='end')
 
@@ -800,7 +832,7 @@ def test_clocks():
     synapse_dt = 0.2*ms
     source = NeuronGroup(1, 'v:1', dt=source_dt, threshold='False')
     target = NeuronGroup(1, 'v:1', dt=target_dt, threshold='False')
-    synapse = Synapses(source, target, 'w:1', pre='v+=1', post='v+=1',
+    synapse = Synapses(source, target, 'w:1', on_pre='v+=1', on_post='v+=1',
                        dt=synapse_dt)
     synapse.connect()
 
@@ -817,7 +849,7 @@ def test_changed_dt_spikes_in_queue():
     G1 = NeuronGroup(1, 'v:1', threshold='v>1', reset='v=0')
     G1.v = 1.1
     G2 = NeuronGroup(10, 'v:1', threshold='v>1', reset='v=0')
-    S = Synapses(G1, G2, pre='v+=1.1')
+    S = Synapses(G1, G2, on_pre='v+=1.1')
     S.connect(True)
     S.delay = 'j*ms'
     mon = SpikeMonitor(G2)
@@ -841,7 +873,7 @@ def test_no_synapses():
     # Synaptic pathway but no synapses
     G1 = NeuronGroup(1, '', threshold='True')
     G2 = NeuronGroup(1, 'v:1')
-    S = Synapses(G1, G2, pre='v+=1', name='synapses_'+str(uuid.uuid4()).replace('-', '_'))
+    S = Synapses(G1, G2, on_pre='v+=1', name='synapses_'+str(uuid.uuid4()).replace('-', '_'))
     net = Network(G1, G2, S)
     with catch_logs() as l:
         net.run(defaultclock.dt)
@@ -857,7 +889,7 @@ def test_summed_variable():
     target = NeuronGroup(2, 'v : 1')
     S = Synapses(source, target, '''w : 1
                                     x : 1
-                                    v_post = x : 1 (summed)''', pre='x+=w',
+                                    v_post = x : 1 (summed)''', on_pre='x+=w',
                  multisynaptic_index='k')
     S.connect('i==j', n=2)
     S.w['k == 0'] = 'i'
@@ -904,7 +936,7 @@ def test_scalar_parameter_access():
     S = Synapses(G, G, '''w : 1
                           s : Hz (shared)
                           number : 1 (shared)''',
-                 pre = 'v+=w*number')
+                 on_pre='v+=w*number')
     S.connect()
 
     # Try setting a scalar variable
@@ -943,7 +975,7 @@ def test_scalar_subexpression():
                            number : 1 (shared)''', threshold='False')
     S = Synapses(G, G, '''s : 1 (shared)
                           sub = number_post + s : 1 (shared)''',
-                 pre='v+=s')
+                 on_pre='v+=s')
     S.connect()
     S.s = 100
     G.number = 50
@@ -951,7 +983,7 @@ def test_scalar_subexpression():
 
     assert_raises(SyntaxError, lambda: Synapses(G, G, '''s : 1 (shared)
                                                      sub = v_post + s : 1 (shared)''',
-                                                pre='v+=s'))
+                                                on_pre='v+=s'))
 
 
 @attr('standalone-compatible')
@@ -963,7 +995,7 @@ def test_external_variables():
     w_var = 1
     amplitude = 2
     syn = Synapses(source, target, 'w=w_var : 1',
-                   pre='v+=amplitude*w')
+                   on_pre='v+=amplitude*w')
     syn.connect()
     run(defaultclock.dt)
     assert target.v[0] == 2
@@ -994,9 +1026,9 @@ def test_event_driven():
                   '''w : 1
                      dApre/dt = -Apre/taupre : 1 (event-driven)
                      dApost/dt = -Apost/taupost : 1 (event-driven)''',
-                  pre='''Apre += dApre
+                  on_pre='''Apre += dApre
                          w = clip(w+Apost, 0, gmax)''',
-                  post='''Apost += dApost
+                  on_post='''Apost += dApost
                           w = clip(w+Apre, 0, gmax)''')
     S1.connect(j='i')
     # not event-driven
@@ -1004,10 +1036,10 @@ def test_event_driven():
                   '''w : 1
                      Apre : 1
                      Apost : 1''',
-                  pre='''Apre=Apre*exp((lastupdate-t)/taupre)+dApre
+                  on_pre='''Apre=Apre*exp((lastupdate-t)/taupre)+dApre
                          Apost=Apost*exp((lastupdate-t)/taupost)
                          w = clip(w+Apost, 0, gmax)''',
-                  post='''Apre=Apre*exp((lastupdate-t)/taupre)
+                  on_post='''Apre=Apre*exp((lastupdate-t)/taupre)
                           Apost=Apost*exp((lastupdate-t)/taupost) +dApost
                           w = clip(w+Apre, 0, gmax)''')
     S2.connect(j='i')
@@ -1025,9 +1057,9 @@ def test_repr():
                  '''w : 1
                     dApre/dt = -Apre/taupre : 1 (event-driven)
                     dApost/dt = -Apost/taupost : 1 (event-driven)''',
-                 pre='''Apre += dApre
+                 on_pre='''Apre += dApre
                         w = clip(w+Apost, 0, gmax)''',
-                 post='''Apost += dApost
+                 on_post='''Apost += dApost
                          w = clip(w+Apre, 0, gmax)''')
     # Test that string/LaTeX representations do not raise errors
     for func in [str, repr, sympy.latex]:
@@ -1316,7 +1348,7 @@ def test_vectorisation():
     target = NeuronGroup(10, '''x : 1
                                 y : 1''')
     syn = Synapses(source, target, 'w_syn : 1',
-                   pre='''v_pre += w_syn
+                   on_pre='''v_pre += w_syn
                           x_post = y_post
                        ''')
     syn.connect()
@@ -1347,11 +1379,11 @@ def test_vectorisation_STDP_like():
     # it simply compares the results to fixed pre-calculated values
     syn = Synapses(neurons[:3], neurons[3:], '''w_dep : 1
                                                 w_fac : 1''',
-                   pre='''ge_post += w_dep - w_fac
+                   on_pre='''ge_post += w_dep - w_fac
                           A_pre += 1
                           w_dep = clip(w_dep + A_post, 0, w_max)
                        ''',
-                   post='''A_post += 1
+                   on_post='''A_post += 1
                            w_fac = clip(w_fac + A_pre, 0, w_max)
                         ''')
     syn.connect()
@@ -1379,6 +1411,8 @@ def test_vectorisation_STDP_like():
                     rtol=1e-6, atol=1e-12)
 
 
+
+
 @attr('standalone-compatible')
 @with_setup(teardown=reinit_devices)
 def test_synaptic_equations():
@@ -1398,10 +1432,10 @@ def test_synapses_to_synapses():
     source = SpikeGeneratorGroup(3, [0, 1, 2], [0, 0, 0]*ms, period=2*ms)
     modulator = SpikeGeneratorGroup(3, [0, 2], [1, 3]*ms)
     target = NeuronGroup(3, 'v : integer')
-    conn = Synapses(source, target, 'w : integer', pre='v += w')
+    conn = Synapses(source, target, 'w : integer', on_pre='v += w')
     conn.connect(j='i')
     conn.w = 1
-    modulatory_conn = Synapses(modulator, conn, pre='w += 1')
+    modulatory_conn = Synapses(modulator, conn, on_pre='w += 1')
     modulatory_conn.connect(j='i')
     run(5*ms)
     # First group has its weight increased to 2 after the first spike
@@ -1450,7 +1484,7 @@ def test_ufunc_at_vectorisation():
                     src = NeuronGroup(3, eqs_src, threshold='True', name='src')
                     tgt = NeuronGroup(3, eqs_tgt, name='tgt')
                     syn = Synapses(src, tgt, eqs_syn,
-                                   pre=code.replace('_syn', '').replace('_const', '').replace('_shared', ''),
+                                   on_pre=code.replace('_syn', '').replace('_const', '').replace('_shared', ''),
                                    name='syn', namespace=vars_const)
                     syn.connect()
                     for G, vars in [(src, vars_src), (tgt, vars_tgt), (syn, vars_syn)]:
@@ -1666,7 +1700,7 @@ def test_synapse_generator_random():
 
     # Use pre-/post-synaptic variables for "stochastic" connections that are
     # actually deterministic
-    S4 = Synapses(G, G2, 'w:1', pre='v+=w')
+    S4 = Synapses(G, G2, 'w:1', on_pre='v+=w')
     S4.connect(j='k for k in sample(N_post, p=int(x_pre==2)*1.0)')
 
     with catch_logs() as _:  # Ignore warnings about empty synapses
@@ -1767,10 +1801,10 @@ def test_synapse_generator_random_with_condition():
     S24.connect(j='k for k in sample(2, p=0.9)')
 
     # Some more tests specific to the generator syntax
-    S25 = Synapses(G, G, 'w:1', pre='v+=w')
+    S25 = Synapses(G, G, 'w:1', on_pre='v+=w')
     S25.connect(j='i+1 for _ in sample(1, p=0.5) if i < N_post-1')
 
-    S26 = Synapses(G, G, 'w:1', pre='v+=w')
+    S26 = Synapses(G, G, 'w:1', on_pre='v+=w')
     S26.connect(j='i+k for k in sample(N_post-i, p=0.5)')
 
 
@@ -1847,6 +1881,7 @@ if __name__ == '__main__':
     test_subexpression_references()
     test_delay_specification()
     test_pre_before_post()
+    test_pre_post_simple()
     test_transmission_simple()
     test_transmission_custom_event()
     test_invalid_custom_event()

--- a/dev/benchmarks/compare_to_brian1.py
+++ b/dev/benchmarks/compare_to_brian1.py
@@ -122,8 +122,8 @@ def brian2_CUBA(N, duration=1,
     wi = (-20 * 4.5 / 10) * mV # inhibitory synaptic weight
     p = min(80./N, 1.0)
     if do_synapses:
-        Ce = Synapses(P, P, pre='ge += we')
-        Ci = Synapses(P, P, pre='gi += wi')
+        Ce = Synapses(P, P, on_pre='ge += we')
+        Ci = Synapses(P, P, on_pre='gi += wi')
         Ce.connect('i<Ne', p=p)
         Ci.connect('i>=Ne', p=p)
     P.v = Vr + rand(len(P)) * (Vt - Vr)

--- a/dev/benchmarks/openmp/STDP_standalone.py
+++ b/dev/benchmarks/openmp/STDP_standalone.py
@@ -45,10 +45,10 @@ S = Synapses(input, neurons,
              '''w:1
                 dApre/dt=-Apre/taupre : 1 (event-driven)    
                 dApost/dt=-Apost/taupost : 1 (event-driven)''',
-             pre='''ge+=w
+             on_pre='''ge+=w
                     Apre+=dApre
                     w=clip(w+Apost,0,gmax)''',
-             post='''Apost+=dApost
+             on_post='''Apost+=dApost
                      w=clip(w+Apre,0,gmax)''')
 S.connect()
 S.w          = 'rand()*gmax'

--- a/dev/ideas/b1h_bridge/sound_localisation_model.py
+++ b/dev/ideas/b1h_bridge/sound_localisation_model.py
@@ -63,7 +63,7 @@ G = FilterbankGroup(cochlea, 'I', eqs, reset='V=0', threshold='V>1', refractory=
 cd = NeuronGroup(num_indices*cfN, eqs, reset='V=0', threshold='V>1', refractory=0*ms, clock=G.clock)
 # Each CD neuron receives precisely two inputs, one from the left ear and
 # one from the right, for each location and each cochlear frequency
-C = Synapses(G, cd, pre='V += 0.5')
+C = Synapses(G, cd, on_pre='V += 0.5')
 for i in xrange(num_indices*cfN):
     C.connect(i, i)                   # from right ear
     C.connect(i+num_indices*cfN, i)   # from left ear

--- a/dev/ideas/conditional_write.py
+++ b/dev/ideas/conditional_write.py
@@ -20,10 +20,10 @@ y -= 0.05
 G = NeuronGroup(2, eqs, threshold='v>1', reset=reset, refractory=1*ms)
 G.el = [2, 0]
 
-Sx = Synapses(H, G, pre='x += dt*100*Hz')
+Sx = Synapses(H, G, on_pre='x += dt*100*Hz')
 Sx.connect(True)
 
-Sy = Synapses(H, G, pre='y += dt*100*Hz')
+Sy = Synapses(H, G, on_pre='y += dt*100*Hz')
 Sy.connect(True)
 
 M = StateMonitor(G, variables=True, record=True)

--- a/dev/ideas/debug_slow_standalone.py
+++ b/dev/ideas/debug_slow_standalone.py
@@ -10,7 +10,7 @@ if M <= 0:
     M = 1
 G = NeuronGroup(M, 'v:1', threshold='True')
 H = NeuronGroup(N, 'w:1')
-S = Synapses(G, H, pre='w += 1.0')
+S = Synapses(G, H, on_pre='w += 1.0')
 S.connect(True, p=1.0)
 
 start_time = time.time()

--- a/dev/ideas/devices/cpp_standalone_licklider.py
+++ b/dev/ideas/devices/cpp_standalone_licklider.py
@@ -37,7 +37,7 @@ dv/dt=-v/tau+sigma*(2./tau)**.5*xi : 1
 
 neurons = NeuronGroup(num_neurons, eqs_neurons, threshold='v>1', reset='v=0')
 
-synapses = Synapses(receptors, neurons, 'w : 1', pre='v+=w')
+synapses = Synapses(receptors, neurons, 'w : 1', on_pre='v+=w')
 synapses.connect()
 synapses.w = 0.5
 

--- a/dev/ideas/devices/cpp_standalone_nonlinear_synapses.py
+++ b/dev/ideas/devices/cpp_standalone_nonlinear_synapses.py
@@ -26,7 +26,7 @@ S=Synapses(input,neurons,
               g_post = g : 1 (summed)
               dx/dt=-c*x : 1
               w : 1 # synaptic weight
-           ''', pre='x+=w') # NMDA synapses
+           ''', on_pre='x+=w') # NMDA synapses
 
 S.connect(True)
 S.w = '1+9*i'

--- a/dev/ideas/devices/cpp_standalone_stdp.py
+++ b/dev/ideas/devices/cpp_standalone_stdp.py
@@ -45,10 +45,10 @@ S = Synapses(input, neurons,
              '''w:1
                 dApre/dt=-Apre/taupre : 1 (event-driven)
                 dApost/dt=-Apost/taupost : 1 (event-driven)''',
-             pre='''ge+=w
+             on_pre='''ge+=w
                     Apre+=dApre
                     w=clip(w+Apost,0,gmax)''',
-             post='''Apost+=dApost
+             on_post='''Apost+=dApost
                      w=clip(w+Apre,0,gmax)''',
              clock=clock,
              )

--- a/dev/ideas/sampling_algorithms.py
+++ b/dev/ideas/sampling_algorithms.py
@@ -51,7 +51,7 @@ def check(N, p):
     global numfails, numchecks, mu, sigma2
     H = NeuronGroup(1, 'v:1', threshold='False', name='H')
     G = NeuronGroup(N, 'v:1', threshold='False', name='G')
-    S = Synapses(H, G, pre='v+=w', name='S')
+    S = Synapses(H, G, on_pre='v+=w', name='S')
     S.connect(p=p)
     m = len(S)
     low, high = binom.interval(alpha, N, p)

--- a/docs_sphinx/advanced/custom_events.rst
+++ b/docs_sphinx/advanced/custom_events.rst
@@ -38,8 +38,8 @@ providing an ``on_event`` keyword that either specifies which event to use for a
 pathways, or a specific event for each pathway (where non-specified pathways use
 the default ``spike`` event)::
 
-    synapse_1 = Synapses(group, another_group, '...', pre='...', on_event='custom_event')
-    synapse_2 = Synapses(group, another_group, '...', pre='...', post='...',
+    synapse_1 = Synapses(group, another_group, '...', on_pre='...', on_event='custom_event')
+    synapse_2 = Synapses(group, another_group, '...', on_pre='...', on_post='...',
                          on_event={'pre': 'custom_event'})
 
 Scheduling

--- a/docs_sphinx/developer/variables_indices.rst
+++ b/docs_sphinx/developer/variables_indices.rst
@@ -83,7 +83,7 @@ different contexts. Let's consider the following example::
 
     G = NeuronGroup(5, 'dv/dt = -v / tau : volt')
     subG = G[2:]
-    S = Synapses(G, G, pre='v+=1*mV')
+    S = Synapses(G, G, on_pre='v+=1*mV')
     S.connect()
 
 All allow an access to the state variable `v` (note the different shapes, these
@@ -119,7 +119,7 @@ into executable code is not straightforward because it can involve variables
 from different contexts. Here is a simple example::
 
     G = NeuronGroup(5, 'dv/dt = -v / tau : volt')
-    S = Synapses(G, G, 'w : volt', pre='v+=w')
+    S = Synapses(G, G, 'w : volt', on_pre='v+=w')
 
 The seemingly trivial operation ``v+=w`` involves the variable ``v`` of the
 `NeuronGroup` and the variable ``w`` of the `Synapses` object which have to be

--- a/docs_sphinx/user/multicompartmental.rst
+++ b/docs_sphinx/user/multicompartmental.rst
@@ -187,15 +187,15 @@ The first one to insert synaptic equations directly in the neuron equations::
 Note that, as for electrode stimulation, the synaptic current must be defined as a point current.
 Then we use a `Synapses` object to connect a spike source to the neuron::
 
-    S = Synapses(stimulation,neuron,pre = 'gs += w')
+    S = Synapses(stimulation, neuron, on_pre='gs += w')
     S.connect(0,50)
     S.connect(1,100)
 
 This creates two synapses, on compartments 50 and 100. One can specify the compartment number
 with its spatial position by indexing the morphology::
 
-    S.connect(0,morpho[25*um])
-    S.connect(1,morpho.axon[30*um])
+    S.connect(0, morpho[25*um])
+    S.connect(1, morpho.axon[30*um])
 
 In this method for creating synapses,
 there is a single value for the synaptic conductance in any compartment.
@@ -210,8 +210,9 @@ The second method, which works in such cases, is to have synaptic equations in t
     gs : siemens
     '''
     neuron = SpatialNeuron(morphology=morpho, model=eqs, Cm=1 * uF / cm ** 2, Ri=100 * ohm * cm)
-    S = Synapses(stimulation,neuron,model='''dg/dt = -g/taus : siemens
-                                             gs_post = g : siemens (summed)''',pre = 'g += w')
+    S = Synapses(stimulation, neuron, model='''dg/dt = -g/taus : siemens
+                                               gs_post = g : siemens (summed)''',
+                 on_pre='g += w')
 
 Here each synapse (instead of each compartment) has an associated value ``g``, and all values of
 ``g`` for each compartment (i.e., all synapses targeting that compartment) are collected

--- a/examples/COBAHH.py
+++ b/examples/COBAHH.py
@@ -65,8 +65,8 @@ P = NeuronGroup(4000, model=eqs, threshold='v>-20*mV', refractory=3*ms,
                 method='exponential_euler')
 Pe = P[:3200]
 Pi = P[3200:]
-Ce = Synapses(Pe, P, pre='ge+=we')
-Ci = Synapses(Pi, P, pre='gi+=wi')
+Ce = Synapses(Pe, P, on_pre='ge+=we')
+Ci = Synapses(Pi, P, on_pre='gi+=wi')
 Ce.connect(p=0.02)
 Ci.connect(p=0.02)
 

--- a/examples/CUBA.py
+++ b/examples/CUBA.py
@@ -36,8 +36,8 @@ P.gi = 0*mV
 
 we = (60*0.27/10)*mV # excitatory synaptic weight (voltage)
 wi = (-20*4.5/10)*mV # inhibitory synaptic weight
-Ce = Synapses(P, P, pre='ge += we')
-Ci = Synapses(P, P, pre='gi += wi')
+Ce = Synapses(P, P, on_pre='ge += we')
+Ci = Synapses(P, P, on_pre='gi += wi')
 Ce.connect('i<3200', p=0.02)
 Ci.connect('i>=3200', p=0.02)
 

--- a/examples/adaptive_threshold.py
+++ b/examples/adaptive_threshold.py
@@ -17,7 +17,7 @@ IF = NeuronGroup(1, model=eqs, reset=reset, threshold='v>vt')
 IF.vt = 10*mV
 PG = PoissonGroup(1, 500 * Hz)
 
-C = Synapses(PG, IF, pre='v += 3*mV')
+C = Synapses(PG, IF, on_pre='v += 3*mV')
 C.connect()
 
 Mv = StateMonitor(IF, 'v', record=True)

--- a/examples/compartmental/bipolar_with_inputs.py
+++ b/examples/compartmental/bipolar_with_inputs.py
@@ -32,7 +32,7 @@ taus = 1*ms
 w = 20*nS
 S = Synapses(stimulation, neuron, model='''dg/dt = -g/taus : siemens (clock-driven)
                                            gs_post = g : siemens (summed)''',
-             pre='g += w')
+             on_pre='g += w')
 
 S.connect(0, morpho.L[-1])
 S.connect(1, morpho.R[-1])

--- a/examples/compartmental/bipolar_with_inputs2.py
+++ b/examples/compartmental/bipolar_with_inputs2.py
@@ -31,7 +31,7 @@ stimulation.x = [0, 0.5] # Asynchronous
 
 # Synapses
 w = 20*nS
-S = Synapses(stimulation, neuron, pre = 'gs += w')
+S = Synapses(stimulation, neuron, on_pre='gs += w')
 S.connect(0, morpho.L[99.9*um])
 S.connect(1, morpho.R[99.9*um])
 

--- a/examples/frompapers/Brette_2012/Fig5A.py
+++ b/examples/frompapers/Brette_2012/Fig5A.py
@@ -43,7 +43,7 @@ neuron.gLx[0] = gL
 neuron.gNa[compartment] = gNa_0 / neuron.area[compartment]
 
 # Reset the entire neuron when there is a spike
-reset = Synapses(neuron, neuron, pre='v = EL')
+reset = Synapses(neuron, neuron, on_pre='v = EL')
 reset.connect('i == compartment')  # Connects the spike initiation compartment to all compartments
 
 # Monitors

--- a/examples/frompapers/Brunel_Hakim_1999.py
+++ b/examples/frompapers/Brunel_Hakim_1999.py
@@ -34,7 +34,7 @@ dV/dt = (-V+muext + sigmaext * sqrt(tau) * xi)/tau : volt
 group = NeuronGroup(N, eqs, threshold='V>theta',
                     reset='V=Vr', refractory=taurefr)
 group.V = Vr
-conn = Synapses(group, group, pre='V += -J', delay=delta)
+conn = Synapses(group, group, on_pre='V += -J', delay=delta)
 conn.connect(p=sparseness)
 M = SpikeMonitor(group)
 LFP = PopulationRateMonitor(group)

--- a/examples/frompapers/Clopath_et_al_2010_homeostasis.py
+++ b/examples/frompapers/Clopath_et_al_2010_homeostasis.py
@@ -119,8 +119,8 @@ Nrns_input = NeuronGroup(Nr_inputs, eqs_inputs, threshold='rand()<rates*dt',
 
 Syn = Synapses(Nrns_input, Nrn_downstream,
                model=Syn_model,
-               pre=Pre_eq,
-               post=Post_eq
+               on_pre=Pre_eq,
+               on_post=Post_eq
                )
 
 Syn.connect(numpy.arange(Nr_inputs), 0)

--- a/examples/frompapers/Clopath_et_al_2010_no_homeostasis.py
+++ b/examples/frompapers/Clopath_et_al_2010_no_homeostasis.py
@@ -107,8 +107,8 @@ Nrns = NeuronGroup(Nr_neurons, eqs_neurons, threshold='v>V_thresh',
 
 Syn = Synapses(Nrns, Nrns,
                model=Syn_model,
-               pre=Pre_eq,
-               post=Post_eq
+               on_pre=Pre_eq,
+               on_post=Post_eq
                )
 
 Syn.connect('i!=j')

--- a/examples/frompapers/Diesmann_et_al_1999.py
+++ b/examples/frompapers/Diesmann_et_al_1999.py
@@ -32,10 +32,10 @@ P = NeuronGroup(N=n_groups*group_size, model=eqs,
 Pinput = SpikeGeneratorGroup(85, np.arange(85),
                              np.random.randn(85)*1*ms + 50*ms)
 # The network structure
-S = Synapses(P, P, pre='y+=weight')
+S = Synapses(P, P, on_pre='y+=weight')
 S.connect(j='k for k in range((int(i/group_size)+1)*group_size, (int(i/group_size)+2)*group_size) '
             'if i<N_pre-group_size')
-Sinput = Synapses(Pinput, P[:group_size], pre='y+=weight')
+Sinput = Synapses(Pinput, P[:group_size], on_pre='y+=weight')
 Sinput.connect()
 
 # Record the spikes

--- a/examples/frompapers/Sturzl_et_al_2000.py
+++ b/examples/frompapers/Sturzl_et_al_2000.py
@@ -59,9 +59,9 @@ dx/dt = (y - x)/taus : 1 # alpha currents
 dy/dt = -y/taus : 1
 '''
 neurons = NeuronGroup(8, model=eqs_neuron, threshold='v>1', reset='v=0')
-synapses_ex = Synapses(legs, neurons, pre='y+=wex')
+synapses_ex = Synapses(legs, neurons, on_pre='y+=wex')
 synapses_ex.connect(j='i')
-synapses_inh = Synapses(legs, neurons, pre='y+=winh', delay=deltaI)
+synapses_inh = Synapses(legs, neurons, on_pre='y+=winh', delay=deltaI)
 synapses_inh.connect('abs(((j - i) % N_post) - N_post/2) <= 1')
 spikes = SpikeMonitor(neurons)
 

--- a/examples/frompapers/Vogels_et_al_2011.py
+++ b/examples/frompapers/Vogels_et_al_2011.py
@@ -58,9 +58,9 @@ Pi = neurons[NE:]
 # Connecting the network 
 # ###########################################
 
-con_e = Synapses(Pe, neurons, pre='g_ampa += 0.3*nS')
+con_e = Synapses(Pe, neurons, on_pre='g_ampa += 0.3*nS')
 con_e.connect(p=epsilon)
-con_ii = Synapses(Pi, Pi, pre='g_gaba += 3*nS')
+con_ii = Synapses(Pi, Pi, on_pre='g_gaba += 3*nS')
 con_ii.connect(p=epsilon)
 
 # ###########################################
@@ -76,10 +76,10 @@ alpha = 3*Hz*tau_stdp*2  # Target rate parameter
 gmax = 100               # Maximum inhibitory weight
 
 con_ie = Synapses(Pi, Pe, model=eqs_stdp_inhib,
-                  pre='''A_pre += 1.
+                  on_pre='''A_pre += 1.
                          w = clip(w+(A_post-alpha)*eta, 0, gmax)
                          g_gaba += w*nS''',
-                  post='''A_post += 1.
+                  on_post='''A_post += 1.
                           w = clip(w+A_pre*eta, 0, gmax)
                        ''')
 con_ie.connect(p=epsilon)

--- a/examples/frompapers/kremer_et_al_2011_barrel_cortex.py
+++ b/examples/frompapers/kremer_et_al_2011_barrel_cortex.py
@@ -105,10 +105,10 @@ feedforward = Synapses(layer4, layer23exc,
                        model='''w:volt
                                 dA_source/dt = -A_source/taup : volt (event-driven)
                                 dA_target/dt = -A_target/taud : volt (event-driven)''',
-                       pre='''ge+=w
+                       on_pre='''ge+=w
                               A_source += Ap
                               w = clip(w+A_target, 0, EPSC)''',
-                       post='''
+                       on_post='''
                               A_target += Ad
                               w = clip(w+A_source, 0, EPSC)''',
                        name='feedforward')
@@ -119,7 +119,7 @@ feedforward.w = EPSC*.5
 
 print('excitatory lateral')
 # Excitatory lateral connections
-recurrent_exc = Synapses(layer23exc, layer23, model='w:volt', pre='ge+=w',
+recurrent_exc = Synapses(layer23exc, layer23, model='w:volt', on_pre='ge+=w',
                          name='recurrent_exc')
 recurrent_exc.connect(p='.15*exp(-.5*(((x_pre-x_post)/.4)**2+((y_pre-y_post)/.4)**2))')
 recurrent_exc.w['j<Nbarrels*N23exc'] = EPSC*.3 # excitatory->excitatory
@@ -128,7 +128,7 @@ recurrent_exc.w['j>=Nbarrels*N23exc'] = EPSC # excitatory->inhibitory
 
 # Inhibitory lateral connections
 print('inhibitory lateral')
-recurrent_inh = Synapses(layer23inh, layer23exc, pre='gi+=IPSC',
+recurrent_inh = Synapses(layer23inh, layer23exc, on_pre='gi+=IPSC',
                          name='recurrent_inh')
 recurrent_inh.connect(p='exp(-.5*(((x_pre-x_post)/.2)**2+((y_pre-y_post)/.2)**2))')
 

--- a/examples/standalone/STDP_standalone.py
+++ b/examples/standalone/STDP_standalone.py
@@ -37,10 +37,10 @@ S = Synapses(input, neurons,
              '''w : 1
                 dApre/dt = -Apre / taupre : 1 (event-driven)
                 dApost/dt = -Apost / taupost : 1 (event-driven)''',
-             pre='''ge += w
+             on_pre='''ge += w
                     Apre += dApre
                     w = clip(w + Apost, 0, gmax)''',
-             post='''Apost += dApost
+             on_post='''Apost += dApost
                      w = clip(w + Apre, 0, gmax)''',
              )
 S.connect()

--- a/examples/standalone/cuba_openmp.py
+++ b/examples/standalone/cuba_openmp.py
@@ -27,8 +27,8 @@ P.gi = 0*mV
 
 we = (60*0.27/10)*mV # excitatory synaptic weight (voltage)
 wi = (-20*4.5/10)*mV # inhibitory synaptic weight
-Ce = Synapses(P, P, pre='ge += we')
-Ci = Synapses(P, P, pre='gi += wi')
+Ce = Synapses(P, P, on_pre='ge += we')
+Ci = Synapses(P, P, on_pre='gi += wi')
 Ce.connect('i<3200', p=0.02)
 Ci.connect('i>=3200', p=0.02)
 

--- a/examples/synapses/STDP.py
+++ b/examples/synapses/STDP.py
@@ -32,10 +32,10 @@ S = Synapses(input, neurons,
              '''w : 1
                 dApre/dt = -Apre / taupre : 1 (event-driven)
                 dApost/dt = -Apost / taupost : 1 (event-driven)''',
-             pre='''ge += w
+             on_pre='''ge += w
                     Apre += dApre
                     w = clip(w + Apost, 0, gmax)''',
-             post='''Apost += dApost
+             on_post='''Apost += dApost
                      w = clip(w + Apre, 0, gmax)''',
              )
 S.connect()

--- a/examples/synapses/efficient_gaussian_connectivity.py
+++ b/examples/synapses/efficient_gaussian_connectivity.py
@@ -75,18 +75,18 @@ import time
 
 def naive(N):
     G = NeuronGroup(N, 'v:1', threshold='v>1', name='G')
-    S = Synapses(G, G, pre='v += 1', name='S')
+    S = Synapses(G, G, on_pre='v += 1', name='S')
     S.connect(p='exp(-0.1*(i-j)**2)')
 
 def limited(N, q=0.001):
     G = NeuronGroup(N, 'v:1', threshold='v>1', name='G')
-    S = Synapses(G, G, pre='v += 1', name='S')
+    S = Synapses(G, G, on_pre='v += 1', name='S')
     w = int(ceil(sqrt(log(q)/-0.1)))
     S.connect(j='k for k in range(i-w, i+w) if rand()<exp(-0.1*(i-j)**2)', skip_if_invalid=True)
 
 def divided(N, q=0.001):
     G = NeuronGroup(N, 'v:1', threshold='v>1', name='G')
-    S = Synapses(G, G, pre='v += 1', name='S')
+    S = Synapses(G, G, on_pre='v += 1', name='S')
     w = int(ceil(sqrt(log(q)/-0.1)))
     S.connect(j='k for k in range(i-w, i+w) if rand()<exp(-0.1*(i-j)**2)', skip_if_invalid=True)
     pmax = exp(-0.1*w**2)

--- a/examples/synapses/jeffress.py
+++ b/examples/synapses/jeffress.py
@@ -41,7 +41,7 @@ dv/dt = -v / tau + sigma * (2 / tau)**.5 * xi : 1
 neurons = NeuronGroup(num_neurons, eqs_neurons, threshold='v>1',
                       reset='v = 0', name='neurons')
 
-synapses = Synapses(ears, neurons, pre='v += .5')
+synapses = Synapses(ears, neurons, on_pre='v += .5')
 synapses.connect()
 
 synapses.delay['i==0'] = '(1.0*j)/(num_neurons-1)*1.1*max_delay'

--- a/examples/synapses/licklider.py
+++ b/examples/synapses/licklider.py
@@ -30,7 +30,7 @@ dv/dt = -v/tau+sigma*(2./tau)**.5*xi : 1
 
 neurons = NeuronGroup(num_neurons, eqs_neurons, threshold='v>1', reset='v=0')
 
-synapses = Synapses(receptors, neurons, pre='v += 0.5')
+synapses = Synapses(receptors, neurons, on_pre='v += 0.5')
 synapses.connect()
 synapses.delay = 'i*1.0/exp(log(min_freq/Hz)+(j*1.0/(num_neurons-1))*log(max_freq/min_freq))*second'
 

--- a/examples/synapses/nonlinear.py
+++ b/examples/synapses/nonlinear.py
@@ -16,7 +16,7 @@ S = Synapses(input, neurons,'''
                 g_post = g_syn : 1 (summed)
                 dx/dt=-c*x : 1 (clock-driven)
                 w : 1 # synaptic weight
-             ''', pre='x += w') # NMDA synapses
+             ''', on_pre='x += w') # NMDA synapses
 
 S.connect()
 S.w = [1., 10.]

--- a/examples/synapses/state_variables.py
+++ b/examples/synapses/state_variables.py
@@ -6,7 +6,7 @@ from brian2 import *
 
 G = NeuronGroup(100, 'v:volt', threshold='v>-50*mV')
 G.v = '(sin(2*pi*i/N) - 70 + 0.25*randn()) * mV'
-S = Synapses(G, G, 'w : volt', pre='v += w')
+S = Synapses(G, G, 'w : volt', on_pre='v += w')
 S.connect()
 
 space_constant = 200.0

--- a/examples/synapses/synapses.py
+++ b/examples/synapses/synapses.py
@@ -9,7 +9,7 @@ G1.v = 1.2
 G2 = NeuronGroup(10, 'dv/dt = -v / (10*ms) : 1',
                  threshold='v > 1', reset='v=0')
  
-syn = Synapses(G1, G2, 'dw/dt = -w / (50*ms): 1 (event-driven)', pre='v += w')
+syn = Synapses(G1, G2, 'dw/dt = -w / (50*ms): 1 (event-driven)', on_pre='v += w')
 
 syn.connect('i == j', p=0.75)
 

--- a/tutorials/2-intro-to-brian-synapses.ipynb
+++ b/tutorials/2-intro-to-brian-synapses.ipynb
@@ -63,7 +63,7 @@
     "G.tau = [10, 100]*ms\n",
     "\n",
     "# Comment these two lines out to see what happens without Synapses\n",
-    "S = Synapses(G, G, pre='v_post += 0.2')\n",
+    "S = Synapses(G, G, on_pre='v_post += 0.2')\n",
     "S.connect(i=0, j=1)\n",
     "\n",
     "M = StateMonitor(G, 'v', record=True)\n",
@@ -85,7 +85,7 @@
    "source": [
     "There are a few things going on here. First of all, let's recap what is going on with the ``NeuronGroup``. We've created two neurons, each of which has the same differential equation but different values for parameters I and tau. Neuron 0 has ``I=2`` and ``tau=10*ms`` which means that is driven to repeatedly spike at a fairly high rate. Neuron 1 has ``I=0`` and ``tau=100*ms`` which means that on its own - without the synapses - it won't spike at all (the driving current I is 0). You can prove this to yourself by commenting out the two lines that define the synapse.\n",
     "\n",
-    "Next we define the synapses: ``Synapses(source, target, ...)`` means that we are defining a synaptic model that goes from ``source`` to ``target``. In this case, the source and target are both the same, the group ``G``. The syntax ``pre='v_post += 0.2'`` means that when a spike occurs in the presynaptic neuron (hence ``pre``) it causes an instantaneous change to happen ``v_post += 0.2``. The ``_post`` means that the value of ``v`` referred to is the post-synaptic value, and it is increased by 0.2. So in total, what this model says is that whenever two neurons in G are connected by a synapse, when the source neuron fires a spike the target neuron will have its value of ``v`` increased by 0.2.\n",
+    "Next we define the synapses: ``Synapses(source, target, ...)`` means that we are defining a synaptic model that goes from ``source`` to ``target``. In this case, the source and target are both the same, the group ``G``. The syntax ``on_pre='v_post += 0.2'`` means that when a spike occurs in the presynaptic neuron (hence ``on_pre``) it causes an instantaneous change to happen ``v_post += 0.2``. The ``_post`` means that the value of ``v`` referred to is the post-synaptic value, and it is increased by 0.2. So in total, what this model says is that whenever two neurons in G are connected by a synapse, when the source neuron fires a spike the target neuron will have its value of ``v`` increased by 0.2.\n",
     "\n",
     "However, at this point we have only defined the synapse model, we haven't actually created any synapses. The next line ``S.connect(i=0, j=1)`` creates a synapse from neuron 0 to neuron 1."
    ]
@@ -122,7 +122,7 @@
     "G.tau = [10, 100, 100]*ms\n",
     "\n",
     "# Comment these two lines out to see what happens without Synapses\n",
-    "S = Synapses(G, G, 'w : 1', pre='v_post += w')\n",
+    "S = Synapses(G, G, 'w : 1', on_pre='v_post += w')\n",
     "S.connect(i=0, j=[1, 2])\n",
     "S.w = 'j*0.2'\n",
     "\n",
@@ -142,7 +142,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This example behaves very similarly to the previous example, but now there's a synaptic weight variable ``w``. The string ``'w : 1'`` is an equation string, precisely the same as for neurons, that defines a single dimensionless parameter ``w``. We changed the behaviour on a spike to ``pre='v_post += w'`` now, so that each synapse can behave differently depending on the value of ``w``. To illustrate this, we've made a third neuron which behaves precisely the same as the second neuron, and connected neuron 0 to both neurons 1 and 2. We've also set the weights via ``S.w = 'j*0.2'``. When ``i`` and ``j`` occur in the context of synapses, ``i`` refers to the source neuron index, and ``j`` to the target neuron index. So this will give a synaptic connection from 0 to 1 with weight ``0.2=0.2*1`` and from 0 to 2 with weight ``0.4=0.2*2``."
+    "This example behaves very similarly to the previous example, but now there's a synaptic weight variable ``w``. The string ``'w : 1'`` is an equation string, precisely the same as for neurons, that defines a single dimensionless parameter ``w``. We changed the behaviour on a spike to ``on_pre='v_post += w'`` now, so that each synapse can behave differently depending on the value of ``w``. To illustrate this, we've made a third neuron which behaves precisely the same as the second neuron, and connected neuron 0 to both neurons 1 and 2. We've also set the weights via ``S.w = 'j*0.2'``. When ``i`` and ``j`` occur in the context of synapses, ``i`` refers to the source neuron index, and ``j`` to the target neuron index. So this will give a synaptic connection from 0 to 1 with weight ``0.2=0.2*1`` and from 0 to 2 with weight ``0.4=0.2*2``."
    ]
   },
   {
@@ -176,7 +176,7 @@
     "G.I = [2, 0, 0]\n",
     "G.tau = [10, 100, 100]*ms\n",
     "\n",
-    "S = Synapses(G, G, 'w : 1', pre='v_post += w')\n",
+    "S = Synapses(G, G, 'w : 1', on_pre='v_post += w')\n",
     "S.connect(i=0, j=[1, 2])\n",
     "S.w = 'j*0.2'\n",
     "S.delay = 'j*2*ms'\n",
@@ -520,12 +520,12 @@
     "             dapre/dt = -apre/taupre : 1 (event-driven)\n",
     "             dapost/dt = -apost/taupost : 1 (event-driven)\n",
     "             ''',\n",
-    "             pre='''\n",
+    "             on_pre='''\n",
     "             v_post += w\n",
     "             apre += Apre\n",
     "             w = clip(w+apost, 0, wmax)\n",
     "             ''',\n",
-    "             post='''\n",
+    "             on_post='''\n",
     "             apost += Apost\n",
     "             w = clip(w+apre, 0, wmax)\n",
     "             ''')"
@@ -537,9 +537,9 @@
    "source": [
     "There are a few things to see there. Firstly, when defining the synapses we've given a more complicated multi-line string defining three synaptic variables (``w``, ``apre`` and ``apost``). We've also got a new bit of syntax there, ``(event-driven)`` after the definitions of ``apre`` and ``apost``. What this means is that although these two variables evolve continuously over time, Brian should only update them at the time of an event (a spike). This is because we don't need the values of ``apre`` and ``apost`` except at spike times, and it is more efficient to only update them when needed.\n",
     "\n",
-    "Next we have a ``pre=...`` argument. The first line is ``v_post += w``: this is the line that actually applies the synaptic weight to the target neuron. The second line is ``apre += Apre`` which encodes the rule above. In the third line, we're also encoding the rule above but we've added one extra feature: we've clamped the synaptic weights between a minimum of 0 and a maximum of ``wmax`` so that the weights can't get too large or negative. The function ``clip(x, low, high)`` does this.\n",
+    "Next we have a ``on_pre=...`` argument. The first line is ``v_post += w``: this is the line that actually applies the synaptic weight to the target neuron. The second line is ``apre += Apre`` which encodes the rule above. In the third line, we're also encoding the rule above but we've added one extra feature: we've clamped the synaptic weights between a minimum of 0 and a maximum of ``wmax`` so that the weights can't get too large or negative. The function ``clip(x, low, high)`` does this.\n",
     "\n",
-    "Finally, we have a ``post=...`` argument. This gives the statements to calculate when a post-synaptic neuron fires. Note that we do not modify ``v`` in this case, only the synaptic variables.\n",
+    "Finally, we have a ``on_post=...`` argument. This gives the statements to calculate when a post-synaptic neuron fires. Note that we do not modify ``v`` in this case, only the synaptic variables.\n",
     "\n",
     "Now let's see how all the variables behave when a presynaptic spike arrives some time before a postsynaptic spike."
    ]
@@ -567,12 +567,12 @@
     "             dapre/dt = -apre/taupre : 1 (clock-driven)\n",
     "             dapost/dt = -apost/taupost : 1 (clock-driven)\n",
     "             ''',\n",
-    "             pre='''\n",
+    "             on_pre='''\n",
     "             v_post += w\n",
     "             apre += Apre\n",
     "             w = clip(w+apost, 0, wmax)\n",
     "             ''',\n",
-    "             post='''\n",
+    "             on_post='''\n",
     "             apost += Apost\n",
     "             w = clip(w+apre, 0, wmax)\n",
     "             ''')\n",
@@ -635,11 +635,11 @@
     "             dapre/dt = -apre/taupre : 1 (event-driven)\n",
     "             dapost/dt = -apost/taupost : 1 (event-driven)\n",
     "             ''',\n",
-    "             pre='''\n",
+    "             on_pre='''\n",
     "             apre += Apre\n",
     "             w = w+apost\n",
     "             ''',\n",
-    "             post='''\n",
+    "             on_post='''\n",
     "             apost += Apost\n",
     "             w = w+apre\n",
     "             ''')\n",


### PR DESCRIPTION
`pre` and `post` still work, but raise a warning
Closes #582 

Should be good to merge.