### PR TITLE
[MRG] Add sys.prefix/lib to the library dir in C++ compilation

### DIFF
--- a/brian2/codegen/cpp_prefs.py
+++ b/brian2/codegen/cpp_prefs.py
@@ -82,6 +82,9 @@ prefs.register_preferences(
         default=[],
         docs='''
         List of directories to search for C/C++ libraries at link time.
+        Note that ``$prefix/lib`` will be appended to the end automatically,
+        where ``$prefix`` is Python's site-specific directory prefix as returned
+        by `sys.prefix`.
         '''
     ),
     runtime_library_dirs=BrianPreference(

--- a/brian2/codegen/runtime/weave_rt/weave_rt.py
+++ b/brian2/codegen/runtime/weave_rt/weave_rt.py
@@ -105,6 +105,7 @@ class WeaveCodeObject(CodeObject):
         synapses_dir = os.path.dirname(synapses.__file__)
         self.include_dirs.append(synapses_dir)
         self.library_dirs = list(prefs['codegen.cpp.library_dirs'])
+        self.library_dirs += [os.path.join(sys.prefix, 'lib')]
         update_for_cross_compilation(self.library_dirs,
                                      self.extra_compile_args,
                                      self.extra_link_args, logger=logger)

--- a/brian2/devices/cpp_standalone/device.py
+++ b/brian2/devices/cpp_standalone/device.py
@@ -949,14 +949,18 @@ class CPPStandaloneDevice(Device):
         compiler, extra_compile_args = get_compiler_and_args()
         compiler_obj = ccompiler.new_compiler(compiler=compiler)
         compiler_flags = (ccompiler.gen_preprocess_options(prefs['codegen.cpp.define_macros'],
-                                                           prefs['codegen.cpp.include_dirs']+['brianlib/randomkit']) +
+                                                           prefs['codegen.cpp.include_dirs'] +
+                                                           ['brianlib/randomkit'] +
+                                                           [sys.prefix+'/include']) +
                           extra_compile_args)
-        if sys.platform=='win32':
+        if sys.platform == 'win32':
             wincrypt = ['advapi32']
         else:
             wincrypt = []
         linker_flags = (ccompiler.gen_lib_options(compiler_obj,
-                                                  library_dirs=prefs['codegen.cpp.library_dirs']+['brianlib/randomkit'],
+                                                  library_dirs=prefs['codegen.cpp.library_dirs'] +
+                                                               ['brianlib/randomkit'] +
+                                                               [sys.prefix+'/lib'],
                                                   runtime_library_dirs=prefs['codegen.cpp.runtime_library_dirs'],
                                                   libraries=prefs['codegen.cpp.libraries']+wincrypt) +
                         prefs['codegen.cpp.extra_link_args'])


### PR DESCRIPTION
This is necessary for linking with C libraries installed via anaconda

It shouldn't hurt when not using anaconda (at least from the Linux perspective): `sys.prefix` for the standard system Python is `/usr`, which means that we'd add `/usr/include` and `/usr/lib` to the include/library paths -- but they are checked by default, anyway.