### PR TITLE
[MRG] Small refactoring to only ask for the platform information once

### DIFF
--- a/brian2/codegen/codeobject.py
+++ b/brian2/codegen/codeobject.py
@@ -2,6 +2,7 @@
 Module providing the base `CodeObject` and related functions.
 '''
 import copy
+import platform
 import weakref
 
 from brian2.core.names import Nameable
@@ -16,6 +17,12 @@ __all__ = ['CodeObject',
            'constant_or_scalar']
 
 logger = get_logger(__name__)
+
+
+#: Dictionary with basic information about the current system (OS, etc.)
+sys_info = {'system': platform.system(),
+            'architecture': platform.architecture(),
+            'machine': platform.machine()}
 
 
 def constant_or_scalar(varname, variable):

--- a/brian2/codegen/cpp_prefs.py
+++ b/brian2/codegen/cpp_prefs.py
@@ -11,6 +11,7 @@ from distutils.ccompiler import get_default_compiler
 from cpuinfo import cpuinfo
 
 from brian2.core.preferences import prefs, BrianPreference
+from .codeobject import sys_info
 
 __all__ = ['get_compiler_and_args']
 
@@ -142,3 +143,38 @@ def get_compiler_and_args():
         if compiler == 'msvc':
             extra_compile_args = prefs['codegen.cpp.extra_compile_args_msvc']
     return compiler, extra_compile_args
+
+
+def update_for_cross_compilation(library_dirs, extra_compile_args,
+                                 extra_link_args, logger=None):
+    '''
+    Update the compiler arguments to allow cross-compilation for 32bit on a
+    64bit Linux system. Uses the provided ``logger`` to print an INFO message
+    and modifies the provided lists in-place.
+
+    Parameters
+    ----------
+    library_dirs : list
+        List of library directories (will be modified in-place).
+    extra_compile_args : list
+        List of extra compile args (will be modified in-place).
+    extra_link_args : list
+        List of extra link args (will be modified in-place).
+    logger : `BrianLogger`, optional
+        The logger to use for the INFO message. Defaults to ``None`` (no
+        message).
+    '''
+    if (sys_info['system'] == 'Linux' and
+                sys_info['architecture'][0] == '32bit' and
+                sys_info['machine'] == 'x86_64'):
+        # We are cross-compiling to 32bit on a 64bit platform
+        if logger is not None:
+            logger.info('Cross-compiling to 32bit on a 64bit platform, a set '
+                        'of standard compiler options will be appended for '
+                        'this purpose (note that you need to have a 32bit '
+                        'version of the standard library for this to work).',
+                        '64bit_to_32bit',
+                        once=True)
+        library_dirs += ['/lib32', '/usr/lib32']
+        extra_compile_args += ['-m32']
+        extra_link_args += ['-m32']

--- a/brian2/codegen/runtime/cython_rt/cython_rt.py
+++ b/brian2/codegen/runtime/cython_rt/cython_rt.py
@@ -73,8 +73,8 @@ class CythonCodeObject(NumpyCodeObject):
         self.runtime_library_dirs = list(prefs['codegen.cpp.runtime_library_dirs'])
         self.libraries = list(prefs['codegen.cpp.libraries'])
 
-    @staticmethod
-    def is_available():
+    @classmethod
+    def is_available(cls):
         try:
             compiler, extra_compile_args = get_compiler_and_args()
             code = '''

--- a/brian2/codegen/runtime/cython_rt/extension_manager.py
+++ b/brian2/codegen/runtime/cython_rt/extension_manager.py
@@ -6,9 +6,9 @@ https://github.com/ipython/ipython/blob/master/IPython/extensions/cythonmagic.py
 '''
 import imp
 import os
-import platform
 import sys
 import time
+
 try:
     import msvcrt
 except ImportError:
@@ -31,6 +31,7 @@ try:
 except ImportError:
     Cython = None
 
+from brian2.codegen.cpp_prefs import update_for_cross_compilation
 from brian2.utils.logger import std_silent, get_logger
 from brian2.utils.stringtools import deindent
 from brian2.core.preferences import prefs
@@ -188,19 +189,9 @@ class CythonExtensionManager(object):
             #    f.write(code)
             open(pyx_file, 'w').write(code)
 
-            if (platform.system() == 'Linux' and
-                        platform.architecture()[0] == '32bit' and
-                        platform.machine() == 'x86_64'):
-                # We are cross-compiling to 32bit on a 64bit platform
-                logger.info('Cross-compiling to 32bit on a 64bit platform, a set '
-                            'of standard compiler options will be appended for '
-                            'this purpose (note that you need to have a 32bit '
-                            'version of the standard library for this to work).',
-                            '64bit_to_32bit',
-                            once=True)
-                library_dirs += ['/lib32', '/usr/lib32']
-                extra_compile_args += ['-m32']
-                extra_link_args += ['-m32']
+            update_for_cross_compilation(library_dirs,
+                                         extra_compile_args,
+                                         extra_link_args, logger=logger)
 
             extension = Extension(
                 name=module_name,

--- a/brian2/codegen/runtime/numpy_rt/numpy_rt.py
+++ b/brian2/codegen/runtime/numpy_rt/numpy_rt.py
@@ -54,8 +54,8 @@ class NumpyCodeObject(CodeObject):
                             template_name, template_source, name=name)
         self.variables_to_namespace()
 
-    @staticmethod
-    def is_available():
+    @classmethod
+    def is_available(cls):
         # no test necessary for numpy
         return True
 

--- a/brian2/tests/test_parsing.py
+++ b/brian2/tests/test_parsing.py
@@ -2,13 +2,13 @@
 Tests the brian2.parsing package
 '''
 from collections import namedtuple
-import platform
 
 from nose.plugins.attrib import attr
 from nose import SkipTest
 from numpy.testing import assert_allclose, assert_raises
 import numpy as np
 
+from brian2.codegen.cpp_prefs import update_for_cross_compilation
 from brian2.codegen.generators.cpp_generator import CPPCodeGenerator
 from brian2.codegen.runtime.weave_rt.weave_rt import get_compiler_and_args
 from brian2.core.preferences import prefs
@@ -124,13 +124,9 @@ def cpp_evaluator(expr, ns):
     compiler, extra_compile_args = get_compiler_and_args()
     library_dirs = prefs['codegen.cpp.library_dirs']
     extra_link_args = prefs['codegen.cpp.extra_link_args']
-    if (platform.system() == 'Linux' and
-                platform.architecture()[0] == '32bit' and
-                platform.machine() == 'x86_64'):
-        # TODO: This should be refactored, it is repeated in several places
-        library_dirs += ['/lib32', '/usr/lib32']
-        extra_compile_args += ['-m32']
-        extra_link_args += ['-m32']
+    update_for_cross_compilation(library_dirs,
+                                 extra_compile_args,
+                                 extra_link_args)
     with std_silent():
         return weave.inline('return_val = %s;' % expr, ns.keys(), local_dict=ns,
                             support_code=CPPCodeGenerator.universal_support_code,


### PR DESCRIPTION
It's a small refactoring change, but we were duplicating some code to enable 64bit->32bit cross-compilation in several places. It also turns out that getting the platform information is somewhat costly (at least on my machine) -- it's only a couple of milliseconds but in the previous code it was asking for this information again and again for each `CodeObject` creation. In a small test with a simulation that included many short `run` statements in a loop (far from optimal with current Brian 2...), this made actually a significant performance difference!