### PR TITLE
[MRG] Define `spike_number` as its own index in `SpikeGeneratorGroup`

### DIFF
--- a/brian2/input/spikegeneratorgroup.py
+++ b/brian2/input/spikegeneratorgroup.py
@@ -120,7 +120,7 @@ class SpikeGeneratorGroup(Group, CodeRunner, SpikeSource):
                                          values=np.arange(len(indices)),
                                          size=len(indices), unit=Unit(1),
                                          dtype=np.int32, read_only=True,
-                                         constant=True,
+                                         constant=True, index='spike_number',
                                          unique=True)
         self.variables.add_dynamic_array('neuron_index', values=indices,
                                          size=len(indices), unit=Unit(1),


### PR DESCRIPTION
This avoids that it is indexed with the default index and therefore with the size of the group (which is the number of "neurons", not spikes)
Fixes #752