### PR TITLE
[MRG] Improve memory usage

### DIFF
--- a/brian2/codegen/runtime/weave_rt/templates/synapses.cpp
+++ b/brian2/codegen/runtime/weave_rt/templates/synapses.cpp
@@ -24,4 +24,5 @@
 
     // Advance the spike queue
     PyObject_CallMethod(_queue, "advance", "");
+    Py_DECREF(_spiking_synapses_obj);
 {% endblock %}

--- a/brian2/units/fundamentalunits.py
+++ b/brian2/units/fundamentalunits.py
@@ -2108,6 +2108,10 @@ class Unit(Quantity):
     def __neq__(self, other):
         return not self.__eq__(other)
 
+    def __hash__(self):
+        return hash((self.dim, self.scalefactor, self.scale,
+                     self.name, self.dispname))
+
 
 class UnitRegistry(object):
     """
@@ -2135,19 +2139,17 @@ class UnitRegistry(object):
 
 
     def __init__(self):
-        self.units = []
-        self.units_for_dimensions = {}
+        self.units = set()
+        self.units_for_dimensions = collections.defaultdict(list)
 
 
     def add(self, u):
         """Add a unit to the registry
         """
-        self.units.append(u)
-        dim = u.dim
-        if not dim in self.units_for_dimensions:
-            self.units_for_dimensions[dim] = [u]
-        else:
-            self.units_for_dimensions[dim].append(u)
+        if u in self.units:
+            return
+        self.units.add(u)
+        self.units_for_dimensions[u.dim].append(u)
 
     def remove(self, u):
         """Remove a unit from the registry
@@ -2269,7 +2271,7 @@ def get_unit(x, *regs):
     for u in all_registered_units(*regs):
         if np.array(u, copy=False) == 1 and have_same_dimensions(u, x):
             return u
-    dim = getattr(x, 'dim', x)  # For units, get dimensions
+    dim = getattr(x, 'dim', DIMENSIONLESS)  # For units, get dimensions
     return Unit(1.0, dim=dim)
 
 

--- a/docs_sphinx/introduction/release_notes.rst
+++ b/docs_sphinx/introduction/release_notes.rst
@@ -3,11 +3,25 @@ Release notes
 
 Current development version
 ---------------------------
+TODO
 
 Improvements and bug fixes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
+* Fix a memory leak in code running with the weave code generation target, and a smaller
+  memory leak related to units stored repetively in the `UnitRegistry`.
 * Fix a difference of one timestep in the number of simulated timesteps between
   runtime and standalone that could arise for very specific values of dt and t (see #695).
+
+Contributions
+~~~~~~~~~~~~~
+Code and documentation contributions (ordered by the number of commits):
+
+TODO
+
+Testing, suggestions and bug reports (ordered alphabetically, apologies to
+anyone we forgot...):
+
+* Sami Abdul-Wahid
 
 Brian 2.0rc1
 ------------


### PR DESCRIPTION
As reported in this [mailing list thread](https://groups.google.com/d/topic/brian-development/CK76RuDHRbg/discussion), there is a memory leak in Brian 2.0rc1. It turned out that there were actually two issues: unit objects were unnecessarily stored over an over again in the unit registry (this is what you see in the output from the `pympler` module). However, this was only a minor memory leak (and one that existed, albeit less severe, in earlier versions). The main memory leak was in the spike propagation template for weave, where we received a reference to a numpy array from the spike queue and did not `PY_DECREF` it in the end. This memory leak would not matter in most use cases, but by using a loop over runs and storing/restoring the network, many spike queues were generated and the memory leak became severe.