### PR TITLE
[MRG] Use a stable sort algorithm so that `Spikemonitor.spike_train` returns sorted spike trains

### DIFF
--- a/brian2/monitors/spikemonitor.py
+++ b/brian2/monitors/spikemonitor.py
@@ -248,7 +248,9 @@ class EventMonitor(Group, CodeRunner):
                                  'Set the record argument to True to record '
                                  'them.')
         indices = self.i[:]
-        sort_indices = np.argsort(indices)
+        # We have to make sure that the sort is stable, otherwise our spike
+        # times do not necessarily remain sorted.
+        sort_indices = np.argsort(indices, kind='mergesort')
         used_indices, first_pos = np.unique(self.i[:][sort_indices],
                                             return_index=True)
         return self._values_dict(first_pos, sort_indices, used_indices, var)


### PR DESCRIPTION
See discussion in #725.

Fixes #725