### PR TITLE
[MRG] Faster before run

### DIFF
--- a/brian2/codegen/codeobject.py
+++ b/brian2/codegen/codeobject.py
@@ -103,60 +103,6 @@ class CodeObject(Nameable):
         raise NotImplementedError()
 
 
-def check_code_units(code, group, user_code=None, additional_variables=None,
-                     level=0, run_namespace=None,):
-    '''
-    Check statements for correct units.
-
-    Parameters
-    ----------
-    code : str
-        The series of statements to check
-    group : `Group`
-        The context for the code execution
-    user_code : str, optional
-        The code that was provided by the user. Used to determine whether to
-        emit warnings and for better error messages. If not specified, assumed
-        to be equal to ``code``.
-    additional_variables : dict-like, optional
-        A mapping of names to `Variable` objects, used in addition to the
-        variables saved in `self.group`.
-    level : int, optional
-        How far to go up in the stack to find the calling frame.
-    run_namespace : dict-like, optional
-        An additional namespace, as provided to `Group.before_run`
-
-    Raises
-    ------
-    DimensionMismatchError
-        If `code` has unit mismatches
-    '''
-    all_variables = dict(group.variables)
-    if additional_variables is not None:
-        all_variables.update(additional_variables)
-
-    if user_code is None:
-        user_code = code
-
-    # Resolve the namespace, resulting in a dictionary containing only the
-    # external variables that are needed by the code -- keep the units for
-    # the unit checks
-    # Note that here we do not need to recursively descend into
-    # subexpressions. For unit checking, we only need to know the units of
-    # the subexpressions not what variables they refer to
-    _, _, unknown = analyse_identifiers(code, all_variables)
-    _, _, unknown_user = analyse_identifiers(user_code, all_variables)
-
-    resolved_namespace = group.resolve_all(unknown,
-                                           unknown_user,
-                                           level=level+1,
-                                           run_namespace=run_namespace)
-
-    all_variables.update(resolved_namespace)
-
-    check_units_statements(code, all_variables)
-
-
 def _error_msg(code, name):
     '''
     Little helper function for error messages.

--- a/brian2/codegen/codeobject.py
+++ b/brian2/codegen/codeobject.py
@@ -173,13 +173,12 @@ def _error_msg(code, name):
 
 
 def create_runner_codeobj(group, code, template_name,
+                          run_namespace,
                           user_code=None,
                           variable_indices=None,
                           name=None, check_units=True,
                           needed_variables=None,
                           additional_variables=None,
-                          level=0,
-                          run_namespace=None,
                           template_kwds=None,
                           override_conditional_write=None,
                           codeobj_class=None
@@ -195,6 +194,10 @@ def create_runner_codeobj(group, code, template_name,
         The code to be executed.
     template_name : str
         The name of the template to use for the code.
+    run_namespace : dict-like
+        An additional namespace that is used for variable lookup (either
+        an explicitly defined namespace or one taken from the local
+        context).
     user_code : str, optional
         The code that had been specified by the user before other code was
         added automatically. If not specified, will be assumed to be identical
@@ -216,11 +219,6 @@ def create_runner_codeobj(group, code, template_name,
     additional_variables : dict-like, optional
         A mapping of names to `Variable` objects, used in addition to the
         variables saved in `group`.
-    level : int, optional
-        How far to go up in the stack to find the call frame.
-    run_namespace : dict-like, optional
-        An additional namespace that is used for variable lookup (if not
-        defined, the implicit namespace of local variables is used).
     template_kwds : dict, optional
         A dictionary of additional information that is passed to the template.
     override_conditional_write: list of str, optional
@@ -286,8 +284,7 @@ def create_runner_codeobj(group, code, template_name,
                                   # template variables are not known to the user:
                                   user_identifiers=user_identifiers,
                                   additional_variables=additional_variables,
-                                  run_namespace=run_namespace,
-                                  level=level+1)
+                                  run_namespace=run_namespace)
     # We raise this error only now, because there is some non-obvious code path
     # where Jinja tries to get a Synapse's "name" attribute via syn['name'],
     # which then triggers the use of the `group_get_indices` template which does

--- a/brian2/core/namespace.py
+++ b/brian2/core/namespace.py
@@ -4,17 +4,11 @@ model equations of `NeuronGroup` and `Synapses`
 '''
 import inspect
 import itertools
