### PR TITLE
[MRG] Use Binder service for tutorials and examples

### DIFF
--- a/brian2/sphinxext/generate_examples.py
+++ b/brian2/sphinxext/generate_examples.py
@@ -113,6 +113,16 @@ def main(rootpath, destdir):
         output = '.. currentmodule:: brian2\n\n'
         output += '.. ' + basename + ':\n\n'
         output += title + '\n' + '=' * len(title) + '\n\n'
+        note = '''
+        .. |launchbinder| image:: http://mybinder.org/badge.svg
+        .. _launchbinder: http://mybinder.org:/repo/bdevans/brian-binder/notebooks/examples/{exname}.ipynb
+
+        .. note::
+           You can launch an interactive, editable version of this
+           example without installing any local files
+           using the Binder service: |launchbinder|_
+        '''.format(exname=exname.replace('.', '/'))
+        output += note + '\n\n'
         output += docs + '\n\n::\n\n'
         output += '\n'.join(['    ' + line for line in afterdoccode.split('\n')])
         output += '\n\n'

--- a/brian2/sphinxext/generate_examples.py
+++ b/brian2/sphinxext/generate_examples.py
@@ -120,7 +120,8 @@ def main(rootpath, destdir):
         .. note::
            You can launch an interactive, editable version of this
            example without installing any local files
-           using the Binder service: |launchbinder|_
+           using the Binder service (although note that at some times this
+           may be slow or fail to open): |launchbinder|_
         '''.format(exname=exname.replace('.', '/'))
         output += note + '\n\n'
         output += docs + '\n\n::\n\n'

--- a/brian2/sphinxext/generate_examples.py
+++ b/brian2/sphinxext/generate_examples.py
@@ -115,7 +115,7 @@ def main(rootpath, destdir):
         output += title + '\n' + '=' * len(title) + '\n\n'
         note = '''
         .. |launchbinder| image:: http://mybinder.org/badge.svg
-        .. _launchbinder: http://mybinder.org:/repo/bdevans/brian-binder/notebooks/examples/{exname}.ipynb
+        .. _launchbinder: http://mybinder.org:/repo/brian-team/brian2-binder/notebooks/examples/{exname}.ipynb
 
         .. note::
            You can launch an interactive, editable version of this

--- a/dev/tools/docs/build_tutorials.py
+++ b/dev/tools/docs/build_tutorials.py
@@ -8,6 +8,8 @@ from nbconvert.preprocessors import ExecutePreprocessor
 from nbconvert.exporters.notebook import NotebookExporter
 from nbconvert.exporters.rst import RSTExporter
 
+from brian2.utils.stringtools import deindent
+
 
 src_dir = os.path.abspath('../../../tutorials')
 target_dir = os.path.abspath('../../../docs_sphinx/resources/tutorials')
@@ -42,20 +44,21 @@ for fname in sorted(glob.glob1(src_dir, '*.ipynb')):
     codecs.open(output_ipynb_fname, 'w', encoding='utf-8').write(output)
 
     # Insert a note about ipython notebooks with a download link
-    note = u'''
+    note = deindent(u'''
     .. |launchbinder| image:: http://mybinder.org/badge.svg
     .. _launchbinder: http://mybinder.org:/repo/brian-team/brian2-binder/notebooks/tutorials/{tutorial}.ipynb
 
     .. note::
        This tutorial is a static non-editable version. You can launch an
        interactive, editable version without installing any local files
-       using the Binder service: |launchbinder|_
+       using the Binder service (although note that at some times this
+       may be slow or fail to open): |launchbinder|_
 
        Alternatively, you can download a copy of the notebook file
        to use locally: :download:`{tutorial}.ipynb`
 
        See the :doc:`tutorial overview page <index>` for more details.
