### PR TITLE
[MRG] Warn about unstable integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -133,6 +133,9 @@ install:
     conda create -n travis_conda --yes --quiet pip python=$PYTHON numpy scipy nose sphinx ipython sympy pyparsing jinja2 setuptools coverage;
     fi
   - source activate travis_conda
+  - if [ ${PYTHON:0:1} == "2" ]; then
+    conda install --yes --quiet bsddb;  # makes weave code generation much faster
+    fi
   - conda install --yes --quiet -c brian-team py-cpuinfo  # install cpuinfo from our own channel
   - if [[ $CYTHON == 'yes' ]]; then conda install --yes cython; SETUP_ARGS=--with-cython; else SETUP_ARGS=''; fi
   - if [[ $REPORT_COVERAGE == 'yes' ]]; then pip install -q coveralls; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -133,8 +133,9 @@ install:
     conda create -n travis_conda --yes --quiet pip python=$PYTHON numpy scipy nose sphinx ipython sympy pyparsing jinja2 setuptools coverage;
     fi
   - source activate travis_conda
+  # makes weave code generation much faster:
   - if [ ${PYTHON:0:1} == "2" ]; then
-    conda install --yes --quiet bsddb;  # makes weave code generation much faster
+    conda install --yes --quiet bsddb;
     fi
   - conda install --yes --quiet -c brian-team py-cpuinfo  # install cpuinfo from our own channel
   - if [[ $CYTHON == 'yes' ]]; then conda install --yes cython; SETUP_ARGS=--with-cython; else SETUP_ARGS=''; fi