-import numbers
-import weakref
-
-import numpy as np
 
 from brian2.utils.logger import get_logger
 from brian2.units.fundamentalunits import standard_unit_register
 from brian2.units.stdunits import stdunits
 from brian2.core.functions import DEFAULT_FUNCTIONS, DEFAULT_CONSTANTS
-
-from .functions import Function
 
 __all__ = ['get_local_namespace',
            'DEFAULT_FUNCTIONS',
@@ -41,7 +35,9 @@ def get_local_namespace(level):
         The locals and globals at the given depth of the stack frame.
     '''
     # Get the locals and globals from the stack frame
-    frame = inspect.stack()[level + 1][0]
+    frame = inspect.currentframe()
+    for _ in xrange(level + 1):
+        frame = frame.f_back
     # We return the full stack here, even if it contains a lot of stuff we are
     # not interested in -- it is cheaper to later raise an error when we find
     # a specific object with an incorrect type instead of going through this big
@@ -60,7 +56,7 @@ def _get_default_unit_namespace():
     -------
     namespace : dict
         The unit namespace
-    '''    
+    '''
     namespace = dict([(u.name, u) for u in standard_unit_register.units])
     namespace.update(stdunits)
     return namespace

--- a/brian2/core/variables.py
+++ b/brian2/core/variables.py
@@ -785,6 +785,7 @@ class VariableView(object):
             An additional namespace that is used for variable lookup (if not
             defined, the implicit namespace of local variables is used).
         '''
+        from brian2.core.namespace import get_local_namespace  # avoids circular import
         if isinstance(item, basestring):
             # Check whether the group still exists to give a more meaningful
             # error message if it does not
@@ -797,13 +798,15 @@ class VariableView(object):
                                       'Consider holding an explicit reference '
                                       'to it to keep it '
                                       'alive.') % self.group_name)
+            if namespace is None:
+                namespace = get_local_namespace(level=level+1)
             values = self.get_with_expression(item,
-                                              level=level+1,
                                               run_namespace=namespace)
         else:
             if isinstance(self.variable, Subexpression):
+                if namespace is None:
+                    namespace = get_local_namespace(level=level + 1)
                 values = self.get_subexpression_with_index_array(item,
-                                                                 level=level+1,
                                                                  run_namespace=namespace)
             else:
                 values = self.get_with_index_array(item)
@@ -836,6 +839,7 @@ class VariableView(object):
             An additional namespace that is used for variable lookup (if not
             defined, the implicit namespace of local variables is used).
         '''
+        from brian2.core.namespace import get_local_namespace  # avoids circular import
         variable = self.variable
         if variable.read_only:
             raise TypeError('Variable %s is read-only.' % self.name)
@@ -850,12 +854,14 @@ class VariableView(object):
 
         check_units = self.unit is not None
 
+        if namespace is None:
+            namespace = get_local_namespace(level=level+1)
+
         # Both index and values are strings, use a single code object do deal
         # with this situation
         if isinstance(value, basestring) and isinstance(item, basestring):
             self.set_with_expression_conditional(item, value,
                                                  check_units=check_units,
-                                                 level=level+1,
                                                  run_namespace=namespace)
         elif isinstance(item, basestring):
             try:
@@ -882,12 +888,10 @@ class VariableView(object):
                 self.set_with_expression_conditional(item,
                                                      repr(value),
                                                      check_units=check_units,
-                                                     level=level+1,
                                                      run_namespace=namespace)
         elif isinstance(value, basestring):
             self.set_with_expression(item, value,
                                      check_units=check_units,
-                                     level=level+1,
                                      run_namespace=namespace)
         else:  # No string expressions involved
             self.set_with_index_array(item, value,
@@ -897,8 +901,7 @@ class VariableView(object):
         self.set_item(item, value, level=1)
 
     @device_override('variableview_set_with_expression')
-    def set_with_expression(self, item, code, check_units=True, level=0,
-                            run_namespace=None):
+    def set_with_expression(self, item, code, run_namespace, check_units=True):
         '''
         Sets a variable using a string expression. Is called by
         `VariableView.set_item` for statements such as
