### PR TITLE
[MRG] Change the stored scalar value of `dt` immediately when the clock is changed …

### DIFF
--- a/brian2/tests/test_clocks.py
+++ b/brian2/tests/test_clocks.py
@@ -3,6 +3,7 @@ from numpy.testing import assert_raises, assert_equal, assert_array_equal
 from nose import with_setup
 from nose.plugins.attrib import attr
 
+
 @attr('codegen-independent')
 @with_setup(teardown=restore_initial_state)
 def test_clock_attributes():
@@ -10,6 +11,7 @@ def test_clock_attributes():
     assert_array_equal(clock.t, 0*second)
     assert_array_equal(clock.timestep, 0)
     assert_array_equal(clock.dt, 1*ms)
+
 
 @attr('codegen-independent')
 @with_setup(teardown=restore_initial_state)
@@ -34,19 +36,18 @@ def test_clock_dt_change():
     clock._set_t_update_dt(target_t=0.1*ms)
     clock.dt = 0.3*ms
     assert_raises(ValueError, lambda: clock._set_t_update_dt(target_t=0.1*ms))
-    clock.dt = 2*ms
-    assert_raises(ValueError, lambda: clock._set_t_update_dt(target_t=0.1*ms))
 
 
 @attr('codegen-independent')
 @with_setup(teardown=restore_initial_state)
-def test_defaultclock():        
+def test_defaultclock():
     defaultclock.dt = 1*ms
     assert_equal(defaultclock.dt, 1*ms)
-    assert defaultclock.name=='defaultclock'
+    assert defaultclock.name == 'defaultclock'
 
-if __name__=='__main__':
-    test_clocks()
+
+if __name__ == '__main__':
+    test_clock_attributes()
     restore_initial_state()
     test_clock_dt_change()
     restore_initial_state()

--- a/brian2/tests/test_devices.py
+++ b/brian2/tests/test_devices.py
@@ -1,3 +1,4 @@
+import numpy as np
 from nose.plugins.attrib import attr
 
 from brian2.devices.device import (Device, all_devices, set_device, get_device,
@@ -9,6 +10,8 @@ class ATestDevice(Device):
         self.build_on_run = build_on_run
         self._options = kwargs
     # These functions are needed during the setup of the defaultclock
+    def get_value(self, var):
+        return np.array([0.0001])
     def add_array(self, var):
         pass
     def init_with_zeros(self, var, dtype):

--- a/brian2/tests/test_network.py
+++ b/brian2/tests/test_network.py
@@ -212,6 +212,8 @@ def test_schedule_warning():
     # TestDevice1 supports arbitrary schedules, TestDevice2 does not
     class TestDevice1(Device):
         # These functions are needed during the setup of the defaultclock
+        def get_value(self, var):
+            return np.array([0.0001])
         def add_array(self, var):
             pass
         def init_with_zeros(self, var, dtype):

--- a/docs_sphinx/introduction/release_notes.rst
+++ b/docs_sphinx/introduction/release_notes.rst
@@ -12,6 +12,7 @@ Improvements and bug fixes
 * Fix a regression from 2.0b4: stochastic differential equations without any non-stochastic
   part (e.g. ``dx/dt = xi/sqrt(ms)```) were not integrated correctly (see #686).
 * Repeatedly calling `restore` (or `Network.restore`) no longer raises an error (see #681).
+* Fix an issue that made `PoissonInput` refuse to run after a change of dt (see #684).
 
 Contributions
 ~~~~~~~~~~~~~
@@ -23,8 +24,8 @@ Testing, suggestions and bug reports (ordered alphabetically, apologies to
 anyone we forgot...):
 
 * Cian O'Donnell
+* Daniel Bliss
 * Ibrahim Ozturk
-* Github users:
 
 Brian 2.0rc
 -----------


### PR DESCRIPTION
… instead of at the start of the run

For technical reasons, when `dt` is changed we delay the change of the internal integer clock until the start of the run (only then we know whether we start a new simulation at t=0s or continue a previous run). For that we need both the old and the new dt. Previously, we just stored the new `dt` in an internal variable and the `dt` getter returned that value so the user would not notice. Still, this meant that the actual value used during simulation (stored in a 1-element array) was not updated until the start of the run. This gives an inconsistent result when you ask an object directly for its `dt` (instead of asking its a clock), which made a check in `PoissonInput` fail. Now, the approach is the inverse, the new value is immediately set but we remember the previous value. This seems to be safer and fixes the problem with `PoissonInput`.

Fixes #684