### PR TITLE
[MRG] Provide an actual `Unit` (and not a `Quantity`) for the `Variable` object in `check_units_statements`

### DIFF
--- a/brian2/core/variables.py
+++ b/brian2/core/variables.py
@@ -12,9 +12,8 @@ import numpy as np
 from brian2.utils.stringtools import get_identifiers, word_substitute
 from brian2.units.fundamentalunits import (Quantity, Unit, DIMENSIONLESS,
                                            fail_for_dimension_mismatch,
-                                           have_same_dimensions)
+                                           have_same_dimensions, get_unit)
 from brian2.utils.logger import get_logger
-from units.fundamentalunits import get_unit
 
 from .base import weakproxy_with_fallback, device_override
 from .preferences import prefs

--- a/brian2/core/variables.py
+++ b/brian2/core/variables.py
@@ -14,6 +14,7 @@ from brian2.units.fundamentalunits import (Quantity, Unit, DIMENSIONLESS,
                                            fail_for_dimension_mismatch,
                                            have_same_dimensions)
 from brian2.utils.logger import get_logger
+from units.fundamentalunits import get_unit
 
 from .base import weakproxy_with_fallback, device_override
 from .preferences import prefs
@@ -130,7 +131,9 @@ class Variable(object):
     def __init__(self, name, unit, owner=None, dtype=None, scalar=False,
                  constant=False, read_only=False, dynamic=False, array=False):
         if not isinstance(unit, Unit):
-            if unit == 1:
+            if isinstance(unit, Quantity):
+                unit = get_unit(unit)
+            elif unit == 1:
                 unit = Unit(1)
             else:
                 raise TypeError(('unit argument has to be a Unit object, was '

--- a/brian2/equations/unitcheck.py
+++ b/brian2/equations/unitcheck.py
@@ -3,7 +3,7 @@ Utility functions for handling the units in `Equations`.
 '''
 import re
 
-from brian2.units.fundamentalunits import (Quantity, Unit,
+from brian2.units.fundamentalunits import (get_unit, Unit,
                                            fail_for_dimension_mismatch)
 
 from brian2.parsing.expressions import parse_expression_unit
@@ -105,7 +105,8 @@ def check_units_statements(code, variables):
                                                                expected_unit))
         elif varname in newly_defined:
             # note the unit for later
-            variables[varname] = Variable(name=varname, unit=expr_unit,
+            variables[varname] = Variable(name=varname,
+                                          unit=get_unit(expr_unit),
                                           scalar=False)
         else:
             raise AssertionError(('Variable "%s" is neither in the variables '

--- a/brian2/tests/test_synapses.py
+++ b/brian2/tests/test_synapses.py
@@ -884,21 +884,21 @@ def test_no_synapses():
 @attr('standalone-compatible')
 @with_setup(teardown=reinit_devices)
 def test_summed_variable():
-    source = NeuronGroup(2, 'v : 1', threshold='v>1', reset='v=0')
-    source.v = 1.1  # will spike immediately
-    target = NeuronGroup(2, 'v : 1')
-    S = Synapses(source, target, '''w : 1
-                                    x : 1
-                                    v_post = x : 1 (summed)''', on_pre='x+=w',
+    source = NeuronGroup(2, 'v : volt', threshold='v>1*volt', reset='v=0*volt')
+    source.v = 1.1*volt  # will spike immediately
+    target = NeuronGroup(2, 'v : volt')
+    S = Synapses(source, target, '''w : volt
+                                    x : volt
+                                    v_post = 2*x : volt (summed)''', on_pre='x+=w',
                  multisynaptic_index='k')
     S.connect('i==j', n=2)
-    S.w['k == 0'] = 'i'
-    S.w['k == 1'] = 'i + 0.5'
+    S.w['k == 0'] = 'i*volt'
+    S.w['k == 1'] = '(i + 0.5)*volt'
     net = Network(source, target, S)
     net.run(1*ms)
 
     # v of the target should be the sum of the two weights
-    assert_equal(target.v, np.array([0.5, 2.5]))
+    assert_equal(target.v, np.array([1.0, 5.0])*volt)
 
 
 def test_summed_variable_errors():


### PR DESCRIPTION
In addition, make the `Variable` constructor handle `Quantity` objects as well.
Change one test for the summed variable mechanism to expose this error.
Fixes #674