### PR TITLE
[MRG] More general tests

### DIFF
--- a/brian2/core/variables.py
+++ b/brian2/core/variables.py
@@ -972,21 +972,23 @@ class VariableView(object):
                                         'ambiguous_string_expression')
                             break  # no need to warn more than once for a variable
 
-        indices = self.indexing(item)
+        indices = np.atleast_1d(self.indexing(item))
         abstract_code = self.name + ' = ' + code
-        variables = Variables(None)
+        variables = Variables(self.group)
         variables.add_array('_group_idx', unit=Unit(1),
-                            size=len(indices), dtype=np.int32)
-        variables['_group_idx'].set_value(indices)
+                            size=len(indices), dtype=np.int32, values=indices)
 
         # TODO: Have an additional argument to avoid going through the index
         # array for situations where iterate_all could be used
         from brian2.codegen.codeobject import create_runner_codeobj
-        from brian2.devices.device import get_default_codeobject_class
+        from brian2.devices.device import get_default_codeobject_class, get_device
+
+        group_index_var = get_device().get_array_name(variables['_group_idx'])
         codeobj = create_runner_codeobj(self.group,
                                         abstract_code,
                                         'group_variable_set',
                                         additional_variables=variables,
+                                        template_kwds={'_group_index_var': group_index_var},
                                         check_units=check_units,
                                         run_namespace=run_namespace,
                                         codeobj_class=get_default_codeobject_class('codegen.string_expression_target'))

--- a/brian2/devices/cpp_standalone/templates/group_variable_set.cpp
+++ b/brian2/devices/cpp_standalone/templates/group_variable_set.cpp
@@ -2,7 +2,7 @@
 
 {% block maincode %}
 	{# USES_VARIABLES { _group_idx } #}
-	//// MAIN CODE ////////////	
+	//// MAIN CODE ////////////
 	// scalar code
     const int _vectorisation_idx = -1;
     {{scalar_code|autoindent}}
@@ -11,7 +11,7 @@
 	for(int _idx_group_idx=0; _idx_group_idx<_num_group_idx; _idx_group_idx++)
 	{
 	    // vector code
-		const int _idx = _group_idx[_idx_group_idx];
+		const int _idx = {{_group_index_var}}[_idx_group_idx];
 		const int _vectorisation_idx = _idx;
         {{vector_code|autoindent}}
 	}

--- a/brian2/tests/__init__.py
+++ b/brian2/tests/__init__.py
@@ -33,11 +33,39 @@ except ImportError:
     nose = None
 
 
+def make_argv(dirnames, attributes):
+    '''
+    Create the list of arguments for the ``nosetests`` call.
+
+    Parameters
+    ----------
+    dirnames : list of str
+        The list of directory names to check for tests.
+    attributes : str
+        The attributes of the tests to include.
+
+    Returns
+    -------
+    argv : list of str
+        The arguments for `nose.main`.
+
+    '''
+    argv = (['nosetests'] + dirnames +
+            ['-c=',  # no config file loading
+             '-I', '^hears\.py$',
+             '-I', '^\.',
+             '-I', '^_',
+             "-a", attributes,
+             '--nologcapture',
+             '--exe'])
+    return argv
+
+
 def run(codegen_targets=None, long_tests=False, test_codegen_independent=True,
         test_standalone=None, test_openmp=False,
         test_in_parallel=['codegen_independent', 'numpy', 'cython', 'cpp_standalone'],
         reset_preferences=True, fail_for_not_implemented=True,
-        build_options=None):
+        build_options=None, extra_test_dirs=None):
     '''
     Run brian's test suite. Needs an installation of the nose testing tool.
 
@@ -79,6 +107,9 @@ def run(codegen_targets=None, long_tests=False, test_codegen_independent=True,
     build_options : dict, optional
         Non-default build options that will be passed as arguments to the
         `set_device` call for the device specified in ``test_standalone``.
+    extra_test_dirs : list of str or str, optional
+        Additional directories as a list of strings (or a single directory as
+        a string) that will be searched for additional tests.
     '''
     if nose is None:
         raise ImportError('Running the test suite requires the "nose" package.')