-    '''.format(tutorial=basename)
+    '''.format(tutorial=basename))
     notebook.cells.insert(1, {
         u'cell_type': u'raw',
         u'metadata': {},
@@ -80,14 +83,15 @@ text = '''
 Tutorials
 =========
 
-The tutorial consists of a series of `Jupyter Notebooks`_ [#]_. If you run such
-a notebook on your own computer, you can interactively change the code in the
-tutorial and experiment with it -- this is the recommended way to get started
-with Brian. The first link for each tutorial below leads to a non-interactive
-version of the notebook; use the links under "Notebook files" to get a file that
-you can run on your computer. You can also copy such a link and paste it at
-http://nbviewer.jupyter.org -- this will get you a nicer (but still
-non-interactive) rendering than the one you see in our documentation.
+The tutorial consists of a series of `Jupyter Notebooks`_ [#]_. You can quickly
+view these using the first links below. To use them interactively - allowing you
+to edit and run the code - there are two options. The easiest option is to click
+on the "Launch Binder" link, which will open up an interactive version in the
+browser without having to install Brian locally. This uses the
+Binder service provided by the
+`Freeman lab <https://www.janelia.org/lab/freeman-lab>`_. Occasionally, this
+service will be down or running slowly. The other option is to download the
+notebook file and run it locally, which requires you to have Brian installed.
 
 For more information about how to use Jupyter Notebooks, see the
 `Jupyter Notebook documentation`_.
@@ -101,12 +105,19 @@ for tutorial, _ in tutorials:
     text += '   ' + tutorial + '\n'
 text += '''
 
-Notebook files
---------------
+Interactive notebooks and files
+-------------------------------
 '''
+for tutorial, _ in tutorials:
+    text += deindent('''
+    .. |launchbinder{tutid}| image:: http://mybinder.org/badge.svg
+    .. _launchbinder{tutid}: http://mybinder.org:/repo/brian-team/brian2-binder/notebooks/tutorials/{tutorial}.ipynb
+
+    '''.format(tutorial=tutorial, tutid=tutorial.replace('-', '')))
+
 for tutorial, title in tutorials:
-    text += '* :download:`{title} <{tutorial}.ipynb>`\n'.format(title=title,
-                                                                tutorial=tutorial)
+    text += '* |launchbinder{tutid}|_ :download:`{title} <{tutorial}.ipynb>`\n'.format(title=title,
+                                                tutorial=tutorial, tutid=tutorial.replace('-', ''))
 text += '''
 
 .. _`Jupyter Notebooks`: http://jupyter-notebook-beginner-guide.readthedocs.org/en/latest/what_is_jupyter.html

--- a/dev/tools/docs/build_tutorials.py
+++ b/dev/tools/docs/build_tutorials.py
@@ -43,12 +43,18 @@ for fname in sorted(glob.glob1(src_dir, '*.ipynb')):
 
     # Insert a note about ipython notebooks with a download link
     note = u'''
-    .. note::
-       This tutorial is written as an interactive notebook that should be run
-       on your own computer. See the :doc:`tutorial overview page <index>` for
-       more details.
+    .. |launchbinder| image:: http://mybinder.org/badge.svg
+    .. _launchbinder: http://mybinder.org:/repo/bdevans/brian-binder/notebooks/tutorials/{tutorial}.ipynb
 
-       Download link for this tutorial: :download:`{tutorial}.ipynb`.
+    .. note::
+       This tutorial is a static non-editable version. You can launch an
+       interactive, editable version without installing any local files
+       using the Binder service: |launchbinder|_
+
+       Alternatively, you can download a copy of the notebook file
+       to use locally: :download:`{tutorial}.ipynb`
+
+       See the :doc:`tutorial overview page <index>` for more details.
     '''.format(tutorial=basename)
     notebook.cells.insert(1, {
         u'cell_type': u'raw',

--- a/dev/tools/docs/build_tutorials.py
+++ b/dev/tools/docs/build_tutorials.py
@@ -44,7 +44,7 @@ for fname in sorted(glob.glob1(src_dir, '*.ipynb')):
     # Insert a note about ipython notebooks with a download link
     note = u'''
     .. |launchbinder| image:: http://mybinder.org/badge.svg
-    .. _launchbinder: http://mybinder.org:/repo/bdevans/brian-binder/notebooks/tutorials/{tutorial}.ipynb
+    .. _launchbinder: http://mybinder.org:/repo/brian-team/brian2-binder/notebooks/tutorials/{tutorial}.ipynb
 
     .. note::
        This tutorial is a static non-editable version. You can launch an

--- a/docs_sphinx/index.rst
+++ b/docs_sphinx/index.rst
@@ -1,6 +1,14 @@
 Brian 2 documentation
 =====================
 
+Brian is a simulator for spiking neural networks. It is written in the Python
+programming language and is available on almost all platforms. We believe
+that a simulator should not only save the time of processors, but also the
+time of scientists. Brian is therefore designed to be easy to learn and use,
+highly flexible and easily extensible.
+
+For new users, take a look at the :doc:`Overview </introduction/overview>`.
+
 Contents:
 
 .. toctree::

--- a/docs_sphinx/introduction/index.rst
+++ b/docs_sphinx/introduction/index.rst
@@ -4,6 +4,7 @@ Introduction
 .. toctree::
    :maxdepth: 1
 
+   overview
    install
    release_notes
    changes

--- a/docs_sphinx/introduction/overview.rst
+++ b/docs_sphinx/introduction/overview.rst
@@ -1,0 +1,24 @@
+Overview
+========
+
+Brian is a simulator for spiking neural networks. It is written in the Python
+programming language and is available on almost all platforms. We believe
+that a simulator should not only save the time of processors, but also the
+time of scientists. Brian is therefore designed to be easy to learn and use,
+highly flexible and easily extensible.
+
+To get an idea of what writing a simulation in Brian looks like, take a look
+at :doc:`a simple example </examples/CUBA>`.
+
+You can actually edit and run the examples in the browser without having to
+install Brian, using the Binder service (note: sometimes this service is down
+or running slowly):
+
+.. image:: http://mybinder.org/badge.svg
+    :target: http://mybinder.org:/repo/brian-team/brian2-binder
+
+Once you have a feel for what is involved in using Brian, we recommend you
+start by following the
+:doc:`installation instructions </introduction/install>`, then going
+through the :doc:`tutorials </resources/tutorials/index>`, and finally
+reading the :doc:`User Guide </user/index>`.

--- a/docs_sphinx/introduction/overview.rst
+++ b/docs_sphinx/introduction/overview.rst
@@ -8,14 +8,15 @@ time of scientists. Brian is therefore designed to be easy to learn and use,
 highly flexible and easily extensible.
 
 To get an idea of what writing a simulation in Brian looks like, take a look
-at :doc:`a simple example </examples/CUBA>`.
+at :doc:`a simple example </examples/CUBA>`, or run our
+`interactive demo <http://mybinder.org/repo/brian-team/brian2-binder/notebooks/demo.ipynb>`_.
 
 You can actually edit and run the examples in the browser without having to
 install Brian, using the Binder service (note: sometimes this service is down
 or running slowly):
 
 .. image:: http://mybinder.org/badge.svg
-    :target: http://mybinder.org:/repo/brian-team/brian2-binder
+    :target: http://mybinder.org/repo/brian-team/brian2-binder
 
 Once you have a feel for what is involved in using Brian, we recommend you
 start by following the

--- a/tutorials/1-intro-to-brian-neurons.ipynb
+++ b/tutorials/1-intro-to-brian-neurons.ipynb
@@ -2,7 +2,10 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "heading_collapsed": false,
+    "level": 1
+   },
    "source": [
     "# Introduction to Brian part 1: Neurons"
    ]
@@ -45,7 +48,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "heading_collapsed": false,
+    "level": 2
+   },
    "source": [
     "## Units system\n",
     "\n",
@@ -60,7 +66,7 @@
    },
    "outputs": [],
    "source": [
-    "print 20*volt"
+    "20*volt"
    ]
   },
   {
@@ -78,7 +84,7 @@
    },
    "outputs": [],
    "source": [
-    "print 1000*amp"
+    "1000*amp"
    ]
   },
   {
@@ -89,7 +95,7 @@
    },
    "outputs": [],
    "source": [
-    "print 1e6*volt"
+    "1e6*volt"
    ]
   },
   {
@@ -100,7 +106,7 @@
    },
    "outputs": [],
    "source": [
-    "print 1000*namp"
+    "1000*namp"
    ]
   },
   {
@@ -118,7 +124,7 @@
    },
    "outputs": [],
    "source": [
-    "print 10*nA*5*Mohm"
+    "10*nA*5*Mohm"
    ]
   },
   {
@@ -136,7 +142,7 @@
    },
    "outputs": [],
    "source": [
-    "print 5*amp+10*volt"
+    "5*amp+10*volt"
    ]
   },
   {
@@ -156,7 +162,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "heading_collapsed": false,
+    "level": 2
+   },
    "source": [
     "## A simple model\n",
     "\n",
@@ -217,7 +226,8 @@
     "eqs = '''\n",
     "dv/dt = 1-v : 1\n",
     "'''\n",
-    "G = NeuronGroup(1, eqs)"
+    "G = NeuronGroup(1, eqs)\n",
+    "run(100*ms)"
    ]
   },
   {
@@ -250,9 +260,13 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "level": 7
+   },
    "source": [
     "First off, ignore that ``start_scope()`` at the top of the cell. You'll see that in each cell in this tutorial where we run a simulation. All it does is make sure that any Brian objects created before the function is called aren't included in the next run of the simulation.\n",
+    "\n",
+    "Secondly, you'll see that there is an \"INFO\" message about not specifying the numerical integration method. This is harmless and just to let you know what method we chose, but we'll fix it in the next cell by specifying the method explicitly.\n",
     "\n",
     "So, what has happened here? Well, the command ``run(100*ms)`` runs the simulation for 100 ms. We can see that this has worked by printing the value of the variable ``v`` before and after the simulation."
    ]
@@ -267,10 +281,10 @@
    "source": [
     "start_scope()\n",
     "\n",
-    "G = NeuronGroup(1, eqs)\n",
-    "print 'Before v =', G.v[0]\n",
+    "G = NeuronGroup(1, eqs, method='linear')\n",
+    "print('Before v = %s' % G.v[0])\n",
     "run(100*ms)\n",
-    "print 'After v =', G.v[0]"
+    "print('After v = %s' % G.v[0])"
    ]
   },
   {
@@ -288,7 +302,7 @@
    },
    "outputs": [],
    "source": [
-    "print 'Expected value of v =', 1-exp(-100*ms/tau)"
+    "print('Expected value of v = %s' % (1-exp(-100*ms/tau)))"
    ]
   },
   {
@@ -310,14 +324,14 @@
    "source": [
     "start_scope()\n",
     "\n",
-    "G = NeuronGroup(1, eqs)\n",
+    "G = NeuronGroup(1, eqs, method='linear')\n",
     "M = StateMonitor(G, 'v', record=True)\n",
     "\n",
     "run(30*ms)\n",
     "\n",
     "plot(M.t/ms, M.v[0])\n",
     "xlabel('Time (ms)')\n",
-    "ylabel('v')"
+    "ylabel('v');"
    ]
   },
   {
@@ -339,7 +353,7 @@
    "source": [
     "start_scope()\n",
     "\n",
-    "G = NeuronGroup(1, eqs)\n",
+    "G = NeuronGroup(1, eqs, method='linear')\n",
     "M = StateMonitor(G, 'v', record=0)\n",
     "\n",
     "run(30*ms)\n",
@@ -348,7 +362,7 @@
     "plot(M.t/ms, 1-exp(-M.t/tau), '--r', lw=2, label='Analytic')\n",
     "xlabel('Time (ms)')\n",
     "ylabel('v')\n",
-    "legend(loc='best')"
+    "legend(loc='best');"
    ]
   },
   {
@@ -377,7 +391,8 @@
     "dv/dt = (sin(2*pi*100*Hz*t)-v)/tau : 1\n",
     "'''\n",
     "\n",
-    "G = NeuronGroup(1, eqs, method='euler') # TODO: we shouldn't have to specify euler here\n",
+    "# Change to Euler method because exact integrator doesn't work here\n",
+    "G = NeuronGroup(1, eqs, method='euler')\n",
     "M = StateMonitor(G, 'v', record=0)\n",
     "\n",
     "G.v = 5 # initial value\n",
@@ -386,12 +401,15 @@
     "\n",
     "plot(M.t/ms, M.v[0])\n",
     "xlabel('Time (ms)')\n",
-    "ylabel('v')"
+    "ylabel('v');"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "heading_collapsed": false,
+    "level": 2
+   },
    "source": [
     "## Adding spikes\n",
     "\n",
@@ -413,13 +431,13 @@
     "dv/dt = (1-v)/tau : 1\n",
     "'''\n",
     "\n",
-    "G = NeuronGroup(1, eqs, threshold='v>0.8', reset='v = 0')\n",
+    "G = NeuronGroup(1, eqs, threshold='v>0.8', reset='v = 0', method='linear')\n",
     "\n",
     "M = StateMonitor(G, 'v', record=0)\n",
     "run(50*ms)\n",
     "plot(M.t/ms, M.v[0])\n",
     "xlabel('Time (ms)')\n",
-    "ylabel('v')"
+    "ylabel('v');"
    ]
   },
   {
@@ -441,13 +459,13 @@
    "source": [
     "start_scope()\n",
     "\n",
-    "G = NeuronGroup(1, eqs, threshold='v>0.8', reset='v = 0')\n",
+    "G = NeuronGroup(1, eqs, threshold='v>0.8', reset='v = 0', method='linear')\n",
     "\n",
     "spikemon = SpikeMonitor(G)\n",
     "\n",
     "run(50*ms)\n",
     "\n",
-    "print 'Spike times:', spikemon.t[:]"
+    "print('Spike times: %s' % spikemon.t[:])"
    ]
   },
   {
@@ -467,7 +485,7 @@
    "source": [
     "start_scope()\n",
     "\n",
-    "G = NeuronGroup(1, eqs, threshold='v>0.8', reset='v = 0')\n",
+    "G = NeuronGroup(1, eqs, threshold='v>0.8', reset='v = 0', method='linear')\n",
     "\n",
     "statemon = StateMonitor(G, 'v', record=0)\n",
     "spikemon = SpikeMonitor(G)\n",
@@ -478,7 +496,7 @@
     "for t in spikemon.t:\n",
     "    axvline(t/ms, ls='--', c='r', lw=3)\n",
     "xlabel('Time (ms)')\n",
-    "ylabel('v')"
+    "ylabel('v');"
    ]
   },
   {
@@ -492,7 +510,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "heading_collapsed": false,
+    "level": 2
+   },
    "source": [
     "## Refractoriness\n",
     "\n",
@@ -514,7 +535,7 @@
     "dv/dt = (1-v)/tau : 1 (unless refractory)\n",
     "'''\n",
     "\n",
-    "G = NeuronGroup(1, eqs, threshold='v>0.8', reset='v = 0', refractory=5*ms)\n",
+    "G = NeuronGroup(1, eqs, threshold='v>0.8', reset='v = 0', refractory=5*ms, method='linear')\n",
     "\n",
     "statemon = StateMonitor(G, 'v', record=0)\n",
     "spikemon = SpikeMonitor(G)\n",
@@ -525,7 +546,7 @@
     "for t in spikemon.t:\n",
     "    axvline(t/ms, ls='--', c='r', lw=3)\n",
     "xlabel('Time (ms)')\n",
-    "ylabel('v')"
+    "ylabel('v');"
    ]
   },
   {
@@ -552,7 +573,7 @@
     "dv/dt = (1-v)/tau : 1\n",
     "'''\n",
     "\n",
-    "G = NeuronGroup(1, eqs, threshold='v>0.8', reset='v = 0', refractory=15*ms)\n",
+    "G = NeuronGroup(1, eqs, threshold='v>0.8', reset='v = 0', refractory=15*ms, method='linear')\n",
     "\n",
     "statemon = StateMonitor(G, 'v', record=0)\n",
     "spikemon = SpikeMonitor(G)\n",
@@ -565,7 +586,7 @@
     "axhline(0.8, ls=':', c='g', lw=3)\n",
     "xlabel('Time (ms)')\n",
     "ylabel('v')\n",
-    "print \"Spike times:\", spikemon.t[:]"
+    "print(\"Spike times: %s\" % spikemon.t[:])"
    ]
   },
   {
@@ -579,7 +600,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "heading_collapsed": false,
+    "level": 2
+   },
    "source": [
     "## Multiple neurons\n",
     "\n",
@@ -602,7 +626,7 @@
     "dv/dt = (2-v)/tau : 1\n",
     "'''\n",
     "\n",
-    "G = NeuronGroup(N, eqs, threshold='v>1', reset='v=0')\n",
+    "G = NeuronGroup(N, eqs, threshold='v>1', reset='v=0', method='linear')\n",
     "G.v = 'rand()'\n",
     "\n",
     "spikemon = SpikeMonitor(G)\n",
@@ -611,7 +635,7 @@
     "\n",
     "plot(spikemon.t/ms, spikemon.i, '.k')\n",
     "xlabel('Time (ms)')\n",
-    "ylabel('Neuron index')"
+    "ylabel('Neuron index');"
    ]
   },
   {
@@ -625,7 +649,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "heading_collapsed": false,
+    "level": 2
+   },
    "source": [
     "## Parameters\n",
     "\n",
@@ -652,7 +679,7 @@
     "v0 : 1\n",
     "'''\n",
     "\n",
-    "G = NeuronGroup(N, eqs, threshold='v>1', reset='v=0', refractory=5*ms)\n",
+    "G = NeuronGroup(N, eqs, threshold='v>1', reset='v=0', refractory=5*ms, method='linear')\n",
     "M = SpikeMonitor(G)\n",
     "\n",
     "G.v0 = 'i*v0_max/(N-1)'\n",
@@ -667,7 +694,7 @@
     "subplot(122)\n",
     "plot(G.v0, M.count/duration)\n",
     "xlabel('v0')\n",
-    "ylabel('Firing rate (sp/s)')"
+    "ylabel('Firing rate (sp/s)');"
    ]
   },
   {
@@ -685,7 +712,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "heading_collapsed": false,
+    "level": 2
+   },
    "source": [
     "## Stochastic neurons\n",
     "\n",
@@ -713,7 +743,7 @@
     "v0 : 1\n",
     "'''\n",
     "\n",
-    "G = NeuronGroup(N, eqs, threshold='v>1', reset='v=0', refractory=5*ms)\n",
+    "G = NeuronGroup(N, eqs, threshold='v>1', reset='v=0', refractory=5*ms, method='euler')\n",
     "M = SpikeMonitor(G)\n",
     "\n",
     "G.v0 = 'i*v0_max/(N-1)'\n",
@@ -728,7 +758,7 @@
     "subplot(122)\n",
     "plot(G.v0, M.count/duration)\n",
     "xlabel('v0')\n",
-    "ylabel('Firing rate (sp/s)')"
+    "ylabel('Firing rate (sp/s)');"
    ]
   },
   {
@@ -741,7 +771,9 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "heading_collapsed": false,
+    "level": 2
    },
    "source": [
     "## End of tutorial\n",
@@ -783,7 +815,7 @@
     "vt += delta_vt0\n",
     "'''\n",
     "\n",
-    "G = NeuronGroup(N, eqs, threshold='v>vt', reset=reset, refractory=5*ms)\n",
+    "G = NeuronGroup(N, eqs, threshold='v>vt', reset=reset, refractory=5*ms, method='euler')\n",
     "spikemon = SpikeMonitor(G)\n",
     "\n",
     "G.v = 'rand()*(vt0-vr)+vr'\n",
@@ -793,7 +825,7 @@
     "\n",
     "_ = hist(spikemon.t/ms, 100, histtype='stepfilled', facecolor='k', weights=ones(len(spikemon))/(N*defaultclock.dt))\n",
     "xlabel('Time (ms)')\n",
-    "ylabel('Instantaneous firing rate (sp/s)')"
+    "ylabel('Instantaneous firing rate (sp/s)');"
    ]
   }
  ],
