### PR TITLE
[MRG] Do not alter the stored state of a network when restoring it

### DIFF
--- a/brian2/core/network.py
+++ b/brian2/core/network.py
@@ -430,7 +430,7 @@ class Network(Nameable):
         else:
             with open(filename, 'rb') as f:
                 state = pickle.load(f)[name]
-        self.t_ = state.pop('0_t')
+        self.t_ = state['0_t']
         clocks = set([obj.clock for obj in self.objects])
         restored_objects = set()
         for obj in self.objects:
@@ -446,7 +446,7 @@ class Network(Nameable):
             clock._restore_from_full_state(state[clock.name])
         clock_names = {c.name for c in clocks}
 
-        unnused = set(state.keys()) - restored_objects - clock_names
+        unnused = set(state.keys()) - restored_objects - clock_names - {'0_t'}
         if len(unnused):
             raise KeyError('The stored state contains the state of the '
                            'following objects which were not present in the '

--- a/brian2/tests/test_network.py
+++ b/brian2/tests/test_network.py
@@ -790,6 +790,12 @@ def test_store_restore():
     assert_equal(spike_indices, spike_mon.i[:])
     assert_equal(spike_times, spike_mon.t_[:])
 
+    # Go back again (see github issue #681)
+    net.restore('second')
+    assert defaultclock.t == 10 * ms
+    assert net.t == 10 * ms
+
+
 @attr('codegen-independent')
 def test_store_restore_to_file():
     filename = tempfile.mktemp(suffix='state', prefix='brian_test')

--- a/docs_sphinx/introduction/release_notes.rst
+++ b/docs_sphinx/introduction/release_notes.rst
@@ -1,6 +1,29 @@
 Release notes
 =============
 
+Changes since previous release (in-development)
+-----------------------------------------------
+
+Major new features
+~~~~~~~~~~~~~~~~~~
+
+Improvements and bug fixes
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+* Repeatedly calling `restore` (or `Network.restore`) no longer raises an error (see #681).
+
+Contributions
+~~~~~~~~~~~~~
+Code and documentation contributions (ordered by the number of commits):
+
+[to be filled in]
+
+Testing, suggestions and bug reports (ordered alphabetically, apologies to
+anyone we forgot...):
+
+* Cian O'Donnell
+* Ibrahim Ozturk
+* Github users:
+
 Brian 2.0rc
 -----------
 This is a release candidate for the final Brian 2.0 release, meaning that from


### PR DESCRIPTION
Fixes #681 

As a side note: I added a commit that mentions the bug (and the users that reported it) already in the next release notes. I think it is a good idea that PRs that introduce a major new feature or fix important bugs do that as part of the PR, that way we'll have less work at release time and it is less likely that we forget something.