### PR TITLE
[MRG] Use `std::make_pair` without template types

### DIFF
--- a/brian2/devices/cpp_standalone/templates/network.cpp
+++ b/brian2/devices/cpp_standalone/templates/network.cpp
@@ -25,9 +25,9 @@ void Network::clear()
 void Network::add(Clock* clock, codeobj_func func)
 {
 #if defined(_MSC_VER) && (_MSC_VER>=1700)
-    objects.push_back(std::make_pair<Clock*, codeobj_func>(std::move(clock), std::move(func)));
+    objects.push_back(std::make_pair(std::move(clock), std::move(func)));
 #else
-    objects.push_back(std::make_pair<Clock*, codeobj_func>(clock, func));
+    objects.push_back(std::make_pair(clock, func));
 #endif
 }
 


### PR DESCRIPTION
I think the general idea of `make_pair` is that it infers its types automatically from the arguments (otherwise you would create the pair explicitly with `std::pair<T1, T2>`). Apparently leaving away the types works on gcc and msvc, while having them does not work with gcc 6 (in its default C++14 mode).

Fixes #701