### PR TITLE
Fix `PopulationRateMonitor` for subgroups

### DIFF
--- a/brian2/codegen/runtime/cython_rt/templates/ratemonitor.pyx
+++ b/brian2/codegen/runtime/cython_rt/templates/ratemonitor.pyx
@@ -8,7 +8,7 @@
     
     # For subgroups, we do not want to record all spikes
     # We assume that spikes are ordered
-    cdef int _start_idx = 0
+    cdef int _start_idx = -1
     cdef int _end_idx = -1
     cdef int _j
     for _j in range(_num_spikes):
@@ -16,6 +16,8 @@
         if _idx >= _source_start:
             _start_idx = _j
             break
+    if _start_idx == -1:
+        _start_idx = _num_spikes
     for _j in range(_start_idx, _num_spikes):
         _idx = {{_spikespace}}[_j]
         if _idx >= _source_stop:

--- a/brian2/codegen/runtime/weave_rt/templates/ratemonitor.cpp
+++ b/brian2/codegen/runtime/weave_rt/templates/ratemonitor.cpp
@@ -6,7 +6,7 @@
 	int _num_spikes = {{_spikespace}}[_num_spikespace-1];
     // For subgroups, we do not want to record all spikes
     // We assume that spikes are ordered
-    int _start_idx = 0;
+    int _start_idx = -1;
     int _end_idx = - 1;
     for(int _j=0; _j<_num_spikes; _j++)
     {
@@ -16,6 +16,8 @@
             break;
         }
     }
+    if (_start_idx == -1)
+        _start_idx = _num_spikes;
     for(int _j=_start_idx; _j<_num_spikes; _j++)
     {
         const int _idx = {{_spikespace}}[_j];
@@ -25,7 +27,7 @@
         }
     }
     if (_end_idx == -1)
-        _end_idx =_num_spikes;
+        _end_idx = _num_spikes;
     _num_spikes = _end_idx - _start_idx;
     // Calculate the new length for the arrays
     const npy_int _new_len = (npy_int)({{_dynamic_t}}.attr("shape")[0]) + 1;

--- a/brian2/devices/cpp_standalone/templates/ratemonitor.cpp
+++ b/brian2/devices/cpp_standalone/templates/ratemonitor.cpp
@@ -7,8 +7,8 @@
 	int _num_spikes = {{_spikespace}}[_num_spikespace-1];
 	// For subgroups, we do not want to record all spikes
     // We assume that spikes are ordered
-    int _start_idx = 0;
-    int _end_idx = - 1;
+    int _start_idx = -1;
+    int _end_idx = -1;
     for(int _j=0; _j<_num_spikes; _j++)
     {
         const int _idx = {{_spikespace}}[_j];
@@ -17,6 +17,8 @@
             break;
         }
     }
+    if (_start_idx == -1)
+        _start_idx = _num_spikes;
     for(int _j=_start_idx; _j<_num_spikes; _j++)
     {
         const int _idx = {{_spikespace}}[_j];

--- a/brian2/tests/test_monitor.py
+++ b/brian2/tests/test_monitor.py
@@ -518,6 +518,19 @@ def test_rate_monitor_subgroups():
     defaultclock.dt = old_dt
 
 
+@attr('standalone-compatible')
+@with_setup(teardown=reinit_devices)
+def test_rate_monitor_subgroups_2():
+    G = NeuronGroup(4, '''do_spike : boolean''', threshold='do_spike')
+    G.do_spike = [True, True, False, False]
+    rate_all = PopulationRateMonitor(G)
+    rate_1 = PopulationRateMonitor(G[:2])
+    rate_2 = PopulationRateMonitor(G[2:])
+    run(2*defaultclock.dt)
+    assert_allclose(rate_all.rate, 0.5/defaultclock.dt)
+    assert_allclose(rate_1.rate, 1 / defaultclock.dt)
+    assert_allclose(rate_2.rate, 0*Hz)
+
 if __name__ == '__main__':
     test_spike_monitor()
     test_spike_monitor_indexing()
@@ -538,3 +551,4 @@ if __name__ == '__main__':
     test_rate_monitor_smoothed_rate_incorrect()
     test_rate_monitor_get_states()
     test_rate_monitor_subgroups()
+    test_rate_monitor_subgroups_2()

--- a/docs_sphinx/introduction/release_notes.rst
+++ b/docs_sphinx/introduction/release_notes.rst
@@ -6,6 +6,7 @@ Current development version (changes since 2.0)
 
 Improvements and bug fixes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
+* Fix `PopulationRateMonitor` for recordings from subgroups (#772)
 * Check that string expressions provided as the ``rates`` argument for
   `PoissonGroup` have correct units.
 


### PR DESCRIPTION
See #772 for details about this bug.

I think we should put this fix out there rather sooner than later. How about doing a 2.0.1 (probably better than 2.1 if there is no new feature, right?) release in a few days?
