### PR TITLE
[MRG] Improve morphology performance

### DIFF
--- a/brian2/spatialneuron/morphology.py
+++ b/brian2/spatialneuron/morphology.py
@@ -738,75 +738,189 @@ class Morphology(object):
         '''
         raise NotImplementedError()
 
-    @abc.abstractproperty
+    @property
     def start_x(self):
         '''
         The x coordinate at the beginning of each compartment. Returns ``None``
         for morphologies without coordinates.
         '''
-        raise NotImplementedError()
+        start_x = self.start_x_
+        if start_x is None:
+            return None
+        else:
+            return Quantity(start_x, dim=meter.dim)
 
-    @abc.abstractproperty
+    @property
     def start_y(self):
         '''
         The y coordinate at the beginning of each compartment. Returns ``None``
         for morphologies without coordinates.
         '''
-        raise NotImplementedError()
+        start_y = self.start_y_
+        if start_y is None:
+            return None
+        else:
+            return Quantity(start_y, dim=meter.dim)
 
-    @abc.abstractproperty
+    @property
     def start_z(self):
         '''
         The z coordinate at the beginning of each compartment. Returns ``None``
         for morphologies without coordinates.
         '''
+        start_z = self.start_z_
+        if start_z is None:
+            return None
+        else:
+            return Quantity(start_z, dim=meter.dim)
+
+    @abc.abstractproperty
+    def start_x_(self):
+        '''
+        The x coordinate (as a unitless floating point number) at the beginning
+        of each compartment. Returns ``None`` for morphologies without
+        coordinates.
+        '''
         raise NotImplementedError()
 
     @abc.abstractproperty
+    def start_y_(self):
+        '''
+        The y coordinate (as a unitless floating point number) at the beginning
+        of each compartment. Returns ``None`` for morphologies without
+        coordinates.
+        '''
+        raise NotImplementedError()
+
+    @abc.abstractproperty
+    def start_z_(self):
+        '''
+        The z coordinate (as a unitless floating point number) at the beginning
+        of each compartment. Returns ``None`` for morphologies without
+        coordinates.
+        '''
+        raise NotImplementedError()
+
+    @property
     def x(self):
         '''
         The x coordinate at the midpoint of each compartment. Returns ``None``
         for morphologies without coordinates.
         '''
-        raise NotImplementedError()
+        x = self.x_
+        if x is None:
+            return None
+        else:
+            return Quantity(x, dim=meter.dim)
 
-    @abc.abstractproperty
+    @property
     def y(self):
         '''
         The y coordinate at the midpoint of each compartment. Returns ``None``
         for morphologies without coordinates.
         '''
-        raise NotImplementedError()
+        y = self.y_
+        if y is None:
+            return None
+        else:
+            return Quantity(y, dim=meter.dim)
 
-    @abc.abstractproperty
+    @property
     def z(self):
         '''
         The y coordinate at the midpoint of each compartment. Returns ``None``
         for morphologies without coordinates.
         '''
+        z = self.z_
+        if z is None:
+            return None
+        else:
+            return Quantity(z, dim=meter.dim)
+
+    @abc.abstractproperty
+    def x_(self):
+        '''
+        The x coordinate (as a unitless floating point number) at the midpoint
+        of each compartment. Returns ``None`` for morphologies without
+        coordinates.
+        '''
         raise NotImplementedError()
 
     @abc.abstractproperty
+    def y_(self):
+        '''
+        The y coordinate (as a unitless floating point number) at the midpoint
+        of each compartment. Returns ``None`` for morphologies without
+        coordinates.
+        '''
+        raise NotImplementedError()
+
+    @abc.abstractproperty
+    def z_(self):
+        '''
+        The z coordinate (as a unitless floating point number) at the midpoint
+        of each compartment. Returns ``None`` for morphologies without
+        coordinates.
+        '''
+        raise NotImplementedError()
+
+    @property
     def end_x(self):
         '''
         The x coordinate at the end of each compartment. Returns ``None``
         for morphologies without coordinates.
         '''
-        raise NotImplementedError()
+        end_x = self.end_x_
+        if end_x is None:
+            return None
+        else:
+            return Quantity(end_x, dim=meter.dim)
 
-    @abc.abstractproperty
+    @property
     def end_y(self):
         '''
         The y coordinate at the end of each compartment. Returns ``None``
         for morphologies without coordinates.
         '''
-        raise NotImplementedError()
+        end_y = self.end_y_
+        if end_y is None:
+            return None
+        else:
+            return Quantity(end_y, dim=meter.dim)
 
-    @abc.abstractproperty
+    @property
     def end_z(self):
         '''
         The z coordinate at the end of each compartment. Returns ``None``
         for morphologies without coordinates.
+        '''
+        end_z = self.end_z_
+        if end_z is None:
+            return None
+        else:
+            return Quantity(end_z, dim=meter.dim)
+
+    @abc.abstractproperty
+    def end_x_(self):
+        '''
+        The x coordinate (as a unitless floating point number) at the end of
+        each compartment. Returns ``None`` for morphologies without coordinates.
+        '''
+        raise NotImplementedError()
+
+    @abc.abstractproperty
+    def end_y_(self):
+        '''
+        The y coordinate (as a unitless floating point number) at the end of
+        each compartment. Returns ``None`` for morphologies without coordinates.
+        '''
+        raise NotImplementedError()
+
+    @abc.abstractproperty
+    def end_z_(self):
+        '''
+        The z coordinate (as a unitless floating point number) at the end of
+        each compartment. Returns ``None`` for morphologies without coordinates.
         '''
         raise NotImplementedError()
 
@@ -821,13 +935,29 @@ class Morphology(object):
         being the x, y, and z coordinates. Returns ``None`` for morphologies
         without coordinates.
         '''
