### PR TITLE
[WIP] Use RandomKit for random number generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+/dev/ideas/randomkit/CUBA
+/brian2/random/randomkit/randkit.c
 /dev/benchmarks/compare_to_brian1.png
 # Compiled Python files
 *.py[cod]

--- a/brian2/devices/cpp_standalone/templates/main.cpp
+++ b/brian2/devices/cpp_standalone/templates/main.cpp
@@ -5,6 +5,7 @@
 {{ openmp_pragma('include') }}
 #include "run.h"
 #include "brianlib/common_math.h"
+#include "randomkit.h"
 
 {% for codeobj in code_objects %}
 #include "code_objects/{{codeobj.name}}.h"

--- a/brian2/devices/cpp_standalone/templates/objects.cpp
+++ b/brian2/devices/cpp_standalone/templates/objects.cpp
@@ -6,11 +6,14 @@
 #include "brianlib/dynamic_array.h"
 #include "brianlib/stdint_compat.h"
 #include "network.h"
+#include "randomkit.h"
 #include<vector>
 #include<iostream>
 #include<fstream>
 
 namespace brian {
+
+rk_state _mersenne_twister_state;
 
 //////////////// networks /////////////////
 {% for net in networks | sort(attribute='name') %}
@@ -265,10 +268,13 @@ void _dealloc_arrays()
 #include "brianlib/dynamic_array.h"
 #include "brianlib/stdint_compat.h"
 #include "network.h"
+#include "randomkit.h"
 #include<vector>
 {{ openmp_pragma('include') }}
 
 namespace brian {
+
+extern rk_state _mersenne_twister_state;
 
 //////////////// clocks ///////////////////
 {% for clock in clocks %}

--- a/brian2/devices/cpp_standalone/templates/run.cpp
+++ b/brian2/devices/cpp_standalone/templates/run.cpp
@@ -2,6 +2,7 @@
 #include<stdlib.h>
 #include "objects.h"
 #include<ctime>
+#include "randomkit.h"
 
 {% for codeobj in code_objects | sort(attribute='name') %}
 #include "code_objects/{{codeobj.name}}.h"
@@ -23,6 +24,7 @@ void brian_start()
     {% endfor %}
 	srand((unsigned int)time(NULL));
 	rand(); // put this in because the first random number generated on some versions of C++ is always almost the same
+	rk_error errcode = rk_randomseed(&brian::_mersenne_twister_state);
 }
 
 void brian_end()

--- a/brian2/devices/cpp_standalone/templates/win_makefile
+++ b/brian2/devices/cpp_standalone/templates/win_makefile
@@ -4,9 +4,9 @@ clean:
     del *.obj /s
     del *.exe /s
 
-{% for base in source_bases %}
+{% for fname, base in zip(source_files, source_bases) %}
 {{base}}.obj:
-    cl /c /EHsc /I. {{compiler_flags}} {{openmp_flag}} {{base}}.cpp /Fo{{base}}.obj
+    cl /c /EHsc /I. {{compiler_flags}} {{openmp_flag}} {{fname}} /Fo{{base}}.obj
     
 {% endfor %}
 

--- a/brian2/random/randomkit/rk.cpp
+++ b/brian2/random/randomkit/rk.cpp
@@ -1,0 +1,8 @@
+#include "rk.h"
+
+rk_state *internal_state = NULL;
+
+rk_state **get_rk_state()
+{
+    return &internal_state;
+}

--- a/brian2/random/randomkit/rk.h
+++ b/brian2/random/randomkit/rk.h
@@ -1,0 +1,4 @@
+#ifndef _BRIAN2_RK_H
+#include "randomkit.h"
+rk_state **get_rk_state();
+#endif

--- a/dev/ideas/randomkit/CUBA.py
+++ b/dev/ideas/randomkit/CUBA.py
@@ -1,0 +1,59 @@
+'''
+This is a Brian script implementing a benchmark described
+in the following review paper:
+
+Simulation of networks of spiking neurons: A review of tools and strategies
+(2007). Brette, Rudolph, Carnevale, Hines, Beeman, Bower, Diesmann, Goodman,
+Harris, Zirpe, Natschlager, Pecevski, Ermentrout, Djurfeldt, Lansner, Rochel,
+Vibert, Alvarez, Muller, Davison, El Boustani and Destexhe.
+Journal of Computational Neuroscience 23(3):349-98
+
+Benchmark 2: random network of integrate-and-fire neurons with exponential
+synaptic currents.
+
+Clock-driven implementation with exact subthreshold integration
+(but spike times are aligned to the grid).
+'''
+from brian2 import *
+
+set_device('cpp_standalone', directory='CUBA')
+
+taum = 20*ms
+taue = 5*ms
+taui = 10*ms
+Vt = -50*mV
+Vr = -60*mV
+El = -49*mV
+
+eqs = '''
+dv/dt  = (ge+gi-(v-El))/taum : volt (unless refractory)
+dge/dt = -ge/taue : volt
+dgi/dt = -gi/taui : volt
+x : 1
+'''
+
+P = NeuronGroup(4000, eqs, threshold='v>Vt', reset='v = Vr', refractory=5*ms)
+P.v = 'Vr + rand() * (Vt - Vr)'
+P.ge = 0*mV
+P.gi = 0*mV
+P.x = 'randn()'
+
+we = (60*0.27/10)*mV # excitatory synaptic weight (voltage)
+wi = (-20*4.5/10)*mV # inhibitory synaptic weight
+Ce = Synapses(P, P, on_pre='ge += we')
+Ci = Synapses(P, P, on_pre='gi += wi')
+Ce.connect('i<3200', p=0.02)
+Ci.connect('i>=3200', p=0.02)
+
+s_mon = SpikeMonitor(P)
+
+run(1 * second)
+
+# hist(P.x[:])
+# show()
+
+
+plot(s_mon.t/ms, s_mon.i, '.k')
+xlabel('Time (ms)')
+ylabel('Neuron index')
+show()

--- a/dev/ideas/randomkit/randkit_from_weave.py
+++ b/dev/ideas/randomkit/randkit_from_weave.py
@@ -1,0 +1,25 @@
+from brian2 import *
+from scipy import weave
+import brian2
+import os
+
+brian2dir, _ = os.path.split(brian2.__file__)
+rkdir = os.path.join(brian2dir, 'random', 'randomkit')
+rkc = os.path.join(rkdir, 'rk.cpp')
+randomkitc = os.path.join(rkdir, 'randomkit.c')
+
+code = '''
+rk_state **internal_state = get_rk_state();
+if(*internal_state==NULL)
+{
+    *internal_state = new rk_state;
+    rk_error errcode = rk_randomseed(*internal_state);
+    std::cout << "Allocated new random state." << std::endl;
+}
+std::cout << rk_double(*internal_state) << std::endl;
+'''
+
+for i in range(2):
+    weave.inline(code+'\n//'+str(i)+'\n', [], {}, compiler='msvc',
+                 headers=['"randomkit.h"', '"rk.h"'], sources=[rkc, randomkitc],
+                 libraries=['advapi32'], include_dirs=[rkdir])


### PR DESCRIPTION
Numpy uses a Mersenne Twister for random number generation based on an open source implementation that as far as I can tell should be fully compatible with our license. I started from this version: https://github.com/stefanv/randkit

So far I've updated C++ standalone to use this library. This entailed a few small changes to CPPStandaloneDevice because it's a C file not C++, and because if you're on Windows you need to link to the ``advapi32`` library. I haven't tested it on Linux yet but all tests pass on Windows.

One issue is using it with OpenMP since I believe the library is not thread safe. However, I'm not sure that we're handling this correctly at the moment anyway since we use ``rand()`` which is also not thread safe. Thoughts on this?

It should also be possible to use this library in weave and Cython, but there are a few issues. In order to use the library, you need to seed and maintain a fairly large amount of state (in the C struct ``rk_state``). This is straightforward in C++ standalone but more of an issue for weave/cython because ideally you'd like to maintain the same state across code objects but this is non-trivial. Some options are:

1. Since we're using an identical implementation to numpy, try to get a pointer to their ``rk_state`` and use this. I haven't worked out how to do this yet. I can get a copy of their ``rk_state`` (it's what is returned by ``RandomState.get_state`` essentially), but not a pointer to it. If we used this copy, we'd have to update it at the end of the loop (which we can do at a small cost). However, if the user was also accessing numpy's random numbers in their code, this would totally mess up the random state. If we could get a pointer to their state (which might be possible using the Cython implementation ``mtrand.pyx`` behind Numpy's ``RandomState``), this would solve this problem. However, if numpy ever changes their RNG we might get into trouble here.
2. We handle our own state separately from numpy's. We copy the pointer into a Python integer and pass that to weave and Cython, reinterpreting as an appropriate pointer type. I think this should be possible although it's a little bit fiddly to do. Advantages: we don't interfere with numpy at all since we never use it. Disadvantages: fiddly, and a potential problem is that the numpy random state might get seeded with the same value as ours. Looking at the source code, if possible it uses OS level entropy functions to seed the RNG (which would work fine because we would get a different and fully independent seed compared to numpy), but it falls back on using the time if they are not available (which might easily lead to us having the same seed as numpy). We could potentially check for this by using ``RandomState.get_state`` and doing a byte-for-byte comparison and raising an error if they are the same, but that's more fiddliness.
3. We have a separate random state for each ``CodeObject``. As above, if the seed value is coming from a good source of entropy then this is fine but if it falls back on using the system time we'd get the same seed for each ``CodeObject`` which would be a problem. A possible solution here would be for each ``CodeObject`` to generate a seed from a global RNG, but I have no idea if that's safe or not (probably not). You can see this approach in ``dev/ideas/randomkit/randkit_from_weave.py``.