### PR TITLE
[MRG] Error message improvements

### DIFF
--- a/brian2/parsing/expressions.py
+++ b/brian2/parsing/expressions.py
@@ -261,6 +261,11 @@ def parse_expression_unit(expr, variables):
             raise ValueError(('Function %s does not specify how it '
                               'deals with units.') % expr.func.id)
 
+        if len(func._arg_units) != len(arg_units):
+            raise SyntaxError('Function %s was called with %d parameters, '
+                              'needs %d.' % (expr.func.id,
+                                             len(arg_units),
+                                             len(func._arg_units)))
         for idx, arg_unit in enumerate(arg_units):
             # A "None" in func._arg_units means: No matter what unit
             if (func._arg_units[idx] is not None and

--- a/brian2/parsing/expressions.py
+++ b/brian2/parsing/expressions.py
@@ -4,6 +4,7 @@ AST parsing based analysis of expressions
 
 import ast
 
+from brian2.core.functions import Function
 from brian2.units.fundamentalunits import (Unit, get_unit_fast,
                                            DimensionMismatchError,
                                            have_same_dimensions,
@@ -217,6 +218,11 @@ def parse_expression_unit(expr, variables):
             raise ValueError('Do not know how to handle value %s' % value)
     if expr.__class__ is ast.Name:
         name = expr.id
+        # Raise an error if a function is called as if it were a variable
+        # (most of the time this happens for a TimedArray)
+        if name in variables and isinstance(variables[name], Function):
+            raise SyntaxError('%s was used like a variable/constant, but it is '
+                              'a function.' % name)
         if name in variables:
             return variables[name].unit
         elif name in ['True', 'False']:

--- a/brian2/parsing/rendering.py
+++ b/brian2/parsing/rendering.py
@@ -114,8 +114,16 @@ class NodeRenderer(object):
         # This means we still put needless parentheses because we ignore
         # precedence rules, e.g. we write "3 + (4 * 5)" but at least we do
         # not do "(3) + ((4) + (5))"
+        op_class = op.__class__.__name__
+        # Give a more useful error message when using bit-wise operators
+        if op_class in ['BitXor', 'BitAnd', 'BitOr']:
+            correction = {'BitXor': ('^', '**'),
+                          'BitAnd': ('&', 'and'),
+                          'BitOr': ('|', 'or')}.get(op_class)
+            raise SyntaxError('The operator "{}" is not supported, use "{}" '
+                              'instead.'.format(correction[0], correction[1]))
         return '%s %s %s' % (self.render_element_parentheses(left),
-                             self.expression_ops[op.__class__.__name__],
+                             self.expression_ops[op_class],
                              self.render_element_parentheses(right))
 
     def render_BinOp(self, node):

--- a/brian2/tests/test_numpy_codegen.py
+++ b/brian2/tests/test_numpy_codegen.py
@@ -1,0 +1,25 @@
+from nose.plugins.skip import SkipTest
+
+from brian2 import *
+
+def test_error_message():
+    if prefs.codegen.target != 'numpy':
+        raise SkipTest('numpy-only test')
+
+    @check_units(x=1, result=1)
+    def foo(x):
+        raise ValueError()
+
+    G = NeuronGroup(1, 'v : 1')
+    G.run_regularly('v = foo(3)')
+    try:
+        run(defaultclock.dt)
+        raise AssertionError('Expected the run to raise a ValueError')
+    except ValueError as exc:
+        # The actual code line should be mentioned in the error message
+        assert 'v = foo(3)' in str(exc)
+
+
+if __name__ == '__main__':
+    prefs.codegen.target = 'numpy'
+    test_error_message()

--- a/brian2/tests/test_parsing.py
+++ b/brian2/tests/test_parsing.py
@@ -441,11 +441,30 @@ def test_sympytools():
         expr2 = sympy_to_str(str_to_sympy(expr))
         assert expr.replace(' ', '') == expr2.replace(' ', ''), '%s != %s' % (expr, expr2)
 
+@attr('codegen-independent')
+def test_error_messages():
+    nr = NodeRenderer()
+    expr_expected = [('3^2', '^', '**'),
+                     ('int(not_refractory | (v > 30))', '|', 'or'),
+                     ('int((v > 30) & (w < 20))', '&', 'and')]
+    for expr, expected_1, expected_2 in expr_expected:
+        try:
+            nr.render_expr(expr)
+            raise AssertionError('Excepted {} to raise a '
+                                 'SyntaxError.'.format(expr))
+        except SyntaxError as exc:
+            message = str(exc)
+            assert expected_1 in message
+            assert expected_2 in message
+
 
 if __name__=='__main__':
     test_parse_expressions_python()
     test_parse_expressions_numpy()
-    test_parse_expressions_cpp()
+    try:
+        test_parse_expressions_cpp()
+    except SkipTest:
+        pass
     test_parse_expressions_sympy()
     test_abstract_code_dependencies()
     test_is_boolean_expression()
@@ -455,3 +474,4 @@ if __name__=='__main__':
     test_extract_abstract_code_functions()
     test_substitute_abstract_code_functions()
     test_sympytools()
+    test_error_messages()

--- a/brian2/tests/test_parsing.py
+++ b/brian2/tests/test_parsing.py
@@ -295,7 +295,10 @@ def test_parse_expression_unit():
         (volt, 'sqrt(randn()*b**2)'),
         (1, 'sin(b/b)'),
         (DimensionMismatchError, 'sin(b)'),
-        (DimensionMismatchError, 'sqrt(b) + b')
+        (DimensionMismatchError, 'sqrt(b) + b'),
+        (SyntaxError, 'sqrt(b, b)'),
+        (SyntaxError, 'sqrt()'),
+        (SyntaxError, 'int(1, 2)'),
         ]
     for expect, expr in EE:
         all_variables = {}
@@ -305,8 +308,8 @@ def test_parse_expression_unit():
             else:
                 all_variables[name] = group._resolve(name, {})
 
-        if expect is DimensionMismatchError:
-            assert_raises(DimensionMismatchError, parse_expression_unit, expr,
+        if isinstance(expect, type) and issubclass(expect, Exception):
+            assert_raises(expect, parse_expression_unit, expr,
                           all_variables)
         else:
             u = parse_expression_unit(expr, all_variables)

--- a/brian2/tests/test_timedarray.py
+++ b/brian2/tests/test_timedarray.py
@@ -1,5 +1,4 @@
-import numpy as np
-from numpy.testing.utils import assert_equal
+from numpy.testing.utils import assert_equal, assert_raises
 from nose import with_setup
 from nose.plugins.attrib import attr
 
@@ -25,6 +24,7 @@ def test_timedarray_direct_use():
     assert ta2d(1*ms, 1) == 4*amp
     assert_equal(ta2d(1*ms, [0, 1, 2]), [3, 4, 5]*amp)
     assert_equal(ta2d(15*ms, [0, 1, 2]), [9, 10, 11]*amp)
+
 
 @attr('standalone-compatible')
 @with_setup(teardown=reinit_devices)
@@ -68,6 +68,20 @@ def test_timedarray_2d():
     assert_equal(mon[1].value_, np.array([1, 4, 7, 10, 10]) + 1)
     assert_equal(mon[2].value_, np.array([2, 5, 8, 11, 11]) + 1)
 
+
+@attr('codegen-independent')
+def test_timedarray_incorrect_use():
+    ta = TimedArray(np.linspace(0, 10, 11), 1*ms)
+    ta2d = TimedArray((np.linspace(0, 11, 12)*amp).reshape(4, 3), 1*ms)
+    G = NeuronGroup(3, 'I : amp')
+    # The weird formulation with the variable name is to get the variable into
+    # the surrounding namespace of the setattr call
+    assert_raises(ValueError, lambda: (ta2d, setattr(G, 'I', 'ta2d(t)*amp')))
+    assert_raises(ValueError, lambda: (ta, setattr(G, 'I', 'ta(t, i)*amp')))
+    assert_raises(ValueError, lambda: (ta, setattr(G, 'I', 'ta()*amp')))
+    assert_raises(ValueError, lambda: (ta, setattr(G, 'I', 'ta*amp')))
+
+
 @attr('standalone-compatible')
 @with_setup(teardown=reinit_devices)
 def test_timedarray_no_upsampling():
@@ -78,6 +92,7 @@ def test_timedarray_no_upsampling():
     mon = StateMonitor(G, 'value', record=True, dt=1*ms)
     run(2.1*ms)
     assert_equal(mon[0].value, [0, 9, 9])
+
 
 #@attr('standalone-compatible')  # see FIXME comment below
 @with_setup(teardown=reinit_devices)
@@ -104,5 +119,6 @@ if __name__ == '__main__':
     test_timedarray_no_units()
     test_timedarray_with_units()
     test_timedarray_2d()
+    test_timedarray_incorrect_use()
     test_timedarray_no_upsampling()
     test_long_timedarray()


### PR DESCRIPTION
This fixes some less than useful error messages that I had on my list for quite a while, see explanations in the commit logs. The only somewhat debatable change is the fix for #646 -- the `exec` used to execute numpy code objects is now wrapped in `try/exec` and will give the actual code line that raised the error. This comes at the cost of a slightly slower code execution, in one example (in some very unsystematic benchmarking) I saw a runtime increase of 10%. I still think this is worth doing, numpy would somewhat become the "debug device". If you see for example a segmentation fault when running your simulation, it is very much possible that switching to numpy will give us a helpful error message (e.g. an `IndexError` when we go beyond array bounds). I actually did this change a few times manually when I was debugging such issues.