### PR TITLE
[MRG] Synapse to synapse fix

### DIFF
--- a/brian2/codegen/runtime/cython_rt/templates/synapses_create_generator.pyx
+++ b/brian2/codegen/runtime/cython_rt/templates/synapses_create_generator.pyx
@@ -14,6 +14,8 @@ cdef int _buffer_size = 1024
 cdef int[:] _prebuf = _numpy.zeros(_buffer_size, dtype=_numpy.int32)
 cdef int[:] _postbuf = _numpy.zeros(_buffer_size, dtype=_numpy.int32)
 cdef int _curbuf = 0
+cdef int _all_pre
+cdef int _all_post
 
 cdef void _flush_buffer(buf, dynarr, int buf_len):
     _curlen = dynarr.shape[0]
@@ -50,7 +52,9 @@ cdef void _flush_buffer(buf, dynarr, int buf_len):
     {{scalar_code['create_cond']|autoindent}}
     {{scalar_code['update_post']|autoindent}}
 
-    for _i in range(_num{{_all_pre}}):
+    for _i in range(N_pre):
+        _all_pre = _i + _source_offset
+
         {% if not postsynaptic_condition %}
         {{vector_code['create_cond']|autoindent}}
         if not _cond:
@@ -88,6 +92,8 @@ cdef void _flush_buffer(buf, dynarr, int buf_len):
                 {% else %}
                 raise IndexError("index j=%d outside allowed range from 0 to %d" % (_j, N_post-1))
                 {% endif %}
+            _all_post = _j + _target_offset
+
             {% if postsynaptic_condition %}
             {{vector_code['create_cond']|autoindent}}
             {% endif %}

