### PR TITLE
[MRG] Error for missing connect call

### DIFF
--- a/brian2/core/variables.py
+++ b/brian2/core/variables.py
@@ -844,6 +844,15 @@ class VariableView(object):
         if variable.read_only:
             raise TypeError('Variable %s is read-only.' % self.name)
 
+        # Check whether the group allows writing to the variable (e.g. for
+        # synaptic variables, writing is only allowed after a connect)
+        try:
+            self.group.check_variable_write(variable)
+        except ReferenceError:
+            # Ignore problems with weakly referenced groups that don't exist
+            # anymore at this time (e.g. when doing neuron.axon.var = ...)
+            pass
+
         # The second part is equivalent to item == slice(None) but formulating
         # it this way prevents a FutureWarning if one of the elements is a
         # numpy array

--- a/brian2/groups/group.py
+++ b/brian2/groups/group.py
@@ -544,6 +544,25 @@ class VariableOwner(Nameable):
             raise NotImplementedError("Format '%s' is not supported" % format)
         ImportExport.methods[format].import_data(self, values, units=units, level=level)
 
+    def check_variable_write(self, variable):
+        '''
+        Function that can be overwritten to raise an error if writing to a
+        variable should not be allowed. Note that this does *not* deal with
+        incorrect writes that are general to all kind of variables (incorrect
+        units, writing to a read-only variable, etc.). This function is only
+        used for type-specific rules, e.g. for raising an error in `Synapses`
+        when writing to a synaptic variable before any `~Synapses.connect`
+        call.
+
+        By default this function does nothing.
+
+        Parameters
+        ----------
+        variable : `Variable`
+            The variable that the user attempts to set.
+        '''
+        pass
+
     def _full_state(self):
         state = {}
         for var in self.variables.itervalues():

--- a/brian2/synapses/synapses.py
+++ b/brian2/synapses/synapses.py
@@ -292,10 +292,12 @@ class SynapticPathway(CodeRunner, Group):
 
     def initialise_queue(self):
         self.eventspace = self.source.variables[self.eventspace_name].get_value()
-        if self.synapse_sources.get_len() == 0:
-            logger.warn(("Synapses object '%s' does not have any synapses. Did "
-                         "you forget a 'connect'?") % self.synapses.name,
-                        'no_synapses', once=True)
+        if not self.synapses._connect_called:
+            raise TypeError(("Synapses object '%s' does not do anything, since "
+                             "it has not created synapses with 'connect'. "
+                             "Set its active attribute to False if you "
+                             "intend to do only do this for a subsequent"
+                             " run.") % self.synapses.name)
         if self.queue is None:
             self.queue = get_device().spike_queue(self.source.start, self.source.stop)
 

--- a/brian2/tests/test_synapses.py
+++ b/brian2/tests/test_synapses.py
@@ -995,6 +995,17 @@ def test_no_synapses():
         assert l[0][1].endswith('.no_synapses')
 
 
+@attr('codegen-independent')
+def test_no_synapses_variable_write():
+    # Synaptic pathway but no synapses
+    G1 = NeuronGroup(1, '', threshold='True')
+    G2 = NeuronGroup(1, 'v:1')
+    S = Synapses(G1, G2, 'w : 1', on_pre='v+=w')
+    # Setting synaptic variables before calling connect is not allowed
+    assert_raises(TypeError, lambda: setattr(S, 'w', 1))
+    assert_raises(TypeError, lambda: setattr(S, 'delay', 1*ms))
+
+
 @attr('standalone-compatible')
 @with_setup(teardown=reinit_devices)
 def test_summed_variable():
@@ -2114,6 +2125,7 @@ if __name__ == '__main__':
     test_clocks()
     test_changed_dt_spikes_in_queue()
     test_no_synapses()
+    test_no_synapses_variable_write()
     test_summed_variable()
     test_summed_variable_pre_and_post()
     test_summed_variable_differing_group_size()

--- a/brian2/tests/test_synapses.py
+++ b/brian2/tests/test_synapses.py
@@ -987,12 +987,9 @@ def test_no_synapses():
     # Synaptic pathway but no synapses
     G1 = NeuronGroup(1, '', threshold='True')
     G2 = NeuronGroup(1, 'v:1')
