### PR TITLE
[MRG] Avoid empty state updaters

### DIFF
--- a/brian2/devices/cpp_standalone/templates/network.cpp
+++ b/brian2/devices/cpp_standalone/templates/network.cpp
@@ -141,7 +141,7 @@ Clock* Network::next_clocks()
 {
     // find minclock, clock with smallest t value
     Clock *minclock = *clocks.begin();
-    if (not minclock) // empty list of clocks
+    if (!minclock) // empty list of clocks
         return NULL;
 
     for(std::set<Clock*>::iterator i=clocks.begin(); i!=clocks.end(); i++)

--- a/brian2/devices/cpp_standalone/templates/network.cpp
+++ b/brian2/devices/cpp_standalone/templates/network.cpp
@@ -87,7 +87,8 @@ void Network::run(const double duration, void (*report_func)(const double, const
             if (curclocks.find(obj_clock) != curclocks.end())
             {
                 codeobj_func func = objects[i].second;
-                func();
+                if (func)  // code objects can be NULL in cases where we store just the clock
+                    func();
             }
         }
         for(std::set<Clock*>::iterator i=curclocks.begin(); i!=curclocks.end(); i++)

--- a/brian2/devices/cpp_standalone/templates/network.cpp
+++ b/brian2/devices/cpp_standalone/templates/network.cpp
@@ -62,7 +62,7 @@ void Network::run(const double duration, void (*report_func)(const double, const
     double elapsed_realtime;
     bool did_break_early = false;
 
-    while(clock->running())
+    while(clock && clock->running())
     {
         t = clock->t[0];
 
@@ -140,6 +140,9 @@ Clock* Network::next_clocks()
 {
     // find minclock, clock with smallest t value
     Clock *minclock = *clocks.begin();
+    if (not minclock) // empty list of clocks
+        return NULL;
+
     for(std::set<Clock*>::iterator i=clocks.begin(); i!=clocks.end(); i++)
     {
         Clock *clock = *i;

--- a/brian2/groups/neurongroup.py
+++ b/brian2/groups/neurongroup.py
@@ -150,11 +150,11 @@ class StateUpdater(CodeRunner):
                                            # be raised in create_runner_codeobj
                                            set(),
                                            run_namespace=run_namespace)
-
-        self.abstract_code += StateUpdateMethod.apply_stateupdater(self.group.equations,
-                                                                   variables,
-                                                                   self.method_choice,
-                                                                   group_name=self.group.name)
+        if len(self.group.equations.diff_eq_names) > 0:
+            self.abstract_code += StateUpdateMethod.apply_stateupdater(self.group.equations,
+                                                                       variables,
+                                                                       self.method_choice,
+                                                                       group_name=self.group.name)
         user_code = '\n'.join(['{var} = {expr}'.format(var=var, expr=expr)
                                for var, expr in
                                self.group.equations.get_substituted_expressions(variables)])

--- a/brian2/groups/neurongroup.py
+++ b/brian2/groups/neurongroup.py
@@ -91,7 +91,8 @@ class StateUpdater(CodeRunner):
                             when='groups',
                             order=group.order,
                             name=group.name + '_stateupdater*',
-                            check_units=False)
+                            check_units=False,
+                            generate_empty_code=False)
 
     def _get_refractory_code(self, run_namespace):
         ref = self.group._refractory

--- a/brian2/synapses/synapses.py
+++ b/brian2/synapses/synapses.py
@@ -55,10 +55,13 @@ class StateUpdater(CodeRunner):
                             generate_empty_code=False)
     
     def update_abstract_code(self, run_namespace=None, level=0):
-        self.abstract_code = StateUpdateMethod.apply_stateupdater(self.group.equations,
-                                                                  self.group.variables,
-                                                                  self.method_choice,
-                                                                  group_name=self.group.name)
+        if len(self.group.equations) > 0:
+            self.abstract_code = StateUpdateMethod.apply_stateupdater(self.group.equations,
+                                                                      self.group.variables,
+                                                                      self.method_choice,
+                                                                      group_name=self.group.name)
+        else:
+            self.abstract_code = ''
 
 
 class SummedVariableUpdater(CodeRunner):

--- a/brian2/synapses/synapses.py
+++ b/brian2/synapses/synapses.py
@@ -51,7 +51,8 @@ class StateUpdater(CodeRunner):
                             when='groups',
                             order=order,
                             name=group.name + '_stateupdater',
-                            check_units=False)
+                            check_units=False,
+                            generate_empty_code=False)
     
     def update_abstract_code(self, run_namespace=None, level=0):
         self.abstract_code = StateUpdateMethod.apply_stateupdater(self.group.equations,

--- a/brian2/tests/test_neurongroup.py
+++ b/brian2/tests/test_neurongroup.py
@@ -1220,6 +1220,20 @@ def test_random_vector_values():
     net.run(defaultclock.dt)
     assert np.var(G.v[:]) > 0
 
+@attr('codegen-independent')
+def test_no_code():
+    # Make sure that we are not unncessarily creating code objects for a state
+    # updater that has nothing to do
+    group_1 = NeuronGroup(10, 'v: 1', threshold='False')
+    # The refractory argument will automatically add a statement for each time
+    # step, so we'll need a state updater here
+    group_2 = NeuronGroup(10, 'v: 1', threshold='False', refractory=2*ms)
+    run(0*ms)
+    assert len(group_1.state_updater.code_objects) == 0
+    assert group_1.state_updater.codeobj is None
+    assert len(group_2.state_updater.code_objects) == 1
+    assert group_2.state_updater.codeobj is not None
+
 
 if __name__ == '__main__':
     test_creation()
@@ -1276,3 +1290,4 @@ if __name__ == '__main__':
         test_aliasing_in_statements()
     test_get_states()
     test_random_vector_values()
+    test_no_code()


### PR DESCRIPTION
This is a small optimization but something that bothered me for a while. With this PR, groups that do not need a state updater (say `G = NeuronGroup(10, 'v:1')` ) will:
* no longer search for and apply an integration algorithm (i.e. no INFO message either)
* no longer generate "do-nothing" state update code that will be executed at every time step