@@ -911,11 +914,11 @@ class VariableView(object):
         code : str
             The code that should be executed to set the variable values.
             Can contain references to indices, such as `i` or `j`
+        run_namespace : dict-like, optional
+            An additional namespace that is used for variable lookup (if not
+            defined, the implicit namespace of local variables is used).
         check_units : bool, optional
             Whether to check the units of the expression.
-        level : int, optional
-            How much farther to go up in the stack to find the implicit
-            namespace (if used, see `run_namespace`).
         run_namespace : dict-like, optional
             An additional namespace that is used for variable lookup (if not
             defined, the implicit namespace of local variables is used).
@@ -932,9 +935,8 @@ class VariableView(object):
             from brian2.codegen.translation import get_identifiers_recursively
             identifiers = get_identifiers_recursively([code],
                                                       self.group.variables)
-            variables = self.group.resolve_all(identifiers, [],
-                                               run_namespace=run_namespace,
-                                               level=level+2)
+            variables = self.group.resolve_all(identifiers, run_namespace,
+                                               user_identifiers=set())
             if not isinstance(item, tuple):
                 index_groups = [item]
             else:
@@ -977,15 +979,13 @@ class VariableView(object):
                                         'group_variable_set',
                                         additional_variables=variables,
                                         check_units=check_units,
-                                        level=level+2,
                                         run_namespace=run_namespace,
                                         codeobj_class=get_default_codeobject_class('codegen.string_expression_target'))
         codeobj()
 
     @device_override('variableview_set_with_expression_conditional')
-    def set_with_expression_conditional(self, cond,
-                                        code, check_units=True, level=0,
-                                        run_namespace=None):
+    def set_with_expression_conditional(self, cond, code, run_namespace,
+                                        check_units=True):
         '''
         Sets a variable using a string expression and string condition. Is
         called by `VariableView.set_item` for statements such as
@@ -997,14 +997,11 @@ class VariableView(object):
             The string condition for which the variables should be set.
         code : str
             The code that should be executed to set the variable values.
-        check_units : bool, optional
-            Whether to check the units of the expression.
-        level : int, optional
-            How much farther to go up in the stack to find the implicit
-            namespace (if used, see `run_namespace`).
         run_namespace : dict-like, optional
             An additional namespace that is used for variable lookup (if not
             defined, the implicit namespace of local variables is used).
+        check_units : bool, optional
+            Whether to check the units of the expression.
         '''
         variable = self.variable
         if variable.scalar and cond != 'True':
@@ -1024,13 +1021,12 @@ class VariableView(object):
                                         'group_variable_set_conditional',
                                         additional_variables=variables,
                                         check_units=check_units,
-                                        level=level+2,
                                         run_namespace=run_namespace,
                                         codeobj_class=get_default_codeobject_class('codegen.string_expression_target'))
         codeobj()
 
     @device_override('variableview_get_with_expression')
