### PR TITLE
[MRG] Logger improvements

### DIFF
--- a/brian2/__init__.py
+++ b/brian2/__init__.py
@@ -102,3 +102,6 @@ for name, version in [('numpy',  '1.8.2'),
                       ('sympy',  '0.7.6'),
                       ('jinja2', '2.7')]:
     _check_dependency_version(name, version)
+
+# Initialize the logging system
+BrianLogger.initialize()

--- a/brian2/tests/__init__.py
+++ b/brian2/tests/__init__.py
@@ -145,9 +145,9 @@ def run(codegen_targets=None, long_tests=False, test_codegen_independent=True,
         prefs.read_preference_file(StringIO(prefs.defaults_as_file))
 
     # Suppress INFO log messages during testing
-    from brian2.utils.logger import CONSOLE_HANDLER, LOG_LEVELS
-    log_level = CONSOLE_HANDLER.level
-    CONSOLE_HANDLER.setLevel(LOG_LEVELS['WARNING'])
+    from brian2.utils.logger import BrianLogger, LOG_LEVELS
+    log_level = BrianLogger.console_handler.level
+    BrianLogger.console_handler.setLevel(LOG_LEVELS['WARNING'])
 
     # Switch off code optimization to get faster compilation times
     prefs['codegen.cpp.extra_compile_args_gcc'].extend(['-w', '-O0'])
@@ -280,11 +280,11 @@ def run(codegen_targets=None, long_tests=False, test_codegen_independent=True,
         return all_success
 
     finally:
-        CONSOLE_HANDLER.setLevel(log_level)
+        BrianLogger.console_handler.setLevel(log_level)
         if reset_preferences:
             # Restore the user preferences
             prefs.read_preference_file(StringIO(stored_prefs))
             prefs._backup()
 
-if __name__=='__main__':
+if __name__ == '__main__':
     run()

--- a/brian2/utils/logger.py
+++ b/brian2/utils/logger.py
@@ -489,8 +489,8 @@ class BrianLogger(object):
             try:
                 # Temporary filename used for logging
                 BrianLogger.tmp_log = tempfile.NamedTemporaryFile(prefix='brian_debug_',
-                                                      suffix='.log',
-                                                      delete=False)
+                                                                  suffix='.log',
+                                                                  delete=False)
                 BrianLogger.tmp_log = BrianLogger.tmp_log.name
                 BrianLogger.file_handler = logging.FileHandler(BrianLogger.tmp_log, mode='wt')
                 BrianLogger.file_handler.setLevel(
@@ -684,17 +684,22 @@ class std_silent(object):
     '''
     dest_stdout = None
     dest_stderr = None
+
     def __init__(self, alwaysprint=False):
         self.alwaysprint = alwaysprint
         if not alwaysprint and std_silent.dest_stdout is None:
             if not prefs['logging.std_redirection']:
                 self.alwaysprint = True
                 return
-            std_silent.dest_fname_stdout = tempfile.mktemp()
-            std_silent.dest_fname_stderr = tempfile.mktemp()
+            std_silent.dest_fname_stdout = tempfile.NamedTemporaryFile(prefix='brian_stdout_',
+                                                                       suffix='.log',
+                                                                       delete=False).name
+            std_silent.dest_fname_stderr = tempfile.NamedTemporaryFile(prefix='brian_stderr_',
+                                                                       suffix='.log',
+                                                                       delete=False).name
             std_silent.dest_stdout = open(std_silent.dest_fname_stdout, 'w')
             std_silent.dest_stderr = open(std_silent.dest_fname_stderr, 'w')
-        
+
     def __enter__(self):
         if not self.alwaysprint:
             sys.stdout.flush()

--- a/docs_sphinx/advanced/index.rst
+++ b/docs_sphinx/advanced/index.rst
@@ -8,6 +8,7 @@ This section has additional information on details not covered in the
    :maxdepth: 2
    
    preferences
+   logging
    namespaces
    refractoriness
    scheduling

--- a/docs_sphinx/advanced/logging.rst
+++ b/docs_sphinx/advanced/logging.rst
@@ -1,0 +1,78 @@
+Logging
+=======
+
+Brian uses a logging system to display warnings and general information messages
+to the user, as well as writing them to a file with more detailed information,
+useful for debugging. Each log message has one of the following "log levels":
+
+``ERROR``
+    Only used when an exception is raised, i.e. an error occurs and the current
+    operation is interrupted. *Example:* You use a variable name in an equation
+    that Brian does not recognize.
+
+``WARNING``
+    Brian thinks that something is most likely a bug, but it cannot be sure.
+    *Example:* You use a `Synapses` object without any synapses in your
+    simulation.
+
+``INFO``
+    Brian wants to make the user aware of some automatic choice that it did for
+    the user. *Example:* You did not specify an integration ``method`` for a
+    `NeuronGroup` and therefore Brian chose an appropriate method for you.
+
+``DEBUG``
+    Additional information that might be useful when a simulation is not working
+    as expected. *Example:* The integration timestep used during the simulation.
+
+``DIAGNOSTIC``
+    Additional information useful when tracking down bugs in Brian itself.
+    *Example:* The generated code for a `CodeObject`.
+
+By default, all messages are written to the log file and all messages of level
+``INFO`` and above are displayed on the console. To change what messages are
+displayed, see below.
+
+.. note:: By default, the log file is deleted after a successful simulation run,
+   i.e. when the simulation exited without an error. To keep the log around,
+   set the `logging.delete_log_on_exit` preference to ``False``.
+
+Showing/hiding log messages
+---------------------------
+If you want to change what messages are displayed on the console, you can call a
+method of the method of `BrianLogger`::
+
+    BrianLogger.log_level_debug() # now also display debug messages
+
+It is also possible to suppress messages for certain sub-hierarchies by using
+`BrianLogger.suppress_hierarchy`::
+
+    # Suppress code generation messages on the console
+    BrianLogger.suppress_hierarchy('brian2.codegen')
+    # Suppress preference messages even in the log file
+    BrianLogger.suppress_hierarchy('brian2.core.preferences',
+                                   filter_log_file=True)
+
+Similarly, messages ending in a certain name can be suppressed with
+`BrianLogger.suppress_name`::
+
+    # Suppress resolution conflict warnings
+    BrianLogger.suppress_name('resolution_conflict')
+
+These functions should be used with care, as they suppresses messages
+independent of the level, i.e. even warning and error messages.
+
+Preferences
+-----------
+You can also change details of the logging system via Brian's :doc:`preferences`
+system. With this mechanism, you can switch the logging to a file off completely
+(by setting `logging.file_log` to ``False``) or have it log less messages (by
+setting `logging.file_log_level` to a level higher than ``DIAGNOSTIC``) -- this
+can be important for long-running simulations where the log might otherwise take
+up a lot of disk space. For a list of all preferences related to logging, see the
+documentation of the `brian2.utils.logger` module.
+
+.. warning:: Most of the logging preferences are only taken into account during
+   the initialization of the logging system which takes place as soon as `brian2`
+   is imported. Therefore, if you use e.g. `prefs.logging.file_log = False` in
+   your script, this will not have the intended effect! Instead, set these
+   preferences in a file (see :doc:`preferences`).

--- a/docs_sphinx/developer/guidelines/logging.rst
+++ b/docs_sphinx/developer/guidelines/logging.rst
@@ -3,12 +3,10 @@
 Logging
 =======
 
+For a description of logging from the users point of view, see :doc:`../advanced/logging`.
+
 Logging in Brian is based on the :mod:`logging` module in Python's standard
-library. In Brian, all logging output is logged to a file (the file name is
-available in `BrianLogger.tmp_log`). This log file will normally be
-deleted on exit, except if an uncaught exception occured or if
-`logging.delete_log_on_exit` is set to ``False``. The default log level for the
-logging on the console is "info".
+library.
 
 Every brian module that needs logging should start with the following line,
 using the `get_logger` function to get an instance of `BrianLogger`::
@@ -84,31 +82,6 @@ messages that the user sees in the default configuration (i.e., ``info`` and
 the renaming of variables, explicitly specifying a state updater instead of
 relying on the automatic system, adding ``(clock-driven)``/``(event-driven)``
 to synaptic equations, etc.
-
-Showing/hiding log messages
----------------------------
-The user can change the level of displayed log messages by using a static
-method of `BrianLogger`::
-
-    BrianLogger.log_level_debug() # now also display debug messages
-
-It is also possible to suppress messages for certain sub-hierarchies by using
-`BrianLogger.suppress_hierarchy`::
-
-    # Suppress code generation messages on the console
-    BrianLogger.suppress_hierarchy('brian2.codegen')
-    # Suppress preference messages even in the log file
-    BrianLogger.suppress_hierarchy('brian2.core.preferences',
-                                   filter_log_file=True)
-
-Similarly, messages ending in a certain name can be suppressed with
-`BrianLogger.suppress_name`::
-
-    # Suppress resolution conflict warnings
-    BrianLogger.suppress_name('resolution_conflict')
-
-These functions should be used with care, as they suppresses messages
-independent of the level, i.e. even warning and error messages.
 
 Testing log messages
 --------------------

--- a/docs_sphinx/developer/guidelines/logging.rst
+++ b/docs_sphinx/developer/guidelines/logging.rst
@@ -5,7 +5,7 @@ Logging
 
 Logging in Brian is based on the :mod:`logging` module in Python's standard
 library. In Brian, all logging output is logged to a file (the file name is
-available in `brian2.utils.logger.TMP_LOG`). This log file will normally be
+available in `BrianLogger.tmp_log`). This log file will normally be
 deleted on exit, except if an uncaught exception occured or if
 `logging.delete_log_on_exit` is set to ``False``. The default log level for the
 logging on the console is "info".

--- a/docs_sphinx/user/models.rst
+++ b/docs_sphinx/user/models.rst
@@ -212,6 +212,16 @@ apply, `NeuronGroup` and `Synapses` will use the first suitable method out of
 the methods ``'linear'``, ``'euler'`` and ``'heun'`` while `SpatialNeuron`
 objects will use ``'linear'``, ``'exponential_euler'``, ``'rk2'`` or ``'heun'``.
 
+You will get an ``INFO`` message telling you which integration method Brian decided to use,
+together with information about how much time it took to apply the integration method
+to your equations. If other methods have been tried but were not applicable, you will
+also see the time it took to try out those other methods. In some cases, checking
+other methods (in particular the ``'linear'`` method which attempts to solve the
+equations analytically) can take a considerable amount of time -- to avoid wasting
+this time, you can always chose the integration method manually (see below). You
+can also suppress the message by raising the log level or by explicitly suppressing
+``'method_choice'`` log messages -- for details, see :doc:`../advanced/logging`.
+
 If you prefer to chose an integration algorithm yourself, you can do so using
 the ``method`` keyword for `NeuronGroup`, `Synapses`, or `SpatialNeuron`.
 The complete list of available methods is the following:


### PR DESCRIPTION
This fixes/improves the issues mentioned in #692 and #691. Most importantly, changing the logging preferences via a file now works (previously, the logging system was initialized before preferences files were loaded). Additional changes:
* new preference to switch off writing stdout/stderr to a file `logging.std_redirection_to_file`
* the stdout/stderr filenames are prefixed with `brian_stdout`/`brian_stderr` to be more consistent with `brian_debug...` and `brian_script...`
* The documentation of the logging system is now split into a part for users and a part for developers, I also added a warning about setting basic logging preferences (which only works via a file, not in the script itself) 