--- a/brian2/codegen/runtime/cython_rt/templates/synapses_create_generator.pyx
+++ b/brian2/codegen/runtime/cython_rt/templates/synapses_create_generator.pyx
@@ -1,6 +1,6 @@
 {% extends 'common.pyx' %}
 {#
-USES_VARIABLES { _synaptic_pre, _synaptic_post, _all_pre, _all_post, rand, N,
+USES_VARIABLES { _synaptic_pre, _synaptic_post, rand, N,
                  N_pre, N_post, _source_offset, _target_offset }
 #}
 {# WRITES_TO_READ_ONLY_VARIABLES { _synaptic_pre, _synaptic_post, N}
@@ -14,8 +14,8 @@ cdef int _buffer_size = 1024
 cdef int[:] _prebuf = _numpy.zeros(_buffer_size, dtype=_numpy.int32)
 cdef int[:] _postbuf = _numpy.zeros(_buffer_size, dtype=_numpy.int32)
 cdef int _curbuf = 0
-cdef int _all_pre
-cdef int _all_post
+cdef int _raw_pre_idx
+cdef int _raw_post_idx
 
 cdef void _flush_buffer(buf, dynarr, int buf_len):
     _curlen = dynarr.shape[0]
@@ -53,7 +53,7 @@ cdef void _flush_buffer(buf, dynarr, int buf_len):
     {{scalar_code['update_post']|autoindent}}
 
     for _i in range(N_pre):
-        _all_pre = _i + _source_offset
+        _raw_pre_idx = _i + _source_offset
 
         {% if not postsynaptic_condition %}
         {{vector_code['create_cond']|autoindent}}
@@ -92,7 +92,7 @@ cdef void _flush_buffer(buf, dynarr, int buf_len):
                 {% else %}
                 raise IndexError("index j=%d outside allowed range from 0 to %d" % (_j, N_post-1))
                 {% endif %}
-            _all_post = _j + _target_offset
+            _raw_post_idx = _j + _target_offset
 
             {% if postsynaptic_condition %}
             {{vector_code['create_cond']|autoindent}}

--- a/brian2/codegen/runtime/numpy_rt/templates/synapses_create_generator.py_
+++ b/brian2/codegen/runtime/numpy_rt/templates/synapses_create_generator.py_
@@ -1,5 +1,5 @@
 {#
-USES_VARIABLES { _synaptic_pre, _synaptic_post, _all_pre, _all_post, N,
+USES_VARIABLES { _synaptic_pre, _synaptic_post, N,
                  N_pre, N_post, _source_offset, _target_offset }
 #}
 {# WRITES_TO_READ_ONLY_VARIABLES { _synaptic_pre, _synaptic_post, N}
@@ -77,7 +77,7 @@ _vectorisation_idx = 1
 {{scalar_code['update_post']|autoindent}}
 
 for _i in range(N_pre):
-    _all_pre = _i + _source_offset
+    _raw_pre_idx = _i + _source_offset
     {% if not postsynaptic_condition %}
     {{vector_code['create_cond']|autoindent}}
     if not _cond:
@@ -114,7 +114,7 @@ for _i in range(N_pre):
         raise IndexError("index j=%d outside allowed range from 0 to %d" % (_max_j, N_post-1))
     {% endif %}
     _vectorisation_idx = _j
-    _all_post = _j + _target_offset
+    _raw_post_idx = _j + _target_offset
     {% if postsynaptic_condition %}
     {{vector_code['create_cond']|autoindent}}
     {% endif %}
@@ -126,7 +126,7 @@ for _i in range(N_pre):
     {% endif %}
 
     _vectorisation_idx = _j
-    _all_post = _j + _target_offset
+    _raw_post_idx = _j + _target_offset
     {{vector_code['update_post']|autoindent}}
 
     if not _numpy.isscalar(_n):

--- a/brian2/codegen/runtime/numpy_rt/templates/synapses_create_generator.py_
+++ b/brian2/codegen/runtime/numpy_rt/templates/synapses_create_generator.py_
@@ -76,9 +76,8 @@ _vectorisation_idx = 1
 {{scalar_code['create_cond']|autoindent}}
 {{scalar_code['update_post']|autoindent}}
 
-_len_all_post = len({{_all_post}})
-
-for _i in range(len({{_all_pre}})):
+for _i in range(N_pre):
+    _all_pre = _i + _source_offset
     {% if not postsynaptic_condition %}
     {{vector_code['create_cond']|autoindent}}
     if not _cond:
@@ -95,14 +94,27 @@ for _i in range(len({{_all_pre}})):
     {{vector_code['create_j']|autoindent}}
     {% if skip_if_invalid %}
     if _numpy.isscalar(_j):
-        if _j<0 or _j>=_len_all_post:
+        if _j<0 or _j>=N_post:
             continue
     else:
-        _in_range = _numpy.logical_and(_j>=0, _j<_len_all_post)
+        _in_range = _numpy.logical_and(_j>=0, _j<N_post)
         _j = _j[_in_range]
         {{iteration_variable}} = {{iteration_variable}}[_in_range]
+    {% else %}
+    if _numpy.isscalar(_j):
+        _min_j = _max_j = _j
+    elif _j.shape == (0, ):
+        continue
+    else:
+        _min_j = _numpy.min(_j)
+        _max_j = _numpy.max(_j)
+    if _min_j < 0:
+        raise IndexError("index j=%d outside allowed range from 0 to %d" % (_min_j, N_post-1))
+    elif _max_j >= N_post:
+        raise IndexError("index j=%d outside allowed range from 0 to %d" % (_max_j, N_post-1))
     {% endif %}
     _vectorisation_idx = _j
+    _all_post = _j + _target_offset
     {% if postsynaptic_condition %}
     {{vector_code['create_cond']|autoindent}}
     {% endif %}
@@ -114,6 +126,7 @@ for _i in range(len({{_all_pre}})):
     {% endif %}
 
     _vectorisation_idx = _j
+    _all_post = _j + _target_offset
     {{vector_code['update_post']|autoindent}}
 
     if not _numpy.isscalar(_n):

--- a/brian2/codegen/runtime/weave_rt/templates/synapses_create_generator.cpp
+++ b/brian2/codegen/runtime/weave_rt/templates/synapses_create_generator.cpp
@@ -2,7 +2,7 @@
 
 {% block maincode %}
     {#
-    USES_VARIABLES { _synaptic_pre, _synaptic_post, _all_pre, _all_post, rand,
+    USES_VARIABLES { _synaptic_pre, _synaptic_post, rand,
                      N_incoming, N_outgoing, N,
                      N_pre, N_post, _source_offset, _target_offset}
     #}
@@ -15,7 +15,7 @@
     int _curbuf = 0;
     const int _N_pre = {{constant_or_scalar('N_pre', variables['N_pre'])}};
     const int _N_post = {{constant_or_scalar('N_post', variables['N_post'])}};
-    int _all_pre, _all_post;
+    int _raw_pre_idx, _raw_post_idx;
     const int oldsize = {{_dynamic__synaptic_pre}}.size();
 
     // scalar code
@@ -27,7 +27,7 @@
     for(int _i=0; _i<_N_pre; _i++)
     {
         bool __cond, _cond;
-        _all_pre = _i + _source_offset;
+        _raw_pre_idx = _i + _source_offset;
         {% if not postsynaptic_condition %}
         {
             {{vector_code['create_cond']|autoindent}}
@@ -106,7 +106,7 @@
                 throw 1;
                 {% endif %}
             }
-            _all_post = _j + _target_offset;
+            _raw_post_idx = _j + _target_offset;
             {% if postsynaptic_condition %}
             {
                 {{vector_code['create_cond']|autoindent}}

--- a/brian2/codegen/runtime/weave_rt/templates/synapses_create_generator.cpp
+++ b/brian2/codegen/runtime/weave_rt/templates/synapses_create_generator.cpp
@@ -9,14 +9,13 @@
     {# WRITES_TO_READ_ONLY_VARIABLES { _synaptic_pre, _synaptic_post,
                       N_incoming, N_outgoing, N}
     #}
-    srand((unsigned int)time(NULL));
     const int _buffer_size = 1024;
     int *const _prebuf = new int[_buffer_size];
     int *const _postbuf = new int[_buffer_size];
     int _curbuf = 0;
     const int _N_pre = {{constant_or_scalar('N_pre', variables['N_pre'])}};
     const int _N_post = {{constant_or_scalar('N_post', variables['N_post'])}};
-
+    int _all_pre, _all_post;
     const int oldsize = {{_dynamic__synaptic_pre}}.size();
 
     // scalar code
@@ -25,9 +24,10 @@
     {{scalar_code['create_j']|autoindent}}
     {{scalar_code['create_cond']|autoindent}}
     {{scalar_code['update_post']|autoindent}}
-    for(int _i=0; _i<_num_all_pre; _i++)
+    for(int _i=0; _i<_N_pre; _i++)
     {
         bool __cond, _cond;
+        _all_pre = _i + _source_offset;
         {% if not postsynaptic_condition %}
         {
             {{vector_code['create_cond']|autoindent}}
@@ -106,6 +106,7 @@
                 throw 1;
                 {% endif %}
             }
+            _all_post = _j + _target_offset;
             {% if postsynaptic_condition %}
             {
                 {{vector_code['create_cond']|autoindent}}

--- a/brian2/devices/cpp_standalone/templates/synapses_create_generator.cpp
+++ b/brian2/devices/cpp_standalone/templates/synapses_create_generator.cpp
@@ -16,7 +16,7 @@
     const int _N_post = {{constant_or_scalar('N_post', variables['N_post'])}};
     {{_dynamic_N_incoming}}.resize(_N_post + _target_offset);
     {{_dynamic_N_outgoing}}.resize(_N_pre + _source_offset);
-    int _all_pre, _all_post;
+    int _raw_pre_idx, _raw_post_idx;
     // scalar code
     const int _vectorisation_idx = -1;
     {{scalar_code['setup_iterator']|autoindent}}
@@ -26,7 +26,7 @@
     for(int _i=0; _i<_N_pre; _i++)
 	{
         bool __cond, _cond;
-        _all_pre = _i + _source_offset;
+        _raw_pre_idx = _i + _source_offset;
         {% if not postsynaptic_condition %}
         {
             {{vector_code['create_cond']|autoindent}}
@@ -96,7 +96,7 @@
             }
             _j = __j; // make the previously locally scoped _j available
             _pre_idx = __pre_idx;
-            _all_post = _j + _target_offset;
+            _raw_post_idx = _j + _target_offset;
             if(_j<0 || _j>=_N_post)
             {
                 {% if skip_if_invalid %}

--- a/brian2/devices/cpp_standalone/templates/synapses_create_generator.cpp
+++ b/brian2/devices/cpp_standalone/templates/synapses_create_generator.cpp
@@ -16,16 +16,17 @@
     const int _N_post = {{constant_or_scalar('N_post', variables['N_post'])}};
     {{_dynamic_N_incoming}}.resize(_N_post + _target_offset);
     {{_dynamic_N_outgoing}}.resize(_N_pre + _source_offset);
-
+    int _all_pre, _all_post;
     // scalar code
     const int _vectorisation_idx = -1;
     {{scalar_code['setup_iterator']|autoindent}}
     {{scalar_code['create_j']|autoindent}}
     {{scalar_code['create_cond']|autoindent}}
     {{scalar_code['update_post']|autoindent}}
-    for(int _i=0; _i<_num_all_pre; _i++)
+    for(int _i=0; _i<_N_pre; _i++)
 	{
         bool __cond, _cond;
+        _all_pre = _i + _source_offset;
         {% if not postsynaptic_condition %}
         {
             {{vector_code['create_cond']|autoindent}}
@@ -95,6 +96,7 @@
             }
             _j = __j; // make the previously locally scoped _j available
             _pre_idx = __pre_idx;
+            _all_post = _j + _target_offset;
             if(_j<0 || _j>=_N_post)
             {
                 {% if skip_if_invalid %}

--- a/brian2/synapses/synapses.py
+++ b/brian2/synapses/synapses.py
@@ -1484,15 +1484,20 @@ class Synapses(Group):
         variables.add_auxiliary_variable('_n', unit=Unit(1),
                                          dtype=np.int32)
 
-        if '_sub_idx' in self.source.variables:
-            variables.add_reference('_all_pre', self.source, '_sub_idx')
+        if '_offset' in self.source.variables:
+            variables.add_reference('_source_offset', self.source, '_offset')
         else:
-            variables.add_reference('_all_pre', self.source, 'i')
+            variables.add_constant('_source_offset', unit=Unit(1), value=0)
 
-        if '_sub_idx' in self.target.variables:
-            variables.add_reference('_all_post', self.target, '_sub_idx')
+        if '_offset' in self.target.variables:
+            variables.add_reference('_target_offset', self.target, '_offset')
         else:
-            variables.add_reference('_all_post', self.target, 'i')
+            variables.add_constant('_target_offset', unit=Unit(1), value=0)
+
+        variables.add_auxiliary_variable('_all_pre', unit=Unit(1),
+                                         dtype=np.int32)
+        variables.add_auxiliary_variable('_all_post', unit=Unit(1),
+                                         dtype=np.int32)
 
         variable_indices = defaultdict(lambda: '_idx')
         for varname in self.variables:
@@ -1500,8 +1505,7 @@ class Synapses(Group):
                 variable_indices[varname] = '_all_pre'
             elif self.variables.indices[varname] == '_postsynaptic_idx':
                 variable_indices[varname] = '_all_post'
-        variable_indices['_all_pre'] = '_i'
-        variable_indices['_all_post'] = '_j'
+
         logger.debug(("Creating synapses from group '%s' to group '%s', "
                       "using generator '%s'") % (self.source.name,
                                                  self.target.name,

--- a/brian2/synapses/synapses.py
+++ b/brian2/synapses/synapses.py
@@ -1444,14 +1444,14 @@ class Synapses(Group):
         template_kwds['postsynaptic_condition'] = postsynaptic_condition
 
         abstract_code['setup_iterator'] += setupiter
-        abstract_code['create_j'] += '_pre_idx = _all_pre \n'
+        abstract_code['create_j'] += '_pre_idx = _raw_pre_idx \n'
         abstract_code['create_j'] += '_j = '+parsed['element']+'\n'
         if postsynaptic_condition:
-            abstract_code['create_cond'] += '_post_idx = _all_post \n'
+            abstract_code['create_cond'] += '_post_idx = _raw_post_idx \n'
         if parsed['if_expression'] is not None:
             abstract_code['create_cond'] += ('_cond = ' +
                                              parsed['if_expression'] + '\n')
-            abstract_code['update_post'] += '_post_idx = _all_post \n'
+            abstract_code['update_post'] += '_post_idx = _raw_post_idx \n'
         abstract_code['update_post'] += '_n = ' + str(n) + '\n'
 
         # This overwrites 'i' and 'j' in the synapses' variables dictionary
@@ -1494,17 +1494,17 @@ class Synapses(Group):
         else:
             variables.add_constant('_target_offset', unit=Unit(1), value=0)
 
-        variables.add_auxiliary_variable('_all_pre', unit=Unit(1),
+        variables.add_auxiliary_variable('_raw_pre_idx', unit=Unit(1),
                                          dtype=np.int32)
-        variables.add_auxiliary_variable('_all_post', unit=Unit(1),
+        variables.add_auxiliary_variable('_raw_post_idx', unit=Unit(1),
                                          dtype=np.int32)
 
         variable_indices = defaultdict(lambda: '_idx')
         for varname in self.variables:
             if self.variables.indices[varname] == '_presynaptic_idx':
-                variable_indices[varname] = '_all_pre'
+                variable_indices[varname] = '_raw_pre_idx'
             elif self.variables.indices[varname] == '_postsynaptic_idx':
-                variable_indices[varname] = '_all_post'
+                variable_indices[varname] = '_raw_post_idx'
 
         logger.debug(("Creating synapses from group '%s' to group '%s', "
                       "using generator '%s'") % (self.source.name,

--- a/brian2/synapses/synapses.py
+++ b/brian2/synapses/synapses.py
@@ -1251,7 +1251,7 @@ class Synapses(Group):
                              "range. Original error message: " + str(e))
 
     def _resize(self, number):
-        if not isinstance(number, numbers.Integral):
+        if not isinstance(number, (numbers.Integral, np.integer)):
             raise TypeError(('Expected an integer number got {} '
                              'instead').format(type(number)))
         if number < self.N:


### PR DESCRIPTION
I realized that our changes to synapse creation did actually break the "synapse-to-synapse" connections we need for the astrocytes project. We had a test for that, but that test used 1-to-1 connections everywhere so the use of incorrect indices went unnoticed. The change is to not rely on the pre-defined arrays of `arange(N)` that every `NeuronGroup` has but instead create them on the fly -- performance-wise it should not change anything (addition of two variables instead of an array lookup), except maybe for numpy (because we now do an explicit check instead of relying on an automatic `IndexError` -- however, this has the advantage that the error message is now clearer and consistent with weave/cython). I did not notice anything significant in some quick testing.

The names `all_pre` and `all_post` are not ideal, maybe we should also use the opportunity to rename them to something more understandable...?