### PR TITLE
[MRG] Correct linear dependency check in SpatialNeuron

### DIFF
--- a/brian2/equations/equations.py
+++ b/brian2/equations/equations.py
@@ -639,16 +639,20 @@ class Equations(collections.Mapping):
         for name in self.names:
             Equations.check_identifier(name)
 
-    def get_substituted_expressions(self, variables=None):
+    def get_substituted_expressions(self, variables=None,
+                                    include_subexpressions=False):
         '''
         Return a list of ``(varname, expr)`` tuples, containing all
-        differential equations with all the subexpression variables
-        substituted with the respective expressions.
+        differential equations (and optionally subexpressions) with all the
+        subexpression variables substituted with the respective expressions.
 
         Parameters
         ----------
         variables : dict, optional
             A mapping of variable names to `Variable`/`Function` objects.
+        include_subexpressions : bool
+            Whether also to return substituted subexpressions. Defaults to
+            ``False``.
 
         Returns
         -------
@@ -671,6 +675,8 @@ class Equations(collections.Mapping):
 
             if eq.type == SUBEXPRESSION:
                 substitutions.update({sympy.Symbol(eq.varname, real=True): str_to_sympy(expr.code, variables)})
+                if include_subexpressions:
+                    subst_exprs.append((eq.varname, expr))
             elif eq.type == DIFFERENTIAL_EQUATION:
                 #  a differential equation that we have to check
                 subst_exprs.append((eq.varname, expr))

--- a/brian2/tests/test_spatialneuron.py
+++ b/brian2/tests/test_spatialneuron.py
@@ -574,7 +574,18 @@ def test_allowed_integration():
                       alphah = 0.07 * exp(-v/(20*mV))/ms : Hz
                       betah = 1/(exp((-v+30*mV) / (10*mV)) + 1)/ms : Hz''',
                    '''Im = gl * (El-v) : amp/meter**2
-                      I_ext = 1*nA + sin(2*pi*100*Hz*t)*nA : amp (point current)''']
+                      I_ext = 1*nA + sin(2*pi*100*Hz*t)*nA : amp (point current)''',
+                   '''Im = I_leak + I_spike : amp/meter**2
+                      I_leak = gL*(EL - v) : amp/meter**2
+                      I_spike = gL*DeltaT*exp((v - VT)/DeltaT): amp/meter**2 (constant over dt)
+                                        ''',
+                   '''
+                   Im = gL*(EL-v) : amp/meter**2
+                   I_NMDA = gNMDA*(ENMDA-v)*Mgblock : amp (point current)
+                   gNMDA : siemens
+                   Mgblock = 1./(1. +  exp(-0.062*v/mV)/3.57) : 1 (constant over dt)
+                   '''
+                   ]
     forbidden_eqs = ['Im = gL*(EL - v) + gL*DeltaT*exp((v - VT)/DeltaT) : amp/meter**2',
                      '''Im = I_leak + I_spike : amp/meter**2
                         I_leak = gL*(EL - v) : amp/meter**2
@@ -585,7 +596,8 @@ def test_allowed_integration():
                      I_NMDA = gNMDA*(ENMDA-v)*Mgblock : amp (point current)
                      gNMDA : siemens
                      Mgblock = 1./(1. +  exp(-0.062*v/mV)/3.57) : 1
-                     ''']
+                     '''
+                     ]
     for eqs in allowed_eqs:
         # Should not raise an error
         neuron = SpatialNeuron(morph, eqs)

--- a/brian2/tests/test_spatialneuron.py
+++ b/brian2/tests/test_spatialneuron.py
@@ -554,6 +554,47 @@ def test_basic_diffusion():
     run(0.25*ms)
     assert all(abs(mon.v[:, -1]/mV + 10) < 0.25), mon.v[:, -1]/mV
 