-    def get_with_expression(self, code, level=0, run_namespace=None):
+    def get_with_expression(self, code, run_namespace):
         '''
         Gets a variable using a string expression. Is called by
         `VariableView.get_item` for statements such as
@@ -1042,12 +1038,10 @@ class VariableView(object):
             An expression that states a condition for elements that should be
             selected. Can contain references to indices, such as ``i`` or ``j``
             and to state variables. For example: ``'i>3 and v>0*mV'``.
-        level : int, optional
-            How much farther to go up in the stack to find the implicit
-            namespace (if used, see `run_namespace`).
-        run_namespace : dict-like, optional
-            An additional namespace that is used for variable lookup (if not
-            defined, the implicit namespace of local variables is used).
+        run_namespace : dict-like
+            An additional namespace that is used for variable lookup (either
+            an explicitly defined namespace or one taken from the local
+            context).
         '''
         variable = self.variable
         if variable.scalar:
@@ -1071,7 +1065,6 @@ class VariableView(object):
                                         abstract_code,
                                         'group_variable_get_conditional',
                                         additional_variables=variables,
-                                        level=level+2,
                                         run_namespace=run_namespace,
                                         codeobj_class=get_default_codeobject_class('codegen.string_expression_target')
                                         )
@@ -1094,7 +1087,7 @@ class VariableView(object):
         return variable.get_value()[indices]
 
     @device_override('variableview_get_subexpression_with_index_array')
-    def get_subexpression_with_index_array(self, item, level=0, run_namespace=None):
+    def get_subexpression_with_index_array(self, item, run_namespace):
         variable = self.variable
         if variable.scalar:
             if not (isinstance(item, slice) and item == slice(None)):
@@ -1141,7 +1134,6 @@ class VariableView(object):
                                         user_code='',
                                         needed_variables=['_group_idx'],
                                         additional_variables=variables,
-                                        level=level+2,
                                         run_namespace=run_namespace,
                                         codeobj_class=get_default_codeobject_class('codegen.string_expression_target')
         )

