### PR TITLE
[MRG] Support user-defined functions with boolean argument/return value

### DIFF
--- a/brian2/groups/group.py
+++ b/brian2/groups/group.py
@@ -861,9 +861,10 @@ class Group(VariableOwner, BrianObject):
 
         # Replace pure Python functions by a Functions object
         if callable(resolved) and not isinstance(resolved, Function):
-            resolved = Function(resolved, stateless=getattr(resolved,
-                                                            'stateless',
-                                                            False))
+            resolved = Function(resolved,
+                                arg_units=getattr(resolved, '_arg_units', None),
+                                return_unit=getattr(resolved, '_return_unit', None),
+                                stateless=getattr(resolved, 'stateless', False))
 
         if not isinstance(resolved, (Function, Variable)):
             # Wrap the value in a Constant object

--- a/brian2/tests/test_units.py
+++ b/brian2/tests/test_units.py
@@ -958,6 +958,19 @@ def test_check_units():
     # Should fail (returns volt)
     assert_raises(DimensionMismatchError, lambda: b_function(False))
 
+    @check_units(a=bool, b=1, result=bool)
+    def c_function(a, b):
+        if a:
+            return b > 0
+        else:
+            return b
+
+    assert c_function(True, 1)
+    assert not c_function(True, -1)
+    assert_raises(TypeError, c_function, 1, 1)
+    assert_raises(TypeError, c_function, 1*mV, 1)
+    assert_raises(TypeError, c_function, False, 1)
+
 
 @attr('codegen-independent')
 def test_get_unit():

--- a/brian2/units/fundamentalunits.py
+++ b/brian2/units/fundamentalunits.py
@@ -2468,7 +2468,10 @@ def check_units(**au):
             new_f._return_unit = None
         else:
             new_f._return_unit = return_unit
-
+        if return_unit == bool:
+            new_f._returns_bool = True
+        else:
+            new_f._returns_bool = False
         new_f._orig_arg_names = arg_names
 
         # copy any annotation attributes
@@ -2477,6 +2480,7 @@ def check_units(**au):
                 setattr(new_f, attrname, getattr(f, attrname))
         new_f._annotation_attributes = getattr(f, '_annotation_attributes', [])+['_arg_units',
                                                                                  '_return_unit',
-                                                                                 '_orig_func']
+                                                                                 '_orig_func',
+                                                                                 '_returns_bool']
         return new_f
     return do_check_units


### PR DESCRIPTION
It's a bit of a messy addition (we should do a bit of refactoring at some point, `parse_expression_unit` and `is_boolean_expression` could potentially be merged, treating "boolean" as a special unit as we do in other places), but I stumbled across this missing feature when documenting how to translate Brian 1's custom thresholds (defined by functions) to Brian 2. This was very cumbersome before this change since you could not define a boolean-returning function that actually gets recognized as such by the parsing system.