+
+@attr('codegen-independent')
+def test_allowed_integration():
+    morph = Soma(diameter=30 * um)
+    EL = -70 * mV
+    gL = 1e-4 * siemens / cm ** 2
+    ENa = 115 * mV
+    gNa = 120 * msiemens / cm ** 2
+    VT = -50.4 * mV
+    DeltaT = 2 * mV
+    ENMDA = 0. * mV
+    allowed_eqs = ['Im = gL*(EL-v) : amp/meter**2',
+                   '''Im = gl * (El-v) + gNa * m**3 * h * (ENa-v) : amp/meter**2
+                      dm/dt = alpham * (1-m) - betam * m : 1
+                      dh/dt = alphah * (1-h) - betah * h : 1
+                      alpham = (0.1/mV) * (-v+25*mV) / (exp((-v+25*mV) / (10*mV)) - 1)/ms : Hz
+                      betam = 4 * exp(-v/(18*mV))/ms : Hz
+                      alphah = 0.07 * exp(-v/(20*mV))/ms : Hz
+                      betah = 1/(exp((-v+30*mV) / (10*mV)) + 1)/ms : Hz''',
+                   '''Im = gl * (El-v) : amp/meter**2
+                      I_ext = 1*nA + sin(2*pi*100*Hz*t)*nA : amp (point current)''']
+    forbidden_eqs = ['Im = gL*(EL - v) + gL*DeltaT*exp((v - VT)/DeltaT) : amp/meter**2',
+                     '''Im = I_leak + I_spike : amp/meter**2
+                        I_leak = gL*(EL - v) : amp/meter**2
+                        I_spike = gL*DeltaT*exp((v - VT)/DeltaT): amp/meter**2
+                     ''',
+                     '''
+                     Im = gL*(EL-v) : amp/meter**2
+                     I_NMDA = gNMDA*(ENMDA-v)*Mgblock : amp (point current)
+                     gNMDA : siemens
+                     Mgblock = 1./(1. +  exp(-0.062*v/mV)/3.57) : 1
+                     ''']
+    for eqs in allowed_eqs:
+        # Should not raise an error
+        neuron = SpatialNeuron(morph, eqs)
+
+    for eqs in forbidden_eqs:
+        # Should raise an error
+        assert_raises(TypeError, SpatialNeuron, morph, eqs)
+
+
 if __name__ == '__main__':
     test_custom_events()
     test_construction()
@@ -565,3 +606,4 @@ if __name__ == '__main__':
     test_rallpack3()
     test_rall()
     test_basic_diffusion()
+    test_allowed_integration()

--- a/docs_sphinx/introduction/release_notes.rst
+++ b/docs_sphinx/introduction/release_notes.rst
@@ -21,6 +21,8 @@ Improvements and bug fixes
   without any preceding connect call now raises an error (#737).
 * Improve the performance of coordinate calculation for `Morphology` objects,
   which previously made plotting very slow for complex morphologies (#741).
+* Fix a bug in `SpatialNeuron` where it did not detect non-linear dependencies
+  on v, introduced via point currents (#743).
 
 Contributions
 ~~~~~~~~~~~~~
@@ -33,7 +35,9 @@ anyone we forgot...):
 
 * Chaofei Hong
 * Daniel Bliss
+* Jacopo Bono
 * Ruben Tikidji-Hamburyan
+
 
 Brian 2.0rc3
 ------------


### PR DESCRIPTION
This fixes #743, where `SpatialNeuron` did not detect a non-linear dependency on ``v`` when it was "hidden" in a point current. The code in `SpatialNeuron.__init__` is far from optimal, it mixes creating new equations from `SingleEquation` objects and from strings, this should be rewritten at some point... Still, this fixes the bug for now. I also enabled the `(constant over dt)`  flag for `SpatialNeuron`. This is quite important, since it is possible that some users cannot run their models with `SpatialNeuron` anymore now that it correctly detects a non-linearity in their equations. By marking the non-linear part as "constant over dt", everything should work again.