@@ -813,7 +845,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython2",
-   "version": "2.7.6"
+   "version": "2.7.12"
   }
  },
  "nbformat": 4,

--- a/tutorials/2-intro-to-brian-synapses.ipynb
+++ b/tutorials/2-intro-to-brian-synapses.ipynb
@@ -58,7 +58,7 @@
     "I : 1\n",
     "tau : second\n",
     "'''\n",
-    "G = NeuronGroup(2, eqs, threshold='v>1', reset='v = 0')\n",
+    "G = NeuronGroup(2, eqs, threshold='v>1', reset='v = 0', method='linear')\n",
     "G.I = [2, 0]\n",
     "G.tau = [10, 100]*ms\n",
     "\n",
@@ -74,7 +74,7 @@
     "plot(M.t/ms, M.v[1], '-g', lw=2, label='Neuron 1')\n",
     "xlabel('Time (ms)')\n",
     "ylabel('v')\n",
-    "legend(loc='best')"
+    "legend(loc='best');"
    ]
   },
   {
@@ -117,7 +117,7 @@
     "I : 1\n",
     "tau : second\n",
     "'''\n",
-    "G = NeuronGroup(3, eqs, threshold='v>1', reset='v = 0')\n",
+    "G = NeuronGroup(3, eqs, threshold='v>1', reset='v = 0', method='linear')\n",
     "G.I = [2, 0, 0]\n",
     "G.tau = [10, 100, 100]*ms\n",
     "\n",
@@ -135,7 +135,7 @@
     "plot(M.t/ms, M.v[2], '-r', lw=2, label='Neuron 1')\n",
     "xlabel('Time (ms)')\n",
     "ylabel('v')\n",
-    "legend(loc='best')"
+    "legend(loc='best');"
    ]
   },
   {
@@ -172,7 +172,7 @@
     "I : 1\n",
     "tau : second\n",
     "'''\n",
-    "G = NeuronGroup(3, eqs, threshold='v>1', reset='v = 0')\n",
+    "G = NeuronGroup(3, eqs, threshold='v>1', reset='v = 0', method='linear')\n",
     "G.I = [2, 0, 0]\n",
     "G.tau = [10, 100, 100]*ms\n",
     "\n",
@@ -190,7 +190,7 @@
     "plot(M.t/ms, M.v[2], '-r', lw=2, label='Neuron 1')\n",
     "xlabel('Time (ms)')\n",
     "ylabel('v')\n",
-    "legend(loc='best')"
+    "legend(loc='best');"
    ]
   },
   {
@@ -418,7 +418,7 @@
     "\n",
     "scatter(G.x[S.i]/um, G.x[S.j]/um, S.w*20)\n",
     "xlabel('Source neuron position (um)')\n",
-    "ylabel('Target neuron position (um)')"
+    "ylabel('Target neuron position (um)');"
    ]
   },
   {
@@ -462,7 +462,7 @@
     "xlabel(r'$\\Delta t$ (ms)')\n",
     "ylabel('W')\n",
     "ylim(-A_post, A_post)\n",
-    "axhline(0, ls='-', c='k')"
+    "axhline(0, ls='-', c='k');"
    ]
   },
   {
@@ -575,7 +575,7 @@
     "             on_post='''\n",
     "             apost += Apost\n",
     "             w = clip(w+apre, 0, wmax)\n",
-    "             ''')\n",
+    "             ''', method='linear')\n",
     "S.connect(i=0, j=1)\n",
     "M = StateMonitor(S, ['w', 'apre', 'apost'], record=True)\n",
     "\n",
@@ -589,7 +589,7 @@
     "subplot(212)\n",
     "plot(M.t/ms, M.w[0], label='w')\n",
     "legend(loc='best')\n",
-    "xlabel('Time (ms)')"
+    "xlabel('Time (ms)');"
    ]
   },
   {
@@ -651,7 +651,7 @@
     "xlabel(r'$\\Delta t$ (ms)')\n",
     "ylabel(r'$\\Delta w$')\n",
     "ylim(-Apost, Apost)\n",
-    "axhline(0, ls='-', c='k')"
+    "axhline(0, ls='-', c='k');"
    ]
   },
   {
@@ -680,7 +680,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython2",
-   "version": "2.7.11"
+   "version": "2.7.12"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This currently works, but there are a few things I'd like to add. Essentially, here we have a few links added to ``bdevans/brian-binder`` via ``mybinder.org``. There are some additional tools in that repo.

Still to do:
- [x] Clone ``bdevans/brian-binder`` to ``brian-team/brian2-binder``
- [ ] Inline links for main docs pages? (this would probably be a lot of work, and can be done later)
- [x] Python 2/3 compatibility (e.g. remove print statements from tutorials)
- [ ] Links from website (including link to GUI notebook)

To do in Brian repo:
- [x] New user overview of Brian with link to Binder
- [ ] Add examples of ``brian2tools``?
- [x] Add warning that Binder can be a little slow/unreliable to launch

To do in ``brian2-binder`` repo:
- [x] Generate ``index.ipynb``
- [x] Credit ``mybinder.org`` and Freeman lab in headers
- [x] Check timeout time in header? (currently says 10m but this may be incorrect)
- [ ] Link back to docs pages from generated binder files (actually not sure if necessary?)
- [ ] In examples, pull out the docstrings into separate markdown cells as in main docs
- [x] Interactive Jupyter notebook with GUI as a first example of Brian for new users considering trying it out

@bdevans