### PR TITLE
[MRG] Do not lose precision when inserting floating point values into standalone code

### DIFF
--- a/brian2/devices/cpp_standalone/device.py
+++ b/brian2/devices/cpp_standalone/device.py
@@ -1052,7 +1052,7 @@ class CPPStandaloneDevice(Device):
             if clock not in all_clocks:
                 run_lines.append('{net.name}.add(&{clock.name}, NULL);'.format(clock=clock, net=net))
 
-        run_lines.append('{net.name}.run({duration}, {report_call}, {report_period});'.format(net=net,
+        run_lines.append('{net.name}.run({duration!r}, {report_call}, {report_period!r});'.format(net=net,
                                                                                               duration=float(duration),
                                                                                               report_call=report_call,
                                                                                               report_period=float(report_period)))

--- a/brian2/tests/test_network.py
+++ b/brian2/tests/test_network.py
@@ -1161,7 +1161,7 @@ def test_magic_scope():
 
 
 @attr('standalone-compatible')
-@with_setup(teardown=restore_initial_state)
+@with_setup(teardown=reinit_devices)
 def test_runtime_rounding():
     # Test that runtime and standalone round in the same way, see github issue
     # #695 for details

--- a/docs_sphinx/introduction/release_notes.rst
+++ b/docs_sphinx/introduction/release_notes.rst
@@ -1,6 +1,14 @@
 Release notes
 =============
 
+Current development version
+---------------------------
+
+Improvements and bug fixes
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+* Fix a difference of one timestep in the number of simulated timesteps between
+  runtime and standalone that could arise for very specific values of dt and t (see #695).
+
 Brian 2.0rc1
 ------------
 This is a bug fix release that we release only about two weeks after the previous


### PR DESCRIPTION
As discussed in #695, using the "str" instead of "repr" representation of the floating point value of the total runtime led to a one-timestep difference under certain (quite specific) circumstances. This should be fixed with this PR.

Fixes #695