### PR TITLE
[MRG] Fix pathway variables and other small issues

### DIFF
--- a/brian2/codegen/codeobject.py
+++ b/brian2/codegen/codeobject.py
@@ -250,14 +250,16 @@ def create_runner_codeobj(group, code, template_name,
         cond_write_var = getattr(var, 'conditional_write', None)
         if cond_write_var in override_conditional_write:
             continue
-        if cond_write_var is not None and cond_write_var not in variables.values():
-            if cond_write_var.name in variables:
-                raise AssertionError(('Variable "%s" is needed for the '
-                                      'conditional write mechanism of variable '
-                                      '"%s". Its name is already used for %r.') % (cond_write_var.name,
-                                                                                   var.name,
-                                                                                   variables[cond_write_var.name]))
-            conditional_write_variables[cond_write_var.name] = cond_write_var
+        if cond_write_var is not None:
+            if (cond_write_var.name in variables and
+                    not variables[cond_write_var.name] is cond_write_var):
+                logger.diagnostic(('Variable "%s" is needed for the '
+                                   'conditional write mechanism of variable '
+                                   '"%s". Its name is already used for %r.') % (cond_write_var.name,
+                                                                                var.name,
+                                                                                variables[cond_write_var.name]))
+            else:
+                conditional_write_variables[cond_write_var.name] = cond_write_var
 
     variables.update(conditional_write_variables)
 

--- a/brian2/codegen/optimisation.py
+++ b/brian2/codegen/optimisation.py
@@ -170,10 +170,10 @@ class ArithmeticSimplifier(BrianASTRenderer):
         These might be the scalar statements for example.
     '''
     def __init__(self, variables):
-        BrianASTRenderer.__init__(self, variables)
+        BrianASTRenderer.__init__(self, variables, copy_variables=False)
         self.assumptions = []
         self.assumptions_ns = dict(defaults_ns)
-        self.bast_renderer = BrianASTRenderer(variables)
+        self.bast_renderer = BrianASTRenderer(variables, copy_variables=False)
 
     def render_node(self, node):
         '''
@@ -298,7 +298,7 @@ class Simplifier(BrianASTRenderer):
         dtypename will be one of ``'boolean'``, ``'integer'``, ``'float'``.
     '''
     def __init__(self, variables, scalar_statements, extra_lio_prefix=''):
-        BrianASTRenderer.__init__(self, variables)
+        BrianASTRenderer.__init__(self, variables, copy_variables=False)
         self.loop_invariants = OrderedDict()
         self.loop_invariant_dtypes = {}
         self.n = 0

--- a/brian2/core/variables.py
+++ b/brian2/core/variables.py
@@ -1678,7 +1678,7 @@ class Variables(collections.Mapping):
         identifiers = subexpr.identifiers
         substitutions = {}
         for identifier in identifiers:
-            if not identifier in subexpr.owner.variables:
+            if identifier not in subexpr.owner.variables:
                 # external variable --> nothing to do
                 continue
             subexpr_var = subexpr.owner.variables[identifier]
@@ -1695,6 +1695,8 @@ class Variables(collections.Mapping):
                 subexpr_var_index = index
             elif subexpr_var_index == '0':
                 pass  # nothing to do for a shared variable
+            elif subexpr_var_index == index:
+                pass  # The same index as the main subexpression
             elif index != self.default_index:
                 index_var = self._variables.get(index, None)
                 if isinstance(index_var, DynamicArrayVariable):

--- a/brian2/parsing/bast.py
+++ b/brian2/parsing/bast.py
@@ -207,7 +207,6 @@ class BrianASTRenderer(object):
         node.dtype = 'boolean'
         for subnode in node.values:
             if subnode.dtype!='boolean':
-                print subnode
                 raise TypeError("Boolean operator acting on non-booleans")
         node.scalar = logical_all(subnode.scalar for subnode in node.values)
         node.complexity = 1+sum(subnode.complexity for subnode in node.values)

--- a/brian2/parsing/bast.py
+++ b/brian2/parsing/bast.py
@@ -109,8 +109,11 @@ class BrianASTRenderer(object):
     '''
     This class is modelled after `NodeRenderer` - see there for details.
     '''
-    def __init__(self, variables):
-        self.variables = variables.copy()
+    def __init__(self, variables, copy_variables=True):
+        if copy_variables:
+            self.variables = variables.copy()
+        else:
+            self.variables = variables
 
     def render_node(self, node):
         nodename = node.__class__.__name__
@@ -204,6 +207,7 @@ class BrianASTRenderer(object):
         node.dtype = 'boolean'
         for subnode in node.values:
             if subnode.dtype!='boolean':
+                print subnode
                 raise TypeError("Boolean operator acting on non-booleans")
         node.scalar = logical_all(subnode.scalar for subnode in node.values)
         node.complexity = 1+sum(subnode.complexity for subnode in node.values)

--- a/brian2/synapses/synapses.py
+++ b/brian2/synapses/synapses.py
@@ -223,13 +223,13 @@ class SynapticPathway(CodeRunner, Group):
 
         # Allow the use of string expressions referring to synaptic (including
         # pre-/post-synaptic) variables
-        # Only include non-private variables (and indices)
-        synaptic_vars = [varname for varname in synapses.variables.keys()
-                         if not varname.startswith('_')]
+        # Only include non-private variables (and their indices)
+        synaptic_vars = {varname for varname in synapses.variables.keys()
+                         if not varname.startswith('_')}
         synaptic_idcs = {varname: synapses.variables.indices[varname]
                          for varname in synaptic_vars}
-        synaptic_vars += [index_name for index_name in synaptic_idcs.values()
-                          if index_name not in ['_idx', '0']]
+        synaptic_vars |= {index_name for index_name in synaptic_idcs.values()
+                          if index_name not in ['_idx', '0']}
         self.variables.add_references(synapses, synaptic_vars)
         self.variables.indices.update(synaptic_idcs)
         self._enable_group_attributes()

--- a/brian2/tests/test_refractory.py
+++ b/brian2/tests/test_refractory.py
@@ -177,6 +177,28 @@ def test_conditional_write_behaviour():
     assert G.v[0] < 1.1
 
 
+@attr('standalone-compatible')
+@with_setup(teardown=reinit_devices)
+def test_conditional_write_automatic_and_manual():
+    source = NeuronGroup(1, '', threshold='True')  # spiking all the time
+    target = NeuronGroup(2, '''dv/dt = 0/ms : 1 (unless refractory)
+                               dw/dt = 0/ms : 1''',
+                         threshold='t == 0*ms',
+                         refractory='False')  # only refractory for the first time step
+    # Cell is spiking/refractory only in the first time step
+    syn = Synapses(source, target, on_pre='''v += 1
+                                             w += 1 * int(not_refractory_post)''')
+    syn.connect()
+    mon = StateMonitor(target, ['v', 'w'], record=True, when='end')
+    run(2*defaultclock.dt)
+
+    # Synapse should not have been effective in the first time step
+    assert_equal(mon.v[:, 0], 0)
+    assert_equal(mon.v[:, 1], 1)
+    assert_equal(mon.w[:, 0], 0)
+    assert_equal(mon.w[:, 1], 1)
+
+
 if __name__ == '__main__':
     test_add_refractoriness()
     test_refractoriness_variables()
@@ -184,3 +206,4 @@ if __name__ == '__main__':
     test_refractoriness_types()
     test_conditional_write_set()
     test_conditional_write_behaviour()
+    test_conditional_write_automatic_and_manual()

--- a/docs_sphinx/introduction/release_notes.rst
+++ b/docs_sphinx/introduction/release_notes.rst
@@ -24,6 +24,8 @@ Improvements and bug fixes
   C++14 mode (see #701)
 * Fix incorrect summation in synapses when using the ``(summed)`` flag and writing to
   *pre*-synaptic variables (see #704)
+* Make synaptic pathways work when connecting groups that define nested subexpressions,
+  instead of failing with a cryptic error message (see #707).
 
 Contributions
 ~~~~~~~~~~~~~
@@ -34,6 +36,8 @@ TODO
 Testing, suggestions and bug reports (ordered alphabetically, apologies to
 anyone we forgot...):
 
+* Craig Henriquez
+* Daniel Bliss
 * David Higgins
 * Gordon Erlebacher
 * Max Gillett


### PR DESCRIPTION
This PR collects fixes for a few issues that were discovered in the context of synaptic pathways (in recent mails to the mailing list):
* nested subexpressions led synaptic pathways to fail because of some unnecessarily complicated attempts to link to them (references to subexpressions are a bit tricky in general because they refer to other variables in the source group, not in the group where they are linked from -- this means we cannot simply use the subexpression literally).
* not related to the synaptic pathway, but it manifested for a user on the mailing list in this context: our conditional write mechanism is a bit fragile, since we include the conditional write variable (i.e. `not_refractory` for `v`) under this name in the variables dictionary. This can clash with an already defined variable of the same name (e.g. in a `StateMonitor` that records both `v` and `not_refractory`). Simply renaming the variable (e.g. use `_cond_write_not_refractory`) does not work, because then the state update does not work correctly. The first thing it does is to set `not_refractory` and if we have included the conditional write variable under a different name, then that one is not updated. I did not find a straight-forward fix, so now the problem is basically ignored (with a DIAGNOSTIC message). I only found situations where this is a false positive (e.g. in the `StateMonitor`, the conditional write is irrelevant since we do not write to `v`) and none where it actually poses a problem. A better fix would be to make the relevant code path aware of what variables are written to and which are not, but this needs some major refactoring.

During test-writing I stumbled across another bug that I fixed here, even though it is not directly related to synaptic pathways:
* There was a problem in the loop-invariant optimisation where the variables dictionary was not shared between the different renderers. This mean that an LIO variable was always considered to be float (the default), which led to errors when it was actually boolean and used in a boolean context.

The two tests that I added cover these three issues.