--- a/brian2/codegen/cpp_prefs.py
+++ b/brian2/codegen/cpp_prefs.py
@@ -56,7 +56,7 @@ prefs.register_preferences(
         '''
         ),
     extra_compile_args_msvc=BrianPreference(
-        default=['/Ox', '/w', '/fp:fast', msvc_arch_flag],
+        default=['/Ox', '/w', msvc_arch_flag],
         docs='''
         Extra compile arguments to pass to MSVC compiler (the default
         ``/arch:`` flag is determined based on the processor architecture)

--- a/brian2/codegen/cpp_prefs.py
+++ b/brian2/codegen/cpp_prefs.py
@@ -56,7 +56,7 @@ prefs.register_preferences(
         '''
         ),
     extra_compile_args_msvc=BrianPreference(
-        default=['/Ox', '/EHsc', '/w', '/fp:fast', msvc_arch_flag],
+        default=['/Ox', '/w', '/fp:fast', msvc_arch_flag],
         docs='''
         Extra compile arguments to pass to MSVC compiler (the default
         ``/arch:`` flag is determined based on the processor architecture)

--- a/brian2/codegen/cpp_prefs.py
+++ b/brian2/codegen/cpp_prefs.py
@@ -50,7 +50,7 @@ prefs.register_preferences(
         '''
         ),
     extra_compile_args_gcc=BrianPreference(
-        default=['-w', '-O3', '-ffast-math', '-march=native'],
+        default=['-w', '-O3', '-ffast-math', '-fno-finite-math-only', '-march=native'],
         docs='''
         Extra compile arguments to pass to GCC compiler
         '''

--- a/brian2/core/network.py
+++ b/brian2/core/network.py
@@ -18,6 +18,7 @@ from brian2.core.names import Nameable
 from brian2.core.base import BrianObject, brian_object_exception
 from brian2.core.clocks import Clock, defaultclock
 from brian2.devices.device import device
+from brian2.groups.group import Group
 from brian2.units.fundamentalunits import check_units, Quantity
 from brian2.units.allunits import second, msecond
 from brian2.core.preferences import prefs, BrianPreference
@@ -888,6 +889,11 @@ class Network(Nameable):
             logger.debug('\n' + str(profiling_summary(self)))
         else:
             self._profiling_info = None
+
+        # check for nans
+        for obj in self.objects:
+            if isinstance(obj, Group):
+                obj._check_for_invalid_states()
 
     @device_override('network_stop')
     def stop(self):

--- a/brian2/core/network.py
+++ b/brian2/core/network.py
@@ -874,6 +874,11 @@ class Network(Nameable):
         else:
             device._last_run_completed_fraction = 1.0
 
+        # check for nans
+        for obj in self.objects:
+            if isinstance(obj, Group):
+                obj._check_for_invalid_states()
+
         if report is not None:
             report_callback((end_time-start_time)*second, 1.0, t_start, duration)
         self.after_run()
@@ -889,11 +894,6 @@ class Network(Nameable):
             logger.debug('\n' + str(profiling_summary(self)))
         else:
             self._profiling_info = None
-
-        # check for nans
-        for obj in self.objects:
-            if isinstance(obj, Group):
-                obj._check_for_invalid_states()
 
     @device_override('network_stop')
     def stop(self):

--- a/brian2/core/variables.py
+++ b/brian2/core/variables.py
@@ -371,7 +371,7 @@ class AuxiliaryVariable(Variable):
                                                 scalar=scalar)
 
     def get_value(self):
-        raise TypeError('Cannot get the value for an auxiliary variable.')
+        raise TypeError('Cannot get the value for an auxiliary variable (%s).' % self.name)
 
 
 class ArrayVariable(Variable):

--- a/brian2/devices/cpp_standalone/device.py
+++ b/brian2/devices/cpp_standalone/device.py
@@ -415,9 +415,9 @@ class CPPStandaloneDevice(Device):
                     if var.size[0] * var.size[1] == len(data):
                         size = var.size
                     elif var.size[0] == 0:
-                        size = (len(data)/var.size[1], var.size[1])
-                    elif var.size[0] == 0:
-                        size = (var.size[0], len(data)/var.size[0])
+                        size = (len(data)//var.size[1], var.size[1])
+                    elif var.size[1] == 0:
+                        size = (var.size[0], len(data)//var.size[0])
                     else:
                         raise IndexError(('Do not now how to deal with 2d '
                                           'array of size %s, the array on disk '

--- a/brian2/devices/cpp_standalone/device.py
+++ b/brian2/devices/cpp_standalone/device.py
@@ -407,6 +407,8 @@ class CPPStandaloneDevice(Device):
                                      self.get_array_filename(var))
                 with open(fname, 'rb') as f:
                     data = np.fromfile(f, dtype=dtype)
+                # check if there are any nan or other invalid values and warn if so
+                var.owner._check_for_invalid_values(var.name, data)
                 # This is a bit of an heuristic, but our 2d dynamic arrays are
                 # only expanding in one dimension, we assume here that the
                 # other dimension has size 0 at the beginning

--- a/brian2/devices/cpp_standalone/device.py
+++ b/brian2/devices/cpp_standalone/device.py
@@ -408,10 +408,6 @@ class CPPStandaloneDevice(Device):
                                      self.get_array_filename(var))
                 with open(fname, 'rb') as f:
                     data = np.fromfile(f, dtype=dtype)
-                # check if there are any nan or other invalid values and warn if so
-                if hasattr(var, 'owner') and isinstance(var.owner, Group):
-                    var.owner._check_for_invalid_values(var.name, data,
-                                                        only_if_has_state_updater=True)
                 # This is a bit of an heuristic, but our 2d dynamic arrays are
                 # only expanding in one dimension, we assume here that the
                 # other dimension has size 0 at the beginning
@@ -853,6 +849,13 @@ class CPPStandaloneDevice(Device):
             if os.path.isfile('results/last_run_info.txt'):
                 last_run_info = open('results/last_run_info.txt', 'r').read()
                 self._last_run_time, self._last_run_completed_fraction = map(float, last_run_info.split())
+
+        # Make sure that integration did not create NaN or very large values
+        owners = [var.owner for var in self.arrays
+                  if isinstance(var.owner, Group)]
+        for owner in owners:
+            owner._check_for_invalid_states()
+
 
     def build(self, directory='output',
               compile=True, run=True, debug=False, clean=True,

--- a/brian2/devices/cpp_standalone/device.py
+++ b/brian2/devices/cpp_standalone/device.py
@@ -22,6 +22,7 @@ from brian2.core.network import Network
 from brian2.devices.device import Device, all_devices, set_device, reset_device
 from brian2.core.variables import *
 from brian2.core.namespace import get_local_namespace
+from brian2.groups.group import Group
 from brian2.parsing.rendering import CPPNodeRenderer
 from brian2.synapses.synapses import Synapses
 from brian2.core.preferences import prefs, BrianPreference
@@ -408,7 +409,9 @@ class CPPStandaloneDevice(Device):
                 with open(fname, 'rb') as f:
                     data = np.fromfile(f, dtype=dtype)
                 # check if there are any nan or other invalid values and warn if so
-                var.owner._check_for_invalid_values(var.name, data)
+                if hasattr(var, 'owner') and isinstance(var.owner, Group):
+                    var.owner._check_for_invalid_values(var.name, data,
+                                                        only_if_has_state_updater=True)
                 # This is a bit of an heuristic, but our 2d dynamic arrays are
                 # only expanding in one dimension, we assume here that the
                 # other dimension has size 0 at the beginning

--- a/brian2/groups/group.py
+++ b/brian2/groups/group.py
@@ -954,9 +954,7 @@ class Group(VariableOwner, BrianObject):
         warning if so.
         '''
         v = np.asarray(v)
-        # Large value check has to be >1e100 because the period of SpikeGeneratorGroup is
-        # by default set to 1e100
-        if np.isnan(v).any() or (np.logical_and(np.abs(v) > 1e150, np.isfinite(v))).any():
+        if np.isnan(v).any() or np.abs(v) > 1e50:
             logger.warn(("{name}'s variable '{k}' has NaN, very large values, "
                          "or encountered an error in numerical integration. "
                          "This is usually a sign that an unstable or invalid "

--- a/brian2/groups/group.py
+++ b/brian2/groups/group.py
@@ -958,6 +958,8 @@ class Group(VariableOwner, BrianObject):
                          "integration method "
                          "was chosen.").format(name=self.name),
                         name_suffix="invalid_values", once=True)
+            # Turn this on to search for errors
+            #raise ValueError("nan for {name}.{k} = {v}".format(name=self.name, k=k, v=v))
 
 
 class CodeRunner(BrianObject):

--- a/brian2/groups/group.py
+++ b/brian2/groups/group.py
@@ -936,18 +936,28 @@ class Group(VariableOwner, BrianObject):
         self.contained_objects.append(runner)
         return runner
 
-    def _check_for_invalid_states(self):
+    def _check_for_invalid_states(self, only_if_has_state_updater=True):
         '''
         Checks if any state variables have invalid values, and logs a warning if so.
         '''
+        if only_if_has_state_updater:
+            if not hasattr(self, 'state_updater'):
+                return
+            if self.state_updater is None:
+                return
         state = self.get_states()
         for k, v in state.iteritems():
             self._check_for_invalid_values(k, v)
 
-    def _check_for_invalid_values(self, k, v):
+    def _check_for_invalid_values(self, k, v, only_if_has_state_updater=False):
         '''
         Checks if variable named k value v has invalid values, and logs a warning if so.
         '''
+        if only_if_has_state_updater:
+            if not hasattr(self, 'state_updater'):
+                return
+            if self.state_updater is None:
+                return
         v = np.asarray(v)
         # Large value check has to be >1e100 because the period of SpikeGeneratorGroup is
         # by default set to 1e100

--- a/brian2/groups/group.py
+++ b/brian2/groups/group.py
@@ -954,7 +954,7 @@ class Group(VariableOwner, BrianObject):
         warning if so.
         '''
         v = np.asarray(v)
-        if np.isnan(v).any() or np.abs(v) > 1e50:
+        if np.isnan(v).any() or (np.abs(v) > 1e50).any():
             logger.warn(("{name}'s variable '{k}' has NaN, very large values, "
                          "or encountered an error in numerical integration. "
                          "This is usually a sign that an unstable or invalid "
@@ -962,6 +962,7 @@ class Group(VariableOwner, BrianObject):
                          "chosen.").format(name=self.name,
                                            k=k),
                         name_suffix="invalid_values", once=True)
+
 
 class CodeRunner(BrianObject):
     '''

--- a/brian2/groups/group.py
+++ b/brian2/groups/group.py
@@ -932,6 +932,34 @@ class Group(VariableOwner, BrianObject):
         self.contained_objects.append(runner)
         return runner
 
+    def _check_for_invalid_states(self):
+        '''
+        Checks if any state variables have invalid values, and logs a warning if so.
+        '''
+        # This is a nasty hack, would be better to find a real solution
+        # try:
+        #     state = self.get_states()
+        # except TypeError: # this is to avoid the "cannot get values of auxiliary variable" error
+        #     return
+        state = self.get_states()
+        for k, v in state.iteritems():
+            self._check_for_invalid_values(k, v)
+
+    def _check_for_invalid_values(self, k, v):
+        '''
+        Checks if variable named k value v has invalid values, and logs a warning if so.
+        '''
+        v = np.asarray(v)
+        # Large value check has to be >1e100 because the period of SpikeGeneratorGroup is by default
+        # set to 1e100
+        if np.isnan(v).any() or (np.logical_and(np.abs(v) > 1e150, np.isfinite(v))).any():
+            logger.warn(("{name} has nan, very large values, or encountered "
+                         "an error in numerical integration. This is "
+                         "usually a sign that an unstable or invalid "
+                         "integration method "
+                         "was chosen.").format(name=self.name),
+                        name_suffix="invalid_values", once=True)
+
 
 class CodeRunner(BrianObject):
     '''

--- a/brian2/parsing/expressions.py
+++ b/brian2/parsing/expressions.py
@@ -298,8 +298,6 @@ def parse_expression_unit(expr, variables):
             # Function always returns the same unit
             return get_unit_fast(func._return_unit)
         else:
-            print "func is", func
-            print 'func._return_unit is', func._return_unit
             # Function returns a unit that depends on the arguments
             arg_units = [parse_expression_unit(arg, variables)
                          for arg in expr.args]

--- a/brian2/tests/test_stateupdaters.py
+++ b/brian2/tests/test_stateupdaters.py
@@ -688,19 +688,20 @@ def test_refractory_stochastic():
 @attr('standalone-compatible')
 @with_setup(teardown=reinit_devices)
 def test_check_for_invalid_values_linear_integrator():
-    # Check 1: a differential equation that cannot be solved by the linear
+    # A differential equation that cannot be solved by the linear
     # integrator should return nan values to warn the user, and not silently
     # return incorrect values. See discussion on
     # https://github.com/brian-team/brian2/issues/626
-    a = 0.0 / second
-    b = 1.0 / second
-    c = -0.5 / second
-    d = -0.1 / second
+    a = 0.0 / ms
+    b = 1.0 / ms
+    c = -0.5 / ms
+    d = -0.1 / ms
     eqs = '''
     dx/dt = a * x + b * y : 1
     dy/dt = c * x + d * y : 1
     '''
-    G = NeuronGroup(1, eqs, threshold='x>100', reset='x = 0; y = 0;', method='linear')
+    G = NeuronGroup(1, eqs, method='linear')
+    G.x = 1
     BrianLogger._log_messages.clear() # because the log message is set to be shown only once
     with catch_logs() as clog:
         run(1*ms)
@@ -709,21 +710,7 @@ def test_check_for_invalid_values_linear_integrator():
         if numpy.isnan(G.x[0]):
             assert 'invalid_values' in repr(clog)
         else:
-            assert G.x[0]!=0
-
-@attr('standalone-compatible')
-@with_setup(teardown=reinit_devices)
-def test_check_for_invalid_values_function():
-    # Check 2: in any case, doing operations like sqrt(-1) should give nans that
-    # get caught
-    G = NeuronGroup(1, 'v:1')
-    G.v = '-1'
-    G.v = 'sqrt(v)'
-    BrianLogger._log_messages.clear() # because the log message is set to be shown only once
-    with catch_logs() as clog:
-        run(1*ms)
-        assert numpy.isnan(G.v[0])
-        assert 'invalid_values' in repr(clog)
+            assert G.x[0] != 0
 
 
 if __name__ == '__main__':
@@ -759,5 +746,4 @@ if __name__ == '__main__':
     test_refractory_stochastic()
     restore_randn()
     test_check_for_invalid_values_linear_integrator()
-    test_check_for_invalid_values_function()
     print 'Tests took', time.time()-start

--- a/brian2/tests/test_stateupdaters.py
+++ b/brian2/tests/test_stateupdaters.py
@@ -700,7 +700,7 @@ def test_check_for_invalid_values_linear_integrator():
     dx/dt = a * x + b * y : 1
     dy/dt = c * x + d * y : 1
     '''
-    G = NeuronGroup(1, eqs, method='linear')
+    G = NeuronGroup(1, eqs, threshold='x > 100', reset='x = 0', method='linear')
     G.x = 1
     BrianLogger._log_messages.clear() # because the log message is set to be shown only once
     with catch_logs() as clog:

--- a/brian2/tests/test_stateupdaters.py
+++ b/brian2/tests/test_stateupdaters.py
@@ -686,6 +686,7 @@ def test_refractory_stochastic():
                                  'differ for method %s.') % method)
 
 @attr('standalone-compatible')
+@with_setup(teardown=reinit_devices)
 def test_check_for_invalid_values_linear_integrator():
     # Check 1: a differential equation that cannot be solved by the linear
     # integrator should return nan values to warn the user, and not silently
@@ -711,6 +712,7 @@ def test_check_for_invalid_values_linear_integrator():
             assert G.x[0]!=0
 
 @attr('standalone-compatible')
+@with_setup(teardown=reinit_devices)
 def test_check_for_invalid_values_function():
     # Check 2: in any case, doing operations like sqrt(-1) should give nans that
     # get caught


### PR DESCRIPTION
This isn't quite ready yet, but the basic ideas are there. Would be interested if you took a look and gave me some feedback @mstimberg.

The first thing is that by changing the default compiler options for MSVC we avoid the problem reported in #626 (see discussion there).

The next thing is that after a run, or on loading a state variable from disk, we check for nans or large values and warn if we find any. Currently, this isn't passing tests because it keeps raising the following error:

```
ERROR: brian2.tests.test_stateupdaters.test_refractory_stochastic
----------------------------------------------------------------------
Traceback (most recent call last):
  File "C:\Anaconda\lib\site-packages\nose\case.py", line 197, in runTest
    self.test(*self.arg)
  File "C:\programming\brian2\brian2\tests\test_stateupdaters.py", line 683, in test_refractory_stochastic
    net.run(10*ms)
  File "C:\programming\brian2\brian2\core\base.py", line 278, in device_override_decorated_function
    return func(*args, **kwds)
  File "C:\programming\brian2\brian2\units\fundamentalunits.py", line 2424, in new_f
    result = f(*args, **kwds)
  File "C:\programming\brian2\brian2\core\network.py", line 896, in run
    obj._check_for_invalid_states()
  File "C:\programming\brian2\brian2\groups\group.py", line 943, in _check_for_invalid_states
    #     return
  File "C:\programming\brian2\brian2\groups\group.py", line 522, in get_states
    data = ImportExport.methods[format].export_data(self, vars, units=units, level=level)
  File "C:\programming\brian2\brian2\importexport\dictlike.py", line 22, in export_data
    level=level+1),
  File "C:\programming\brian2\brian2\groups\neurongroup.py", line 516, in state
    return Group.state(self, name, use_units=use_units, level=level+1)
  File "C:\programming\brian2\brian2\groups\group.py", line 349, in state
    return var.get_addressable_value_with_unit(name=name, group=self)
  File "C:\programming\brian2\brian2\core\variables.py", line 256, in get_addressable_value_with_unit
    return self.get_value_with_unit()
  File "C:\programming\brian2\brian2\core\variables.py", line 208, in get_value_with_unit
    return Quantity(self.get_value(), self.unit.dimensions)
  File "C:\programming\brian2\brian2\core\variables.py", line 374, in get_value
    raise TypeError('Cannot get the value for an auxiliary variable.')
TypeError: Cannot get the value for an auxiliary variable.
```

It seems this error is just being raised by calling ``get_states()`` on certain types of object.

The check for "large" values is ``abs(v)>1e150`` - I chose this value because SpikeGeneratorGroup has a period of 1e100. However, we could reduce the size of the default period instead of having such a massive threshold for "too large" values. A value of 1e50 seems like it would be better, since the largest SI prefix is 1e24.

Might also be worth adding some tests, and checking performance implications of this test.

Fixes #554