### PR TITLE
[MRG] Remove MSVC workarounds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -120,6 +120,10 @@ before_install:
 # command to install dependencies
 install:
   - conda update --yes conda
+  # For faster tests, only build conda packages for the master branch or pull requests
+  - if [[ $TRAVIS_PULL_REQUEST == 'false' ]] && [[ $TRAVIS_BRANCH != 'master' ]]; then
+       CONDA_BUILD='no';
+    fi
   - if [[ $CONDA_BUILD == 'yes' ]]; then
        conda install --yes --quiet anaconda-client conda-build jinja2 pip setuptools;
     fi

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -94,10 +94,7 @@ environment:
 
 install:
   # Add the paths
-  - 'set PATH=%PYTHON%;%PYTHON%\Scripts;%PATH%'
-  # Create a new environment with the exact Python version and activate it
-  - 'conda create --yes --quiet -n appveyor_test python=%PYTHON_VERSION%'
-  - 'activate appveyor_test'
+  - 'set PATH=%PYTHON%;%PYTHON%\Library\bin;%PYTHON%\Scripts;%PATH%'
 
   # Check that we have the expected version and architecture for Python
   - 'python --version'
@@ -127,7 +124,6 @@ after_test:
           cd %SRC_DIR% &&
           %CMD_IN_ENV% python setup.py bdist_wheel &&
           %CMD_IN_ENV% python setup.py bdist_wininst &&
-          deactivate &&
           %CMD_IN_ENV% conda install --yes --quiet conda-build anaconda-client pip &&
           %CMD_IN_ENV% conda build --quiet -c brian-team dev\conda-recipe --numpy 1.9 &&
           %CMD_IN_ENV% conda build --quiet -c brian-team dev\conda-recipe --numpy 1.10 &&

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -106,6 +106,8 @@ install:
   # Install the build dependencies of the project via conda
   - 'conda install --yes --quiet numpy scipy nose sphinx sympy pyparsing jinja2 ipython setuptools cython'
   - 'conda install --yes --quiet -c brian-team py-cpuinfo'
+  # For faster tests, only build conda packages for the master branch or pull requests
+  - 'if "%APPVEYOR_PULL_REQUEST_NUMBER%" == "" if not "%APPVEYOR_REPO_BRANCH%" == "master" set CONDA_BUILD=FALSE'
 
 build: false  # Not a C# project, build stuff at the test step instead.
 

--- a/brian2/__init__.py
+++ b/brian2/__init__.py
@@ -5,14 +5,6 @@ Brian 2.0
 # working weave/Cython on Windows with the Python for C++ compiler
 import setuptools as _setuptools
 
-# Hack to fix a problem with weave on Windows, introduced in numpy 1.10
-try:
-    import numpy.distutils.msvccompiler as _msvccompiler
-    if not hasattr(_msvccompiler.MSVCCompiler, 'compiler_cxx'):
-        _msvccompiler.MSVCCompiler.compiler_cxx = 'cl.exe'
-except ImportError:
-    pass
-
 # Check basic dependencies
 import sys
 from distutils.version import LooseVersion

--- a/brian2/devices/cpp_standalone/device.py
+++ b/brian2/devices/cpp_standalone/device.py
@@ -775,13 +775,8 @@ class CPPStandaloneDevice(Device):
                     for version in xrange(16, 8, -1):
                         fname = msvc9compiler.find_vcvarsall(version)
                         if fname:
