### PR TITLE
[MRG] Recurse into subexpressions when getting identifiers from a synaptic condition

### DIFF
--- a/brian2/synapses/synapses.py
+++ b/brian2/synapses/synapses.py
@@ -15,6 +15,7 @@ from brian2.core.base import device_override
 from brian2.core.namespace import get_local_namespace
 from brian2.core.variables import (DynamicArrayVariable, Variables)
 from brian2.codegen.codeobject import create_runner_codeobj
+from brian2.codegen.translation import get_identifiers_recursively
 from brian2.devices.device import get_device
 from brian2.equations.equations import (Equations, SingleEquation,
                                         DIFFERENTIAL_EQUATION, SUBEXPRESSION,
@@ -1452,7 +1453,7 @@ class Synapses(Group):
         deps = set()
         if additional_indices is None:
             additional_indices = {}
-        for varname in get_identifiers(expr):
+        for varname in get_identifiers_recursively([expr], self.variables):
             if varname in additional_indices:
                 deps.add(additional_indices[varname])
             else:

--- a/brian2/tests/test_synapses.py
+++ b/brian2/tests/test_synapses.py
@@ -206,6 +206,12 @@ def test_connection_string_deterministic():
     S9 = Synapses(G, G, 'w:1', 'v+=w')
     S9.connect('v_pre == v_post')
 
+    S9b = Synapses(G, G, '''
+                         sub_1 = v_pre : 1
+                         sub_2 = v_post : 1
+                         w:1''', 'v+=w')
+    S9b.connect('sub_1 == sub_2')
+
     S10 = Synapses(G, G, 'w:1', 'v+=w')
     S10.connect(j='i')
 
@@ -236,6 +242,8 @@ def test_connection_string_deterministic():
     _compare(S7, expected_no_self)
     _compare(S8, expected_one_to_one)
     _compare(S9, expected_one_to_one)
+    _compare(S9b, expected_one_to_one)
+    _compare(S10, expected_one_to_one)
     _compare(S11, expected_custom)
     _compare(S12, expected_custom)
 


### PR DESCRIPTION
Fixes #794