@@ -88,6 +119,11 @@ def run(codegen_targets=None, long_tests=False, test_codegen_independent=True,
 
     if os.name == 'nt':
         test_in_parallel = []
+
+    if extra_test_dirs is None:
+        extra_test_dirs = []
+    elif isinstance(extra_test_dirs, basestring):
+        extra_test_dirs = [extra_test_dirs]
 
     multiprocess_arguments = ['--processes=-1',
                               '--process-timeout=3600',  # we don't want them to time out
@@ -113,8 +149,9 @@ def run(codegen_targets=None, long_tests=False, test_codegen_independent=True,
         codegen_targets = [codegen_targets]
 
     dirname = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+    dirnames = [dirname] + extra_test_dirs
     # We write to stderr since nose does all of its output on stderr as well
-    sys.stderr.write('Running tests in "%s" ' % dirname)
+    sys.stderr.write('Running tests in %s ' % (', '.join(dirnames)))
     if codegen_targets:
         sys.stderr.write('for targets %s' % (', '.join(codegen_targets)))
     ex_in = 'including' if long_tests else 'excluding'
@@ -180,15 +217,7 @@ def run(codegen_targets=None, long_tests=False, test_codegen_independent=True,
             # Some doctests do actually use code generation, use numpy for that
             prefs.codegen.target = 'numpy'
             prefs._backup()
-            argv = ['nosetests', dirname,
-                    '-c=',  # no config file loading
-                    '-I', '^hears\.py$',
-                    '-I', '^\.',
-                    '-I', '^_',
-                    '--with-doctest',
-                    "-a", "codegen-independent",
-                    '--nologcapture',
-                    '--exe']
+            argv = make_argv(dirnames, "codegen-independent")
             if 'codegen_independent' in test_in_parallel:
                 argv.extend(multiprocess_arguments)
             success.append(nose.run(argv=argv,
@@ -206,16 +235,7 @@ def run(codegen_targets=None, long_tests=False, test_codegen_independent=True,
                 exclude_str += ',!long'
             # explicitly ignore the brian2.hears file for testing, otherwise the
             # doctest search will import it, failing on Python 3
-            argv = ['nosetests', dirname,
-                    '-c=',  # no config file loading
-                    '-I', '^hears\.py$',
-                    '-I', '^\.',
-                    '-I', '^_',
-                    # Do not run standalone or
-                    # codegen-independent tests
-                    "-a", exclude_str,
-                    '--nologcapture',
-                    '--exe']
+            argv = make_argv(dirnames, exclude_str)
             if target in test_in_parallel:
                 argv.extend(multiprocess_arguments)
             success.append(nose.run(argv=argv,
@@ -228,15 +248,7 @@ def run(codegen_targets=None, long_tests=False, test_codegen_independent=True,
             sys.stderr.write('Testing standalone device "%s"\n' % test_standalone)
             sys.stderr.write('Running standalone-compatible standard tests\n')
             exclude_str = ',!long' if not long_tests else ''
-            argv = ['nosetests', dirname,
-                    '-c=',  # no config file loading
-                    '-I', '^hears\.py$',
-                    '-I', '^\.',
-                    '-I', '^_',
-                    # Only run standalone tests
-                    '-a', 'standalone-compatible'+exclude_str,
-                    '--nologcapture',
-                    '--exe']
+            argv = make_argv(dirnames, 'standalone_compatible'+exclude_str)
             if test_standalone in test_in_parallel:
                 argv.extend(multiprocess_arguments)
             success.append(nose.run(argv=argv,
@@ -248,15 +260,8 @@ def run(codegen_targets=None, long_tests=False, test_codegen_independent=True,
                 prefs._backup()
                 sys.stderr.write('Running standalone-compatible standard tests with OpenMP\n')
                 exclude_str = ',!long' if not long_tests else ''
-                argv = ['nosetests', dirname,
-                        '-c=',  # no config file loading
-                        '-I', '^hears\.py$',
-                        '-I', '^\.',
-                        '-I', '^_',
-                        # Only run standalone tests
-                        '-a', 'standalone-compatible'+exclude_str,
-                        '--nologcapture',
-                        '--exe']
+                argv = make_argv(dirnames,
+                                 'standalone_compatible' + exclude_str)
                 success.append(nose.run(argv=argv,
                                         addplugins=plugins))
                 prefs.devices.cpp_standalone.openmp_threads = 0
@@ -266,15 +271,7 @@ def run(codegen_targets=None, long_tests=False, test_codegen_independent=True,
 
             sys.stderr.write('Running standalone-specific tests\n')
             exclude_openmp = ',!openmp' if not test_openmp else ''
-            argv = ['nosetests', dirname,
-                    '-c=',  # no config file loading
-                    '-I', '^hears\.py$',
-                    '-I', '^\.',
-                    '-I', '^_',
-                    # Only run standalone tests
-                    '-a', test_standalone+exclude_openmp,
-                    '--nologcapture',
-                    '--exe']
+            argv = make_argv(dirnames, test_standalone+exclude_openmp)
             if test_standalone in test_in_parallel:
                 argv.extend(multiprocess_arguments)
             success.append(nose.run(argv=argv,
@@ -295,6 +292,7 @@ def run(codegen_targets=None, long_tests=False, test_codegen_independent=True,
             # Restore the user preferences
             prefs.read_preference_file(StringIO(stored_prefs))
             prefs._backup()
+
 
 if __name__ == '__main__':
     run()

--- a/brian2/tests/__init__.py
+++ b/brian2/tests/__init__.py
@@ -246,9 +246,23 @@ def run(codegen_targets=None, long_tests=False, test_codegen_independent=True,
             set_device(test_standalone, directory=None,  # use temp directory
                        with_output=False, **build_options)
             sys.stderr.write('Testing standalone device "%s"\n' % test_standalone)
-            sys.stderr.write('Running standalone-compatible standard tests\n')
+            sys.stderr.write('Running standalone-compatible standard tests (single run statement)\n')
             exclude_str = ',!long' if not long_tests else ''
-            argv = make_argv(dirnames, 'standalone_compatible'+exclude_str)
+            exclude_str += ',!multiple-runs'
+            argv = make_argv(dirnames, 'standalone-compatible'+exclude_str)
+            if test_standalone in test_in_parallel:
+                argv.extend(multiprocess_arguments)
+            success.append(nose.run(argv=argv,
+                                    addplugins=plugins))
+
+            reset_device()
+
+            sys.stderr.write('Running standalone-compatible standard tests (multiple run statements)\n')
+            set_device(test_standalone, directory=None,  # use temp directory
+                       with_output=False, build_on_run=False, **build_options)
+            exclude_str = ',!long' if not long_tests else ''
+            exclude_str += ',multiple-runs'
+            argv = make_argv(dirnames, 'standalone-compatible'+exclude_str)
             if test_standalone in test_in_parallel:
                 argv.extend(multiprocess_arguments)
             success.append(nose.run(argv=argv,

--- a/brian2/tests/test_functions.py
+++ b/brian2/tests/test_functions.py
@@ -16,18 +16,18 @@ def test_constants_sympy():
     assert sympy_to_str(str_to_sympy('sin(pi)')) == '0'
     assert sympy_to_str(str_to_sympy('log(e)')) == '1'
 
-
+@attr('standalone-compatible')
+@with_setup(teardown=reinit_devices)
 def test_constants_values():
     '''
     Make sure that symbolic constants use the correct values in code
     '''
-    G = NeuronGroup(1, 'v : 1')
-    G.v = 'pi'
-    assert G.v == np.pi
-    G.v = 'e'
-    assert G.v == np.e
-    G.v = 'inf'
-    assert G.v == np.inf
+    G = NeuronGroup(3, 'v : 1')
+    G.v[0] = 'pi'
+    G.v[1] = 'e'
+    G.v[2] = 'inf'
+    run(0*ms)
+    assert_allclose(G.v[:], [np.pi, np.e, np.inf])
 
 
 def test_math_functions():

--- a/brian2/tests/test_network.py
+++ b/brian2/tests/test_network.py
@@ -767,51 +767,38 @@ def test_progress_report_incorrect():
     assert_raises(TypeError, lambda: net.run(1*ms, report=object()))
 
 
-@attr('cpp_standalone', 'standalone-only')
+@attr('standalone-compatible', 'multiple-runs')
 @with_setup(teardown=reinit_devices)
-def test_multiple_runs_report_standalone(with_output=False):
-    set_device('cpp_standalone', build_on_run=False)
+def test_multiple_runs_report_standalone():
     group = NeuronGroup(1, 'dv/dt = 1*Hz : 1')
     run(1*ms, report='text')
     run(1*ms)
-    tempdir = tempfile.mkdtemp()
-    if with_output:
-        print tempdir
-    device.build(directory=tempdir, compile=True, run=True,
-                 with_output=with_output)
+    device.build(direct_call=False, **device.build_options)
 
 
-@attr('cpp_standalone', 'standalone-only')
+@attr('standalone-compatible', 'multiple-runs')
 @with_setup(teardown=reinit_devices)
-def test_multiple_runs_report_standalone_2(with_output=False):
-    set_device('cpp_standalone', build_on_run=False)
+def test_multiple_runs_report_standalone_2():
     group = NeuronGroup(1, 'dv/dt = 1*Hz : 1')
     run(1*ms)
     run(1*ms, report='text')
-    tempdir = tempfile.mkdtemp()
-    if with_output:
-        print tempdir
-    device.build(directory=tempdir, compile=True, run=True,
-                 with_output=with_output)
+    device.build(direct_call=False, **device.build_options)
 
 
-@attr('cpp_standalone', 'standalone-only')
+@attr('standalone-compatible', 'multiple-runs')
 @with_setup(teardown=reinit_devices)
-def test_multiple_runs_report_standalone_3(with_output=False):
-    set_device('cpp_standalone', build_on_run=False)
+def test_multiple_runs_report_standalone_3():
     group = NeuronGroup(1, 'dv/dt = 1*Hz : 1')
     run(1*ms, report='text')
     run(1*ms, report='text')
-    tempdir = tempfile.mkdtemp()
-    if with_output:
-        print tempdir
-    device.build(directory=tempdir, compile=True, run=True,
-                 with_output=with_output)
+    device.build(direct_call=False, **device.build_options)
 
 
+# This tests a specific limitation of the C++ standalone mode (cannot mix
+# multiple report methods)
 @attr('cpp_standalone', 'standalone-only')
 @with_setup(teardown=reinit_devices)
-def test_multiple_runs_report_standalone_incorrect(with_output=False):
+def test_multiple_runs_report_standalone_incorrect():
     set_device('cpp_standalone', build_on_run=False)
     group = NeuronGroup(1, 'dv/dt = 1*Hz : 1')
     run(1*ms, report='text')
@@ -1069,7 +1056,8 @@ def test_defaultclock_dt_changes():
         net.run(2*dt)
         assert_equal(mon.t[:], [0, dt/ms]*ms)
 
-@with_setup(teardown=restore_initial_state)
+@attr('standalone-compatible', 'multiple-runs')
+@with_setup(teardown=reinit_devices)
 def test_dt_changes_between_runs():
     defaultclock.dt = 0.1*ms
     G = NeuronGroup(1, 'v:1')
@@ -1079,6 +1067,7 @@ def test_dt_changes_between_runs():
     run(.5*ms)
     defaultclock.dt = 0.1*ms
     run(.5*ms)
+    device.build(direct_call=False, **device.build_options)
     assert len(mon.t[:]) == 5 + 1 + 5
     assert_allclose(mon.t[:],
                     [0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 1., 1.1, 1.2, 1.3, 1.4]*ms)

--- a/brian2/tests/test_synapses.py
+++ b/brian2/tests/test_synapses.py
@@ -13,7 +13,7 @@ from brian2.core.variables import variables_by_owner, ArrayVariable, Constant
 from brian2.core.functions import DEFAULT_FUNCTIONS
 from brian2.utils.logger import catch_logs
 from brian2.utils.stringtools import get_identifiers, word_substitute, indent, deindent
-from brian2.devices.device import reinit_devices, all_devices, get_device, set_device, reset_device
+from brian2.devices.device import reinit_devices, all_devices, get_device
 from brian2.codegen.permutation_analysis import check_for_order_independence, OrderDependenceError
 from brian2.synapses.parse_synaptic_generator_syntax import parse_synapse_generator
 

--- a/docs_sphinx/developer/guidelines/testing.rst
+++ b/docs_sphinx/developer/guidelines/testing.rst
@@ -15,7 +15,7 @@ suite with:
 
 	$ nosetests brian2 --with-doctest
 
-This should show no errors or failures but ususally a number of skipped tests.
+This should show no errors or failures but usually a number of skipped tests.
 The recommended way however is to import brian2 and call the test function,
 which gives you convenient control over which tests are run::
 


### PR DESCRIPTION
This adds features to our test suite to allow easier testing for devices not shipped as part of Brian 2. The two main changes are:
* `brian2.test` has a new argument to provide additional directories with tests to execute
* Tests with more than one run statement can be marked as `standalone-compatible` as well, they need an additional `multiple-runs` flag and an explicit `device.build` call (which will be ignored for runtime devices).

All of this is documented in the testing guidelines. Fixes #789 