### PR TITLE
[MRG] Check units in PoissonGroup rates defined by strings

### DIFF
--- a/brian2/tests/test_poissongroup.py
+++ b/brian2/tests/test_poissongroup.py
@@ -1,4 +1,4 @@
-from numpy.testing.utils import assert_equal
+from numpy.testing.utils import assert_equal, assert_raises
 from nose import with_setup
 from nose.plugins.attrib import attr
 
@@ -32,6 +32,21 @@ def test_rate_arrays():
 
     assert_equal(spikes.count, np.array([0, 2]))
 
+@attr('codegen-independent')
+def test_rate_unit_check():
+    assert_raises(DimensionMismatchError,
+                  lambda: PoissonGroup(1, np.array([1, 2])))
+    assert_raises(DimensionMismatchError,
+                  lambda: PoissonGroup(1, np.array([1, 2])*ms))
+    P = PoissonGroup(1, 'i*mV')
+    net = Network(P)
+    assert_raises(DimensionMismatchError,
+                  lambda: net.run(0*ms))
+
+    P = PoissonGroup(1, 'i')
+    net = Network(P)
+    assert_raises(DimensionMismatchError,
+                  lambda: net.run(0 * ms))
 
 @attr('standalone-compatible')
 @with_setup(teardown=reinit_devices)
@@ -86,6 +101,7 @@ def test_poissongroup_subgroup():
 if __name__ == '__main__':
     test_single_rates()
     test_rate_arrays()
+    test_rate_unit_check()
     test_time_dependent_rate()
     test_propagation()
     test_poissongroup_subgroup()

--- a/docs_sphinx/introduction/release_notes.rst
+++ b/docs_sphinx/introduction/release_notes.rst
@@ -1,6 +1,16 @@
 Release notes
 =============
 
+Current development version (changes since 2.0)
+-----------------------------------------------
+
+Improvements and bug fixes
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+* Check that string expressions provided as the ``rates`` argument for
+  `PoissonGroup` have correct units.
+
+
+
 Brian 2.0 (changes since 1.4)
 -----------------------------
 

--- a/docs_sphinx/user/input.rst
+++ b/docs_sphinx/user/input.rst
@@ -174,7 +174,7 @@ inhomogeneous Poisson processes. For example, the following code
 `PoissonGroup` as a function of time, resulting in five 100ms blocks of 100 Hz
 stimulation, followed by 100ms of silence::
 
-    stimulus = TimedArray(np.tile([100., 0.], 5), dt=100.*ms)
+    stimulus = TimedArray(np.tile([100., 0.], 5)*Hz, dt=100.*ms)
     P = PoissonGroup(1, rates='stimulus(t)')
 
 Note that, as can be seen in its equivalent `NeuronGroup` formulation, a


### PR DESCRIPTION
After merging #770 I noticed that the example code in the documentation is actually slightly wrong:
```Python
stimulus = TimedArray(np.tile([100., 0.], 5), dt=100.*ms)
P = PoissonGroup(1, rates='stimulus(t)')
```
The `TimedArray` is dimensionless, `stimulus(t)` therefore needs to be multiplied by `Hz` before using it as a rate.

With this PR, the above code now raises a `DimensionMismatchError`.