### PR TITLE
[MRG] Re-enable the warning about a missing `refractory` argument

### DIFF
--- a/brian2/groups/neurongroup.py
+++ b/brian2/groups/neurongroup.py
@@ -750,10 +750,13 @@ class NeuronGroup(Group, SpikeSource):
 
         # Add the conditional-write attribute for variables with the
         # "unless refractory" flag
-        for eq in self.equations.itervalues():
-            if eq.type == DIFFERENTIAL_EQUATION and 'unless refractory' in eq.flags:
-                not_refractory_var = self.variables['not_refractory']
-                self.variables[eq.varname].set_conditional_write(not_refractory_var)
+        if self._refractory is not False:
+            for eq in self.equations.itervalues():
+                if (eq.type == DIFFERENTIAL_EQUATION and
+                            'unless refractory' in eq.flags):
+                    not_refractory_var = self.variables['not_refractory']
+                    var = self.variables[eq.varname]
+                    var.set_conditional_write(not_refractory_var)
 
         # Stochastic variables
         for xi in self.equations.stochastic_variables:

--- a/brian2/tests/test_refractory.py
+++ b/brian2/tests/test_refractory.py
@@ -1,3 +1,4 @@
+from brian2.utils.logger import catch_logs
 from nose import with_setup
 from nose.plugins.attrib import attr
 from numpy.testing.utils import assert_equal, assert_allclose, assert_raises
@@ -19,6 +20,17 @@ def test_add_refractoriness():
     # Check that the parameters were added
     assert 'not_refractory' in eqs
     assert 'lastspike' in eqs
+
+
+@attr('codegen-independent')
+def test_missing_refractory_warning():
+    # Forgotten refractory argument
+    with catch_logs() as l:
+        group = NeuronGroup(1, 'dv/dt = -v / (10*ms) : 1 (unless refractory)',
+                            threshold='v > 1', reset='v = 0')
+    assert len(l) == 1
+    assert l[0][0] == 'WARNING' and l[0][1].endswith('no_refractory')
+
 
 @attr('standalone-compatible')
 @with_setup(teardown=reinit_devices)
@@ -201,6 +213,7 @@ def test_conditional_write_automatic_and_manual():
 
 if __name__ == '__main__':
     test_add_refractoriness()
+    test_missing_refractory_warning()
     test_refractoriness_variables()
     test_refractoriness_threshold()
     test_refractoriness_types()


### PR DESCRIPTION
It turned out #764 was a regression, the `KeyError` was raised before the warning we already had in place. This commit fixes this and adds a test for the presence of the warning.

A general remark: I activated the new "review required" feature that github introduced recently. Instead of just commenting and saying "good to merge", we can now do an official review and set the status -- let's see how this goes!
Not relevant for the current PR:= but github also has a new nice "rebase and merge" feature, we should try this when a branch got outdated by other merges, this should make our development history easier to follow.