### PR TITLE
[MRG] Parallel compile

### DIFF
--- a/brian2/codegen/cpp_prefs.py
+++ b/brian2/codegen/cpp_prefs.py
@@ -57,7 +57,7 @@ prefs.register_preferences(
         '''
         ),
     extra_compile_args_msvc=BrianPreference(
-        default=['/Ox', '/w', msvc_arch_flag],
+        default=['/Ox', '/w', msvc_arch_flag, '/MP'],
         docs='''
         Extra compile arguments to pass to MSVC compiler (the default
         ``/arch:`` flag is determined based on the processor architecture)

--- a/brian2/devices/cpp_standalone/device.py
+++ b/brian2/devices/cpp_standalone/device.py
@@ -69,7 +69,20 @@ prefs.register_preferences(
         be used when using no more than three threads or when the morphology
         has less than three branches in total.
         '''
-    )
+        ),
+    extra_make_args_unix=BrianPreference(
+        default=['-j'],
+        docs='''
+        Additional flags to pass to the GNU make command on Linux/OS-X.
+        Defaults to "-j" for parallel compilation.'''
+        ),
+    extra_make_args_windows=BrianPreference(
+        default=[],
+        docs='''
+        Additional flags to pass to the nmake command on Windows. By default, no
+        additional flags are passed.
+        '''
+        )
     )
 
 
@@ -795,12 +808,15 @@ class CPPStandaloneDevice(Device):
                 vcvars_cmd = '"{vcvars_loc}" {arch_name}'.format(
                         vcvars_loc=vcvars_loc, arch_name=arch_name)
                 make_cmd = 'nmake /f win_makefile'
+                make_args = ' '.join(prefs.devices.cpp_standalone.extra_make_args_windows)
                 if os.path.exists('winmake.log'):
                     os.remove('winmake.log')
                 with std_silent(debug):
                     if clean:
                         os.system('%s >>winmake.log 2>&1 && %s clean >>winmake.log 2>&1' % (vcvars_cmd, make_cmd))
-                    x = os.system('%s >>winmake.log 2>&1 && %s >>winmake.log 2>&1' % (vcvars_cmd, make_cmd))
+                    x = os.system('%s >>winmake.log 2>&1 && %s %s>>winmake.log 2>&1' % (vcvars_cmd,
+                                                                                        make_cmd,
+                                                                                        make_args))
                     if x!=0:
                         if os.path.exists('winmake.log'):
                             print open('winmake.log', 'r').read()
@@ -812,7 +828,8 @@ class CPPStandaloneDevice(Device):
                     if debug:
                         x = os.system('make debug')
                     else:
-                        x = os.system('make')
+                        make_args = ' '.join(prefs.devices.cpp_standalone.extra_make_args_unix)
+                        x = os.system('make %s' % (make_args, ))
                     if x!=0:
                         raise RuntimeError("Project compilation failed")
 

--- a/dev/continuous-integration/run_test_suite.py
+++ b/dev/continuous-integration/run_test_suite.py
@@ -25,7 +25,7 @@ else:
     targets = None
     independent = True
 
-if operating_system == 'windows' or report_coverage:
+if operating_system == 'windows' or report_coverage or standalone:
     in_parallel = []
 else:
     in_parallel = ['codegen_independent', 'numpy', 'cython', 'cpp_standalone']


### PR DESCRIPTION
I was a bit annoyed with the standalone compilation taking so much time and it turned out that just using `make` with parallel jobs reduced the time drastically (at least on Linux). I added two new preferences for arguments to the `make`/`nmake` commands, and added `-j` for Linux by default. I also enabled parallel compilation for Windows, but this does not seem to have much of an effect (at least on our test server).

I think we could also drastically improve Cython runtime compilation, but this requires refactoring the code a bit (the `compile` step would trigger compilation in a separate process, a result would only be required when we reach `run`. This is a longer term project (and then, we might reconsider our codegen targets anyway), so let's not worry about that for now. 