-    S = Synapses(G1, G2, on_pre='v+=1', name='synapses_'+str(uuid.uuid4()).replace('-', '_'))
+    S = Synapses(G1, G2, on_pre='v+=1')
     net = Network(G1, G2, S)
-    with catch_logs() as l:
-        net.run(defaultclock.dt)
-        assert len(l) == 1, 'expected 1 warning, got %d' % len(l)
-        assert l[0][1].endswith('.no_synapses')
+    assert_raises(TypeError, lambda: net.run(1*ms))
 
 
 @attr('codegen-independent')

--- a/docs_sphinx/introduction/release_notes.rst
+++ b/docs_sphinx/introduction/release_notes.rst
@@ -17,8 +17,8 @@ Improvements and bug fixes
   sorted spike/event times (#725).
 * Respect the ``active`` attribute in C++ standalone mode (#718).
 * More consistent check of compatible time and dt values (#730).
-* Setting a synaptic variable without any preceding connect call now raises
-  an error (#737).
+* Attempting to set a synaptic variable or to start a simulation with synapses
+  without any preceding connect call now raises an error (#737).
 
 Contributions
 ~~~~~~~~~~~~~

--- a/docs_sphinx/introduction/release_notes.rst
+++ b/docs_sphinx/introduction/release_notes.rst
@@ -17,6 +17,8 @@ Improvements and bug fixes
   sorted spike/event times (#725).
 * Respect the ``active`` attribute in C++ standalone mode (#718).
 * More consistent check of compatible time and dt values (#730).
+* Setting a synaptic variable without any preceding connect call now raises
+  an error (#737).
 
 Contributions
 ~~~~~~~~~~~~~
@@ -29,6 +31,7 @@ anyone we forgot...):
 
 * Chaofei Hong
 * Daniel Bliss
+* Ruben Tikidji-Hamburyan
 
 Brian 2.0rc3
 ------------

--- a/docs_sphinx/user/synapses.rst
+++ b/docs_sphinx/user/synapses.rst
@@ -328,6 +328,9 @@ Accessing synaptic variables
 Synaptic variables can be accessed in a similar way as `NeuronGroup` variables. They can be indexed
 with two indexes, corresponding to the indexes of pre and postsynaptic neurons, or with string expressions (referring
 to ``i`` and ``j`` as the pre-/post-synaptic indices, or to other state variables of the synapse or the connected neurons).
+Note that setting a synaptic variable always refers to the synapses that *currently exist*, i.e. you have to set them
+*after* the relevant `Synapses.connect` call.
+
 Here are a few examples::
 
     S.w[2, 5] = 1*nS
@@ -367,7 +370,18 @@ pathway: ``pre.delay``. When there is a  postsynaptic code (keyword ``post``),
 the delay of the postsynaptic pathway can be accessed as ``post.delay``.
 
 The delay variable(s) can be set and accessed in the same way as other synaptic
-variables.
+variables. The same semantics as for other synaptic variables apply, which means
+in particular that the delay is only set for the synapses that have been already
+created with `Synapses.connect`. If you want to set a global delay for all
+synapses of a `Synapses` object, you can directly specify that delay as part
+of the `Synapses` initializer::
+
+    synapses = Synapses(sources, targets, '...', on_pre='...', delay=1*ms)
+
+When you use this syntax, you can still change the delay afterwards by setting
+``synapses.delay``, but you can only set it to another scalar value. If you need
+different delays across synapses, do not use this syntax but instead set the
+delay variable as any other synaptic variable (see above).
 
 Multiple pathways
 -----------------


### PR DESCRIPTION
This implements the error messages as dicussed in #737 -- you get an error when you write to a synaptic variable without a preceding `connect` or when you include a `Synapses` object without a `connect` in a simulation and run it.

I realized that a warning for a `connect` that results in 0 synapses is actually not that trivial to implement. The synapse creation is done in the template and on the Python level, we do not know about the number of synapses created. We could make a change to the templates so that they return the number of created synapses but this might be a bit of a waste since we probably want to change this again when we implement #263. Also, we need to deal with standalone (same for the simple solution where we check the number of synapses before and after the synapse creation).

I am tempted to postpone this warning to post-2.0 and maybe deal with it at the same time as #263. What do you think?