### PR TITLE
[MRG] Spikemonitor subgroup fix

### DIFF
--- a/brian2/codegen/runtime/numpy_rt/templates/spikemonitor.py_
+++ b/brian2/codegen/runtime/numpy_rt/templates/spikemonitor.py_
@@ -10,7 +10,8 @@ if _n_events > 0:
     # Take subgroups into account
     if _source_start!=0 or _source_stop!={{N}}:
         _events = _events[(_events >= _source_start) & (_events < _source_stop)]
-    _n_events = len(_events)
+        _n_events = len(_events)
+
     if _n_events > 0:
         _vectorisation_idx = 1
         {{scalar_code|autoindent}}

--- a/brian2/codegen/runtime/weave_rt/templates/spikemonitor.cpp
+++ b/brian2/codegen/runtime/weave_rt/templates/spikemonitor.cpp
@@ -22,7 +22,7 @@
                 break;
             }
         }
-        for(int _j=_num_events-1; _j>=_source_start; _j--)
+        for(int _j=_num_events-1; _j>=_start_idx; _j--)
         {
             const int _idx = {{_eventspace}}[_j];
             if (_idx < _source_stop) {

--- a/brian2/devices/cpp_standalone/templates/spikemonitor.cpp
+++ b/brian2/devices/cpp_standalone/templates/spikemonitor.cpp
@@ -21,13 +21,13 @@
                 break;
             }
         }
-        for(int _j=_start_idx; _j<_num_events; _j++)
+        for(int _j=_num_events-1; _j>=_start_idx; _j--)
         {
             const int _idx = {{_eventspace}}[_j];
-            if (_idx >= _source_stop) {
-                _end_idx = _j;
+            if (_idx < _source_stop) {
                 break;
             }
+            _end_idx = _j;
         }
         _num_events = _end_idx - _start_idx;
         if (_num_events > 0) {

--- a/docs_sphinx/introduction/release_notes.rst
+++ b/docs_sphinx/introduction/release_notes.rst
@@ -7,6 +7,7 @@ Current development version (changes since 2.0)
 Improvements and bug fixes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 * Fix `PopulationRateMonitor` for recordings from subgroups (#772)
+* Fix `SpikeMonitor` for recordings from subgroups (#777)
 * Check that string expressions provided as the ``rates`` argument for
   `PoissonGroup` have correct units.
 


### PR DESCRIPTION
Here's the fix for #777, see the issue for more details.

In addition to the bug fix this PR includes two micro optimisations (one for numpy, one for C++ standalone) for better `SpikeMonitor` performance when it does not record from a subgroup. The optimisation for C++ standalone is simply a copy of the improved algorithm in weave (without the bug of course ;-) ).