--- a/brian2/devices/cpp_standalone/device.py
+++ b/brian2/devices/cpp_standalone/device.py
@@ -429,7 +429,7 @@ class CPPStandaloneDevice(Device):
                                       'simulation has been run.')
 
     def variableview_get_subexpression_with_index_array(self, variableview,
-                                                        item, level=0,
+                                                        item,
                                                         run_namespace=None):
         if not self.has_been_run:
             raise NotImplementedError('Cannot retrieve the values of state '
@@ -439,12 +439,11 @@ class CPPStandaloneDevice(Device):
         # (based on the values stored on disk)
         set_device('runtime')
         result = VariableView.get_subexpression_with_index_array(variableview, item,
-                                                                 level=level+2,
                                                                  run_namespace=run_namespace)
         reset_device()
         return result
 
-    def variableview_get_with_expression(self, variableview, code, level=0,
+    def variableview_get_with_expression(self, variableview, code,
                                          run_namespace=None):
         raise NotImplementedError('Cannot retrieve the values of state '
                                   'variables with string expressions in '

--- a/brian2/equations/equations.py
+++ b/brian2/equations/equations.py
@@ -814,7 +814,7 @@ class Equations(collections.Mapping):
             elif eq.type == PARAMETER:
                 eq.update_order = len(sorted_eqs) + 1
 
-    def check_units(self, group, run_namespace=None, level=0):
+    def check_units(self, group, run_namespace):
         '''
         Check all the units for consistency.
         
@@ -822,8 +822,9 @@ class Equations(collections.Mapping):
         ----------
         group : `Group`
             The group providing the context
-        run_namespace : dict, optional
-            A namespace provided to the `Network.run` function.
+        run_namespace : dict-like, optional
+            An additional namespace that is used for variable lookup (if not
+            defined, the implicit namespace of local variables is used).
         level : int, optional
             How much further to go up in the stack to find the calling frame
 
@@ -837,10 +838,9 @@ class Equations(collections.Mapping):
                                      for _, expr in self.eq_expressions])
         external -= set(all_variables.keys())
 
-        resolved_namespace = group.resolve_all(external,
-                                               external,  # all variables are user defined
-                                               run_namespace=run_namespace,
-                                               level=level+1)
+        resolved_namespace = group.resolve_all(external, run_namespace,
+                                               user_identifiers=external)  # all variables are user defined
+
         all_variables.update(resolved_namespace)
         for var, eq in self._equations.iteritems():
             if eq.type == PARAMETER:

--- a/brian2/groups/neurongroup.py
+++ b/brian2/groups/neurongroup.py
@@ -12,7 +12,6 @@ from brian2.equations.equations import (Equations, DIFFERENTIAL_EQUATION,
 from brian2.equations.refractory import add_refractoriness
 from brian2.stateupdaters.base import StateUpdateMethod
 from brian2.codegen.translation import analyse_identifiers
-from brian2.codegen.codeobject import check_code_units
 from brian2.core.variables import (Variables, LinkedVariable,
                                    DynamicArrayVariable, Subexpression)
 from brian2.core.spikesource import SpikeSource

--- a/brian2/groups/neurongroup.py
+++ b/brian2/groups/neurongroup.py
@@ -110,8 +110,8 @@ class StateUpdater(CodeRunner):
         else:
             identifiers = get_identifiers(ref)
             variables = self.group.resolve_all(identifiers,
-                                               identifiers,
-                                               run_namespace=run_namespace)
+                                               run_namespace,
+                                               user_identifiers=identifiers)
             unit = parse_expression_unit(str(ref), variables)
             if have_same_dimensions(unit, second):
                 abstract_code = 'not_refractory = (t - lastspike) > %s\n' % ref
@@ -146,11 +146,11 @@ class StateUpdater(CodeRunner):
         external_names = self.group.equations.identifiers | {'dt'}
 
         variables = self.group.resolve_all(used_known | unknown | names | external_names,
+                                           run_namespace,
                                            # we don't need to raise any warnings
                                            # for the user here, warnings will
                                            # be raised in create_runner_codeobj
-                                           set(),
-                                           run_namespace=run_namespace)
+                                           user_identifiers=set())
         if len(self.group.equations.diff_eq_names) > 0:
             self.abstract_code += StateUpdateMethod.apply_stateupdater(self.group.equations,
                                                                        variables,
@@ -217,8 +217,8 @@ class Thresholder(CodeRunner):
 
         identifiers = get_identifiers(code)
         variables = self.group.resolve_all(identifiers,
-                                           identifiers,
-                                           run_namespace=run_namespace)
+                                           run_namespace,
+                                           user_identifiers=identifiers)
         if not is_boolean_expression(code, variables):
             raise TypeError(('Threshold condition "%s" is not a boolean '
                              'expression') % code)

--- a/brian2/parsing/sympytools.py
+++ b/brian2/parsing/sympytools.py
@@ -14,21 +14,24 @@ from brian2.parsing.rendering import SympyNodeRenderer
 
 
 def check_expression_for_multiple_stateful_functions(expr, variables):
-    identifiers = re.findall('\w+', expr)
+    identifiers = re.findall(r'\w+', expr)
+    # Don't bother counting if we don't have any duplicates in the first place
+    if len(identifiers) == len(set(identifiers)):
+        return
     identifier_count = Counter(identifiers)
     for identifier, count in identifier_count.iteritems():
-        if isinstance(variables.get(identifier, None), Function):
-            if not variables[identifier].stateless and count > 1:
-                raise NotImplementedError(('The expression "{expr}" contains '
-                                           'more than one call of {func}, this '
-                                           'is currently not supported since '
-                                           '{func} is a stateful function and '
-                                           'its multiple calls might be '
-                                           'treated incorrectly (e.g.'
-                                           '"rand() - rand()" could be '
-                                           ' simplified to '
-                                           '"0.0").').format(expr=expr,
-                                                             func=identifier))
+        var = variables.get(identifier, None)
+        if count > 1 and isinstance(var, Function) and not var.stateless:
+            raise NotImplementedError(('The expression "{expr}" contains '
+                                       'more than one call of {func}, this '
+                                       'is currently not supported since '
+                                       '{func} is a stateful function and '
+                                       'its multiple calls might be '
+                                       'treated incorrectly (e.g.'
+                                       '"rand() - rand()" could be '
+                                       ' simplified to '
+                                       '"0.0").').format(expr=expr,
+                                                         func=identifier))
 
 
 SYMPY_NAMESPACE = None

--- a/brian2/synapses/synapses.py
+++ b/brian2/synapses/synapses.py
@@ -857,10 +857,6 @@ class Synapses(Group):
         indices = self.indices[item]
         return SynapticSubgroup(self, indices)
 
-    def before_run(self, run_namespace):
-        self.state('lastupdate')[:] = 't'
-        super(Synapses, self).before_run(run_namespace)
-
     def _add_updater(self, code, prepost, objname=None, delay=None,
                      event='spike'):
         '''

--- a/brian2/tests/test_equations.py
+++ b/brian2/tests/test_equations.py
@@ -286,23 +286,23 @@ def test_unit_checking():
     eqs = Equations('dv/dt = -v : volt')
     group = SimpleGroup({'v': S(volt)})
     assert_raises(DimensionMismatchError,
-                  lambda: eqs.check_units(group))
+                  lambda: eqs.check_units(group, {}))
 
     eqs = Equations('dv/dt = -v / tau: volt')
     group = SimpleGroup(namespace={'tau': 5*mV}, variables={'v': S(volt)})
     assert_raises(DimensionMismatchError,
-                  lambda: eqs.check_units(group))
+                  lambda: eqs.check_units(group, {}))
     group = SimpleGroup(namespace={'I': 3*second}, variables={'v': S(volt)})
     eqs = Equations('dv/dt = -(v + I) / (5 * ms): volt')
     assert_raises(DimensionMismatchError,
-                  lambda: eqs.check_units(group))
+                  lambda: eqs.check_units(group, {}))
 
     eqs = Equations('''dv/dt = -(v + I) / (5 * ms): volt
                        I : second''')
     group = SimpleGroup(variables={'v': S(volt),
                                    'I': S(second)}, namespace={})
     assert_raises(DimensionMismatchError,
-                  lambda: eqs.check_units(group))
+                  lambda: eqs.check_units(group, {}))
     
     # inconsistent unit for a subexpression
     eqs = Equations('''dv/dt = -v / (5 * ms) : volt
@@ -310,7 +310,7 @@ def test_unit_checking():
     group = SimpleGroup(variables={'v': S(volt),
                                    'I': S(second)}, namespace={})
     assert_raises(DimensionMismatchError,
-                  lambda: eqs.check_units(group))
+                  lambda: eqs.check_units(group, {}))
     
 
 @attr('codegen-independent')


### PR DESCRIPTION
While looking into #699 I noticed that the code in 2.0rc1 not only had a memory leak but was also running somewhat slower than in 2.0b4. The test code was certainly a bit extreme (very short run repeated many times), but similar use cases are common. While profiling I noticed that the namespace resolution took a lot of time, because we'll ask for the stack frame again and again, whenever we resolve names in code (even if we resolve the names with internal names, we still check for name clashes with external names to issue a warning). This pull request changes this and gets the local namespace once at the earliest point of time (most importantly in `run()`, but also when setting a variable with a string expression or when connecting synapses). The namespace dictionary is then passed down (instead of passing down the level argument, increasing it by 1 at every step and getting the namespace in the end). I also added a few smaller optimisations.

I did not run extensive benchmarking on this, but it is certainly faster than current master. Compared to 2.0b4 I am not that sure, I got some contradicting results (quite a bit changed since then, you have to re-compile the Cython spike queue, etc.), but I think it is not worth spending more time on this right now.
In general it would of course be nice to set up some automatic benchmarking (#33) so we have a clearer picture of where we stand.