### PR TITLE
[MRG] Standalone multiple runs report fix

### DIFF
--- a/brian2/devices/cpp_standalone/device.py
+++ b/brian2/devices/cpp_standalone/device.py
@@ -1081,13 +1081,13 @@ class CPPStandaloneDevice(Device):
         }
         '''
         if report is None:
-            self.report_func = ''
+            report_func = ''
         elif report == 'text' or report == 'stdout':
-            self.report_func = standard_code.replace('%STREAMNAME%', 'std::cout')
+            report_func = standard_code.replace('%STREAMNAME%', 'std::cout')
         elif report == 'stderr':
-            self.report_func = standard_code.replace('%STREAMNAME%', 'std::cerr')
+            report_func = standard_code.replace('%STREAMNAME%', 'std::cerr')
         elif isinstance(report, basestring):
-            self.report_func = '''
+            report_func = '''
             void report_progress(const double elapsed, const double completed, const double start, const double duration)
             {
             %REPORT%
@@ -1097,6 +1097,14 @@ class CPPStandaloneDevice(Device):
             raise TypeError(('report argument has to be either "text", '
                              '"stdout", "stderr", or the code for a report '
                              'function'))
+
+        if report_func != '':
+            if self.report_func != '' and report_func != self.report_func:
+                raise NotImplementedError('The C++ standalone device does not '
+                                          'support multiple report functions, '
+                                          'each run has to use the same (or '
+                                          'none).')
+            self.report_func = report_func
 
         if report is not None:
             report_call = 'report_progress'

--- a/docs_sphinx/introduction/known_issues.rst
+++ b/docs_sphinx/introduction/known_issues.rst
@@ -30,3 +30,13 @@ appropriate, because of a choice of parameters that couldn't be determined in
 advance. In this case, typically you will get nan (not a number) values in the
 results, or large oscillations. In this case, Brian will generate a warning to
 let you know, but will not raise an error.
+
+Jupyter notebooks and C++ standalone mode progress reporting
+------------------------------------------------------------
+
+When you run simulations in C++ standalone mode and enable progress reporting
+(e.g. by using ``report='text'`` as a keyword argument), the progress will not
+be displayed in the jupyter notebook. If you started the notebook from a
+terminal, you will find the output there. Unfortunately, this is a tricky
+problem to solve at the moment, due to the details of how the jupyter notebook
+handles output.

--- a/docs_sphinx/introduction/release_notes.rst
+++ b/docs_sphinx/introduction/release_notes.rst
@@ -9,7 +9,8 @@ Improvements and bug fixes
 * Fix `PopulationRateMonitor` for recordings from subgroups (#772)
 * Check that string expressions provided as the ``rates`` argument for
   `PoissonGroup` have correct units.
-
+* Fix compilation errors when multiple run statements with different ``report``
+  arguments are used in C++ standalone mode.
 
 
 Brian 2.0 (changes since 1.4)


### PR DESCRIPTION
This was more an annoyance than a serious bug, but for users it was very hard to figure out what went wrong. If you wrote the following code in standalone mode:
```Python
run(some_time, report='text')
run(some_time)
```
you'd get a compilation error. The reason was that the standalone device stored the reporting function to use in its `report_function` attribute, and that was overwritten with the second run call.
Now in principle we could support multiple report functions (e.g. `CPPStandaloneDevice.report_function` could be a list), but I did not want to bother complicating the code for that rather unimportant use case. What is allowed now is code like the above, i.e. some runs with a report function and some without, but using different report function (e.g. `report='stdout'` and `report='stderr'`) will raise an error.

Not directly related to that, I also added a paragraph to "Known issues" about standalone progress reports in jupyter notebooks.