### PR TITLE
[MRG] Fix the handling of empty non-stochastic parts in equations

### DIFF
--- a/brian2/equations/codestrings.py
+++ b/brian2/equations/codestrings.py
@@ -153,7 +153,10 @@ class Expression(CodeString):
                                   'stochastic and non-stochastic '
                                   'term') % self.code)
 
-        return (f_expr, stochastic_expressions)
+        if f_expr is None:
+            f_expr = Expression('0.0')
+
+        return f_expr, stochastic_expressions
 
     def _repr_pretty_(self, p, cycle):
         '''

--- a/brian2/stateupdaters/explicit.py
+++ b/brian2/stateupdaters/explicit.py
@@ -513,9 +513,8 @@ class ExplicitStateUpdater(StateUpdateMethod):
         
         non_stochastic, stochastic = expr.split_stochastic()
 
-        if not (non_stochastic is None or non_stochastic_expr is None):
-            # We do have a non-stochastic part in our equation and in the state
-            # updater description
+        if non_stochastic_expr is not None:
+            # We do have a non-stochastic part in the state updater description
             non_stochastic_results = self._non_stochastic_part(eq_symbols,
                                                                non_stochastic,
                                                                non_stochastic_expr,
@@ -525,7 +524,7 @@ class ExplicitStateUpdater(StateUpdateMethod):
             non_stochastic_results = []
 
         if not (stochastic is None or stochastic_expr is None):
-            # We do have a stochastic part in our equation and in the state
+            # We do have a stochastic part in the state
             # updater description
             stochastic_results = self._stochastic_part(eq_symbols,
                                                        stochastic,
@@ -534,7 +533,7 @@ class ExplicitStateUpdater(StateUpdateMethod):
                                                        temp_vars, var)
         else:
             stochastic_results = []
-        
+
         RHS = sympy.Number(0)
         # All the parts (one non-stochastic and potentially more than one
         # stochastic part) are combined with addition

--- a/brian2/tests/test_codestrings.py
+++ b/brian2/tests/test_codestrings.py
@@ -38,7 +38,15 @@ def test_split_stochastic():
     expr = Expression('(-v + I) / tau')
     # No stochastic part
     assert expr.split_stochastic() == (expr, None)
-    
+
+    # No non-stochastic part -- note that it should return 0 and not None
+    expr = Expression('sigma*xi/tau**.5')
+    non_stochastic, stochastic = expr.split_stochastic()
+    assert sympy_equals(non_stochastic, 0)
+    assert 'xi' in stochastic
+    assert len(stochastic) == 1
+    assert sympy_equals(stochastic['xi'].code, 'sigma/tau**.5')
+
     expr = Expression('(-v + I) / tau + sigma*xi/tau**.5')
     non_stochastic, stochastic = expr.split_stochastic()
     assert 'xi' in stochastic

--- a/brian2/tests/test_stateupdaters.py
+++ b/brian2/tests/test_stateupdaters.py
@@ -180,6 +180,19 @@ def test_multiple_noise_variables_deterministic_noise():
                             err_msg='Method %s gave incorrect results' % method_name)
 
 
+@with_setup(setup=store_randn, teardown=restore_randn)
+def test_pure_noise_deterministic():
+    DEFAULT_FUNCTIONS['randn'] = fake_randn
+    sigma = 3
+    eqs = Equations('dx/dt = sigma*xi/sqrt(ms) : 1')
+    dt = 0.1*ms
+    for method in ['euler', 'heun', 'milstein']:
+        G = NeuronGroup(1, eqs, dt=dt, method=method)
+        run(10*dt)
+        assert_allclose(G.x, sqrt(dt)*sigma*0.5/sqrt(1*ms)*10,
+                        err_msg='method %s did not give the expected result' % method)
+
+
 @attr('codegen-independent')
 def test_temporary_variables():
     '''
@@ -680,6 +693,9 @@ if __name__ == '__main__':
     test_multiple_noise_variables_extended()
     store_randn()
     test_multiple_noise_variables_deterministic_noise()
+    restore_randn()
+    store_randn()
+    test_pure_noise_deterministic()
     restore_randn()
     test_temporary_variables()
     test_temporary_variables2()

--- a/docs_sphinx/introduction/release_notes.rst
+++ b/docs_sphinx/introduction/release_notes.rst
@@ -9,6 +9,8 @@ Major new features
 
 Improvements and bug fixes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
+* Fix a regression from 2.0b4: stochastic differential equations without any non-stochastic
+  part (e.g. ``dx/dt = xi/sqrt(ms)```) were not integrated correctly (see #686).
 * Repeatedly calling `restore` (or `Network.restore`) no longer raises an error (see #681).
 
 Contributions


### PR DESCRIPTION
 Fixes #686 

There were two issues that together led to the bug:
1. The explicit state updater code does not apply the stochastic part `g(x,t) * dW` of a state updater description to an expression if that expression does not have a `...*xi` term. This is fine, the problem is that the same logic was applied to the *non-stochastic* part, but that part is (e.g. for Euler) `x + dt*f(x, t)`, i.e. even if there is no `f(x, t)` in the expression, it should still include the `x`.
2. The above approach was present in the code for a long time but it did not lead to any issue because our code to split an expression into stochastic and non-stochastic part did return `0.0` (and not `None`) for an empty non-stochastic part, meaning that the non-stochastic part of the state updater description was *always* applied.

The second point changed as part of a performance optimisation (replacing the use of sympy's `match` by `collect`) and therefore the problem was introduced.

In this PR, I changed both: the non-stochastic expression will be `0.0` instead of `None` and just to be sure (though this should not be necessary) we'll always apply the non-stochastic part of the state updater description. I updated the test suite as well to guard us from a future regression.