-                            if version==14 and num_threads>0:
-                                logger.warn("Found Visual Studio 2015, but due to a bug in OpenMP support in "
-                                            "that version it is being ignored. We will use another version if "
-                                            "we find one, or you can switch OpenMP support off.", once=True)
-                            else:
-                                vcvars_loc = fname
-                                break
+                            vcvars_loc = fname
+                            break
                 if vcvars_loc == '':
                     raise IOError("Cannot find vcvarsall.bat on standard "
                                   "search path. Set the "

--- a/dev/conda-recipe/bld.bat
+++ b/dev/conda-recipe/bld.bat
@@ -1,4 +1,0 @@
-xcopy /I /Y /e "%RECIPE_DIR%\..\..\brian2" "%SRC_DIR%\brian2\"
-xcopy "%RECIPE_DIR%\..\..\setup.py" "%SRC_DIR%"
-"%PYTHON%" "%SRC_DIR%"\setup.py install --with-cython --fail-on-error --single-version-externally-managed --record=record.txt
-if errorlevel 1 exit 1

--- a/dev/conda-recipe/build.sh
+++ b/dev/conda-recipe/build.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-cp -r $RECIPE_DIR/../../brian2 $SRC_DIR
-cp $RECIPE_DIR/../../setup.py $SRC_DIR
-$PYTHON $SRC_DIR/setup.py install --with-cython --fail-on-error --single-version-externally-managed --record=record.txt

--- a/dev/conda-recipe/meta.yaml
+++ b/dev/conda-recipe/meta.yaml
@@ -69,5 +69,9 @@ build:
 
 about:
   home: http://www.briansimulator.org/
+  dev_url: https://github.com/brian-team/brian2
+  doc_url: http://brian2.readthedocs.io/
   license: CeCILL-2.1
+  license_family: Other
+  license_file: LICENSE
   summary: 'A clock-driven simulator for spiking neural networks'

--- a/dev/conda-recipe/meta.yaml
+++ b/dev/conda-recipe/meta.yaml
@@ -61,6 +61,12 @@ test:
   requires:
     - nose
 
+source:
+  path: ../..
+
+build:
+  script: python setup.py install --with-cython --fail-on-error --single-version-externally-managed --record=record.txt
+
 about:
   home: http://www.briansimulator.org/
   license: CeCILL-2.1

--- a/docs_sphinx/introduction/install.rst
+++ b/docs_sphinx/introduction/install.rst
@@ -133,10 +133,10 @@ using ``pip install cython`` or ``pip install weave``.
 
 On Linux and Mac OS X, you will most likely already have a working C++ compiler
 installed (try calling ``g++ --version`` in a terminal). If not, use your
-distribution's package manager to install a ``g++`` package, or install ``gcc``
-via Anaconda (``conda install gcc``).
+distribution's package manager to install a ``g++`` package.
 
-On Windows, the necessary steps depend on the Python version you are using:
+On Windows, the necessary steps to get :ref:`runtime` (i.e. Cython/weave) to work
+depend on the Python version you are using:
 
 **Python 2.7**
 
@@ -149,7 +149,7 @@ This should be all you need.
 * Download and install the `Microsoft .NET Framework 4 <https://www.microsoft.com/en-us/download/details.aspx?id=17851>`_
 * Download and install the `Microsoft Windows SDK for Windows 7 and .NET Framework 4 <http://www.microsoft.com/en-in/download/details.aspx?id=8279>`_
 
-For 64 Bit Windows (and Python 3.4), you have to additionally set up your
+For 64 Bit Windows with Python 3.4, you have to additionally set up your
 environment correctly every time you run your Brian script (this is why we
 recommend against using this combination on Windows). To do this, run the
 following commands (assuming the default installation path) at the CMD prompt,
@@ -158,6 +158,15 @@ or put them in a batch file::
     setlocal EnableDelayedExpansion
     CALL "C:\Program Files\Microsoft SDKs\Windows\v7.1\Bin\SetEnv.cmd" /x64 /release
     set DISTUTILS_USE_SDK=1
+
+**Python 3.5**
+
+* Download and install `Visual Studio Community 2015 <https://www.visualstudio.com/>`_. Do not chose the default
+  install but instead customize it, the only necessary option is "Programming Languages / Visual C++ / Common Tools for
+  Visual C++ 2015"
+
+For :ref:`cpp_standalone`, you can either use the compiler installed above or any other version of Visual Studio -- in this
+case, the Python version does not matter.
 
 Try running the test suite (see :ref:`testing_brian` below) after the
 installation to make sure everything is working as expected.

--- a/docs_sphinx/introduction/known_issues.rst
+++ b/docs_sphinx/introduction/known_issues.rst
@@ -22,11 +22,3 @@ This can in particular happen for complicated equations where sympy's solvers
 take a long time trying to solve the equations symbolically (typically failing
 in the end). We try to improve this situation (see #351) but until then, chose
 a numerical integration algorithm explicitly (:ref:`numerical_integration`).
-
-Cannot find vcvarsall.bat on standard search path
--------------------------------------------------
-
-If you have Windows and Microsoft Visual Studio 2015 installed, and you are
-trying to run with OpenMP support, you will see this error. There is a bug in
-OpenMP support for this version of Visual Studio. You can either install a
-different version or switch OpenMP off.


### PR DESCRIPTION
This removes the workarounds for MSVC that are no longer necessary: VS 2015 works fine with OpenMP now and numpy 0.10.2 fixed the `compiler_cxx` issue.
I also updated the installation instructions for code generation on Windows with Python 3.5. Unfortunately we still need a manual installation of compilers, the runtime environment that I mentioned in issue #591 does not include the compilers.
I also changed a small thing in the appveyor builds: conda packages are now only built for pull requests or on the master branch, that makes the tests slightly faster in development branches (and the conda builds do sometimes fail anyway just because of server issues).

It *seems* that the issue reported in #724 has fixed itself, but let's wait for the tests to run through.