### PR TITLE
[MRG] Interpret string expressions for the `rates` argument of `PoissonGroup` at every timestep

### DIFF
--- a/docs_sphinx/introduction/release_notes.rst
+++ b/docs_sphinx/introduction/release_notes.rst
@@ -13,6 +13,9 @@ Improvements and bug fixes
   part (e.g. ``dx/dt = xi/sqrt(ms)```) were not integrated correctly (see #686).
 * Repeatedly calling `restore` (or `Network.restore`) no longer raises an error (see #681).
 * Fix an issue that made `PoissonInput` refuse to run after a change of dt (see #684).
+* If the ``rates`` argument of `PoissonGroup` is a string, it will now be evaluated at
+  every time step instead of once at construction time. This makes time-dependent rate
+  expressions work as expected (see #660).
 
 Contributions
 ~~~~~~~~~~~~~
@@ -26,6 +29,7 @@ anyone we forgot...):
 * Cian O'Donnell
 * Daniel Bliss
 * Ibrahim Ozturk
+* Olivia Gozel
 
 Brian 2.0rc
 -----------

--- a/docs_sphinx/user/input.rst
+++ b/docs_sphinx/user/input.rst
@@ -8,20 +8,20 @@ a range of options, detailed below.
 Poisson input
 -------------
 For generating spikes according to a Poisson point process, `PoissonGroup` can
-be used. It takes a rate or an array of rates (one rate per neuron) as an
-argument and can be connected to a `NeuronGroup` via the usual `Synapses`
-mechanism. At the moment, using ``PoissonGroup(N, rates)`` is equivalent to
+be used. It takes a rate, an array of rates (one rate per neuron), or a string
+expression evaluating to a rate as an argument and can be connected to a
+`NeuronGroup` via the usual `Synapses` mechanism.
+If the given value for ``rates`` is a constant, then using
+``PoissonGroup(N, rates)`` is equivalent to
 ``NeuronGroup(N, 'rates : Hz', threshold='rand()<rates*dt')`` and setting the
-group's ``rates`` attribute. The explicit creation of such a `NeuronGroup` might
-be useful if the rates for the neurons are not constant in time, since it allows
-using the techniques mentioned below (formulating rates as equations or
-referring to a timed array). In the future, the implementation of `PoissonGroup`
-will change to a more efficient spike generation mechanism, based on the
-calculation of inter-spike intervals. Note that, as can be seen in its equivalent
-`NeuronGroup` formulation, a `PoissonGroup` does not work for high rates where
-more than one spike might fall into a single timestep. Use several units with
-lower rates in this case (e.g. use ``PoissonGroup(10, 1000*Hz)`` instead of
-``PoissonGroup(1, 10000*Hz)``).
+group's ``rates`` attribute. If ``rates`` is a string, then it is equivalent
+to ``NeuronGroup(N, 'rates = ... Hz', threshold='rand()<rates*dt')`` with the
+respective expression for the rates (which will be evaluated at every time step
+and therefore allows time-dependent rates). Note that, as can be seen in its
+equivalent `NeuronGroup` formulation, a `PoissonGroup` does not work for high
+rates where more than one spike might fall into a single timestep. Use several
+units with lower rates in this case (e.g. use ``PoissonGroup(10, 1000*Hz)``
+instead of ``PoissonGroup(1, 10000*Hz)``).
 
 Example use::
 


### PR DESCRIPTION
Following our discussion at #660 I did not add any warning or additional mechanism to use the previous behaviour (but I adapted the documentation).

Closes #660 