-        if self.x is None:
+        if self.x_ is None:
             return None
         else:
-            return Quantity(np.vstack([np.hstack([self.start_x[0], self.end_x[:]]),
-                                       np.hstack([self.start_y[0], self.end_y[:]]),
-                                       np.hstack([self.start_z[0], self.end_z[:]])]).T,
-                            dim=meter.dim)
+            return Quantity(self.coordinates_, dim=meter.dim)
+
+    @property
+    def coordinates_(self):
+        r'''
+        Array with all coordinates (as unitless floating point numbers) at the
+        start- and end-points of each compartment in this section. The array has
+        size :math:`(n+1) \times 3`, where :math:`n` is the number of
+        compartments in this section. Each row is one point (start point of
+        first compartment, end point of first compartment, end point of second
+        compartment, ...), with the columns being the x, y, and z coordinates.
+        Returns ``None`` for morphologies without coordinates.
+        '''
+        if self.x_ is None:
+            return None
+        else:
+            return np.vstack([np.hstack([self.start_x_[0], self.end_x_[:]]),
+                              np.hstack([self.start_y_[0], self.end_y_[:]]),
+                              np.hstack([self.start_z_[0], self.end_z_[:]])]).T
+
 
     @staticmethod
     def _create_section(compartments, name, parent, sections,
@@ -1248,9 +1378,11 @@ class SubMorphology(object):
         The x coordinate at the beginning of each compartment in this
         sub-section. Returns ``None`` for morphologies without coordinates.
         '''
-        if self._morphology.start_x is None:
+        start_x = self.start_x_
+        if start_x is None:
             return None
-        return self._morphology.start_x[self._i:self._j]
+        else:
+            return Quantity(start_x, dim=meter.dim)
 
     @property
     def start_y(self):
@@ -1258,19 +1390,56 @@ class SubMorphology(object):
         The y coordinate at the beginning of each compartment in this
         sub-section. Returns ``None`` for morphologies without coordinates.
         '''
-        if self._morphology.start_y is None:
+        start_y = self.start_y_
+        if start_y is None:
             return None
-        return self._morphology.start_y[self._i:self._j]
+        else:
+            return Quantity(start_y, dim=meter.dim)
 
     @property
     def start_z(self):
         '''
-        The z coordinate at the beginning of each compartment in this
+        The x coordinate at the beginning of each compartment in this
         sub-section. Returns ``None`` for morphologies without coordinates.
         '''
-        if self._morphology.start_z is None:
+        start_z = self.start_z_
+        if start_z is None:
             return None
-        return self._morphology.start_z[self._i:self._j]
+        else:
+            return Quantity(start_z, dim=meter.dim)
+
+    @property
+    def start_x_(self):
+        '''
+        The x coordinate (as a unitless floating point number) at the beginning
+        of each compartment in this sub-section. Returns ``None`` for
+        morphologies without coordinates.
+        '''
+        if self._morphology.start_x_ is None:
+            return None
+        return self._morphology.start_x_[self._i:self._j]
+
+    @property
+    def start_y_(self):
+        '''
+        The y coordinate (as a unitless floating point number) at the beginning
+        of each compartment in this sub-section. Returns ``None`` for
+        morphologies without coordinates.
+        '''
+        if self._morphology.start_y_ is None:
+            return None
+        return self._morphology.start_y_[self._i:self._j]
+
+    @property
+    def start_z_(self):
+        '''
+        The z coordinate (as a unitless floating point number) at the beginning
+        of each compartment in this sub-section. Returns ``None`` for
+        morphologies without coordinates.
+        '''
+        if self._morphology.start_z_ is None:
+            return None
+        return self._morphology.start_z_[self._i:self._j]
 
     @property
     def x(self):
@@ -1278,9 +1447,11 @@ class SubMorphology(object):
         The x coordinate at the midpoint of each compartment in this
         sub-section. Returns ``None`` for morphologies without coordinates.
         '''
-        if self._morphology.x is None:
-            return None
-        return self._morphology.x[self._i:self._j]
+        x = self.x_
+        if x is None:
+            return x
+        else:
+            return Quantity(x, dim=meter.dim)
 
     @property
     def y(self):
@@ -1288,9 +1459,11 @@ class SubMorphology(object):
         The y coordinate at the midpoint of each compartment in this
         sub-section. Returns ``None`` for morphologies without coordinates.
         '''
-        if self._morphology.y is None:
-            return None
-        return self._morphology.y[self._i:self._j]
+        y = self.y_
+        if y is None:
+            return y
+        else:
+            return Quantity(y, dim=meter.dim)
 
     @property
     def z(self):
@@ -1298,9 +1471,44 @@ class SubMorphology(object):
         The z coordinate at the midpoint of each compartment in this
         sub-section. Returns ``None`` for morphologies without coordinates.
         '''
-        if self._morphology.z is None:
+        z = self.z_
+        if z is None:
+            return z
+        else:
+            return Quantity(z, dim=meter.dim)
+
+    @property
+    def x_(self):
+        '''
+        The x coordinate (as a unitless floating point number) at the midpoint
+        of each compartment in this sub-section. Returns ``None`` for
+        morphologies without coordinates.
+        '''
+        if self._morphology.x_ is None:
             return None
-        return self._morphology.z[self._i:self._j]
+        return self._morphology.x_[self._i:self._j]
+
+    @property
+    def y_(self):
+        '''
+        The y coordinate (as a unitless floating point number) at the midpoint
+        of each compartment in this sub-section. Returns ``None`` for
+        morphologies without coordinates.
+        '''
+        if self._morphology.y_ is None:
+            return None
+        return self._morphology.y_[self._i:self._j]
+
+    @property
+    def z_(self):
+        '''
+        The z coordinate (as a unitless floating point number) at the midpoint
+        of each compartment in this sub-section. Returns ``None`` for
+        morphologies without coordinates.
+        '''
+        if self._morphology.z_ is None:
+            return None
+        return self._morphology.z_[self._i:self._j]
 
     @property
     def end_x(self):
@@ -1308,9 +1516,11 @@ class SubMorphology(object):
         The x coordinate at the end of each compartment in this sub-section.
         Returns ``None`` for morphologies without coordinates.
         '''
-        if self._morphology.end_x is None:
+        x = self.end_x_
+        if x is None:
             return None
-        return self._morphology.end_x[self._i:self._j]
+        else:
+            return Quantity(x, dim=meter.dim)
 
     @property
     def end_y(self):
@@ -1318,15 +1528,52 @@ class SubMorphology(object):
         The y coordinate at the end of each compartment in this sub-section.
         Returns ``None`` for morphologies without coordinates.
         '''
-        if self._morphology.end_y is None:
+        y = self.end_y_
+        if y is None:
             return None
-        return self._morphology.end_y[self._i:self._j]
+        else:
+            return Quantity(y, dim=meter.dim)
 
     @property
     def end_z(self):
         '''
         The z coordinate at the end of each compartment in this sub-section.
         Returns ``None`` for morphologies without coordinates.
+        '''
+        z = self.end_z_
+        if z is None:
+            return None
+        else:
+            return Quantity(z, dim=meter.dim)
+
+    @property
+    def end_x_(self):
+        '''
+        The x coordinate (as a unitless floating point number) at the end of
+        each compartment in this sub-section. Returns ``None`` for morphologies
+        without coordinates.
+        '''
+        if self._morphology.end_x is None:
+            return None
+        return self._morphology.end_x[self._i:self._j]
+
+    @property
+    def end_y_(self):
+        '''
+        The y coordinate (as a unitless floating point number) at the end of
+        each compartment in this sub-section. Returns ``None`` for morphologies
+        without coordinates.
+        '''
+        if self._morphology.end_y is None:
+            return None
+        return self._morphology.end_y[self._i:self._j]
+
+    @property
+    def end_z_(self):
+        '''
+        The z coordinate (as a unitless floating point number) at the end of
+        each compartment in this sub-section. Returns ``None`` for morphologies
+        without coordinates.
         '''
         if self._morphology.end_z is None:
             return None
@@ -1361,12 +1608,12 @@ class Soma(Morphology):
                 raise TypeError('Coordinates have to be scalar values.')
         self._diameter = np.ones(1) * diameter
         if any(coord is not None for coord in (x, y, z)):
-            default_value = [0]*um
+            default_value = np.array([0.0])
         else:
             default_value = None
-        self._x = np.atleast_1d(x) if x is not None else default_value
-        self._y = np.atleast_1d(y) if y is not None else default_value
-        self._z = np.atleast_1d(z) if z is not None else default_value
+        self._x = np.atleast_1d(np.asarray(x)) if x is not None else default_value
+        self._y = np.atleast_1d(np.asarray(y)) if y is not None else default_value
+        self._z = np.atleast_1d(np.asarray(z)) if z is not None else default_value
 
     def __repr__(self):
         s = '{klass}(diameter={diam!r}'.format(klass=self.__class__.__name__,
@@ -1445,7 +1692,7 @@ class Soma(Morphology):
         return dist
 
     @property
-    def start_x(self):
+    def start_x_(self):
         '''
         The x-coordinate of the current section (as an array of length 1). Note
         that a `Soma` is modelled as a "point" with finite surface/volume,
@@ -1455,7 +1702,7 @@ class Soma(Morphology):
         return self._x
 
     @property
-    def start_y(self):
+    def start_y_(self):
         '''
         The y-coordinate of the current section (as an array of length 1). Note
         that a `Soma` is modelled as a "point" with finite surface/volume,
@@ -1465,7 +1712,7 @@ class Soma(Morphology):
         return self._y
 
     @property
-    def start_z(self):
+    def start_z_(self):
         '''
         The z-coordinate of the current section (as an array of length 1). Note
         that a `Soma` is modelled as a "point" with finite surface/volume,
@@ -1475,7 +1722,7 @@ class Soma(Morphology):
         return self._z
 
     @property
-    def x(self):
+    def x_(self):
         '''
         The x-coordinate of the current section (as an array of length 1). Note
         that a `Soma` is modelled as a "point" with finite surface/volume,
@@ -1485,7 +1732,7 @@ class Soma(Morphology):
         return self._x
 
     @property
-    def y(self):
+    def y_(self):
         '''
         The y-coordinate of the current section (as an array of length 1). Note
         that a `Soma` is modelled as a "point" with finite surface/volume,
@@ -1495,7 +1742,7 @@ class Soma(Morphology):
         return self._y
 
     @property
-    def z(self):
+    def z_(self):
         '''
         The z-coordinate of the current section (as an array of length 1). Note
         that a `Soma` is modelled as a "point" with finite surface/volume,
@@ -1505,7 +1752,7 @@ class Soma(Morphology):
         return self._z
 
     @property
-    def end_x(self):
+    def end_x_(self):
         '''
         The x-coordinate of the current section (as an array of length 1). Note
         that a `Soma` is modelled as a "point" with finite surface/volume,
@@ -1515,7 +1762,7 @@ class Soma(Morphology):
         return self._x
 
     @property
-    def end_y(self):
+    def end_y_(self):
         '''
         The y-coordinate of the current section (as an array of length 1). Note
         that a `Soma` is modelled as a "point" with finite surface/volume,
@@ -1525,7 +1772,7 @@ class Soma(Morphology):
         return self._y
 
     @property
-    def end_z(self):
+    def end_z_(self):
         '''
         The z-coordinate of the current section (as an array of length 1). Note
         that a `Soma` is modelled as a "point" with finite surface/volume,
@@ -1618,9 +1865,9 @@ class Section(Morphology):
                 if value is not None and (value.ndim != 1 or len(value) != n + 1):
                     raise TypeError(('%s needs to be a 1-dimensional array '
                                      'of length %d.') % (name, n + 1))
-            self._x = Quantity(x, copy=True).reshape((n+1, )) if x is not None else np.zeros(n + 1)*um
-            self._y = Quantity(y, copy=True).reshape((n+1, )) if y is not None else np.zeros(n + 1)*um
-            self._z = Quantity(z, copy=True).reshape((n+1, )) if z is not None else np.zeros(n + 1)*um
+            self._x = np.asarray(x).reshape((n+1, )) if x is not None else np.zeros(n + 1)
+            self._y = np.asarray(y).reshape((n+1, )) if y is not None else np.zeros(n + 1)
+            self._z = np.asarray(z).reshape((n+1, )) if z is not None else np.zeros(n + 1)
 
             length = np.sqrt((self.end_x - self.start_x) ** 2 +
                              (self.end_y - self.start_y) ** 2 +
@@ -1653,7 +1900,7 @@ class Section(Morphology):
             x, y, z = None, None, None
             length = self.length
         else:
-            x, y, z = self._x, self._y, self._z
+            x, y, z = self._x*meter, self._y*meter, self._z*meter
             length = None
         return Section(diameter=self._diameter, n=self.n, x=x, y=y, z=z,
                        length=length, type=self.type)
@@ -1757,113 +2004,119 @@ class Section(Morphology):
         return np.pi/2 * (d_1 * d_2)/self._length
 
     @property
-    def start_x(self):
+    def start_x_(self):
         '''
-        The x coordinate at the beginning of each compartment. Returns ``None``
-        for morphologies without coordinates.
+        The x coordinate (as a unitless floating point number) at the beginning
+        of each compartment. Returns ``None`` for morphologies without
+        coordinates.
         '''
         if self._x is None:
             return None
         elif self.parent is not None and self.parent.end_x is not None:
-            return self.parent.end_x[-1] + self._x[:-1]
+            return self.parent.end_x_[-1] + self._x[:-1]
         else:
             return self._x[:-1]
 
     @property
-    def start_y(self):
+    def start_y_(self):
         '''
-        The y coordinate at the beginning of each compartment. Returns ``None``
-        for morphologies without coordinates.
+        The y coordinate (as a unitless floating point number) at the beginning
+        of each compartment. Returns ``None`` for morphologies without
+        coordinates.
         '''
         if self._y is None:
             return None
         elif self.parent is not None and self.parent.end_y is not None:
-            return self.parent.end_y[-1] + self._y[:-1]
+            return self.parent.end_y_[-1] + self._y[:-1]
         else:
             return self._y[:-1]
 
     @property
-    def start_z(self):
+    def start_z_(self):
         '''
-        The z coordinate at the beginning of each compartment. Returns ``None``
-        for morphologies without coordinates.
+        The z coordinate (as a unitless floating point number) at the beginning
+        of each compartment. Returns ``None`` for morphologies without
+        coordinates.
         '''
         if self._z is None:
             return None
-        elif self.parent is not None and self.parent.end_z is not None:
-            return self.parent.end_z[-1] + self._z[:-1]
+        elif self.parent is not None and self.parent.end_z_ is not None:
+            return self.parent.end_z_[-1] + self._z[:-1]
         else:
             return self._z[:-1]
 
     @property
-    def x(self):
+    def x_(self):
         '''
-        The x coordinate at the midpoint of each compartment. Returns ``None``
-        for morphologies without coordinates.
+        The x coordinate (as a unitless floating point number) at the midpoint
+        of each compartment. Returns ``None`` for morphologies without
+        coordinates.
         '''
         if self._x is None:
             return None
-        diff_x = (self.end_x - self.start_x)
-        return self.start_x + 0.5*diff_x
+        diff_x = (self.end_x_ - self.start_x_)
+        return self.start_x_ + 0.5*diff_x
 
     @property
-    def y(self):
+    def y_(self):
         '''
-        The y coordinate at the midpoint of each compartment. Returns ``None``
-        for morphologies without coordinates.
+        The y coordinate (as a unitless floating point number) at the midpoint
+        of each compartment. Returns ``None`` for morphologies without
+        coordinates.
         '''
         if self._y is None:
             return None
-        diff_y = (self.end_y - self.start_y)
-        return self.start_y + 0.5*diff_y
+        diff_y = (self.end_y_ - self.start_y_)
+        return self.start_y_ + 0.5*diff_y
 
     @property
-    def z(self):
+    def z_(self):
         '''
-        The z coordinate at the midpoint of each compartment. Returns ``None``
-        for morphologies without coordinates.
+        The z coordinate (as a unitless floating point number) at the midpoint
+        of each compartment. Returns ``None`` for morphologies without
+        coordinates.
         '''
         if self._z is None:
             return None
-        diff_z = (self.end_z - self.start_z)
-        return self.start_z + 0.5*diff_z
+        diff_z = (self.end_z_ - self.start_z_)
+        return self.start_z_ + 0.5*diff_z
 
     @property
-    def end_x(self):
+    def end_x_(self):
         '''
-        The x coordinate at the end of each compartment. Returns ``None``
-        for morphologies without coordinates.
+        The x coordinate (as a unitless floating point number) at the end of
+        each compartment. Returns ``None`` for morphologies without coordinates.
         '''
         if self._x is None:
             return None
-        elif self.parent is not None and self.parent.end_x is not None:
-            return self.parent.end_x[-1] + self._x[1:]
+        elif self.parent is not None and self.parent.end_x_ is not None:
+            return self.parent.end_x_[-1] + self._x[1:]
         else:
             return self._x[1:]
 
     @property
-    def end_y(self):
+    def end_y_(self):
         '''
-        The y coordinate at the end of each compartment. Returns ``None``
-        for morphologies without coordinates.
+        The y coordinate (as a unitless floating point number) at the end of
+        each compartment. Returns ``None`` for morphologies without coordinates.
         '''
         if self._y is None:
             return None
-        elif self.parent is not None and self.parent.end_y is not None:
-            return self.parent.end_y[-1] + self._y[1:]
+        elif self.parent is not None and self.parent.end_y_ is not None:
+            return self.parent.end_y_[-1] + self._y[1:]
         else:
             return self._y[1:]
 
     @property
-    def end_z(self):
+    def end_z_(self):
         '''
-        The z coordinate at the end of each compartment. Returns ``None``
-        for morphologies without coordinates.
+        The z coordinate (as a unitless floating point number) at the end of
+        each compartment. Returns ``None`` for morphologies without coordinates.
         '''
         if self._z is None:
             return None
-        elif self.parent is not None and self.parent.end_z is not None:
-            return self.parent.end_z[-1] + self._z[1:]
+        elif self.parent is not None and self.parent.end_z_ is not None:
+            return self.parent.end_z_[-1] + self._z[1:]
         else:
             return self._z[1:]
 
@@ -1931,9 +2184,9 @@ class Cylinder(Section):
                 if value is not None and (value.ndim != 1 or len(value) != 2):
                     raise TypeError('%s needs to be a 1-dimensional array of '
                                     'length 2 (start and end point)' % name)
-            self._x = np.linspace(x[0], x[1], n+1) if x is not None else np.zeros(n+1)*um
-            self._y = np.linspace(y[0], y[1], n+1) if y is not None else np.zeros(n+1)*um
-            self._z = np.linspace(z[0], z[1], n+1) if z is not None else np.zeros(n+1)*um
+            self._x = np.asarray(np.linspace(x[0], x[1], n+1)) if x is not None else np.zeros(n+1)
+            self._y = np.asarray(np.linspace(y[0], y[1], n+1)) if y is not None else np.zeros(n+1)
+            self._z = np.asarray(np.linspace(z[0], z[1], n+1)) if z is not None else np.zeros(n+1)
             length = np.sqrt((self.end_x - self.start_x) ** 2 +
                              (self.end_y - self.start_y) ** 2 +
                              (self.end_z - self.start_z) ** 2)

--- a/brian2/spatialneuron/morphology.py
+++ b/brian2/spatialneuron/morphology.py
@@ -2012,8 +2012,9 @@ class Section(Morphology):
         '''
         if self._x is None:
             return None
-        elif self.parent is not None and self.parent.end_x is not None:
-            return self.parent.end_x_[-1] + self._x[:-1]
+        parent_end_x = self.parent.end_x_ if self.parent is not None else None
+        if parent_end_x is not None:
+            return parent_end_x[-1] + self._x[:-1]
         else:
             return self._x[:-1]
 
@@ -2026,8 +2027,9 @@ class Section(Morphology):
         '''
         if self._y is None:
             return None
-        elif self.parent is not None and self.parent.end_y is not None:
-            return self.parent.end_y_[-1] + self._y[:-1]
+        parent_end_y = self.parent.end_y_ if self.parent is not None else None
+        if parent_end_y is not None:
+            return parent_end_y[-1] + self._y[:-1]
         else:
             return self._y[:-1]
 
@@ -2040,8 +2042,9 @@ class Section(Morphology):
         '''
         if self._z is None:
             return None
-        elif self.parent is not None and self.parent.end_z_ is not None:
-            return self.parent.end_z_[-1] + self._z[:-1]
+        parent_end_z = self.parent.end_z_ if self.parent is not None else None
+        if parent_end_z is not None:
+            return parent_end_z[-1] + self._z[:-1]
         else:
             return self._z[:-1]
 
@@ -2054,8 +2057,9 @@ class Section(Morphology):
         '''
         if self._x is None:
             return None
-        diff_x = (self.end_x_ - self.start_x_)
-        return self.start_x_ + 0.5*diff_x
+        start_x = self.start_x_
+        diff_x = (self.end_x_ - start_x)
+        return start_x + 0.5*diff_x
 
     @property
     def y_(self):
@@ -2066,8 +2070,9 @@ class Section(Morphology):
         '''
         if self._y is None:
             return None
-        diff_y = (self.end_y_ - self.start_y_)
-        return self.start_y_ + 0.5*diff_y
+        start_y = self.start_y_
+        diff_y = (self.end_y_ - start_y)
+        return start_y + 0.5*diff_y
 
     @property
     def z_(self):
@@ -2078,8 +2083,9 @@ class Section(Morphology):
         '''
         if self._z is None:
             return None
-        diff_z = (self.end_z_ - self.start_z_)
-        return self.start_z_ + 0.5*diff_z
+        start_z = self.start_z_
+        diff_z = (self.end_z_ - start_z)
+        return start_z + 0.5*diff_z
 
     @property
     def end_x_(self):
@@ -2089,8 +2095,9 @@ class Section(Morphology):
         '''
         if self._x is None:
             return None
-        elif self.parent is not None and self.parent.end_x_ is not None:
-            return self.parent.end_x_[-1] + self._x[1:]
+        parent_end_x = self.parent.end_x_ if self.parent is not None else None
+        if parent_end_x is not None:
+            return parent_end_x[-1] + self._x[1:]
         else:
             return self._x[1:]
 
@@ -2102,8 +2109,9 @@ class Section(Morphology):
         '''
         if self._y is None:
             return None
-        elif self.parent is not None and self.parent.end_y_ is not None:
-            return self.parent.end_y_[-1] + self._y[1:]
+        parent_end_y = self.parent.end_y_ if self.parent is not None else None
+        if parent_end_y is not None:
+            return parent_end_y[-1] + self._y[1:]
         else:
             return self._y[1:]
 
@@ -2115,8 +2123,9 @@ class Section(Morphology):
         '''
         if self._z is None:
             return None
-        elif self.parent is not None and self.parent.end_z_ is not None:
-            return self.parent.end_z_[-1] + self._z[1:]
+        parent_end_z = self.parent.end_z_ if self.parent is not None else None
+        if parent_end_z is not None:
+            return parent_end_z[-1] + self._z[1:]
         else:
             return self._z[1:]
 

--- a/brian2/spatialneuron/morphology.py
+++ b/brian2/spatialneuron/morphology.py
@@ -1764,11 +1764,10 @@ class Section(Morphology):
         '''
         if self._x is None:
             return None
-        if self.parent is not None and self.parent.end_x is not None:
-            parent_x = self.parent.end_x[-1]
+        elif self.parent is not None and self.parent.end_x is not None:
+            return self.parent.end_x[-1] + self._x[:-1]
         else:
-            parent_x = 0*um
-        return parent_x + self._x[:-1]
+            return self._x[:-1]
 
     @property
     def start_y(self):
@@ -1778,11 +1777,10 @@ class Section(Morphology):
         '''
         if self._y is None:
             return None
-        if self.parent is not None and self.parent.end_y is not None:
-            parent_y = self.parent.end_y[-1]
+        elif self.parent is not None and self.parent.end_y is not None:
+            return self.parent.end_y[-1] + self._y[:-1]
         else:
-            parent_y = 0*um
-        return parent_y + self._y[:-1]
+            return self._y[:-1]
 
     @property
     def start_z(self):
@@ -1792,11 +1790,10 @@ class Section(Morphology):
         '''
         if self._z is None:
             return None
-        if self.parent is not None and self.parent.end_z is not None:
-            parent_z = self.parent.end_z[-1]
+        elif self.parent is not None and self.parent.end_z is not None:
+            return self.parent.end_z[-1] + self._z[:-1]
         else:
-            parent_z = 0*um
-        return parent_z + self._z[:-1]
+            return self._z[:-1]
 
     @property
     def x(self):
@@ -1839,11 +1836,10 @@ class Section(Morphology):
         '''
         if self._x is None:
             return None
-        if self.parent is not None and self.parent.end_x is not None:
-            parent_x = self.parent.end_x[-1]
+        elif self.parent is not None and self.parent.end_x is not None:
+            return self.parent.end_x[-1] + self._x[1:]
         else:
-            parent_x = 0*um
-        return parent_x + self._x[1:]
+            return self._x[1:]
 
     @property
     def end_y(self):
@@ -1853,11 +1849,10 @@ class Section(Morphology):
         '''
         if self._y is None:
             return None
-        if self.parent is not None and self.parent.end_y is not None:
-            parent_y = self.parent.end_y[-1]
+        elif self.parent is not None and self.parent.end_y is not None:
+            return self.parent.end_y[-1] + self._y[1:]
         else:
-            parent_y = 0*um
-        return parent_y + self._y[1:]
+            return self._y[1:]
 
     @property
     def end_z(self):
@@ -1867,11 +1862,10 @@ class Section(Morphology):
         '''
         if self._z is None:
             return None
-        if self.parent is not None and self.parent.end_z is not None:
-            parent_z = self.parent.end_z[-1]
+        elif self.parent is not None and self.parent.end_z is not None:
+            return self.parent.end_z[-1] + self._z[1:]
         else:
-            parent_z = 0*um
-        return parent_z + self._z[1:]
+            return self._z[1:]
 
 
 class Cylinder(Section):

--- a/brian2/spatialneuron/morphology.py
+++ b/brian2/spatialneuron/morphology.py
@@ -24,6 +24,27 @@ Node = namedtuple('Node',
                   field_names='index,comp_name,x,y,z,diameter,parent,children')
 
 
+def _to_meters(value):
+    '''
+    Helper function to convert a floating point value (or array) to a `Quantity`
+    in units of "meter", but also allow for ``None`` and return it as it is.
+    '''
+    if value is None:
+        return None
+    else:
+        return Quantity(value, dim=meter.dim)
+
+
+def _from_morphology(variable, i, j):
+    '''
+    Helper function to return coordinates from a main morphology (used by
+    `SubMorphology`), dealing with ``None``.
+    '''
+    if variable is None:
+        return None
+    return variable[i:j]
+
+
 class MorphologyIndexWrapper(object):
     '''
     A simpler version of `~brian2.groups.group.IndexWrapper`, not allowing for
@@ -744,11 +765,7 @@ class Morphology(object):
         The x coordinate at the beginning of each compartment. Returns ``None``
         for morphologies without coordinates.
         '''
-        start_x = self.start_x_
-        if start_x is None:
-            return None
-        else:
-            return Quantity(start_x, dim=meter.dim)
+        return _to_meters(self.start_x_)
 
     @property
     def start_y(self):
@@ -756,11 +773,7 @@ class Morphology(object):
         The y coordinate at the beginning of each compartment. Returns ``None``
         for morphologies without coordinates.
         '''
-        start_y = self.start_y_
-        if start_y is None:
-            return None
-        else:
-            return Quantity(start_y, dim=meter.dim)
+        return _to_meters(self.start_y_)
 
     @property
     def start_z(self):
@@ -768,11 +781,7 @@ class Morphology(object):
         The z coordinate at the beginning of each compartment. Returns ``None``
         for morphologies without coordinates.
         '''
-        start_z = self.start_z_
-        if start_z is None:
-            return None
-        else:
-            return Quantity(start_z, dim=meter.dim)
+        return _to_meters(self.start_z_)
 
     @abc.abstractproperty
     def start_x_(self):
@@ -807,11 +816,7 @@ class Morphology(object):
         The x coordinate at the midpoint of each compartment. Returns ``None``
         for morphologies without coordinates.
         '''
-        x = self.x_
-        if x is None:
-            return None
-        else:
-            return Quantity(x, dim=meter.dim)
+        return _to_meters(self.x_)
 
     @property
     def y(self):
@@ -819,11 +824,7 @@ class Morphology(object):
         The y coordinate at the midpoint of each compartment. Returns ``None``
         for morphologies without coordinates.
         '''
-        y = self.y_
-        if y is None:
-            return None
-        else:
-            return Quantity(y, dim=meter.dim)
+        return _to_meters(self.y_)
 
     @property
     def z(self):
@@ -831,11 +832,7 @@ class Morphology(object):
         The y coordinate at the midpoint of each compartment. Returns ``None``
         for morphologies without coordinates.
         '''
-        z = self.z_
-        if z is None:
-            return None
-        else:
-            return Quantity(z, dim=meter.dim)
+        return _to_meters(self.z_)
 
     @abc.abstractproperty
     def x_(self):
@@ -870,11 +867,7 @@ class Morphology(object):
         The x coordinate at the end of each compartment. Returns ``None``
         for morphologies without coordinates.
         '''
-        end_x = self.end_x_
-        if end_x is None:
-            return None
-        else:
-            return Quantity(end_x, dim=meter.dim)
+        return _to_meters(self.end_x_)
 
     @property
     def end_y(self):
@@ -882,11 +875,7 @@ class Morphology(object):
         The y coordinate at the end of each compartment. Returns ``None``
         for morphologies without coordinates.
         '''
-        end_y = self.end_y_
-        if end_y is None:
-            return None
-        else:
-            return Quantity(end_y, dim=meter.dim)
+        return _to_meters(self.end_y_)
 
     @property
     def end_z(self):
@@ -894,11 +883,7 @@ class Morphology(object):
         The z coordinate at the end of each compartment. Returns ``None``
         for morphologies without coordinates.
         '''
-        end_z = self.end_z_
-        if end_z is None:
-            return None
-        else:
-            return Quantity(end_z, dim=meter.dim)
+        return _to_meters(self.end_z_)
 
     @abc.abstractproperty
     def end_x_(self):
@@ -1378,11 +1363,7 @@ class SubMorphology(object):
         The x coordinate at the beginning of each compartment in this
         sub-section. Returns ``None`` for morphologies without coordinates.
         '''
-        start_x = self.start_x_
-        if start_x is None:
-            return None
-        else:
-            return Quantity(start_x, dim=meter.dim)
+        return _to_meters(self.start_x_)
 
     @property
     def start_y(self):
@@ -1390,11 +1371,7 @@ class SubMorphology(object):
         The y coordinate at the beginning of each compartment in this
         sub-section. Returns ``None`` for morphologies without coordinates.
         '''
-        start_y = self.start_y_
-        if start_y is None:
-            return None
-        else:
-            return Quantity(start_y, dim=meter.dim)
+        return _to_meters(self.start_y_)
 
     @property
     def start_z(self):
@@ -1402,11 +1379,7 @@ class SubMorphology(object):
         The x coordinate at the beginning of each compartment in this
         sub-section. Returns ``None`` for morphologies without coordinates.
         '''
-        start_z = self.start_z_
-        if start_z is None:
-            return None
-        else:
-            return Quantity(start_z, dim=meter.dim)
+        return _to_meters(self.start_z_)
 
     @property
     def start_x_(self):
@@ -1415,9 +1388,7 @@ class SubMorphology(object):
         of each compartment in this sub-section. Returns ``None`` for
         morphologies without coordinates.
         '''
-        if self._morphology.start_x_ is None:
-            return None
-        return self._morphology.start_x_[self._i:self._j]
+        return _from_morphology(self._morphology.start_x_, self._i, self._j)
 
     @property
     def start_y_(self):
@@ -1426,9 +1397,7 @@ class SubMorphology(object):
         of each compartment in this sub-section. Returns ``None`` for
         morphologies without coordinates.
         '''
-        if self._morphology.start_y_ is None:
-            return None
-        return self._morphology.start_y_[self._i:self._j]
+        return _from_morphology(self._morphology.start_y_, self._i, self._j)
 
     @property
     def start_z_(self):
@@ -1437,9 +1406,7 @@ class SubMorphology(object):
         of each compartment in this sub-section. Returns ``None`` for
         morphologies without coordinates.
         '''
-        if self._morphology.start_z_ is None:
-            return None
-        return self._morphology.start_z_[self._i:self._j]
+        return _from_morphology(self._morphology.start_z_, self._i, self._j)
 
     @property
     def x(self):
@@ -1447,11 +1414,7 @@ class SubMorphology(object):
         The x coordinate at the midpoint of each compartment in this
         sub-section. Returns ``None`` for morphologies without coordinates.
         '''
-        x = self.x_
-        if x is None:
-            return x
-        else:
-            return Quantity(x, dim=meter.dim)
+        return _to_meters(self.x_)
 
     @property
     def y(self):
@@ -1459,11 +1422,7 @@ class SubMorphology(object):
         The y coordinate at the midpoint of each compartment in this
         sub-section. Returns ``None`` for morphologies without coordinates.
         '''
-        y = self.y_
-        if y is None:
-            return y
-        else:
-            return Quantity(y, dim=meter.dim)
+        return _to_meters(self.y_)
 
     @property
     def z(self):
@@ -1471,11 +1430,7 @@ class SubMorphology(object):
         The z coordinate at the midpoint of each compartment in this
         sub-section. Returns ``None`` for morphologies without coordinates.
         '''
-        z = self.z_
-        if z is None:
-            return z
-        else:
-            return Quantity(z, dim=meter.dim)
+        return _to_meters(self.z_)
 
     @property
     def x_(self):
@@ -1484,9 +1439,7 @@ class SubMorphology(object):
         of each compartment in this sub-section. Returns ``None`` for
         morphologies without coordinates.
         '''
-        if self._morphology.x_ is None:
-            return None
-        return self._morphology.x_[self._i:self._j]
+        return _from_morphology(self._morphology.x_, self._i, self._j)
 
     @property
     def y_(self):
@@ -1495,9 +1448,7 @@ class SubMorphology(object):
         of each compartment in this sub-section. Returns ``None`` for
         morphologies without coordinates.
         '''
-        if self._morphology.y_ is None:
-            return None
-        return self._morphology.y_[self._i:self._j]
+        return _from_morphology(self._morphology.y_, self._i, self._j)
 
     @property
     def z_(self):
@@ -1506,9 +1457,7 @@ class SubMorphology(object):
         of each compartment in this sub-section. Returns ``None`` for
         morphologies without coordinates.
         '''
-        if self._morphology.z_ is None:
-            return None
-        return self._morphology.z_[self._i:self._j]
+        return _from_morphology(self._morphology.z_, self._i, self._j)
 
     @property
     def end_x(self):
@@ -1516,11 +1465,7 @@ class SubMorphology(object):
         The x coordinate at the end of each compartment in this sub-section.
         Returns ``None`` for morphologies without coordinates.
         '''
-        x = self.end_x_
-        if x is None:
-            return None
-        else:
-            return Quantity(x, dim=meter.dim)
+        return _to_meters(self.end_x_)
 
     @property
     def end_y(self):
@@ -1528,11 +1473,7 @@ class SubMorphology(object):
         The y coordinate at the end of each compartment in this sub-section.
         Returns ``None`` for morphologies without coordinates.
         '''
-        y = self.end_y_
-        if y is None:
-            return None
-        else:
-            return Quantity(y, dim=meter.dim)
+        return _to_meters(self.end_y_)
 
     @property
     def end_z(self):
@@ -1540,11 +1481,7 @@ class SubMorphology(object):
         The z coordinate at the end of each compartment in this sub-section.
         Returns ``None`` for morphologies without coordinates.
         '''
-        z = self.end_z_
-        if z is None:
-            return None
-        else:
-            return Quantity(z, dim=meter.dim)
+        return _to_meters(self.end_z_)
 
     @property
     def end_x_(self):
@@ -1553,9 +1490,7 @@ class SubMorphology(object):
         each compartment in this sub-section. Returns ``None`` for morphologies
         without coordinates.
         '''
-        if self._morphology.end_x is None:
-            return None
-        return self._morphology.end_x[self._i:self._j]
+        return _from_morphology(self._morphology.end_x_, self._i, self._j)
 
     @property
     def end_y_(self):
@@ -1564,9 +1499,7 @@ class SubMorphology(object):
         each compartment in this sub-section. Returns ``None`` for morphologies
         without coordinates.
         '''
-        if self._morphology.end_y is None:
-            return None
-        return self._morphology.end_y[self._i:self._j]
+        return _from_morphology(self._morphology.end_y_, self._i, self._j)
 
     @property
     def end_z_(self):
@@ -1575,9 +1508,7 @@ class SubMorphology(object):
         each compartment in this sub-section. Returns ``None`` for morphologies
         without coordinates.
         '''
-        if self._morphology.end_z is None:
-            return None
-        return self._morphology.end_z[self._i:self._j]
+        return _from_morphology(self._morphology.end_z_, self._i, self._j)
 
 
 class Soma(Morphology):

--- a/docs_sphinx/introduction/release_notes.rst
+++ b/docs_sphinx/introduction/release_notes.rst
@@ -19,6 +19,8 @@ Improvements and bug fixes
 * More consistent check of compatible time and dt values (#730).
 * Attempting to set a synaptic variable or to start a simulation with synapses
   without any preceding connect call now raises an error (#737).
+* Improve the performance of coordinate calculation for `Morphology` objects,
+  which previously made plotting very slow for complex morphologies (#741).
 
 Contributions
 ~~~~~~~~~~~~~


### PR DESCRIPTION
This fixes certain inefficiencies in the `Morphology` class. Coordinates are now internally stored without units (you can access the unitless coordinates using names with a trailing underscore) and a lot of unnecessary evaluations of (calculated) coordinates are removed. 

Plotting the morphology mentioned in brian-team/brian2tools#13 now takes 0.5s in 2D and 3.5s in 3D on my machine -- there's still room for improvement (also on the `brian2tools` side), but this is much better than "forever" :)

Closes #741 