### PR TITLE
[MRG] Unit/dimensions refactoring

### DIFF
--- a/brian2/codegen/generators/cpp_generator.py
+++ b/brian2/codegen/generators/cpp_generator.py
@@ -367,7 +367,7 @@ class CPPCodeGenerator(CodeGenerator):
                 pointer_name = self.get_array_name(var)
                 if pointer_name in handled_pointers:
                     continue
-                if getattr(var, 'dimensions', 1) > 1:
+                if getattr(var, 'ndim', 1) > 1:
                     continue  # multidimensional (dynamic) arrays have to be treated differently
                 restrict = self.restrict
                 # turn off restricted pointers for scalars for safety

--- a/brian2/codegen/generators/cython_generator.py
+++ b/brian2/codegen/generators/cython_generator.py
@@ -249,7 +249,7 @@ class CythonCodeGenerator(CodeGenerator):
                 pointer_name = self.get_array_name(var)
                 if pointer_name in handled_pointers:
                     continue
-                if getattr(var, 'dimensions', 1) > 1:
+                if getattr(var, 'ndim', 1) > 1:
                     continue  # multidimensional (dynamic) arrays have to be treated differently
                 if get_dtype_str(var.dtype) == 'bool':
                     newlines = ["cdef _numpy.ndarray[char, ndim=1, mode='c', cast=True] _buf_{array_name} = _namespace['{array_name}']",

--- a/brian2/codegen/optimisation.py
+++ b/brian2/codegen/optimisation.py
@@ -12,7 +12,7 @@ from brian2.parsing.bast import (brian_ast, BrianASTRenderer, dtype_hierarchy,
                                  brian_dtype_from_dtype, brian_dtype_from_value)
 from brian2.parsing.rendering import NodeRenderer
 from brian2.utils.stringtools import get_identifiers, word_substitute
-from brian2.units.fundamentalunits import Unit
+from brian2.units.fundamentalunits import DIMENSIONLESS
 
 from .statements import Statement
 
@@ -334,7 +334,7 @@ class Simplifier(BrianASTRenderer):
                 numpy_dtype = {'boolean': bool,
                                'integer': int,
                                'float': float}[node.dtype]
-                self.variables[name] = AuxiliaryVariable(name, Unit(1), dtype=numpy_dtype, scalar=True)
+                self.variables[name] = AuxiliaryVariable(name, DIMENSIONLESS, dtype=numpy_dtype, scalar=True)
             # None is the expression context, we don't use it so we just set to None
             newnode = ast.Name(name, None)
             newnode.scalar = True

--- a/brian2/codegen/optimisation.py
+++ b/brian2/codegen/optimisation.py
@@ -334,7 +334,9 @@ class Simplifier(BrianASTRenderer):
                 numpy_dtype = {'boolean': bool,
                                'integer': int,
                                'float': float}[node.dtype]
-                self.variables[name] = AuxiliaryVariable(name, DIMENSIONLESS, dtype=numpy_dtype, scalar=True)
+                self.variables[name] = AuxiliaryVariable(name,
+                                                         dtype=numpy_dtype,
+                                                         scalar=True)
             # None is the expression context, we don't use it so we just set to None
             newnode = ast.Name(name, None)
             newnode.scalar = True

--- a/brian2/codegen/translation.py
+++ b/brian2/codegen/translation.py
@@ -26,7 +26,7 @@ from brian2.core.functions import Function
 from brian2.utils.stringtools import (deindent, strip_empty_lines,
                                       get_identifiers)
 from brian2.utils.topsort import topsort
-from brian2.units.fundamentalunits import Unit
+from brian2.units.fundamentalunits import Unit, DIMENSIONLESS
 from brian2.parsing.statements import parse_statement
 from brian2.parsing.sympytools import (str_to_sympy, sympy_to_str,
                                        check_expression_for_multiple_stateful_functions)
@@ -89,8 +89,7 @@ def analyse_identifiers(code, variables, recursive=False):
                     if not isinstance(k, AuxiliaryVariable))
     else:
         known = set(variables)
-        variables = dict((k, Variable(unit=1, name=k,
-                                      dtype=np.float64))
+        variables = dict((k, Variable(name=k, dtype=np.float64))
                          for k in known)
 
     known |= STANDARD_IDENTIFIERS
@@ -230,7 +229,7 @@ def make_statements(code, variables, dtype, optimise=True, blockname=''):
                 defined.add(var)
                 if var not in variables:
                     is_scalar = is_scalar_expression(expr, variables)
-                    new_var = AuxiliaryVariable(var, Unit(1), # doesn't matter here
+                    new_var = AuxiliaryVariable(var, DIMENSIONLESS, # doesn't matter here
                                                 dtype=dtype, scalar=is_scalar)
                     variables[var] = new_var
             elif not variables[var].is_boolean:

--- a/brian2/codegen/translation.py
+++ b/brian2/codegen/translation.py
@@ -229,8 +229,8 @@ def make_statements(code, variables, dtype, optimise=True, blockname=''):
                 defined.add(var)
                 if var not in variables:
                     is_scalar = is_scalar_expression(expr, variables)
-                    new_var = AuxiliaryVariable(var, DIMENSIONLESS, # doesn't matter here
-                                                dtype=dtype, scalar=is_scalar)
+                    new_var = AuxiliaryVariable(var, dtype=dtype,
+                                                scalar=is_scalar)
                     variables[var] = new_var
             elif not variables[var].is_boolean:
                 sympy_expr = str_to_sympy(expr, variables)

--- a/brian2/core/clocks.py
+++ b/brian2/core/clocks.py
@@ -10,7 +10,7 @@ from brian2.utils.logger import get_logger
 from brian2.core.names import Nameable
 from brian2.core.variables import Variables
 from brian2.groups.group import VariableOwner
-from brian2.units.fundamentalunits import check_units, Quantity, Unit
+from brian2.units.fundamentalunits import check_units, Quantity, DIMENSIONLESS
 from brian2.units.allunits import second
 
 __all__ = ['Clock', 'defaultclock']
@@ -86,14 +86,14 @@ class Clock(VariableOwner):
         Nameable.__init__(self, name=name)
         self._old_dt = None
         self.variables = Variables(self)
-        self.variables.add_array('timestep', unit=Unit(1), size=1,
-                                 dtype=np.uint64, read_only=True, scalar=True)
-        self.variables.add_array('t', unit=second, size=1,
+        self.variables.add_array('timestep', size=1, dtype=np.uint64,
+                                 read_only=True, scalar=True)
+        self.variables.add_array('t', dimensions=second.dim, size=1,
                                  dtype=np.double, read_only=True, scalar=True)
-        self.variables.add_array('dt', unit=second, size=1, values=float(dt),
+        self.variables.add_array('dt', dimensions=second.dim, size=1, values=float(dt),
                                  dtype=np.float, read_only=True, constant=True,
                                  scalar=True)
-        self.variables.add_constant('N', unit=Unit(1), value=1)
+        self.variables.add_constant('N', value=1)
         self._enable_group_attributes()
         self.dt = dt
         logger.diagnostic("Created clock {name} with dt={dt}".format(name=self.name,

--- a/brian2/core/functions.py
+++ b/brian2/core/functions.py
@@ -521,8 +521,7 @@ class SymbolicConstant(Constant):
     Class for representing constants (e.g. pi) that are understood by sympy.
     '''
     def __init__(self, name, sympy_obj, value):
-        super(SymbolicConstant, self).__init__(name, unit=Unit(1),
-                                               value=value)
+        super(SymbolicConstant, self).__init__(name, value=value)
         self.sympy_obj = sympy_obj
 
 

--- a/brian2/core/variables.py
+++ b/brian2/core/variables.py
@@ -102,8 +102,8 @@ class Variable(object):
         name in the owning group. The same variable may be known under other
         names in other groups (e.g. the variable ``v`` of a `NeuronGroup` is
         known as ``v_post`` in a `Synapse` connecting to the group).
-    dimensions : `Dimensions`, optional
-        The dimensions of the variable.
+    dimensions : `Dimension`, optional
+        The physical dimensions of the variable.
     owner : `Nameable`, optional
         The object that "owns" this variable, e.g. the `NeuronGroup` or
         `Synapses` object that declares the variable in its model equations.
@@ -292,8 +292,8 @@ class Constant(Variable):
     name : str
         The name of the variable
     dimensions : `Dimension`, optional
-        The dimensions of the variable. Note that the variable itself (as
-        referenced by value) should never have units attached.
+        The physical dimensions of the variable. Note that the variable itself
+        (as referenced by value) should never have units attached.
     value: reference to the variable value
         The value of the constant.
     owner : `Nameable`, optional
@@ -352,7 +352,7 @@ class AuxiliaryVariable(Variable):
     name : str
         The name of the variable
     dimensions : `Dimension`, optional
-        The dimensions of the variable.
+        The physical dimensions of the variable.
     dtype : `dtype`, optional
         The dtype used for storing the variable. If none is given, defaults
         to `core.default_float_dtype`.
@@ -383,7 +383,7 @@ class ArrayVariable(Variable):
         names in other groups (e.g. the variable ``v`` of a `NeuronGroup` is
         known as ``v_post`` in a `Synapse` connecting to the group).
     dimensions : `Dimension`, optional
-        The dimensions of the variable
+        The physical dimensions of the variable
     owner : `Nameable`
         The object that "owns" this variable, e.g. the `NeuronGroup` or
         `Synapses` object that declares the variable in its model equations.
@@ -480,7 +480,7 @@ class DynamicArrayVariable(ArrayVariable):
         names in other groups (e.g. the variable ``v`` of a `NeuronGroup` is
         known as ``v_post`` in a `Synapse` connecting to the group).
     dimensions : `Dimension`, optional
-        The dimensinos of the variable
+        The physical dimensions of the variable.
     owner : `Nameable`
         The object that "owns" this variable, e.g. the `NeuronGroup` or
         `Synapses` object that declares the variable in its model equations.
@@ -579,7 +579,7 @@ class Subexpression(Variable):
     name : str
         The name of the subexpression.
     dimensions : `Dimension`, optional
-        The dimensions of the subexpression.
+        The physical dimensions of the subexpression.
     owner : `Group`
         The group to which the expression refers.
     expr : str
@@ -731,8 +731,9 @@ class VariableView(object):
         The group through which the variable is accessed (not necessarily the
         same as `variable.owner`).
     dimensions : `Dimension`, optional
-        The dimensinos to be used for the variable, should be `None` when a
-        variable is accessed without units (e.g. when accessing ``G.var_``).
+        The physical dimensions to be used for the variable, should be `None`
+        when a variable is accessed without units (e.g. when accessing
+        ``G.var_``).
     '''
     def __init__(self, name, variable, group, dimensions=None):
         self.name = name
@@ -1424,7 +1425,7 @@ class Variables(collections.Mapping):
         name : str
             The name of the variable.
         dimensions : `Dimension`, optional
-            The dimensions of the variable.
+            The physical dimensions of the variable.
         size : int
             The size of the array.
         values : `ndarray`, optional
@@ -1487,7 +1488,7 @@ class Variables(collections.Mapping):
         names : list of str
             The names of the variable.
         dimensions : `Dimension`, optional
-            The dimensions of the variable.
+            The physical dimensions of the variable.
         size : int
             The sizes of the arrays.
         dtype : `dtype`, optional
@@ -1527,7 +1528,7 @@ class Variables(collections.Mapping):
         name : str
             The name of the variable.
         dimensions : `Dimension`, optional
-            The dimensions of the variable.
+            The physical dimensions of the variable.
         size : int or tuple of int
             The (initital) size of the array.
         values : `ndarray`, optional
@@ -1610,7 +1611,6 @@ class Variables(collections.Mapping):
                        index=index)
         self.device.init_with_arange(self._variables[name], start, dtype=dtype)
 
-
     def add_constant(self, name, value, dimensions=DIMENSIONLESS):
         '''
         Add a scalar constant (e.g. the number of neurons `N`).
@@ -1622,10 +1622,11 @@ class Variables(collections.Mapping):
         value: reference to the variable value
             The value of the constant.
         dimensions : `Dimension`, optional
-            The dimensions of the variable. Note that the variable itself (as
-            referenced by value) should never have units attached.
+            The physical dimensions of the variable. Note that the variable
+            itself (as referenced by value) should never have units attached.
         '''
-        var = Constant(name=name, dimensions=dimensions, owner=self.owner, value=value)
+        var = Constant(name=name, dimensions=dimensions, owner=self.owner,
+                       value=value)
         self._add_variable(name, var)
 
     def add_subexpression(self, name, expr, dimensions=DIMENSIONLESS,
@@ -1638,7 +1639,7 @@ class Variables(collections.Mapping):
         name : str
             The name of the subexpression.
         dimensions : `Dimension`
-            The dimensions of the subexpression.
+            The physical dimensions of the subexpression.
         expr : str
             The subexpression itself.
         dtype : `dtype`, optional
@@ -1667,7 +1668,7 @@ class Variables(collections.Mapping):
         name : str
             The name of the variable
         dimensions : `Dimension`
-            The dimensions of the variable.
+            The physical dimensions of the variable.
         dtype : `dtype`, optional
             The dtype used for storing the variable. If none is given, defaults
             to `core.default_float_dtype`.

--- a/brian2/core/variables.py
+++ b/brian2/core/variables.py
@@ -179,11 +179,8 @@ class Variable(object):
     @property
     def unit(self):
         '''
-        Returns the `Unit` of this variable (deprecated, get the dimensions with
-        `Variable.dim` instead.)
+        The `Unit` of this variable
         '''
-        logger.warn("The 'unit' property is deprecated, use 'dim' instead.",
-                    'deprecated_variable_unit', once=True)
         return get_unit(self.dim)
 
     def get_value(self):
@@ -765,11 +762,8 @@ class VariableView(object):
     @property
     def unit(self):
         '''
-        Returns the `Unit` of this equation (deprecated, get the dimensions with
-        `SingleEquation.dim` instead.)
+        The `Unit` of this variable
         '''
-        logger.warn("The 'unit' property is deprecated, use 'dim' instead.",
-                    'deprecated_variableview_unit', once=True)
         return get_unit(self.dim)
 
     def get_item(self, item, level=0, namespace=None):

--- a/brian2/core/variables.py
+++ b/brian2/core/variables.py
@@ -133,7 +133,7 @@ class Variable(object):
         assert isinstance(dimensions, Dimension)
 
         #: The variable's dimensions.
-        self.dimensions = dimensions
+        self.dim = dimensions
 
         #: The variable's name.
         self.name = name
@@ -170,13 +170,6 @@ class Variable(object):
         return np.issubdtype(np.bool, self.dtype)
 
     @property
-    def dim(self):
-        '''
-        The dimensions of this variable.
-        '''
-        return self.dimensions
-    
-    @property
     def dtype_str(self):
         '''
         String representation of the numpy dtype
@@ -200,7 +193,7 @@ class Variable(object):
         '''
         Return the value associated with the variable (with units).
         '''
-        return Quantity(self.get_value(), self.dimensions)
+        return Quantity(self.get_value(), self.dim)
 
     def get_addressable_value(self, name, group):
         '''
@@ -268,7 +261,7 @@ class Variable(object):
                        ' dtype={dtype}, scalar={scalar}, constant={constant},'
                        ' read_only={read_only})>')
         return description.format(classname=self.__class__.__name__,
-                                  dimensions=repr(self.dimensions),
+                                  dimensions=repr(self.dim),
                                   dtype=repr(self.dtype),
                                   scalar=repr(self.scalar),
                                   constant=repr(self.constant),
@@ -641,7 +634,7 @@ class Subexpression(Variable):
                        'expr={expr}, owner=<{owner}>)>')
         return description.format(classname=self.__class__.__name__,
                                   name=repr(self.name),
-                                  dimensions=repr(self.dimensions),
+                                  dimensions=repr(self.dim),
                                   dtype=repr(self.dtype),
                                   expr=repr(self.expr),
                                   owner=self.owner.name)
@@ -757,14 +750,7 @@ class VariableView(object):
         # We keep a strong reference to the `Indexing` object so that basic
         # indexing is still possible, even if the group no longer exists
         self.indexing = self.group._indices
-        self.dimensions = dimensions
-
-    @property
-    def dim(self):
-        '''
-        The dimensions of this variable.
-        '''
-        return self.dimensions
+        self.dim = dimensions
 
     def get_item(self, item, level=0, namespace=None):
         '''
@@ -807,10 +793,10 @@ class VariableView(object):
             else:
                 values = self.get_with_index_array(item)
 
-        if self.dimensions is None:
+        if self.dim is None:
             return values
         else:
-            return Quantity(values, self.dimensions)
+            return Quantity(values, self.dim)
 
     def __getitem__(self, item):
         return self.get_item(item, level=1)
@@ -857,7 +843,7 @@ class VariableView(object):
                                         item.step is None):
             item = 'True'
 
-        check_units = self.dimensions is not None
+        check_units = self.dim is not None
 
         if namespace is None:
             namespace = get_local_namespace(level=level+1)
@@ -1187,7 +1173,7 @@ class VariableView(object):
         return np.asanyarray(self[:], dtype=dtype)
 
     def __array_prepare__(self, array, context=None):
-        if self.dimensions is None:
+        if self.dim is None:
             return array
         else:
             this = self[:]
@@ -1198,7 +1184,7 @@ class VariableView(object):
                 return array
 
     def __array_wrap__(self, out_arr, context=None):
-        if self.dimensions is None:
+        if self.dim is None:
             return out_arr
         else:
             this = self[:]
@@ -1323,7 +1309,7 @@ class VariableView(object):
 
     def __repr__(self):
         varname = self.name
-        if self.dimensions is None:
+        if self.dim is None:
             varname += '_'
 
         if self.variable.scalar:
@@ -1729,7 +1715,7 @@ class Variables(collections.Mapping):
 
         new_expr = word_substitute(subexpr.expr, substitutions)
         new_subexpr = Subexpression(name, self.owner, new_expr,
-                                    dimensions=subexpr.dimensions,
+                                    dimensions=subexpr.dim,
                                     device=subexpr.device,
                                     dtype=subexpr.dtype,
                                     scalar=subexpr.scalar)

--- a/brian2/core/variables.py
+++ b/brian2/core/variables.py
@@ -102,7 +102,7 @@ class Variable(object):
         name in the owning group. The same variable may be known under other
         names in other groups (e.g. the variable ``v`` of a `NeuronGroup` is
         known as ``v_post`` in a `Synapse` connecting to the group).
-    dimensions : `Dimensions`
+    dimensions : `Dimensions`, optional
         The dimensions of the variable.
     owner : `Nameable`, optional
         The object that "owns" this variable, e.g. the `NeuronGroup` or
@@ -284,9 +284,9 @@ class Constant(Variable):
     ----------
     name : str
         The name of the variable
-    unit : `Unit`
-        The unit of the variable. Note that the variable itself (as referenced
-        by value) should never have units attached.
+    dimensions : `Dimension`, optional
+        The dimensions of the variable. Note that the variable itself (as
+        referenced by value) should never have units attached.
     value: reference to the variable value
         The value of the constant.
     owner : `Nameable`, optional
@@ -344,8 +344,8 @@ class AuxiliaryVariable(Variable):
     ----------
     name : str
         The name of the variable
-    unit : `Unit`
-        The unit of the variable.
+    dimensions : `Dimension`, optional
+        The dimensions of the variable.
     dtype : `dtype`, optional
         The dtype used for storing the variable. If none is given, defaults
         to `core.default_float_dtype`.
@@ -375,8 +375,8 @@ class ArrayVariable(Variable):
         name in the owning group. The same variable may be known under other
         names in other groups (e.g. the variable ``v`` of a `NeuronGroup` is
         known as ``v_post`` in a `Synapse` connecting to the group).
-    unit : `Unit`
-        The unit of the variable
+    dimensions : `Dimension`, optional
+        The dimensions of the variable
     owner : `Nameable`
         The object that "owns" this variable, e.g. the `NeuronGroup` or
         `Synapses` object that declares the variable in its model equations.
@@ -472,8 +472,8 @@ class DynamicArrayVariable(ArrayVariable):
         name in the owning group. The same variable may be known under other
         names in other groups (e.g. the variable ``v`` of a `NeuronGroup` is
         known as ``v_post`` in a `Synapse` connecting to the group).
-    unit : `Unit`
-        The unit of the variable
+    dimensions : `Dimension`, optional
+        The dimensinos of the variable
     owner : `Nameable`
         The object that "owns" this variable, e.g. the `NeuronGroup` or
         `Synapses` object that declares the variable in its model equations.
@@ -571,8 +571,8 @@ class Subexpression(Variable):
     ----------
     name : str
         The name of the subexpression.
-    unit : `Unit`
-        The unit of the subexpression.
+    dimensions : `Dimension`, optional
+        The dimensions of the subexpression.
     owner : `Group`
         The group to which the expression refers.
     expr : str
@@ -723,9 +723,9 @@ class VariableView(object):
     group : `Group`
         The group through which the variable is accessed (not necessarily the
         same as `variable.owner`).
-    unit : `Unit`, optional
-        The unit to be used for the variable, should be `None` when a variable
-         is accessed without units (e.g. when accessing ``G.var_``).
+    dimensions : `Dimension`, optional
+        The dimensinos to be used for the variable, should be `None` when a
+        variable is accessed without units (e.g. when accessing ``G.var_``).
     '''
     def __init__(self, name, variable, group, dimensions=None):
         self.name = name
@@ -1409,8 +1409,8 @@ class Variables(collections.Mapping):
         ----------
         name : str
             The name of the variable.
-        unit : `Unit`
-            The unit of the variable
+        dimensions : `Dimension`, optional
+            The dimensions of the variable.
         size : int
             The size of the array.
         values : `ndarray`, optional
@@ -1461,7 +1461,7 @@ class Variables(collections.Mapping):
                                       'size: %d != %d') % (len(values), size))
                 self.device.fill_with_array(var, values)
 
-    def add_arrays(self, names, size, dimensions=DIMENSIONLESS, values=None,
+    def add_arrays(self, names, size, dimensions=DIMENSIONLESS,
                    dtype=None, constant=False, read_only=False, scalar=False,
                    unique=False, index=None):
         '''
@@ -1472,8 +1472,8 @@ class Variables(collections.Mapping):
         ----------
         names : list of str
             The names of the variable.
-        unit : `Unit`
-            The unit of the variables
+        dimensions : `Dimension`, optional
+            The dimensions of the variable.
         size : int
             The sizes of the arrays.
         dtype : `dtype`, optional
@@ -1512,8 +1512,8 @@ class Variables(collections.Mapping):
         ----------
         name : str
             The name of the variable.
-        unit : `Unit`
-            The unit of the variable
+        dimensions : `Dimension`, optional
+            The dimensions of the variable.
         size : int or tuple of int
             The (initital) size of the array.
         values : `ndarray`, optional
@@ -1605,11 +1605,11 @@ class Variables(collections.Mapping):
         ----------
         name : str
             The name of the variable
-        unit : `Unit`
-            The unit of the variable. Note that the variable itself (as referenced
-            by value) should never have units attached.
         value: reference to the variable value
             The value of the constant.
+        dimensions : `Dimension`, optional
+            The dimensions of the variable. Note that the variable itself (as
+            referenced by value) should never have units attached.
         '''
         var = Constant(name=name, dimensions=dimensions, owner=self.owner, value=value)
         self._add_variable(name, var)

--- a/brian2/core/variables.py
+++ b/brian2/core/variables.py
@@ -10,7 +10,7 @@ import sympy
 import numpy as np
 
 from brian2.utils.stringtools import get_identifiers, word_substitute
-from brian2.units.fundamentalunits import (Quantity, Unit, DIMENSIONLESS,
+from brian2.units.fundamentalunits import (Quantity, get_unit, DIMENSIONLESS,
                                            fail_for_dimension_mismatch,
                                            Dimension)
 from brian2.utils.logger import get_logger
@@ -175,6 +175,16 @@ class Variable(object):
         String representation of the numpy dtype
         '''
         return get_dtype_str(self)
+
+    @property
+    def unit(self):
+        '''
+        Returns the `Unit` of this variable (deprecated, get the dimensions with
+        `Variable.dim` instead.)
+        '''
+        logger.warn("The 'unit' property is deprecated, use 'dim' instead.",
+                    'deprecated_variable_unit', once=True)
+        return get_unit(self.dim)
 
     def get_value(self):
         '''
@@ -751,6 +761,16 @@ class VariableView(object):
         # indexing is still possible, even if the group no longer exists
         self.indexing = self.group._indices
         self.dim = dimensions
+
+    @property
+    def unit(self):
+        '''
+        Returns the `Unit` of this equation (deprecated, get the dimensions with
+        `SingleEquation.dim` instead.)
+        '''
+        logger.warn("The 'unit' property is deprecated, use 'dim' instead.",
+                    'deprecated_variableview_unit', once=True)
+        return get_unit(self.dim)
 
     def get_item(self, item, level=0, namespace=None):
         '''

--- a/brian2/core/variables.py
+++ b/brian2/core/variables.py
@@ -12,7 +12,7 @@ import numpy as np
 from brian2.utils.stringtools import get_identifiers, word_substitute
 from brian2.units.fundamentalunits import (Quantity, Unit, DIMENSIONLESS,
                                            fail_for_dimension_mismatch,
-                                           have_same_dimensions, get_unit)
+                                           Dimension)
 from brian2.utils.logger import get_logger
 
 from .base import weakproxy_with_fallback, device_override
@@ -102,8 +102,8 @@ class Variable(object):
         name in the owning group. The same variable may be known under other
         names in other groups (e.g. the variable ``v`` of a `NeuronGroup` is
         known as ``v_post`` in a `Synapse` connecting to the group).
-    unit : `Unit`
-        The unit of the variable.
+    dimensions : `Dimensions`
+        The dimensions of the variable.
     owner : `Nameable`, optional
         The object that "owns" this variable, e.g. the `NeuronGroup` or
         `Synapses` object that declares the variable in its model equations.
@@ -127,18 +127,13 @@ class Variable(object):
         Whether this variable is an array. Allows for simpler check than testing
         ``isinstance(var, ArrayVariable)``. Defaults to ``False``.
     '''
-    def __init__(self, name, unit, owner=None, dtype=None, scalar=False,
-                 constant=False, read_only=False, dynamic=False, array=False):
-        if not isinstance(unit, Unit):
-            if isinstance(unit, Quantity):
-                unit = get_unit(unit)
-            elif unit == 1:
-                unit = Unit(1)
-            else:
-                raise TypeError(('unit argument has to be a Unit object, was '
-                                 'type %s instead') % type(unit))
-        #: The variable's unit.
-        self.unit = unit
+    def __init__(self, name, dimensions=DIMENSIONLESS, owner=None, dtype=None,
+                 scalar=False, constant=False, read_only=False, dynamic=False,
+                 array=False):
+        assert isinstance(dimensions, Dimension)
+
+        #: The variable's dimensions.
+        self.dimensions = dimensions
 
         #: The variable's name.
         self.name = name
@@ -152,7 +147,7 @@ class Variable(object):
             self.dtype = prefs.core.default_float_dtype
 
         if self.is_boolean:
-            if not have_same_dimensions(unit, 1):
+            if dimensions is not DIMENSIONLESS:
                 raise ValueError('Boolean variables can only be dimensionless')
 
         #: Whether the variable is a scalar
@@ -179,7 +174,7 @@ class Variable(object):
         '''
         The dimensions of this variable.
         '''
-        return self.unit.dim
+        return self.dimensions
     
     @property
     def dtype_str(self):
@@ -205,7 +200,7 @@ class Variable(object):
         '''
         Return the value associated with the variable (with units).
         '''
-        return Quantity(self.get_value(), self.unit.dimensions)
+        return Quantity(self.get_value(), self.dimensions)
 
     def get_addressable_value(self, name, group):
         '''
@@ -269,11 +264,11 @@ class Variable(object):
         return self.get_len()
 
     def __repr__(self):
-        description = ('<{classname}(unit={unit}, '
+        description = ('<{classname}(dimensions={dimensions}, '
                        ' dtype={dtype}, scalar={scalar}, constant={constant},'
                        ' read_only={read_only})>')
         return description.format(classname=self.__class__.__name__,
-                                  unit=repr(self.unit),
+                                  dimensions=repr(self.dimensions),
                                   dtype=repr(self.dtype),
                                   scalar=repr(self.scalar),
                                   constant=repr(self.constant),
@@ -306,7 +301,7 @@ class Constant(Variable):
         specific group, e.g. the ``N`` constant for a `NeuronGroup`. External
         constants will have ``None`` (the default value).
     '''
-    def __init__(self, name, unit, value, owner=None):
+    def __init__(self, name, value, dimensions=DIMENSIONLESS, owner=None):
         # Determine the type of the value
         is_bool = (value is True or
                    value is False or
@@ -336,7 +331,7 @@ class Constant(Variable):
         #: The constant's value
         self.value = value
 
-        super(Constant, self).__init__(unit=unit, name=name, owner=owner,
+        super(Constant, self).__init__(dimensions=dimensions, name=name, owner=owner,
                                        dtype=dtype, scalar=True, constant=True,
                                        read_only=True)
 
@@ -365,8 +360,8 @@ class AuxiliaryVariable(Variable):
         Whether the variable is a scalar value (``True``) or vector-valued, e.g.
         defined for every neuron (``False``). Defaults to ``False``.
     '''
-    def __init__(self, name, unit, dtype=None, scalar=False):
-        super(AuxiliaryVariable, self).__init__(unit=unit,
+    def __init__(self, name, dimensions=DIMENSIONLESS, dtype=None, scalar=False):
+        super(AuxiliaryVariable, self).__init__(dimensions=dimensions,
                                                 name=name, dtype=dtype,
                                                 scalar=scalar)
 
@@ -418,10 +413,11 @@ class ArrayVariable(Variable):
         corresponding pre- and post-synaptic indices are not). Defaults to
         ``False``.
     '''
-    def __init__(self, name, unit, owner, size, device, dtype=None,
-                 constant=False, scalar=False, read_only=False, dynamic=False,
-                 unique=False):
-        super(ArrayVariable, self).__init__(unit=unit, name=name, owner=owner,
+    def __init__(self, name, owner, size, device, dimensions=DIMENSIONLESS,
+                 dtype=None, constant=False, scalar=False, read_only=False,
+                 dynamic=False, unique=False):
+        super(ArrayVariable, self).__init__(dimensions=dimensions, name=name,
+                                            owner=owner,
                                             dtype=dtype, scalar=scalar,
                                             constant=constant,
                                             read_only=read_only,
@@ -463,11 +459,11 @@ class ArrayVariable(Variable):
         return self.size
 
     def get_addressable_value(self, name, group):
-        return VariableView(name=name, variable=self, group=group, unit=None)
+        return VariableView(name=name, variable=self, group=group, dimensions=None)
 
     def get_addressable_value_with_unit(self, name, group):
         return VariableView(name=name, variable=self, group=group,
-                            unit=self.unit)
+                            dimensions=self.dim)
 
 
 class DynamicArrayVariable(ArrayVariable):
@@ -519,18 +515,18 @@ class DynamicArrayVariable(ArrayVariable):
         ``False``.
     '''
 
-    def __init__(self, name, unit, owner, size, device, dtype=None,
-                 constant=False, needs_reference_update=False,
+    def __init__(self, name, owner, size, device, dimensions=DIMENSIONLESS,
+                 dtype=None, constant=False, needs_reference_update=False,
                  resize_along_first=False, scalar=False, read_only=False,
                  unique=False):
 
         if isinstance(size, int):
-            dimensions = 1
+            ndim = 1
         else:
-            dimensions = len(size)
+            ndim = len(size)
 
         #: The number of dimensions
-        self.dimensions = dimensions
+        self.ndim = ndim
 
         if constant and needs_reference_update:
             raise ValueError('A variable cannot be constant and '
@@ -542,7 +538,7 @@ class DynamicArrayVariable(ArrayVariable):
         #: Whether this array will be only resized along the first dimension
         self.resize_along_first = resize_along_first
 
-        super(DynamicArrayVariable, self).__init__(unit=unit,
+        super(DynamicArrayVariable, self).__init__(dimensions=dimensions,
                                                    owner=owner,
                                                    name=name,
                                                    size=size,
@@ -572,7 +568,6 @@ class DynamicArrayVariable(ArrayVariable):
         self.size = new_size
 
 
-
 class Subexpression(Variable):
     '''
     An object providing information about a named subexpression in a model.
@@ -598,9 +593,9 @@ class Subexpression(Variable):
         Whether this is an expression only referring to scalar variables.
         Defaults to ``False``
     '''
-    def __init__(self, name, unit, owner, expr, device, dtype=None,
-                 scalar=False):
-        super(Subexpression, self).__init__(unit=unit, owner=owner,
+    def __init__(self, name, owner, expr, device, dimensions=DIMENSIONLESS,
+                 dtype=None, scalar=False):
+        super(Subexpression, self).__init__(dimensions=dimensions, owner=owner,
                                             name=name, dtype=dtype,
                                             scalar=scalar,
                                             constant=False, read_only=True)
@@ -631,21 +626,22 @@ class Subexpression(Variable):
         self.identifiers = get_identifiers(expr)
 
     def get_addressable_value(self, name, group):
-        return VariableView(name=name, variable=self, group=group, unit=None)
+        return VariableView(name=name, variable=self, group=group,
+                            dimensions=None)
 
     def get_addressable_value_with_unit(self, name, group):
         return VariableView(name=name, variable=self, group=group,
-                            unit=self.unit)
+                            dimensions=self.dim)
 
     def __contains__(self, var):
         return var in self.identifiers
 
     def __repr__(self):
-        description = ('<{classname}(name={name}, unit={unit}, dtype={dtype}, '
+        description = ('<{classname}(name={name}, dimensions={dimensions}, dtype={dtype}, '
                        'expr={expr}, owner=<{owner}>)>')
         return description.format(classname=self.__class__.__name__,
                                   name=repr(self.name),
-                                  unit=repr(self.unit),
+                                  dimensions=repr(self.dimensions),
                                   dtype=repr(self.dtype),
                                   expr=repr(self.expr),
                                   owner=self.owner.name)
@@ -738,7 +734,7 @@ class VariableView(object):
         The unit to be used for the variable, should be `None` when a variable
          is accessed without units (e.g. when accessing ``G.var_``).
     '''
-    def __init__(self, name, variable, group, unit=None):
+    def __init__(self, name, variable, group, dimensions=None):
         self.name = name
         self.variable = variable
         self.index_var_name = group.variables.indices[name]
@@ -761,14 +757,14 @@ class VariableView(object):
         # We keep a strong reference to the `Indexing` object so that basic
         # indexing is still possible, even if the group no longer exists
         self.indexing = self.group._indices
-        self.unit = unit
+        self.dimensions = dimensions
 
     @property
     def dim(self):
         '''
         The dimensions of this variable.
         '''
-        return self.unit.dim
+        return self.dimensions
 
     def get_item(self, item, level=0, namespace=None):
         '''
@@ -811,10 +807,10 @@ class VariableView(object):
             else:
                 values = self.get_with_index_array(item)
 
-        if self.unit is None:
+        if self.dimensions is None:
             return values
         else:
-            return Quantity(values, self.unit.dimensions)
+            return Quantity(values, self.dimensions)
 
     def __getitem__(self, item):
         return self.get_item(item, level=1)
@@ -861,7 +857,7 @@ class VariableView(object):
                                         item.step is None):
             item = 'True'
 
-        check_units = self.unit is not None
+        check_units = self.dimensions is not None
 
         if namespace is None:
             namespace = get_local_namespace(level=level+1)
@@ -975,8 +971,8 @@ class VariableView(object):
         indices = np.atleast_1d(self.indexing(item))
         abstract_code = self.name + ' = ' + code
         variables = Variables(self.group)
-        variables.add_array('_group_idx', unit=Unit(1),
-                            size=len(indices), dtype=np.int32, values=indices)
+        variables.add_array('_group_idx', size=len(indices), dtype=np.int32,
+                            values=indices)
 
         # TODO: Have an additional argument to avoid going through the index
         # array for situations where iterate_all could be used
@@ -1019,7 +1015,7 @@ class VariableView(object):
         abstract_code_cond = '_cond = '+cond
         abstract_code = self.name + ' = ' + code
         variables = Variables(None)
-        variables.add_auxiliary_variable('_cond', unit=Unit(1), dtype=np.bool)
+        variables.add_auxiliary_variable('_cond', dtype=np.bool)
         from brian2.codegen.codeobject import create_runner_codeobj
         # TODO: Have an additional argument to avoid going through the index
         # array for situations where iterate_all could be used
@@ -1061,10 +1057,10 @@ class VariableView(object):
         # dictionary. Important to deal correctly with
         # the type of the variable in C++
         variables = Variables(None)
-        variables.add_auxiliary_variable('_variable', unit=variable.unit,
+        variables.add_auxiliary_variable('_variable', dimensions=variable.dim,
                                          dtype=variable.dtype,
                                          scalar=variable.scalar)
-        variables.add_auxiliary_variable('_cond', unit=Unit(1), dtype=np.bool)
+        variables.add_auxiliary_variable('_cond', dtype=np.bool)
 
         abstract_code = '_variable = ' + self.name + '\n'
         abstract_code += '_cond = ' + code
@@ -1111,7 +1107,7 @@ class VariableView(object):
         # have to evaluate code for the given indices
         variables = Variables(None, default_index='_group_index')
         variables.add_auxiliary_variable('_variable',
-                                         unit=variable.unit,
+                                         dimensions=variable.dim,
                                          dtype=variable.dtype,
                                          scalar=variable.scalar)
         if indices.shape == ():
@@ -1119,8 +1115,7 @@ class VariableView(object):
             indices = np.array([indices])
         else:
             single_index = False
-        variables.add_array('_group_idx', unit=Unit(1),
-                            size=len(indices), dtype=np.int32)
+        variables.add_array('_group_idx', size=len(indices), dtype=np.int32)
         variables['_group_idx'].set_value(indices)
         # Force the use of this variable as a replacement for the original
         # index variable
@@ -1156,7 +1151,7 @@ class VariableView(object):
     def set_with_index_array(self, item, value, check_units):
         variable = self.variable
         if check_units:
-            fail_for_dimension_mismatch(variable.unit, value,
+            fail_for_dimension_mismatch(variable.dim, value,
                                         'Incorrect unit for setting variable %s' % self.name)
         if variable.scalar:
             if not (isinstance(item, slice) and item == slice(None)):
@@ -1192,7 +1187,7 @@ class VariableView(object):
         return np.asanyarray(self[:], dtype=dtype)
 
     def __array_prepare__(self, array, context=None):
-        if self.unit is None:
+        if self.dimensions is None:
             return array
         else:
             this = self[:]
@@ -1203,7 +1198,7 @@ class VariableView(object):
                 return array
 
     def __array_wrap__(self, out_arr, context=None):
-        if self.unit is None:
+        if self.dimensions is None:
             return out_arr
         else:
             this = self[:]
@@ -1328,11 +1323,11 @@ class VariableView(object):
 
     def __repr__(self):
         varname = self.name
-        if self.unit is None:
+        if self.dimensions is None:
             varname += '_'
 
         if self.variable.scalar:
-            dim = self.unit.dim if self.unit is not None else DIMENSIONLESS
+            dim = self.dim if self.dim is not None else DIMENSIONLESS
             values = repr(Quantity(self.variable.get_value().item(),
                                    dim=dim))
         else:
@@ -1418,9 +1413,9 @@ class Variables(collections.Mapping):
         if index is not None:
             self.indices[name] = index
 
-    def add_array(self, name, unit, size, values=None, dtype=None,
-                  constant=False, read_only=False, scalar=False, unique=False,
-                  index=None):
+    def add_array(self, name, size, dimensions=DIMENSIONLESS, values=None,
+                  dtype=None, constant=False, read_only=False, scalar=False,
+                  unique=False, index=None):
         '''
         Add an array (initialized with zeros).
 
@@ -1458,7 +1453,7 @@ class Variables(collections.Mapping):
             # We want a basic Python type for the size instead of something
             # like numpy.int64
             size = int(size)
-        var = ArrayVariable(name=name, unit=unit, owner=self.owner,
+        var = ArrayVariable(name=name, dimensions=dimensions, owner=self.owner,
                             device=self.device, size=size,
                             dtype=dtype,
                             constant=constant,
@@ -1480,9 +1475,9 @@ class Variables(collections.Mapping):
                                       'size: %d != %d') % (len(values), size))
                 self.device.fill_with_array(var, values)
 
-    def add_arrays(self, names, unit, size, values=None, dtype=None,
-                  constant=False, read_only=False, scalar=False, unique=False,
-                  index=None):
+    def add_arrays(self, names, size, dimensions=DIMENSIONLESS, values=None,
+                   dtype=None, constant=False, read_only=False, scalar=False,
+                   unique=False, index=None):
         '''
         Adds several arrays (initialized with zeros) with the same attributes
         (size, units, etc.).
@@ -1515,12 +1510,13 @@ class Variables(collections.Mapping):
             See `ArrayVariable`. Defaults to ``False``.
         '''
         for name in names:
-            self.add_array(name, unit=unit, size=size, dtype=dtype,
+            self.add_array(name, dimensions=dimensions, size=size, dtype=dtype,
                            constant=constant, read_only=read_only,
                            scalar=scalar, unique=unique, index=index)
 
-    def add_dynamic_array(self, name, unit, size, values=None, dtype=None,
-                          constant=False, needs_reference_update=False,
+    def add_dynamic_array(self, name, size, dimensions=DIMENSIONLESS,
+                          values=None, dtype=None, constant=False,
+                          needs_reference_update=False,
                           resize_along_first=False, read_only=False,
                           unique=False, scalar=False, index=None):
         '''
@@ -1560,7 +1556,7 @@ class Variables(collections.Mapping):
         unique : bool, optional
             See `DynamicArrayVariable`. Defaults to ``False``.
         '''
-        var = DynamicArrayVariable(name=name, unit=unit, owner=self.owner,
+        var = DynamicArrayVariable(name=name, dimensions=dimensions, owner=self.owner,
                                    device=self.device,
                                    size=size, dtype=dtype,
                                    constant=constant,
@@ -1609,13 +1605,13 @@ class Variables(collections.Mapping):
         unique : bool, optional
             See `ArrayVariable`. Defaults to ``True`` here.
         '''
-        self.add_array(name=name, unit=Unit(1), size=size, dtype=dtype,
+        self.add_array(name=name, dimensions=DIMENSIONLESS, size=size, dtype=dtype,
                        constant=constant, read_only=read_only, unique=unique,
                        index=index)
         self.device.init_with_arange(self._variables[name], start, dtype=dtype)
 
 
-    def add_constant(self, name, unit, value):
+    def add_constant(self, name, value, dimensions=DIMENSIONLESS):
         '''
         Add a scalar constant (e.g. the number of neurons `N`).
 
@@ -1629,11 +1625,11 @@ class Variables(collections.Mapping):
         value: reference to the variable value
             The value of the constant.
         '''
-        var = Constant(name=name, unit=unit, owner=self.owner, value=value)
+        var = Constant(name=name, dimensions=dimensions, owner=self.owner, value=value)
         self._add_variable(name, var)
 
-    def add_subexpression(self, name, unit, expr, dtype=None, scalar=False,
-                          index=None):
+    def add_subexpression(self, name, expr, dimensions=DIMENSIONLESS,
+                          dtype=None, scalar=False, index=None):
         '''
         Add a named subexpression.
 
@@ -1641,8 +1637,8 @@ class Variables(collections.Mapping):
         ----------
         name : str
             The name of the subexpression.
-        unit : `Unit`
-            The unit of the subexpression.
+        dimensions : `Dimension`
+            The dimensions of the subexpression.
         expr : str
             The subexpression itself.
         dtype : `dtype`, optional
@@ -1655,11 +1651,12 @@ class Variables(collections.Mapping):
             The index to use for this variable. Defaults to
             `Variables.default_index`.
         '''
-        var = Subexpression(name=name, unit=unit, expr=expr, owner=self.owner,
+        var = Subexpression(name=name, dimensions=dimensions, expr=expr, owner=self.owner,
                             dtype=dtype, device=self.device, scalar=scalar)
         self._add_variable(name, var, index=index)
 
-    def add_auxiliary_variable(self, name, unit, dtype=None, scalar=False):
+    def add_auxiliary_variable(self, name, dimensions=DIMENSIONLESS,
+                               dtype=None, scalar=False):
         '''
         Add an auxiliary variable (most likely one that is added automatically
         to abstract code, e.g. ``_cond`` for a threshold condition),
@@ -1669,8 +1666,8 @@ class Variables(collections.Mapping):
         ----------
         name : str
             The name of the variable
-        unit : `Unit`
-            The unit of the variable.
+        dimensions : `Dimension`
+            The dimensions of the variable.
         dtype : `dtype`, optional
             The dtype used for storing the variable. If none is given, defaults
             to `core.default_float_dtype`.
@@ -1678,7 +1675,7 @@ class Variables(collections.Mapping):
             Whether the variable is a scalar value (``True``) or vector-valued,
             e.g. defined for every neuron (``False``). Defaults to ``False``.
         '''
-        var = AuxiliaryVariable(name=name, unit=unit, dtype=dtype,
+        var = AuxiliaryVariable(name=name, dimensions=dimensions, dtype=dtype,
                                 scalar=scalar)
         self._add_variable(name, var)
 
@@ -1731,7 +1728,8 @@ class Variables(collections.Mapping):
                                    subexpr_var_index)
 
         new_expr = word_substitute(subexpr.expr, substitutions)
-        new_subexpr = Subexpression(name, subexpr.unit, self.owner, new_expr,
+        new_subexpr = Subexpression(name, self.owner, new_expr,
+                                    dimensions=subexpr.dimensions,
                                     device=subexpr.device,
                                     dtype=subexpr.dtype,
                                     scalar=subexpr.scalar)

--- a/brian2/devices/cpp_standalone/device.py
+++ b/brian2/devices/cpp_standalone/device.py
@@ -29,8 +29,8 @@ from brian2.core.preferences import prefs, BrianPreference
 from brian2.utils.filetools import copy_directory, ensure_directory, in_directory
 from brian2.utils.stringtools import word_substitute
 from brian2.codegen.generators.cpp_generator import c_data_type
-from brian2.units.fundamentalunits import Quantity, have_same_dimensions
-from brian2.units import second, ms
+from brian2.units.fundamentalunits import Quantity
+from brian2.units import second
 from brian2.utils.logger import get_logger, std_silent
 
 from .codeobject import CPPStandaloneCodeObject, openmp_pragma
@@ -230,7 +230,7 @@ class CPPStandaloneDevice(Device):
         if isinstance(var, DynamicArrayVariable):
             if access_data:
                 return self.arrays[var]
-            elif var.dimensions == 1:
+            elif var.ndim == 1:
                 return self.dynamic_arrays[var]
             else:
                 return self.dynamic_arrays_2d[var]
@@ -283,13 +283,13 @@ class CPPStandaloneDevice(Device):
             orig_array_name = array_name = '_array_%s_%s' % (var.owner.name, var.name)
             suffix = 0
 
-            if var.dimensions == 1:
+            if var.ndim == 1:
                 dynamic_dict = self.dynamic_arrays
-            elif var.dimensions == 2:
+            elif var.ndim == 2:
                 dynamic_dict = self.dynamic_arrays_2d
             else:
                 raise AssertionError(('Did not expect a dynamic array with %d '
-                                      'dimensions.') % var.dimensions)
+                                      'dimensions.') % var.ndim)
             while (dynamic_name in dynamic_dict.values() or
                    array_name in self.arrays.values()):
                 suffix += 1
@@ -636,7 +636,7 @@ class CPPStandaloneDevice(Device):
                 if isinstance(v, ArrayVariable):
                     try:
                         if isinstance(v, DynamicArrayVariable):
-                            if v.dimensions == 1:
+                            if v.ndim == 1:
                                 dyn_array_name = self.dynamic_arrays[v]
                                 array_name = self.arrays[v]
                                 line = '{c_type}* const {array_name} = {dyn_array_name}.empty()? 0 : &{dyn_array_name}[0];'

--- a/brian2/devices/device.py
+++ b/brian2/devices/device.py
@@ -396,7 +396,7 @@ class RuntimeDevice(Device):
     def add_array(self, var):
         # This creates the actual numpy arrays (or DynamicArrayVariable objects)
         if isinstance(var, DynamicArrayVariable):
-            if var.dimensions == 1:
+            if var.ndim == 1:
                 arr = DynamicArray1D(var.size, dtype=var.dtype)
             else:
                 arr = DynamicArray(var.size, dtype=var.dtype)

--- a/brian2/equations/equations.py
+++ b/brian2/equations/equations.py
@@ -357,7 +357,7 @@ class SingleEquation(object):
                  flags=None):
         self.type = type
         self.varname = varname
-        self.dimensions = get_dimensions(dimensions)
+        self.dim = get_dimensions(dimensions)
         self.var_type = var_type
         if dimensions is not DIMENSIONLESS:
             if var_type == BOOLEAN:
@@ -376,9 +376,6 @@ class SingleEquation(object):
 
         # will be set later in the sort_subexpressions method of Equations
         self.update_order = -1
-
-    dim = property(lambda self: self.dimensions,
-                   doc='The dimensions of the variable defined by this equation.')
 
     identifiers = property(lambda self: self.expr.identifiers
                            if not self.expr is None else set([]),
@@ -407,7 +404,7 @@ class SingleEquation(object):
         if not self.expr is None:
             s += ' = ' + str(self.expr)
 
-        s += ' : ' + str(get_unit(self.dimensions))
+        s += ' : ' + str(get_unit(self.dim))
 
         if len(self.flags):
             s += ' (' + ', '.join(self.flags) + ')'
@@ -420,7 +417,7 @@ class SingleEquation(object):
         if not self.expr is None:
             s += ': ' + self.expr.code
 
-        s += ' (Unit: ' + str(get_unit(self.dimensions))
+        s += ' (Unit: ' + str(get_unit(self.dim))
 
         if len(self.flags):
             s += ', flags: ' + ', '.join(self.flags)
@@ -446,7 +443,7 @@ class SingleEquation(object):
             p.pretty(self.expr)
 
         p.text(' : ')
-        p.pretty(get_unit(self.dimensions))
+        p.pretty(get_unit(self.dim))
 
         if len(self.flags):
             p.text(' (' + ', '.join(self.flags) + ')')
@@ -767,7 +764,7 @@ class Equations(collections.Mapping):
                                              if eq.type == PARAMETER]),
                                doc='All parameter names.')
 
-    dimensions = property(lambda self: dict([(var, eq.dimensions) for var, eq in
+    dimensions = property(lambda self: dict([(var, eq.dim) for var, eq in
                                        self._equations.iteritems()]),
                      doc='Dictionary of all internal variables and their corresponding dimensions.')
 
@@ -1060,7 +1057,7 @@ def extract_constant_subexpressions(eqs):
                 flags = None
             without_const_subexpressions.append(SingleEquation(PARAMETER,
                                                                eq.varname,
-                                                               eq.dimensions,
+                                                               eq.dim,
                                                                var_type=eq.var_type,
                                                                flags=flags))
             const_subexpressions.append(eq)

--- a/brian2/equations/equations.py
+++ b/brian2/equations/equations.py
@@ -377,6 +377,16 @@ class SingleEquation(object):
         # will be set later in the sort_subexpressions method of Equations
         self.update_order = -1
 
+    @property
+    def unit(self):
+        '''
+        Returns the `Unit` of this equation (deprecated, get the dimensions with
+        `SingleEquation.dim` instead.)
+        '''
+        logger.warn("The 'unit' property is deprecated, use 'dim' instead.",
+                    'deprecated_equation_unit', once=True)
+        return get_unit(self.dim)
+
     identifiers = property(lambda self: self.expr.identifiers
                            if not self.expr is None else set([]),
                            doc='All identifiers in the RHS of this equation.')

--- a/brian2/equations/equations.py
+++ b/brian2/equations/equations.py
@@ -216,7 +216,7 @@ def dimensions_and_type_from_string(unit_string):
     Returns
     -------
     d, type : (`Dimension`, {FLOAT, INTEGER or BOOL})
-        The resulting dimensions and the type of the variable.
+        The resulting physical dimensions and the type of the variable.
 
     Raises
     ------
@@ -767,8 +767,9 @@ class Equations(collections.Mapping):
                                doc='All parameter names.')
 
     dimensions = property(lambda self: dict([(var, eq.dim) for var, eq in
-                                       self._equations.iteritems()]),
-                     doc='Dictionary of all internal variables and their corresponding dimensions.')
+                                             self._equations.iteritems()]),
+                          doc='Dictionary of all internal variables and their '
+                              'corresponding physical dimensions.')
 
 
     identifiers = property(lambda self: set().union(*[eq.identifiers for

--- a/brian2/equations/equations.py
+++ b/brian2/equations/equations.py
@@ -215,8 +215,8 @@ def dimensions_and_type_from_string(unit_string):
 
     Returns
     -------
-    u, type : (Dimension, {FLOAT, INTEGER or BOOL})
-        The resulting unit and the type of the variable.
+    d, type : (`Dimension`, {FLOAT, INTEGER or BOOL})
+        The resulting dimensions and the type of the variable.
 
     Raises
     ------

--- a/brian2/equations/equations.py
+++ b/brian2/equations/equations.py
@@ -5,7 +5,7 @@ import collections
 import keyword
 import re
 import string
-import numpy as np
+
 import sympy
 from pyparsing import (Group, ZeroOrMore, OneOrMore, Optional, Word, CharsNotIn,
                        Combine, Suppress, restOfLine, LineEnd, ParseException)
@@ -13,13 +13,11 @@ from pyparsing import (Group, ZeroOrMore, OneOrMore, Optional, Word, CharsNotIn,
 from brian2.core.namespace import (DEFAULT_FUNCTIONS,
                                    DEFAULT_CONSTANTS,
                                    DEFAULT_UNITS)
-from brian2.core.variables import Constant
-from brian2.core.functions import Function
-from brian2.equations.codestrings import is_constant_over_dt
 from brian2.parsing.sympytools import sympy_to_str, str_to_sympy
-from brian2.units.fundamentalunits import (Unit, Quantity, have_same_dimensions,
-                                           get_unit, DIMENSIONLESS,
-                                           DimensionMismatchError)
+from brian2.units.fundamentalunits import (Unit, Quantity, get_unit,
+                                           DIMENSIONLESS,
+                                           DimensionMismatchError,
+                                           get_dimensions, Dimension)
 from brian2.units.allunits import (metre, meter, second, amp, kelvin, mole,
                                    candle, kilogram, radian, steradian, hertz,
                                    newton, pascal, joule, watt, coulomb, volt,
@@ -30,7 +28,7 @@ from brian2.utils.logger import get_logger
 from brian2.utils.topsort import topsort
 
 from .codestrings import Expression
-from .unitcheck import check_unit
+from .unitcheck import check_dimensions
 
 
 __all__ = ['Equations']
@@ -203,7 +201,7 @@ def check_identifier_constants(identifier):
                          'variable name.' % identifier)
 
 
-def unit_and_type_from_string(unit_string):
+def dimensions_and_type_from_string(unit_string):
     '''
     Returns the unit that results from evaluating a string like
     "siemens / metre ** 2", allowing for the special string "1" to signify
@@ -217,7 +215,7 @@ def unit_and_type_from_string(unit_string):
 
     Returns
     -------
-    u, type : (Unit, {FLOAT, INTEGER or BOOL})
+    u, type : (Dimension, {FLOAT, INTEGER or BOOL})
         The resulting unit and the type of the variable.
 
     Raises
@@ -240,18 +238,18 @@ def unit_and_type_from_string(unit_string):
 
     # Special case: dimensionless unit
     if unit_string == '1':
-        return Unit(1, dim=DIMENSIONLESS), FLOAT
+        return DIMENSIONLESS, FLOAT
 
     # Another special case: boolean variable
     if unit_string == 'boolean':
-        return Unit(1, dim=DIMENSIONLESS), BOOLEAN
+        return DIMENSIONLESS, BOOLEAN
     if unit_string == 'bool':
         raise TypeError("Use 'boolean' not 'bool' as the unit for a boolean "
                         "variable.")
 
     # Yet another special case: integer variable
     if unit_string == 'integer':
-        return Unit(1, dim=DIMENSIONLESS), INTEGER
+        return DIMENSIONLESS, INTEGER
 
     # Check first whether the expression evaluates at all, using only base units
     try:
@@ -274,7 +272,7 @@ def unit_and_type_from_string(unit_string):
                                                        type(evaluated_unit))))
 
     # No error has been raised, all good
-    return evaluated_unit, FLOAT
+    return evaluated_unit.dim, FLOAT
 
 
 def parse_string_equations(eqns):
@@ -307,7 +305,7 @@ def parse_string_equations(eqns):
         identifier = eq_content['identifier']
 
         # Convert unit string to Unit object
-        unit, var_type = unit_and_type_from_string(eq_content['unit'])
+        dims, var_type = dimensions_and_type_from_string(eq_content['unit'])
 
         expression = eq_content.get('expression', None)
         if not expression is None:
@@ -317,7 +315,7 @@ def parse_string_equations(eqns):
             expression = Expression(p.sub(' ', expression))
         flags = list(eq_content.get('flags', []))
 
-        equation = SingleEquation(eq_type, identifier, unit, var_type=var_type,
+        equation = SingleEquation(eq_type, identifier, dims, var_type=var_type,
                                   expr=expression, flags=flags)
 
         if identifier in equations:
@@ -343,8 +341,8 @@ class SingleEquation(object):
         The type of the equation.
     varname : str
         The variable that is defined by this equation.
-    unit : Unit
-        The unit of the variable
+    dimensions : `Dimension`
+        The dimensions of the variable
     var_type : {FLOAT, INTEGER, BOOLEAN}
         The type of the variable (floating point value or boolean).
     expr : `Expression`, optional
@@ -355,13 +353,13 @@ class SingleEquation(object):
         context.
     
     '''
-    def __init__(self, type, varname, unit, var_type=FLOAT, expr=None,
+    def __init__(self, type, varname, dimensions, var_type=FLOAT, expr=None,
                  flags=None):
         self.type = type
         self.varname = varname
-        self.unit = unit
+        self.dimensions = get_dimensions(dimensions)
         self.var_type = var_type
-        if not have_same_dimensions(unit, 1):
+        if dimensions is not DIMENSIONLESS:
             if var_type == BOOLEAN:
                 raise TypeError('Boolean variables are necessarily dimensionless.')
             elif var_type == INTEGER:
@@ -379,6 +377,8 @@ class SingleEquation(object):
         # will be set later in the sort_subexpressions method of Equations
         self.update_order = -1
 
+    dim = property(lambda self: self.dimensions,
+                   doc='The dimensions of the variable defined by this equation.')
 
     identifiers = property(lambda self: self.expr.identifiers
                            if not self.expr is None else set([]),
@@ -407,7 +407,7 @@ class SingleEquation(object):
         if not self.expr is None:
             s += ' = ' + str(self.expr)
 
-        s += ' : ' + str(self.unit)
+        s += ' : ' + str(get_unit(self.dimensions))
 
         if len(self.flags):
             s += ' (' + ', '.join(self.flags) + ')'
@@ -420,7 +420,7 @@ class SingleEquation(object):
         if not self.expr is None:
             s += ': ' + self.expr.code
 
-        s += ' (Unit: ' + str(self.unit)
+        s += ' (Unit: ' + str(get_unit(self.dimensions))
 
         if len(self.flags):
             s += ', flags: ' + ', '.join(self.flags)
@@ -446,7 +446,7 @@ class SingleEquation(object):
             p.pretty(self.expr)
 
         p.text(' : ')
-        p.pretty(self.unit)
+        p.pretty(get_unit(self.dimensions))
 
         if len(self.flags):
             p.text(' (' + ', '.join(self.flags) + ')')
@@ -767,9 +767,9 @@ class Equations(collections.Mapping):
                                              if eq.type == PARAMETER]),
                                doc='All parameter names.')
 
-    units = property(lambda self:dict([(var, eq.unit) for var, eq in
+    dimensions = property(lambda self: dict([(var, eq.dimensions) for var, eq in
                                        self._equations.iteritems()]),
-                     doc='Dictionary of all internal variables and their corresponding units.')
+                     doc='Dictionary of all internal variables and their corresponding dimensions.')
 
 
     identifiers = property(lambda self: set().union(*[eq.identifiers for
@@ -856,8 +856,8 @@ class Equations(collections.Mapping):
 
             if eq.type == DIFFERENTIAL_EQUATION:
                 try:
-                    check_unit(str(eq.expr), self.units[var] / second,
-                               all_variables)
+                    check_dimensions(str(eq.expr), self.dimensions[var] / second.dim,
+                                     all_variables)
                 except DimensionMismatchError as ex:
                     raise DimensionMismatchError(('Inconsistent units in '
                                                   'differential equation '
@@ -867,8 +867,8 @@ class Equations(collections.Mapping):
                                                  *ex.dims)
             elif eq.type == SUBEXPRESSION:
                 try:
-                    check_unit(str(eq.expr), self.units[var],
-                           all_variables)
+                    check_dimensions(str(eq.expr), self.dimensions[var],
+                                     all_variables)
                 except DimensionMismatchError as ex:
                     raise DimensionMismatchError(('Inconsistent units in '
                                                   'subexpression %s:'
@@ -954,13 +954,13 @@ class Equations(collections.Mapping):
                 flag_str = ''
             if eq.type == PARAMETER:
                 eq_latex = r'%s &&& \text{(unit: $%s$%s)}' % (sympy.latex(lhs),                                 
-                                                              sympy.latex(eq.unit),
+                                                              sympy.latex(get_unit(eq.dim)),
                                                               flag_str)
             else:
                 eq_latex = r'%s &= %s && \text{(unit of $%s$: $%s$%s)}' % (sympy.latex(lhs),
                                                                            sympy.latex(rhs),
                                                                            sympy.latex(varname),
-                                                                           sympy.latex(eq.unit),
+                                                                           sympy.latex(get_unit(eq.dim)),
                                                                            flag_str)
             equations.append(eq_latex)
         return r'\begin{align*}' + (r'\\' + '\n').join(equations) + r'\end{align*}'
@@ -1060,7 +1060,7 @@ def extract_constant_subexpressions(eqs):
                 flags = None
             without_const_subexpressions.append(SingleEquation(PARAMETER,
                                                                eq.varname,
-                                                               eq.unit,
+                                                               eq.dimensions,
                                                                var_type=eq.var_type,
                                                                flags=flags))
             const_subexpressions.append(eq)

--- a/brian2/equations/equations.py
+++ b/brian2/equations/equations.py
@@ -203,7 +203,7 @@ def check_identifier_constants(identifier):
 
 def dimensions_and_type_from_string(unit_string):
     '''
-    Returns the unit that results from evaluating a string like
+    Returns the physical dimensions that results from evaluating a string like
     "siemens / metre ** 2", allowing for the special string "1" to signify
     dimensionless units, the string "boolean" for a boolean and "integer" for
     an integer variable.
@@ -342,7 +342,7 @@ class SingleEquation(object):
     varname : str
         The variable that is defined by this equation.
     dimensions : `Dimension`
-        The dimensions of the variable
+        The physical dimensions of the variable
     var_type : {FLOAT, INTEGER, BOOLEAN}
         The type of the variable (floating point value or boolean).
     expr : `Expression`, optional
@@ -351,7 +351,6 @@ class SingleEquation(object):
         A list of flags that give additional information about this equation.
         What flags are possible depends on the type of the equation and the
         context.
-    
     '''
     def __init__(self, type, varname, dimensions, var_type=FLOAT, expr=None,
                  flags=None):

--- a/brian2/equations/equations.py
+++ b/brian2/equations/equations.py
@@ -377,15 +377,8 @@ class SingleEquation(object):
         # will be set later in the sort_subexpressions method of Equations
         self.update_order = -1
 
-    @property
-    def unit(self):
-        '''
-        Returns the `Unit` of this equation (deprecated, get the dimensions with
-        `SingleEquation.dim` instead.)
-        '''
-        logger.warn("The 'unit' property is deprecated, use 'dim' instead.",
-                    'deprecated_equation_unit', once=True)
-        return get_unit(self.dim)
+    unit = property(lambda self: get_unit(self.dim),
+                    doc='The `Unit` of this equation.')
 
     identifiers = property(lambda self: self.expr.identifiers
                            if not self.expr is None else set([]),

--- a/brian2/equations/refractory.py
+++ b/brian2/equations/refractory.py
@@ -2,7 +2,7 @@
 Module implementing Brian's refractory mechanism.
 '''
 
-from brian2.units.fundamentalunits import Unit
+from brian2.units.fundamentalunits import Unit, DIMENSIONLESS
 from brian2.units.allunits import second
 
 from .equations import (Equations, SingleEquation, DIFFERENTIAL_EQUATION,
@@ -59,15 +59,15 @@ def add_refractoriness(eqs):
             # the only case where we have to change anything
             new_code = 'int(not_refractory)*(' + eq.expr.code + ')'
             new_equations.append(SingleEquation(DIFFERENTIAL_EQUATION,
-                                                eq.varname, eq.unit,
+                                                eq.varname, eq.dim,
                                                 expr=Expression(new_code),
                                                 flags=eq.flags))
         else:
             new_equations.append(eq)
     
     # add new parameters
-    new_equations.append(SingleEquation(PARAMETER, 'not_refractory', Unit(1),
-                                        var_type=BOOLEAN))
-    new_equations.append(SingleEquation(PARAMETER, 'lastspike', second))
+    new_equations.append(SingleEquation(PARAMETER, 'not_refractory',
+                                        DIMENSIONLESS, var_type=BOOLEAN))
+    new_equations.append(SingleEquation(PARAMETER, 'lastspike', second.dim))
 
     return Equations(new_equations)

--- a/brian2/equations/unitcheck.py
+++ b/brian2/equations/unitcheck.py
@@ -38,11 +38,10 @@ def check_dimensions(expression, dimensions, variables):
         If an unit mismatch occurs during the evaluation.
     '''
     expr_dims = parse_expression_dimensions(expression, variables)
-    # FIXME: The error message is not great
-    fail_for_dimension_mismatch(expr_dims, dimensions,
-                                ('Expression %s does not have the expected '
-                                 'unit {expected_unit}') % expression.strip(),
-                                expected_unit=dimensions)
+    err_msg = ('Expression {expr} does not have the '
+               'expected unit {expected}').format(expr=expression.strip(),
+                                                  expected=repr(get_unit(dimensions)))
+    fail_for_dimension_mismatch(expr_dims, dimensions, err_msg)
 
 
 def check_units_statements(code, variables):

--- a/brian2/equations/unitcheck.py
+++ b/brian2/equations/unitcheck.py
@@ -100,7 +100,7 @@ def check_units_statements(code, variables):
         expr_unit = parse_expression_dimensions(expr, variables)
 
         if varname in variables:
-            expected_unit = variables[varname].dimensions
+            expected_unit = variables[varname].dim
             fail_for_dimension_mismatch(expr_unit, expected_unit,
                                         ('The right-hand-side of code '
                                          'statement ""%s" does not have the '

--- a/brian2/equations/unitcheck.py
+++ b/brian2/equations/unitcheck.py
@@ -4,9 +4,10 @@ Utility functions for handling the units in `Equations`.
 import re
 
 from brian2.units.fundamentalunits import (get_unit, Unit,
-                                           fail_for_dimension_mismatch)
+                                           fail_for_dimension_mismatch,
+                                           get_dimensions)
 
-from brian2.parsing.expressions import parse_expression_unit
+from brian2.parsing.expressions import parse_expression_dimensions
 from brian2.parsing.statements import parse_statement
 from brian2.core.variables import Variable
 
@@ -36,7 +37,7 @@ def check_unit(expression, unit, variables):
     DimensionMismatchError
         If an unit mismatch occurs during the evaluation.
     '''
-    expr_unit = parse_expression_unit(expression, variables)
+    expr_unit = parse_expression_dimensions(expression, variables)
     fail_for_dimension_mismatch(expr_unit, unit, ('Expression %s does not '
                                                   'have the expected unit %r') %
                                                   (expression.strip(), unit))
@@ -94,10 +95,10 @@ def check_units_statements(code, variables):
         else:
             raise AssertionError('Unknown operator "%s"' % op) 
 
-        expr_unit = parse_expression_unit(expr, variables)
+        expr_unit = parse_expression_dimensions(expr, variables)
 
         if varname in variables:
-            expected_unit = variables[varname].unit
+            expected_unit = variables[varname].dimensions
             fail_for_dimension_mismatch(expr_unit, expected_unit,
                                         ('The right-hand-side of code '
                                          'statement ""%s" does not have the '
@@ -106,7 +107,7 @@ def check_units_statements(code, variables):
         elif varname in newly_defined:
             # note the unit for later
             variables[varname] = Variable(name=varname,
-                                          unit=get_unit(expr_unit),
+                                          dimensions=get_dimensions(expr_unit),
                                           scalar=False)
         else:
             raise AssertionError(('Variable "%s" is neither in the variables '

--- a/brian2/equations/unitcheck.py
+++ b/brian2/equations/unitcheck.py
@@ -11,11 +11,11 @@ from brian2.parsing.expressions import parse_expression_dimensions
 from brian2.parsing.statements import parse_statement
 from brian2.core.variables import Variable
 
-__all__ = ['unit_from_expression', 'check_unit',
+__all__ = ['unit_from_expression', 'check_dimensions',
            'check_units_statements']
 
 
-def check_unit(expression, unit, variables):
+def check_dimensions(expression, dimensions, variables):
     '''
     Compares the unit for an expression to an expected unit in a given
     namespace.
@@ -24,8 +24,8 @@ def check_unit(expression, unit, variables):
     ----------
     expression : str
         The expression to evaluate.
-    unit : `Unit`
-        The expected unit for the `expression`.
+    dimensions : `Dimension`
+        The expected dimensions for the `expression`.
     variables : dict
         Dictionary of all variables (including external constants) used in
         the `expression`.
@@ -37,10 +37,12 @@ def check_unit(expression, unit, variables):
     DimensionMismatchError
         If an unit mismatch occurs during the evaluation.
     '''
-    expr_unit = parse_expression_dimensions(expression, variables)
-    fail_for_dimension_mismatch(expr_unit, unit, ('Expression %s does not '
-                                                  'have the expected unit %r') %
-                                                  (expression.strip(), unit))
+    expr_dims = parse_expression_dimensions(expression, variables)
+    # FIXME: The error message is not great
+    fail_for_dimension_mismatch(expr_dims, dimensions,
+                                ('Expression %s does not have the expected '
+                                 'unit {expected_unit}') % expression.strip(),
+                                expected_unit=dimensions)
 
 
 def check_units_statements(code, variables):

--- a/brian2/equations/unitcheck.py
+++ b/brian2/equations/unitcheck.py
@@ -17,19 +17,19 @@ __all__ = ['unit_from_expression', 'check_dimensions',
 
 def check_dimensions(expression, dimensions, variables):
     '''
-    Compares the unit for an expression to an expected unit in a given
-    namespace.
-    
+    Compares the physical dimensions of an expression to expected dimensions in
+    a given namespace.
+
     Parameters
     ----------
     expression : str
         The expression to evaluate.
     dimensions : `Dimension`
-        The expected dimensions for the `expression`.
+        The expected physical dimensions for the `expression`.
     variables : dict
         Dictionary of all variables (including external constants) used in
         the `expression`.
-    
+
     Raises
     ------
     KeyError

--- a/brian2/groups/group.py
+++ b/brian2/groups/group.py
@@ -278,10 +278,8 @@ class IndexWrapper(object):
     def __getitem__(self, item):
         if isinstance(item, basestring):
             variables = Variables(None)
-            variables.add_auxiliary_variable('_indices', unit=Unit(1),
-                                             dtype=np.int32)
-            variables.add_auxiliary_variable('_cond', unit=Unit(1),
-                                             dtype=np.bool)
+            variables.add_auxiliary_variable('_indices', dtype=np.int32)
+            variables.add_auxiliary_variable('_cond', dtype=np.bool)
 
             abstract_code = '_cond = ' + item
             namespace = get_local_namespace(level=1)
@@ -395,17 +393,17 @@ class VariableOwner(Nameable):
         elif name in self.variables:
             var = self.variables[name]
             if not isinstance(val, basestring):
-                if var.unit.dim is DIMENSIONLESS:
-                    fail_for_dimension_mismatch(val, var.unit,
+                if var.dim is DIMENSIONLESS:
+                    fail_for_dimension_mismatch(val, var.dim,
                                                 ('%s should be set with a '
                                                  'dimensionless value, but got '
                                                  '{value}') % name,
                                                 value=val)
                 else:
-                    fail_for_dimension_mismatch(val, var.unit,
+                    fail_for_dimension_mismatch(val, var.dim,
                                                 ('%s should be set with a '
                                                  'value with units %r, but got '
-                                                 '{value}') % (name, var.unit),
+                                                 '{value}') % (name, get_unit(var.dim)),
                                                 value=val)
             if var.read_only:
                 raise TypeError('Variable %s is read-only.' % name)
@@ -872,12 +870,12 @@ class Group(VariableOwner, BrianObject):
 
         if not isinstance(resolved, (Function, Variable)):
             # Wrap the value in a Constant object
-            unit = get_unit(resolved)
+            dimensions = getattr(resolved, 'dim', DIMENSIONLESS)
             value = np.asarray(resolved)
             if value.shape != ():
                 raise KeyError('Variable %s was found in the namespace, but is'
                                ' not a scalar value' % identifier)
-            resolved = Constant(identifier, unit=unit, value=value)
+            resolved = Constant(identifier, dimensions=dimensions, value=value)
 
         return resolved
 

--- a/brian2/groups/neurongroup.py
+++ b/brian2/groups/neurongroup.py
@@ -111,10 +111,10 @@ class StateUpdater(CodeRunner):
             variables = self.group.resolve_all(identifiers,
                                                run_namespace,
                                                user_identifiers=identifiers)
-            unit = parse_expression_dimensions(str(ref), variables)
-            if have_same_dimensions(unit, second):
+            dims = parse_expression_dimensions(str(ref), variables)
+            if dims is second.dim:
                 abstract_code = 'not_refractory = (t - lastspike) > %s\n' % ref
-            elif have_same_dimensions(unit, Unit(1)):
+            elif dims is DIMENSIONLESS:
                 if not is_boolean_expression(str(ref), variables):
                     raise TypeError(('Refractory expression is dimensionless '
                                      'but not a boolean value. It needs to '
@@ -128,7 +128,7 @@ class StateUpdater(CodeRunner):
             else:
                 raise TypeError(('Refractory expression has to evaluate to a '
                                  'timespan or a boolean value, expression'
-                                 '"%s" has units %s instead') % (ref, unit))
+                                 '"%s" has units %s instead') % (ref, dims))
         return abstract_code
 
     def update_abstract_code(self, run_namespace):
@@ -602,7 +602,7 @@ class NeuronGroup(Group, SpikeSource):
                                            'size.') % linked_var.name)
 
             eq = self.equations[key]
-            if eq.unit.dim != linked_var.dim:
+            if eq.dim != linked_var.dim:
                 raise DimensionMismatchError(('Unit of variable %s does not '
                                               'match its link target %s') % (key,
                                                                              linked_var.name))
@@ -737,11 +737,11 @@ class NeuronGroup(Group, SpikeSource):
                     shared = 'shared' in eq.flags
                     size = 1 if shared else self._N
                     self.variables.add_array(eq.varname, size=size,
-                                             dimensions=eq.unit.dim, dtype=dtype,
+                                             dimensions=eq.dim, dtype=dtype,
                                              constant=constant,
                                              scalar=shared)
             elif eq.type == SUBEXPRESSION:
-                self.variables.add_subexpression(eq.varname, dimensions=eq.unit.dim,
+                self.variables.add_subexpression(eq.varname, dimensions=eq.dim,
                                                  expr=str(eq.expr),
                                                  dtype=dtype,
                                                  scalar='shared' in eq.flags)

--- a/brian2/groups/neurongroup.py
+++ b/brian2/groups/neurongroup.py
@@ -16,11 +16,11 @@ from brian2.equations.equations import (Equations, DIFFERENTIAL_EQUATION,
                                         check_subexpressions,
                                         extract_constant_subexpressions)
 from brian2.equations.refractory import add_refractoriness
-from brian2.parsing.expressions import (parse_expression_unit,
+from brian2.parsing.expressions import (parse_expression_dimensions,
                                         is_boolean_expression)
 from brian2.stateupdaters.base import StateUpdateMethod
 from brian2.units.allunits import second
-from brian2.units.fundamentalunits import (Quantity, Unit,
+from brian2.units.fundamentalunits import (Quantity, Unit, DIMENSIONLESS,
                                            have_same_dimensions,
                                            DimensionMismatchError,
                                            fail_for_dimension_mismatch)
@@ -111,7 +111,7 @@ class StateUpdater(CodeRunner):
             variables = self.group.resolve_all(identifiers,
                                                run_namespace,
                                                user_identifiers=identifiers)
-            unit = parse_expression_unit(str(ref), variables)
+            unit = parse_expression_dimensions(str(ref), variables)
             if have_same_dimensions(unit, second):
                 abstract_code = 'not_refractory = (t - lastspike) > %s\n' % ref
             elif have_same_dimensions(unit, Unit(1)):
@@ -202,8 +202,7 @@ class Thresholder(CodeRunner):
         template_kwds['eventspace_variable'] = group.variables[eventspace_name]
         needed_variables.append(eventspace_name)
         self.variables = Variables(self)
-        self.variables.add_auxiliary_variable('_cond', unit=Unit(1),
-                                              dtype=np.bool)
+        self.variables.add_auxiliary_variable('_cond', dtype=np.bool)
         CodeRunner.__init__(self, group,
                             'threshold',
                             code='',  # will be set in update_abstract_code
@@ -603,7 +602,7 @@ class NeuronGroup(Group, SpikeSource):
                                            'size.') % linked_var.name)
 
             eq = self.equations[key]
-            if eq.unit != linked_var.unit:
+            if eq.unit.dim != linked_var.dim:
                 raise DimensionMismatchError(('Unit of variable %s does not '
                                               'match its link target %s') % (key,
                                                                              linked_var.name))
@@ -640,7 +639,7 @@ class NeuronGroup(Group, SpikeSource):
                                      'contains values outside of the valid '
                                      'range [0, %d[' % (key,
                                                         var_length))
-                self.variables.add_array('_%s_indices' % key, unit=Unit(1),
+                self.variables.add_array('_%s_indices' % key,
                                          size=size, dtype=index_array.dtype,
                                          constant=True, read_only=True,
                                          values=index_array)
@@ -710,11 +709,11 @@ class NeuronGroup(Group, SpikeSource):
         entries for the equation variables and some standard entries.
         '''
         self.variables = Variables(self)
-        self.variables.add_constant('N', Unit(1), self._N)
+        self.variables.add_constant('N', self._N)
 
         # Standard variables always present
         for event in events:
-            self.variables.add_array('_{}space'.format(event), unit=Unit(1),
+            self.variables.add_array('_{}space'.format(event),
                                      size=self._N+1, dtype=np.int32,
                                      constant=False)
         # Add the special variable "i" which can be used to refer to the neuron index
@@ -738,11 +737,11 @@ class NeuronGroup(Group, SpikeSource):
                     shared = 'shared' in eq.flags
                     size = 1 if shared else self._N
                     self.variables.add_array(eq.varname, size=size,
-                                             unit=eq.unit, dtype=dtype,
+                                             dimensions=eq.unit.dim, dtype=dtype,
                                              constant=constant,
                                              scalar=shared)
             elif eq.type == SUBEXPRESSION:
-                self.variables.add_subexpression(eq.varname, unit=eq.unit,
+                self.variables.add_subexpression(eq.varname, dimensions=eq.unit.dim,
                                                  expr=str(eq.expr),
                                                  dtype=dtype,
                                                  scalar='shared' in eq.flags)
@@ -761,7 +760,7 @@ class NeuronGroup(Group, SpikeSource):
 
         # Stochastic variables
         for xi in self.equations.stochastic_variables:
-            self.variables.add_auxiliary_variable(xi, unit=second**-0.5)
+            self.variables.add_auxiliary_variable(xi, dimensions=(second ** -0.5).dim)
 
         # Check scalar subexpressions
         for eq in self.equations.itervalues():

--- a/brian2/groups/neurongroup.py
+++ b/brian2/groups/neurongroup.py
@@ -602,7 +602,7 @@ class NeuronGroup(Group, SpikeSource):
                                            'size.') % linked_var.name)
 
             eq = self.equations[key]
-            if eq.dim != linked_var.dim:
+            if eq.dim is not linked_var.dim:
                 raise DimensionMismatchError(('Unit of variable %s does not '
                                               'match its link target %s') % (key,
                                                                              linked_var.name))

--- a/brian2/groups/subgroup.py
+++ b/brian2/groups/subgroup.py
@@ -54,9 +54,9 @@ class Subgroup(Group, SpikeSource):
 
         # overwrite the meaning of N and i
         if self.start > 0:
-            self.variables.add_constant('_offset', unit=Unit(1), value=self.start)
+            self.variables.add_constant('_offset', value=self.start)
             self.variables.add_reference('_source_i', source, 'i')
-            self.variables.add_subexpression('i', unit=Unit(1),
+            self.variables.add_subexpression('i',
                                              dtype=source.variables['i'].dtype,
                                              expr='_source_i - _offset',
                                              index='_idx')
@@ -64,7 +64,7 @@ class Subgroup(Group, SpikeSource):
             # no need to calculate anything if this is a subgroup starting at 0
             self.variables.add_reference('i', source)
 
-        self.variables.add_constant('N', unit=Unit(1), value=self._N)
+        self.variables.add_constant('N', value=self._N)
         # add references for all variables in the original group
         self.variables.add_references(source, source.variables.keys())
 

--- a/brian2/input/poissongroup.py
+++ b/brian2/input/poissongroup.py
@@ -6,7 +6,7 @@ import numpy as np
 
 from brian2.core.spikesource import SpikeSource
 from brian2.core.variables import Variables, Subexpression
-from brian2.parsing.expressions import parse_expression_unit
+from brian2.parsing.expressions import parse_expression_dimensions
 from brian2.units.fundamentalunits import (check_units, Unit,
                                            fail_for_dimension_mismatch)
 from brian2.units.stdunits import Hz
@@ -73,18 +73,17 @@ class PoissonGroup(Group, SpikeSource):
 
         self.variables = Variables(self)
         # standard variables
-        self.variables.add_constant('N', unit=Unit(1), value=self._N)
+        self.variables.add_constant('N', value=self._N)
         self.variables.add_arange('i', self._N, constant=True, read_only=True)
-        self.variables.add_array('_spikespace', size=N+1, unit=Unit(1),
-                                 dtype=np.int32)
+        self.variables.add_array('_spikespace', size=N+1, dtype=np.int32)
         self.variables.create_clock_variables(self._clock)
 
         # The firing rates
         if isinstance(rates, basestring):
-            self.variables.add_subexpression('rates', unit=Hz,
+            self.variables.add_subexpression('rates', dimensions=Hz.dim,
                                              expr=rates)
         else:
-            self.variables.add_array('rates', size=N, unit=Hz)
+            self.variables.add_array('rates', size=N, dimensions=Hz.dim)
         self._rates = rates
 
         self.start = 0
@@ -122,7 +121,7 @@ class PoissonGroup(Group, SpikeSource):
             variables = self.resolve_all(identifiers,
                                          run_namespace,
                                          user_identifiers=identifiers)
-            unit = parse_expression_unit(rates_var.expr, variables)
+            unit = parse_expression_dimensions(rates_var.expr, variables)
             fail_for_dimension_mismatch(unit, Hz, "The expression provided for "
                                                   "PoissonGroup's 'rates' "
                                                   "argument, has to have units "

--- a/brian2/input/poissoninput.py
+++ b/brian2/input/poissoninput.py
@@ -7,7 +7,8 @@ from brian2.core.variables import Variables
 from brian2.groups.group import CodeRunner
 from brian2.units.fundamentalunits import (check_units, have_same_dimensions,
                                            get_unit, Quantity,
-                                           DimensionMismatchError)
+                                           DimensionMismatchError,
+                                           get_dimensions)
 from brian2.units.stdunits import Hz
 
 
@@ -58,18 +59,18 @@ class PoissonInput(CodeRunner):
         if isinstance(weight, basestring):
             weight = '(%s)' % weight
         else:
-            weight_unit = get_unit(weight)
-            weight = repr(weight)
-            target_unit = target.variables[target_var].unit
+            weight_dims = get_dimensions(weight)
+            target_dims = target.variables[target_var].dim
             # This will be checked automatically in the abstract code as well
             # but doing an explicit check here allows for a clearer error
             # message
-            if not have_same_dimensions(weight_unit, target_unit):
+            if not have_same_dimensions(weight_dims, target_dims):
                 raise DimensionMismatchError(('The provided weight does not '
                                               'have the same unit as the '
                                               'target variable "%s"') % target_var,
-                                             weight_unit.dim,
-                                             target_unit.dim)
+                                             weight_dims,
+                                             target_dims)
+            weight = repr(weight)
         self._N = N
         self._rate = rate
         binomial_sampling = BinomialFunction(N, rate*target.clock.dt,

--- a/brian2/input/spikegeneratorgroup.py
+++ b/brian2/input/spikegeneratorgroup.py
@@ -112,27 +112,26 @@ class SpikeGeneratorGroup(Group, CodeRunner, SpikeSource):
         self._neuron_index = indices
 
         # standard variables
-        self.variables.add_constant('N', unit=Unit(1), value=N)
-        self.variables.add_array('period', unit=second, size=1,
+        self.variables.add_constant('N', value=N)
+        self.variables.add_array('period', dimensions=second.dim, size=1,
                                  constant=True, read_only=True, scalar=True)
         self.variables.add_arange('i', N)
         self.variables.add_dynamic_array('spike_number',
                                          values=np.arange(len(indices)),
-                                         size=len(indices), unit=Unit(1),
+                                         size=len(indices),
                                          dtype=np.int32, read_only=True,
                                          constant=True, index='spike_number',
                                          unique=True)
         self.variables.add_dynamic_array('neuron_index', values=indices,
-                                         size=len(indices), unit=Unit(1),
+                                         size=len(indices),
                                          dtype=np.int32, index='spike_number',
                                          read_only=True, constant=True)
         self.variables.add_dynamic_array('spike_time', values=times, size=len(times),
-                                         unit=second, index='spike_number',
+                                         dimensions=second.dim, index='spike_number',
                                          read_only=True, constant=True)
-        self.variables.add_array('_spikespace', size=N+1, unit=Unit(1),
-                                 dtype=np.int32)
-        self.variables.add_array('_lastindex', size=1, values=0, unit=Unit(1),
-                                 dtype=np.int32, read_only=True, scalar=True)
+        self.variables.add_array('_spikespace', size=N+1, dtype=np.int32)
+        self.variables.add_array('_lastindex', size=1, values=0, dtype=np.int32,
+                                 read_only=True, scalar=True)
         self.variables.create_clock_variables(self._clock)
 
         #: Remember the dt we used the last time when we checked the spike bins

--- a/brian2/input/timedarray.py
+++ b/brian2/input/timedarray.py
@@ -7,7 +7,8 @@ import numpy as np
 from brian2.core.clocks import defaultclock
 from brian2.core.functions import Function
 from brian2.units.allunits import second
-from brian2.units.fundamentalunits import check_units, get_unit
+from brian2.units.fundamentalunits import check_units, get_dimensions, Quantity, \
+    get_unit
 from brian2.core.names import Nameable
 from brian2.utils.logger import get_logger
 from brian2.utils.stringtools import replace
@@ -86,8 +87,8 @@ class TimedArray(Function, Nameable):
         if name is None:
             name = '_timedarray*'
         Nameable.__init__(self, name)
-        unit = get_unit(values)
-        self.unit = unit
+        dimensions = get_dimensions(values)
+        self.dim = dimensions
         values = np.asarray(values, dtype=np.double)
         self.values = values
         dt = float(dt)
@@ -101,7 +102,8 @@ class TimedArray(Function, Nameable):
                                        'for TimedArray'))
 
     def _init_1d(self):
-        unit = self.unit
+        dimensions = self.dim
+        unit = get_unit(dimensions)
         values = self.values
         dt = self.dt
 
@@ -114,7 +116,7 @@ class TimedArray(Function, Nameable):
             epsilon = dt / K
             i = np.clip(np.int_(np.round(np.asarray(t/epsilon)) / K),
                         0, len(values)-1)
-            return values[i] * unit
+            return Quantity(values[i], dim=dimensions)
 
         Function.__init__(self, pyfunc=timed_array_func)
 
@@ -192,7 +194,8 @@ class TimedArray(Function, Nameable):
 
 
     def _init_2d(self):
-        unit = self.unit
+        dimensions = self.dim
+        unit = get_unit(dimensions)
         values = self.values
         dt = self.dt
 
@@ -205,7 +208,7 @@ class TimedArray(Function, Nameable):
             epsilon = dt / K
             time_step = np.clip(np.int_(np.round(np.asarray(t/epsilon)) / K),
                         0, len(values)-1)
-            return values[time_step, i] * unit
+            return Quantity(values[time_step, i], dim=dimensions)
 
         Function.__init__(self, pyfunc=timed_array_func)
 
@@ -300,7 +303,6 @@ class TimedArray(Function, Nameable):
                                                         code=create_cython_implementation,
                                                         namespace=create_cython_namespace,
                                                         name=self.name)
-
 
     def is_locally_constant(self, dt):
         if dt > self.dt:

--- a/brian2/monitors/ratemonitor.py
+++ b/brian2/monitors/ratemonitor.py
@@ -51,15 +51,15 @@ class PopulationRateMonitor(Group, CodeRunner):
         # Handle subgroups correctly
         start = getattr(source, 'start', 0)
         stop = getattr(source, 'stop', len(source))
-        self.variables.add_constant('_source_start', Unit(1), start)
-        self.variables.add_constant('_source_stop', Unit(1), stop)
+        self.variables.add_constant('_source_start', start)
+        self.variables.add_constant('_source_stop', stop)
         self.variables.add_reference('_spikespace', source)
-        self.variables.add_dynamic_array('rate', size=0, unit=hertz,
+        self.variables.add_dynamic_array('rate', size=0, dimensions=hertz.dim,
                                          read_only=True)
-        self.variables.add_dynamic_array('t', size=0, unit=second,
+        self.variables.add_dynamic_array('t', size=0, dimensions=second.dim,
                                          read_only=True)
         self.variables.add_reference('_num_source_neurons', source, 'N')
-        self.variables.add_array('N', unit=Unit(1), dtype=np.int32, size=1,
+        self.variables.add_array('N', dtype=np.int32, size=1,
                                  scalar=True, read_only=True)
         self.variables.create_clock_variables(self._clock,
                                               prefix='_clock_')

--- a/brian2/monitors/spikemonitor.py
+++ b/brian2/monitors/spikemonitor.py
@@ -124,10 +124,10 @@ class EventMonitor(Group, CodeRunner):
             self.variables.add_reference('_source_%s' % variable,
                                          source, variable)
             self.variables.add_auxiliary_variable('_to_record_%s' % variable,
-                                                  dimensions=source_var.dimensions,
+                                                  dimensions=source_var.dim,
                                                   dtype=source_var.dtype)
             self.variables.add_dynamic_array(variable, size=0,
-                                             dimensions=source_var.dimensions,
+                                             dimensions=source_var.dim,
                                              dtype=source_var.dtype,
                                              read_only=True)
         self.variables.add_arange('_source_idx', size=len(source))

--- a/brian2/monitors/spikemonitor.py
+++ b/brian2/monitors/spikemonitor.py
@@ -5,7 +5,7 @@ import numpy as np
 from brian2.core.variables import Variables
 from brian2.core.names import Nameable
 from brian2.core.spikesource import SpikeSource
-from brian2.units.fundamentalunits import Unit, Quantity
+from brian2.units.fundamentalunits import Quantity, DIMENSIONLESS
 from brian2.groups.group import CodeRunner, Group
 
 __all__ = ['EventMonitor', 'SpikeMonitor']
@@ -124,20 +124,19 @@ class EventMonitor(Group, CodeRunner):
             self.variables.add_reference('_source_%s' % variable,
                                          source, variable)
             self.variables.add_auxiliary_variable('_to_record_%s' % variable,
-                                                   unit=source_var.unit,
-                                                   dtype=source_var.dtype)
+                                                  dimensions=source_var.dimensions,
+                                                  dtype=source_var.dtype)
             self.variables.add_dynamic_array(variable, size=0,
-                                             unit=source_var.unit,
+                                             dimensions=source_var.dimensions,
                                              dtype=source_var.dtype,
                                              read_only=True)
         self.variables.add_arange('_source_idx', size=len(source))
-        self.variables.add_array('count', size=len(source), unit=Unit(1),
-                                 dtype=np.int32, read_only=True,
-                                 index='_source_idx')
-        self.variables.add_constant('_source_start', Unit(1), start)
-        self.variables.add_constant('_source_stop', Unit(1), stop)
-        self.variables.add_array('N', unit=Unit(1), size=1, dtype=np.int32,
-                                 read_only=True, scalar=True)
+        self.variables.add_array('count', size=len(source), dtype=np.int32,
+                                 read_only=True, index='_source_idx')
+        self.variables.add_constant('_source_start', start)
+        self.variables.add_constant('_source_stop', stop)
+        self.variables.add_array('N', size=1, dtype=np.int32, read_only=True,
+                                 scalar=True)
 
         record_variables = {varname: self.variables[varname]
                             for varname in self.record_variables}
@@ -195,7 +194,7 @@ class EventMonitor(Group, CodeRunner):
 
     def _values_dict(self, first_pos, sort_indices, used_indices, var):
         sorted_values = self.state(var, use_units=False)[sort_indices]
-        dim = self.variables[var].unit.dim
+        dim = self.variables[var].dim
         event_values = {}
         current_pos = 0  # position in the all_indices array
         for idx in xrange(len(self.source)):

--- a/brian2/monitors/statemonitor.py
+++ b/brian2/monitors/statemonitor.py
@@ -39,9 +39,9 @@ class StateMonitorView(object):
         elif item == 't_':
             return mon.variables['t'].get_value()
         elif item in mon.record_variables:
-            unit = mon.variables[item].unit
+            dims = mon.variables[item].dim
             return Quantity(mon.variables[item].get_value().T[self.indices],
-                            dim=unit.dim, copy=True)
+                            dim=dims, copy=True)
         elif item.endswith('_') and item[:-1] in mon.record_variables:
             return mon.variables[item[:-1]].get_value().T[self.indices].copy()
         else:
@@ -229,14 +229,13 @@ class StateMonitor(Group, CodeRunner):
         # Setup variables
         self.variables = Variables(self)
 
-        self.variables.add_dynamic_array('t', size=0, unit=second,
+        self.variables.add_dynamic_array('t', size=0, dimensions=second.dim,
                                          constant=False)
-        self.variables.add_array('N', unit=Unit(1), dtype=np.int32,
-                                 size=1, scalar=True, read_only=True)
+        self.variables.add_array('N', dtype=np.int32, size=1, scalar=True,
+                                 read_only=True)
         self.variables.add_array('_indices', size=len(self.record),
-                                 unit=Unit(1), dtype=self.record.dtype,
-                                 constant=True, read_only=True,
-                                 values=self.record)
+                                 dtype=self.record.dtype, constant=True,
+                                 read_only=True, values=self.record)
         self.variables.create_clock_variables(self._clock,
                                               prefix='_clock_')
         for varname in variables:
@@ -253,7 +252,7 @@ class StateMonitor(Group, CodeRunner):
             self.variables.add_dynamic_array(varname,
                                              size=(0, len(self.record)),
                                              resize_along_first=True,
-                                             unit=var.unit,
+                                             dimensions=var.dim,
                                              dtype=var.dtype,
                                              constant=False,
                                              read_only=True)
@@ -261,7 +260,7 @@ class StateMonitor(Group, CodeRunner):
         for varname in variables:
             var = self.source.variables[varname]
             self.variables.add_auxiliary_variable('_to_record_' + varname,
-                                                  unit=var.unit,
+                                                  dimensions=var.dim,
                                                   dtype=var.dtype,
                                                   scalar=var.scalar)
 
@@ -315,9 +314,9 @@ class StateMonitor(Group, CodeRunner):
         if not hasattr(self, '_group_attribute_access_active'):
             raise AttributeError
         if item in self.record_variables:
-            unit = self.variables[item].unit
+            var_dim = self.variables[item].dim
             return Quantity(self.variables[item].get_value().T,
-                            dim=unit.dim, copy=True)
+                            dim=var_dim, copy=True)
         elif item.endswith('_') and item[:-1] in self.record_variables:
             return self.variables[item[:-1]].get_value().T
         else:

--- a/brian2/parsing/bast.py
+++ b/brian2/parsing/bast.py
@@ -118,9 +118,10 @@ class BrianASTRenderer(object):
     def render_node(self, node):
         nodename = node.__class__.__name__
         methname = 'render_'+nodename
-        if not hasattr(self, methname):
-            raise SyntaxError("Unknown syntax: "+nodename)
-        return getattr(self, methname)(node)
+        try:
+            return getattr(self, methname)(node)
+        except AttributeError:
+            raise SyntaxError("Unknown syntax: " + nodename)
 
     def render_NameConstant(self, node):
         if node.value is not True and node.value is not False:

--- a/brian2/parsing/expressions.py
+++ b/brian2/parsing/expressions.py
@@ -6,11 +6,11 @@ import ast
 
 from brian2.core.functions import Function
 from brian2.parsing.rendering import NodeRenderer
-from brian2.units.fundamentalunits import (Unit, get_unit_fast,
+from brian2.units.fundamentalunits import (Unit,
                                            DimensionMismatchError,
                                            have_same_dimensions,
                                            get_dimensions,
-                                           get_unit, DIMENSIONLESS,
+                                           DIMENSIONLESS,
                                            fail_for_dimension_mismatch)
 
 __all__ = ['is_boolean_expression',

--- a/brian2/parsing/expressions.py
+++ b/brian2/parsing/expressions.py
@@ -9,11 +9,12 @@ from brian2.parsing.rendering import NodeRenderer
 from brian2.units.fundamentalunits import (Unit, get_unit_fast,
                                            DimensionMismatchError,
                                            have_same_dimensions,
-                                           get_dimensions
-                                           )
+                                           get_dimensions,
+                                           get_unit, DIMENSIONLESS,
+                                           fail_for_dimension_mismatch)
 
 __all__ = ['is_boolean_expression',
-           'parse_expression_unit',]
+           'parse_expression_dimensions', ]
 
 
 def is_boolean_expression(expr, variables):
@@ -181,7 +182,7 @@ def _get_value_from_expression(expr, variables):
         raise SyntaxError('Unsupported operation ' + str(expr.__class__))
 
     
-def parse_expression_unit(expr, variables):
+def parse_expression_dimensions(expr, variables):
     '''
     Returns the unit value of an expression, and checks its validity
     
@@ -215,7 +216,7 @@ def parse_expression_unit(expr, variables):
         # new class for True, False, None in Python 3.4
         value = expr.value
         if value is True or value is False:
-            return Unit(1)
+            return DIMENSIONLESS
         else:
             raise ValueError('Do not know how to handle value %s' % value)
     if expr.__class__ is ast.Name:
@@ -226,25 +227,25 @@ def parse_expression_unit(expr, variables):
             raise SyntaxError('%s was used like a variable/constant, but it is '
                               'a function.' % name)
         if name in variables:
-            return variables[name].unit
+            return variables[name].dimensions
         elif name in ['True', 'False']:
-            return Unit(1)
+            return DIMENSIONLESS
         else:
             raise KeyError('Unknown identifier %s' % name)
     elif expr.__class__ is ast.Num:
-        return get_unit_fast(1)
+        return DIMENSIONLESS
     elif expr.__class__ is ast.BoolOp:
         # check that the units are valid in each subexpression
         for node in expr.values:
-            parse_expression_unit(node, variables)
+            parse_expression_dimensions(node, variables)
         # but the result is a bool, so we just return 1 as the unit
-        return get_unit_fast(1)
+        return DIMENSIONLESS
     elif expr.__class__ is ast.Compare:
         # check that the units are consistent in each subexpression
         subexprs = [expr.left]+expr.comparators
         subunits = []
         for node in subexprs:
-            subunits.append(parse_expression_unit(node, variables))
+            subunits.append(parse_expression_dimensions(node, variables))
         for left, right in zip(subunits[:-1], subunits[1:]):
             if not have_same_dimensions(left, right):
                 msg = ('Comparison of expressions with different units. Expression '
@@ -253,7 +254,7 @@ def parse_expression_unit(expr, variables):
                             NodeRenderer().render_node(expr.comparators[0]), get_dimensions(right))
                 raise DimensionMismatchError(msg)
         # but the result is a bool, so we just return 1 as the unit
-        return get_unit_fast(1)
+        return DIMENSIONLESS
     elif expr.__class__ is ast.Call:
         if len(expr.keywords):
             raise ValueError("Keyword arguments not supported.")
@@ -287,7 +288,7 @@ def parse_expression_unit(expr, variables):
                                      '"%s".') % (idx + 1, expr.func.id,
                                                  NodeRenderer().render_node(arg)))
             else:
-                arg_unit = parse_expression_unit(arg, variables)
+                arg_unit = parse_expression_dimensions(arg, variables)
                 if not have_same_dimensions(arg_unit, expected_unit):
                     msg = ('Argument number {} for function {} does not have the '
                            'correct units. Expression "{}" has units ({}), but '
@@ -298,42 +299,47 @@ def parse_expression_unit(expr, variables):
                     raise DimensionMismatchError(msg)
 
         if func._return_unit == bool:
-            return Unit(1)
+            return DIMENSIONLESS
         elif isinstance(func._return_unit, (Unit, int)):
             # Function always returns the same unit
-            return get_unit_fast(func._return_unit)
+            return getattr(func._return_unit, 'dim', DIMENSIONLESS)
         else:
             # Function returns a unit that depends on the arguments
-            arg_units = [parse_expression_unit(arg, variables)
+            arg_units = [parse_expression_dimensions(arg, variables)
                          for arg in expr.args]
-            return func._return_unit(*arg_units)
+            return func._return_unit(*arg_units).dim
 
     elif expr.__class__ is ast.BinOp:
         op = expr.op.__class__.__name__
-        left = parse_expression_unit(expr.left, variables)
-        right = parse_expression_unit(expr.right, variables)
-        if op=='Add' or op=='Sub':
-            u = left+right
+        left = parse_expression_dimensions(expr.left, variables)
+        right = parse_expression_dimensions(expr.right, variables)
+        if op=='Add' or op=='Sub' or op=='Mod':
+            # dimensions should be the same
+            op_symbol = {'Add': '+', 'Sub': '-', 'Mod': '%'}.get(op)
+            fail_for_dimension_mismatch(left, right,
+                                        'Cannot determine units for '
+                                        '%s %s %s' % (NodeRenderer().render_node(expr.left),
+                                                      op_symbol,
+                                                      NodeRenderer().render_node(expr.right)))
+            u = left
         elif op=='Mult':
             u = left*right
         elif op=='Div':
             u = left/right
         elif op=='Pow':
             if have_same_dimensions(left, 1) and have_same_dimensions(right, 1):
-                return get_unit_fast(1)
+                return DIMENSIONLESS
             n = _get_value_from_expression(expr.right, variables)
             u = left**n
-        elif op=='Mod':
-            u = left % right
         else:
             raise SyntaxError("Unsupported operation "+op)
         return u
     elif expr.__class__ is ast.UnaryOp:
         op = expr.op.__class__.__name__
         # check validity of operand and get its unit
-        u = parse_expression_unit(expr.operand, variables)
+        u = parse_expression_dimensions(expr.operand, variables)
         if op=='Not':
-            return get_unit_fast(1)
+            return DIMENSIONLESS
         else:
             return u
     else:

--- a/brian2/parsing/expressions.py
+++ b/brian2/parsing/expressions.py
@@ -227,7 +227,7 @@ def parse_expression_dimensions(expr, variables):
             raise SyntaxError('%s was used like a variable/constant, but it is '
                               'a function.' % name)
         if name in variables:
-            return variables[name].dimensions
+            return variables[name].dim
         elif name in ['True', 'False']:
             return DIMENSIONLESS
         else:

--- a/brian2/parsing/rendering.py
+++ b/brian2/parsing/rendering.py
@@ -61,9 +61,10 @@ class NodeRenderer(object):
     def render_node(self, node):
         nodename = node.__class__.__name__
         methname = 'render_'+nodename
-        if not hasattr(self, methname):
-            raise SyntaxError("Unknown syntax: "+nodename)
-        return getattr(self, methname)(node)
+        try:
+            return getattr(self, methname)(node)
+        except AttributeError:
+            raise SyntaxError("Unknown syntax: " + nodename)
 
     def render_func(self, node):
         return self.render_Name(node)

--- a/brian2/spatialneuron/spatialneuron.py
+++ b/brian2/spatialneuron/spatialneuron.py
@@ -279,18 +279,18 @@ class SpatialNeuron(NeuronGroup):
             if eq.varname == 'Im':
                 continue  # ignore -- handled separately
             if 'point current' in eq.flags:
-                fail_for_dimension_mismatch(eq.unit, amp,
+                fail_for_dimension_mismatch(eq.dim, amp,
                                             "Point current " + eq.varname + " should be in amp")
                 membrane_expr = Expression(
                     str(membrane_expr.code) + '+' + eq.varname + '/area')
-                eq = SingleEquation(eq.type, eq.varname, eq.unit, expr=eq.expr,
+                eq = SingleEquation(eq.type, eq.varname, eq.dim, expr=eq.expr,
                                     flags=list(set(eq.flags)-set(['point current'])))
             model_equations.append(eq)
 
         model_equations.append(SingleEquation(SUBEXPRESSION, 'Im',
-                                              unit=amp/meter**2,
+                                              dimensions=(amp/meter**2).dim,
                                               expr=membrane_expr))
-        model_equations.append(SingleEquation(PARAMETER, 'v', unit=volt))
+        model_equations.append(SingleEquation(PARAMETER, 'v', volt.dim))
         model = Equations(model_equations)
 
         ###### Process model equations (Im) to extract total conductance and the remaining current

--- a/brian2/spatialneuron/spatialneuron.py
+++ b/brian2/spatialneuron/spatialneuron.py
@@ -382,7 +382,7 @@ class SpatialNeuron(NeuronGroup):
                                    # The following two are only necessary for
                                    # C code where we cannot deal with scalars
                                    # and arrays interchangeably:
-                                   '_I0_all', '_gtot_all'], unit=1,
+                                   '_I0_all', '_gtot_all'],
                                   size=self.N, read_only=True)
 
         self.Cm = Cm
@@ -536,34 +536,35 @@ class SpatialStateUpdater(CodeRunner, Group):
         self.variables.add_reference('N', group)
         # One value per compartment
         self.variables.add_arange('_compartment_idx', size=compartments)
-        self.variables.add_array('_invr', unit=siemens, size=compartments,
-                                 constant=True, index='_compartment_idx')
+        self.variables.add_array('_invr', dimensions=siemens.dim,
+                                 size=compartments, constant=True,
+                                 index='_compartment_idx')
         # one value per section
         self.variables.add_arange('_section_idx', size=sections)
-        self.variables.add_array('_P_parent', unit=Unit(1), size=sections,
+        self.variables.add_array('_P_parent', size=sections,
                                  constant=True)  # elements below diagonal
         self.variables.add_arrays(['_morph_idxchild', '_morph_parent_i',
-                                   '_starts', '_ends'], unit=Unit(1),
-                                  size=sections, dtype=np.int32, constant=True)
-        self.variables.add_arrays(['_invr0', '_invrn'], unit=siemens,
+                                   '_starts', '_ends'], size=sections,
+                                  dtype=np.int32, constant=True)
+        self.variables.add_arrays(['_invr0', '_invrn'], dimensions=siemens.dim,
                                   size=sections, constant=True)
         # one value per section + 1 value for the root
         self.variables.add_arange('_section_root_idx', size=sections+1)
-        self.variables.add_array('_P_diag', unit=Unit(1), size=sections+1,
+        self.variables.add_array('_P_diag', size=sections+1,
                                  constant=True, index='_section_root_idx')
-        self.variables.add_array('_B', unit=Unit(1), size=sections+1,
+        self.variables.add_array('_B', size=sections+1,
                                  constant=True, index='_section_root_idx')
-        self.variables.add_array('_morph_children_num', unit=Unit(1),
+        self.variables.add_array('_morph_children_num',
                                  size=sections+1, dtype=np.int32,
                                  constant=True, index='_section_root_idx')
         # 2D matrices of size (sections + 1) x max children per section
         self.variables.add_arange('_morph_children_idx',
                                   size=len(group.flat_morphology.morph_children))
-        self.variables.add_array('_P_children', unit=Unit(1),
+        self.variables.add_array('_P_children',
                                  size=len(group.flat_morphology.morph_children),
                                  index='_morph_children_idx',
                                  constant=True)  # elements above diagonal
-        self.variables.add_array('_morph_children', unit=Unit(1),
+        self.variables.add_array('_morph_children',
                                  size=len(group.flat_morphology.morph_children),
                                  dtype=np.int32, constant=True,
                                  index='_morph_children_idx')

--- a/brian2/synapses/synapses.py
+++ b/brian2/synapses/synapses.py
@@ -26,7 +26,7 @@ from brian2.groups.neurongroup import (extract_constant_subexpressions,
                                        SubexpressionUpdater)
 from brian2.stateupdaters.base import StateUpdateMethod
 from brian2.stateupdaters.exact import independent
-from brian2.units.fundamentalunits import (Unit, Quantity,
+from brian2.units.fundamentalunits import (Unit, Quantity, DIMENSIONLESS,
                                            fail_for_dimension_mismatch)
 from brian2.units.allunits import second
 from brian2.utils.logger import get_logger
@@ -182,7 +182,7 @@ class SynapticPathway(CodeRunner, Group):
                 n_synapses = synapses.N
             else:
                 n_synapses = 0
-            self.variables.add_dynamic_array('delay', unit=second,
+            self.variables.add_dynamic_array('delay', dimensions=second.dim,
                                              size=n_synapses, constant=True)
             # Register the object with the `SynapticIndex` object so it gets
             # automatically resized
@@ -204,7 +204,7 @@ class SynapticPathway(CodeRunner, Group):
             # We use a "dynamic" array of constant size here because it makes
             # the generated code easier, we don't need to deal with a different
             # type for scalar and variable delays
-            self.variables.add_dynamic_array('delay', unit=second,
+            self.variables.add_dynamic_array('delay', dimensions=second.dim,
                                              size=1, constant=True,
                                              scalar=True)
             # Since this array does not grow with the number of synapses, we
@@ -867,8 +867,8 @@ class Synapses(Group):
                                   'target group.') % (varname,
                                                       orig_varname))
 
-            fail_for_dimension_mismatch(self.variables['_summed_'+varname].unit,
-                                        self.variables[varname].unit,
+            fail_for_dimension_mismatch(self.variables['_summed_'+varname].dim,
+                                        self.variables[varname].dim,
                                         ('Summed variables need to have '
                                          'the same units in Synapses '
                                          'and the target group'))
@@ -958,9 +958,9 @@ class Synapses(Group):
         self.variables = Variables(self)
 
         # Standard variables always present
-        self.variables.add_dynamic_array('_synaptic_pre', size=0, unit=Unit(1),
+        self.variables.add_dynamic_array('_synaptic_pre', size=0,
                                          dtype=np.int32)
-        self.variables.add_dynamic_array('_synaptic_post', size=0, unit=Unit(1),
+        self.variables.add_dynamic_array('_synaptic_post', size=0,
                                          dtype=np.int32)
         self.variables.add_reference('i', self.source, 'i',
                                      index='_presynaptic_idx')
@@ -972,20 +972,18 @@ class Synapses(Group):
             self.variables.add_reference('_target_offset', self.target,
                                          '_offset')
         else:
-            self.variables.add_constant('_target_offset', unit=Unit(1), value=0)
+            self.variables.add_constant('_target_offset', value=0)
         if '_offset' in self.source.variables:
             self.variables.add_reference('_source_offset', self.source,
                                          '_offset')
         else:
-            self.variables.add_constant('_source_offset', unit=Unit(1), value=0)
+            self.variables.add_constant('_source_offset', value=0)
         # To cope with connections to/from other synapses, N_incoming/N_outgoing
         # will be resized when synapses are created
-        self.variables.add_dynamic_array('N_incoming', size=0,
-                                         unit=Unit(1), dtype=np.int32,
+        self.variables.add_dynamic_array('N_incoming', size=0, dtype=np.int32,
                                          constant=True,  read_only=True,
                                          index='_postsynaptic_idx')
-        self.variables.add_dynamic_array('N_outgoing', size=0,
-                                         unit=Unit(1), dtype=np.int32,
+        self.variables.add_dynamic_array('N_outgoing', size=0, dtype=np.int32,
                                          constant=True,  read_only=True,
                                          index='_presynaptic_idx')
 
@@ -1003,9 +1001,8 @@ class Synapses(Group):
                                      '_synaptic_post')
 
         # Add the standard variables
-        self.variables.add_array('N', unit=Unit(1), dtype=np.int32,
-                                 size=1, scalar=True, constant=True,
-                                 read_only=True)
+        self.variables.add_array('N',  dtype=np.int32, size=1, scalar=True,
+                                 constant=True, read_only=True)
 
         for eq in equations.itervalues():
             dtype = get_dtype(eq, user_dtype)
@@ -1014,14 +1011,14 @@ class Synapses(Group):
                 shared = 'shared' in eq.flags
                 if shared:
                     self.variables.add_array(eq.varname, size=1,
-                                             unit=eq.unit,
+                                             dimensions=eq.unit.dim,
                                              dtype=dtype,
                                              constant=constant,
                                              scalar=True,
                                              index='0')
                 else:
                     self.variables.add_dynamic_array(eq.varname, size=0,
-                                                     unit=eq.unit,
+                                                     dimensions=eq.unit.dim,
                                                      dtype=dtype,
                                                      constant=constant)
             elif eq.type == SUBEXPRESSION:
@@ -1032,7 +1029,7 @@ class Synapses(Group):
                     varname = '_summed_'+eq.varname
                 else:
                     varname = eq.varname
-                self.variables.add_subexpression(varname, unit=eq.unit,
+                self.variables.add_subexpression(varname, dimensions=eq.unit.dim,
                                                  expr=str(eq.expr),
                                                  scalar='shared' in eq.flags,
                                                  dtype=dtype)
@@ -1041,7 +1038,7 @@ class Synapses(Group):
 
         # Stochastic variables
         for xi in equations.stochastic_variables:
-            self.variables.add_auxiliary_variable(xi, unit=second**-0.5)
+            self.variables.add_auxiliary_variable(xi, dimensions=(second ** -0.5).dim)
 
         # Add all the pre and post variables with _pre and _post suffixes
         for name in getattr(self.source, 'variables', {}).iterkeys():
@@ -1410,15 +1407,13 @@ class Synapses(Group):
         sources = sources.repeat(n)
         targets = targets.repeat(n)
 
-        variables.add_array('sources', Unit(1), len(sources), dtype=np.int32,
+        variables.add_array('sources', len(sources), dtype=np.int32,
                             values=sources)
-        variables.add_array('targets', Unit(1), len(targets), dtype=np.int32,
+        variables.add_array('targets', len(targets), dtype=np.int32,
                             values=targets)
         # These definitions are important to get the types right in C++
-        variables.add_auxiliary_variable('_real_sources', Unit(1),
-                                         dtype=np.int32)
-        variables.add_auxiliary_variable('_real_targets', Unit(1),
-                                         dtype=np.int32)
+        variables.add_auxiliary_variable('_real_sources', dtype=np.int32)
+        variables.add_auxiliary_variable('_real_targets', dtype=np.int32)
         abstract_code = ''
         if '_offset' in self.source.variables:
             variables.add_reference('_source_offset', self.source, '_offset')
@@ -1517,44 +1512,34 @@ class Synapses(Group):
         # synapses but to all the possible sources/targets
         variables = Variables(None)
         # Will be set in the template
-        variables.add_auxiliary_variable('_i', unit=Unit(1), dtype=np.int32)
-        variables.add_auxiliary_variable('_j', unit=Unit(1), dtype=np.int32)
-        variables.add_auxiliary_variable('_iter_low', unit=Unit(1),
-                                         dtype=np.int32)
-        variables.add_auxiliary_variable('_iter_high', unit=Unit(1),
-                                         dtype=np.int32)
-        variables.add_auxiliary_variable('_iter_step', unit=Unit(1),
-                                         dtype=np.int32)
-        variables.add_auxiliary_variable('_iter_p', unit=Unit(1))
-        variables.add_auxiliary_variable('_iter_size', unit=Unit(1),
-                                         dtype=np.int32)
+        variables.add_auxiliary_variable('_i', dtype=np.int32)
+        variables.add_auxiliary_variable('_j', dtype=np.int32)
+        variables.add_auxiliary_variable('_iter_low', dtype=np.int32)
+        variables.add_auxiliary_variable('_iter_high', dtype=np.int32)
+        variables.add_auxiliary_variable('_iter_step', dtype=np.int32)
+        variables.add_auxiliary_variable('_iter_p')
+        variables.add_auxiliary_variable('_iter_size', dtype=np.int32)
         variables.add_auxiliary_variable(parsed['iteration_variable'],
-                                         unit=Unit(1), dtype=np.int32)
+                                         dtype=np.int32)
         # Make sure that variables have the correct type in the code
-        variables.add_auxiliary_variable('_pre_idx', unit=Unit(1),
-                                         dtype=np.int32)
-        variables.add_auxiliary_variable('_post_idx', unit=Unit(1),
-                                         dtype=np.int32)
+        variables.add_auxiliary_variable('_pre_idx', dtype=np.int32)
+        variables.add_auxiliary_variable('_post_idx', dtype=np.int32)
         if parsed['if_expression'] is not None:
-            variables.add_auxiliary_variable('_cond', unit=Unit(1),
-                                             dtype=np.bool)
-        variables.add_auxiliary_variable('_n', unit=Unit(1),
-                                         dtype=np.int32)
+            variables.add_auxiliary_variable('_cond', dtype=np.bool)
+        variables.add_auxiliary_variable('_n', dtype=np.int32)
 
         if '_offset' in self.source.variables:
             variables.add_reference('_source_offset', self.source, '_offset')
         else:
-            variables.add_constant('_source_offset', unit=Unit(1), value=0)
+            variables.add_constant('_source_offset', value=0)
 
         if '_offset' in self.target.variables:
             variables.add_reference('_target_offset', self.target, '_offset')
         else:
-            variables.add_constant('_target_offset', unit=Unit(1), value=0)
+            variables.add_constant('_target_offset', value=0)
 
-        variables.add_auxiliary_variable('_raw_pre_idx', unit=Unit(1),
-                                         dtype=np.int32)
-        variables.add_auxiliary_variable('_raw_post_idx', unit=Unit(1),
-                                         dtype=np.int32)
+        variables.add_auxiliary_variable('_raw_pre_idx', dtype=np.int32)
+        variables.add_auxiliary_variable('_raw_post_idx', dtype=np.int32)
 
         variable_indices = defaultdict(lambda: '_idx')
         for varname in self.variables:

--- a/brian2/synapses/synapses.py
+++ b/brian2/synapses/synapses.py
@@ -696,7 +696,7 @@ class Synapses(Group):
             raise SyntaxError('lastupdate is a reserved name.')
         model._equations['lastupdate'] = SingleEquation(PARAMETER,
                                                         'lastupdate',
-                                                        second)
+                                                        second.dim)
         # Add the "multisynaptic index", if desired
         self.multisynaptic_index = multisynaptic_index
         if multisynaptic_index is not None:
@@ -704,7 +704,7 @@ class Synapses(Group):
                 raise TypeError('multisynaptic_index argument has to be a string')
             model._equations[multisynaptic_index] = SingleEquation(PARAMETER,
                                                                    multisynaptic_index,
-                                                                   unit=Unit(1),
+                                                                   DIMENSIONLESS,
                                                                    var_type=INTEGER)
 
         # Separate subexpressions depending whether they are considered to be
@@ -1011,14 +1011,14 @@ class Synapses(Group):
                 shared = 'shared' in eq.flags
                 if shared:
                     self.variables.add_array(eq.varname, size=1,
-                                             dimensions=eq.unit.dim,
+                                             dimensions=eq.dim,
                                              dtype=dtype,
                                              constant=constant,
                                              scalar=True,
                                              index='0')
                 else:
                     self.variables.add_dynamic_array(eq.varname, size=0,
-                                                     dimensions=eq.unit.dim,
+                                                     dimensions=eq.dim,
                                                      dtype=dtype,
                                                      constant=constant)
             elif eq.type == SUBEXPRESSION:
@@ -1029,7 +1029,7 @@ class Synapses(Group):
                     varname = '_summed_'+eq.varname
                 else:
                     varname = eq.varname
-                self.variables.add_subexpression(varname, dimensions=eq.unit.dim,
+                self.variables.add_subexpression(varname, dimensions=eq.dim,
                                                  expr=str(eq.expr),
                                                  scalar='shared' in eq.flags,
                                                  dtype=dtype)

--- a/brian2/tests/test_codegen.py
+++ b/brian2/tests/test_codegen.py
@@ -35,10 +35,10 @@ def test_analyse_identifiers():
     a = b+c
     d = e+f
     '''
-    known = {'b': Variable(unit=1, name='b'),
-             'c': Variable(unit=1, name='c'),
-             'd': Variable(unit=1, name='d'),
-             'g': Variable(unit=1, name='g')}
+    known = {'b': Variable(name='b'),
+             'c': Variable(name='c'),
+             'd': Variable(name='d'),
+             'g': Variable(name='g')}
     
     defined, used_known, dependent = analyse_identifiers(code, known)
     assert 'a' in defined  # There might be an additional constant added by the
@@ -52,15 +52,15 @@ def test_get_identifiers_recursively():
     '''
     Test finding identifiers including subexpressions.
     '''
-    variables = {'sub1': Subexpression(name='sub1', unit=Unit(1),
+    variables = {'sub1': Subexpression(name='sub1',
                                        dtype=np.float32, expr='sub2 * z',
                                        owner=FakeGroup(variables={}),
                                        device=None),
-                 'sub2': Subexpression(name='sub2', unit=Unit(1),
+                 'sub2': Subexpression(name='sub2',
                                        dtype=np.float32, expr='5 + y',
                                        owner=FakeGroup(variables={}),
                                        device=None),
-                 'x': Variable(unit=1, name='x')}
+                 'x': Variable(name='x')}
     identifiers = get_identifiers_recursively(['_x = sub1 + x'],
                                               variables)
     assert identifiers == {'x', '_x', 'y', 'z', 'sub1', 'sub2'}
@@ -79,12 +79,12 @@ def test_nested_subexpressions():
     x = a + b + c
     '''
     variables = {
-        'a': Subexpression(name='a', unit=Unit(1), dtype=np.float32, owner=FakeGroup(variables={}), device=None,
+        'a': Subexpression(name='a', dtype=np.float32, owner=FakeGroup(variables={}), device=None,
                            expr='b*b+d'),
-        'b': Subexpression(name='b', unit=Unit(1), dtype=np.float32, owner=FakeGroup(variables={}), device=None,
+        'b': Subexpression(name='b', dtype=np.float32, owner=FakeGroup(variables={}), device=None,
                            expr='c*c*c'),
-        'c': Variable(unit=1, name='c'),
-        'd': Variable(unit=1, name='d'),
+        'c': Variable(name='c'),
+        'd': Variable(name='d'),
         }
     scalar_stmts, vector_stmts = make_statements(code, variables, np.float32)
     assert len(scalar_stmts) == 0
@@ -98,10 +98,10 @@ def test_nested_subexpressions():
 
 @attr('codegen-independent')
 def test_apply_loop_invariant_optimisation():
-    variables = {'v': Variable('v', Unit(1), scalar=False),
-                 'w': Variable('w', Unit(1), scalar=False),
-                 'dt': Constant('dt', second, 0.1*ms),
-                 'tau': Constant('tau', second, 10*ms),
+    variables = {'v': Variable('v', scalar=False),
+                 'w': Variable('w', scalar=False),
+                 'dt': Constant('dt', dimensions=second.dim, value=0.1*ms),
+                 'tau': Constant('tau', dimensions=second.dim, value=10*ms),
                  'exp': DEFAULT_FUNCTIONS['exp']}
     statements = [Statement('v', '=', 'dt*w*exp(-dt/tau)/tau + v*exp(-dt/tau)', '', np.float32),
                   Statement('w', '=', 'w*exp(-dt/tau)', '', np.float32)]
@@ -115,14 +115,14 @@ def test_apply_loop_invariant_optimisation():
 
 @attr('codegen-independent')
 def test_apply_loop_invariant_optimisation_integer():
-    variables = {'v': Variable('v', Unit(1), scalar=False),
-                 'N': Constant('N', Unit(1), 10),
-                 'b': Variable('b', Unit(1), scalar=True, dtype=int),
-                 'c': Variable('c', Unit(1), scalar=True, dtype=int),
-                 'd': Variable('d', Unit(1), scalar=True, dtype=int),
-                 'y': Variable('y', Unit(1), scalar=True, dtype=float),
-                 'z': Variable('z', Unit(1), scalar=True, dtype=float),
-                 'w': Variable('w', Unit(1), scalar=True, dtype=float),
+    variables = {'v': Variable('v', scalar=False),
+                 'N': Constant('N', 10),
+                 'b': Variable('b', scalar=True, dtype=int),
+                 'c': Variable('c', scalar=True, dtype=int),
+                 'd': Variable('d', scalar=True, dtype=int),
+                 'y': Variable('y', scalar=True, dtype=float),
+                 'z': Variable('z', scalar=True, dtype=float),
+                 'w': Variable('w', scalar=True, dtype=float),
                  }
     statements = [Statement('v', '=', 'v % (2*3*N)', '', np.float32),
                   # integer version doesn't get rewritten but float version does
@@ -146,11 +146,11 @@ def test_apply_loop_invariant_optimisation_integer():
 
 @attr('codegen-independent')
 def test_apply_loop_invariant_optimisation_boolean():
-    variables = {'v1': Variable('v1', Unit(1), scalar=False),
-                 'v2': Variable('v2', Unit(1), scalar=False),
-                 'N': Constant('N', Unit(1), 10),
-                 'b': Variable('b', Unit(1), scalar=True, dtype=bool),
-                 'c': Variable('c', Unit(1), scalar=True, dtype=bool),
+    variables = {'v1': Variable('v1', scalar=False),
+                 'v2': Variable('v2', scalar=False),
+                 'N': Constant('N', 10),
+                 'b': Variable('b', scalar=True, dtype=bool),
+                 'c': Variable('c', scalar=True, dtype=bool),
                  'int': DEFAULT_FUNCTIONS['int'],
                  'foo': Function(lambda x: None,
                                  arg_units=[Unit(1)], return_unit=Unit(1),
@@ -177,11 +177,11 @@ def test_apply_loop_invariant_optimisation_boolean():
 
 @attr('codegen-independent')
 def test_apply_loop_invariant_optimisation_no_optimisation():
-    variables = {'v1': Variable('v1', Unit(1), scalar=False),
-                 'v2': Variable('v2', Unit(1), scalar=False),
-                 'N': Constant('N', Unit(1), 10),
-                 's1': Variable('s1', Unit(1), scalar=True, dtype=float),
-                 's2': Variable('s2', Unit(1), scalar=True, dtype=float),
+    variables = {'v1': Variable('v1', scalar=False),
+                 'v2': Variable('v2', scalar=False),
+                 'N': Constant('N', 10),
+                 's1': Variable('s1', scalar=True, dtype=float),
+                 's2': Variable('s2', scalar=True, dtype=float),
                  'rand': DEFAULT_FUNCTIONS['rand']
                  }
     statements = [
@@ -205,10 +205,10 @@ def test_apply_loop_invariant_optimisation_no_optimisation():
 
 @attr('codegen-independent')
 def test_apply_loop_invariant_optimisation_simplification():
-    variables = {'v1': Variable('v1', Unit(1), scalar=False),
-                 'v2': Variable('v2', Unit(1), scalar=False),
-                 'i1': Variable('i1', Unit(1), scalar=False, dtype=int),
-                 'N': Constant('N', Unit(1), 10)
+    variables = {'v1': Variable('v1', scalar=False),
+                 'v2': Variable('v2', scalar=False),
+                 'i1': Variable('i1', scalar=False, dtype=int),
+                 'N': Constant('N', 10)
                  }
     statements = [
         # Should be simplified to 0.0
@@ -268,12 +268,12 @@ def test_apply_loop_invariant_optimisation_simplification():
 
 @attr('codegen-independent')
 def test_apply_loop_invariant_optimisation_constant_evaluation():
-    variables = {'v1': Variable('v1', Unit(1), scalar=False),
-                 'v2': Variable('v2', Unit(1), scalar=False),
-                 'i1': Variable('i1', Unit(1), scalar=False, dtype=int),
-                 'N': Constant('N', Unit(1), 10),
-                 's1': Variable('s1', Unit(1), scalar=True, dtype=float),
-                 's2': Variable('s2', Unit(1), scalar=True, dtype=float),
+    variables = {'v1': Variable('v1', scalar=False),
+                 'v2': Variable('v2', scalar=False),
+                 'i1': Variable('i1', scalar=False, dtype=int),
+                 'N': Constant('N', 10),
+                 's1': Variable('s1', scalar=True, dtype=float),
+                 's2': Variable('s2', scalar=True, dtype=float),
                  'exp': DEFAULT_FUNCTIONS['exp']
                  }
     statements = [
@@ -299,13 +299,13 @@ def test_automatic_augmented_assignments():
     # We test that statements that could be rewritten as augmented assignments
     # are correctly rewritten (using sympy to test for symbolic equality)
     variables = {
-        'x': ArrayVariable('x', unit=Unit(1), owner=None, size=10,
+        'x': ArrayVariable('x', owner=None, size=10,
                            device=device),
-        'y': ArrayVariable('y', unit=Unit(1), owner=None, size=10,
+        'y': ArrayVariable('y', owner=None, size=10,
                            device=device),
-        'z': ArrayVariable('y', unit=Unit(1), owner=None, size=10,
+        'z': ArrayVariable('y', owner=None, size=10,
                            device=device),
-        'b': ArrayVariable('b', unit=Unit(1), owner=None, size=10,
+        'b': ArrayVariable('b', owner=None, size=10,
                            dtype=np.bool, device=device),
         'clip': DEFAULT_FUNCTIONS['clip'],
         'inf': DEFAULT_CONSTANTS['inf']

--- a/brian2/tests/test_equations.py
+++ b/brian2/tests/test_equations.py
@@ -124,7 +124,7 @@ def test_parse_equations():
     # A simple equation
     eqs = parse_string_equations('dv/dt = -v / tau : 1')
     assert len(eqs.keys()) == 1 and 'v' in eqs and eqs['v'].type == DIFFERENTIAL_EQUATION
-    assert eqs['v'].dimensions is DIMENSIONLESS
+    assert eqs['v'].dim is DIMENSIONLESS
 
     # A complex one
     eqs = parse_string_equations('''dv/dt = -(v +
@@ -147,10 +147,10 @@ def test_parse_equations():
     assert eqs['f'].var_type == FLOAT
     assert eqs['b'].var_type == BOOLEAN
     assert eqs['n'].var_type == INTEGER
-    assert eqs['v'].dimensions == volt.dim
-    assert eqs['ge'].dimensions == volt.dim
-    assert eqs['I'].dimensions == volt.dim
-    assert eqs['f'].dimensions == Hz.dim
+    assert eqs['v'].dim == volt.dim
+    assert eqs['ge'].dim == volt.dim
+    assert eqs['I'].dim == volt.dim
+    assert eqs['f'].dim == Hz.dim
     assert eqs['v'].flags == []
     assert eqs['ge'].flags == []
     assert eqs['I'].flags == []

--- a/brian2/tests/test_equations.py
+++ b/brian2/tests/test_equations.py
@@ -147,10 +147,10 @@ def test_parse_equations():
     assert eqs['f'].var_type == FLOAT
     assert eqs['b'].var_type == BOOLEAN
     assert eqs['n'].var_type == INTEGER
-    assert eqs['v'].dim == volt.dim
-    assert eqs['ge'].dim == volt.dim
-    assert eqs['I'].dim == volt.dim
-    assert eqs['f'].dim == Hz.dim
+    assert eqs['v'].dim is volt.dim
+    assert eqs['ge'].dim is volt.dim
+    assert eqs['I'].dim is volt.dim
+    assert eqs['f'].dim is Hz.dim
     assert eqs['v'].flags == []
     assert eqs['ge'].flags == []
     assert eqs['I'].flags == []

--- a/brian2/tests/test_equations.py
+++ b/brian2/tests/test_equations.py
@@ -350,6 +350,7 @@ def test_properties():
     assert (len(eqs.ordered) == 4 and
             all((isinstance(eq, SingleEquation) for eq in eqs.ordered)) and
             [eq.varname for eq in eqs.ordered] == ['f', 'I', 'v', 'freq'])
+    assert [eq.unit for eq in eqs.ordered] == [Hz, volt, volt, 1]
     assert eqs.names == {'v', 'I', 'f', 'freq'}
     assert eqs.parameter_names == {'freq'}
     assert eqs.subexpr_names == {'I', 'f'}

--- a/brian2/tests/test_equations.py
+++ b/brian2/tests/test_equations.py
@@ -291,8 +291,8 @@ def test_construction_errors():
 def test_unit_checking():
     # dummy Variable class
     class S(object):
-        def __init__(self, unit):
-            self.unit = unit
+        def __init__(self, dimensions):
+            self.dimensions = get_dimensions(dimensions)
 
     # inconsistent unit for a differential equation
     eqs = Equations('dv/dt = -v : volt')

--- a/brian2/tests/test_equations.py
+++ b/brian2/tests/test_equations.py
@@ -292,7 +292,7 @@ def test_unit_checking():
     # dummy Variable class
     class S(object):
         def __init__(self, dimensions):
-            self.dimensions = get_dimensions(dimensions)
+            self.dim = get_dimensions(dimensions)
 
     # inconsistent unit for a differential equation
     eqs = Equations('dv/dt = -v : volt')

--- a/brian2/tests/test_namespaces.py
+++ b/brian2/tests/test_namespaces.py
@@ -129,9 +129,9 @@ def test_warning():
 @attr('codegen-independent')
 def test_warning_internal_variables():
     group1 = SimpleGroup(namespace=None,
-                         variables={'N': Constant('N', Unit(1), 5)})
+                         variables={'N': Constant('N', 5)})
     group2 = SimpleGroup(namespace=None,
-                         variables={'N': Constant('N', Unit(1), 7)})
+                         variables={'N': Constant('N', 7)})
     with catch_logs() as l:
         group1.resolve_all(['N'], run_namespace={'N': 5})  # should not raise a warning
         assert len(l) == 0, 'got warnings: %s' % str(l)

--- a/brian2/tests/test_parsing.py
+++ b/brian2/tests/test_parsing.py
@@ -264,10 +264,10 @@ def test_is_boolean_expression():
 
 @attr('codegen-independent')
 def test_parse_expression_unit():
-    Var = namedtuple('Var', ['dimensions', 'dtype'])
-    variables = {'a': Var(dimensions=(volt*amp).dim, dtype=np.float64),
-                 'b': Var(dimensions=volt.dim, dtype=np.float64),
-                 'c': Var(dimensions=amp.dim, dtype=np.float64)}
+    Var = namedtuple('Var', ['dim', 'dtype'])
+    variables = {'a': Var(dim=(volt*amp).dim, dtype=np.float64),
+                 'b': Var(dim=volt.dim, dtype=np.float64),
+                 'c': Var(dim=amp.dim, dtype=np.float64)}
     group = SimpleGroup(namespace={}, variables=variables)
     EE = [
         (volt*amp, 'a+b*c'),

--- a/brian2/tests/test_stateupdaters.py
+++ b/brian2/tests/test_stateupdaters.py
@@ -300,7 +300,7 @@ def test_integrator_code2():
 def test_illegal_calls():
     eqs = Equations('dv/dt = -v / (10*ms) : 1')
     clock = Clock(dt=0.1*ms)
-    variables = {'v': ArrayVariable(name='name', unit=Unit(1), size=10,
+    variables = {'v': ArrayVariable(name='name', size=10,
                                     owner=None, device=None, dtype=np.float64,
                                     constant=False),
                  't': clock.variables['t'],
@@ -326,7 +326,7 @@ def test_priority():
     # Equations that work for the state updater
     eqs = Equations('dv/dt = -v / (10*ms) : 1')
     clock = Clock(dt=0.1*ms)
-    variables = {'v': ArrayVariable(name='name', unit=Unit(1), size=10,
+    variables = {'v': ArrayVariable(name='name', size=10,
                                     owner=None, device=None, dtype=np.float64,
                                     constant=False),
                  't': clock.variables['t'],
@@ -425,8 +425,8 @@ def test_determination():
     
     eqs = Equations('dv/dt = -v / (10*ms) : 1')
     # Just make sure that state updaters know about the two state variables
-    variables = {'v': Variable(name='v', unit=1),
-                 'w': Variable(name='w', unit=1)}
+    variables = {'v': Variable(name='v'),
+                 'w': Variable(name='w')}
     
     # all methods should work for these equations.
     # First, specify them explicitly (using the object)

--- a/brian2/tests/test_synapses.py
+++ b/brian2/tests/test_synapses.py
@@ -1343,11 +1343,11 @@ def check_permutation_code(code):
     variables.update(DEFAULT_FUNCTIONS)
     for var in indices:
         if var.endswith('_const'):
-            variables[var] = Constant(var, 1, 42, owner=device)
+            variables[var] = Constant(var, 42, owner=device)
         else:
-            variables[var] = ArrayVariable(var, 1, None, 10, device)
-    variables['_presynaptic_idx'] = ArrayVariable(var, 1, None, 10, device)
-    variables['_postsynaptic_idx'] = ArrayVariable(var, 1, None, 10, device)
+            variables[var] = ArrayVariable(var, None, 10, device)
+    variables['_presynaptic_idx'] = ArrayVariable(var, None, 10, device)
+    variables['_postsynaptic_idx'] = ArrayVariable(var, None, 10, device)
     scalar_statements, vector_statements = make_statements(code, variables, float64)
     check_for_order_independence(vector_statements, variables, indices)
 

--- a/brian2/tests/test_units.py
+++ b/brian2/tests/test_units.py
@@ -20,7 +20,7 @@ from brian2.units.fundamentalunits import (UFUNCS_DIMENSIONLESS,
                                            DimensionMismatchError,
                                            check_units,
                                            in_unit,
-                                           get_unit, get_unit_fast,
+                                           get_unit,
                                            get_or_create_dimension,
                                            DIMENSIONLESS,
                                            fail_for_dimension_mismatch)
@@ -975,7 +975,7 @@ def test_check_units():
 @attr('codegen-independent')
 def test_get_unit():
     '''
-    Test get_unit and get_unit_fast
+    Test get_unit
     '''
     values = [3 * mV, np.array([1, 2]) * mV,
               np.arange(12).reshape(4, 3) * mV]
@@ -983,7 +983,6 @@ def test_get_unit():
         unit = get_unit(value)
         assert isinstance(unit, Unit)
         assert unit == volt
-        assert_quantity(get_unit_fast(value), 1, volt)
 
     values = [3 * amp/metre**2, np.array([1, 2]) * amp/metre**2,
               np.arange(12).reshape(4, 3) * amp/metre**2]
@@ -992,7 +991,6 @@ def test_get_unit():
         assert isinstance(unit, Unit)
         assert unit == amp/metre**2
         assert float(unit) == 1.
-        assert_quantity(get_unit_fast(value), 1, amp/metre**2)
 
 
 @attr('codegen-independent')

--- a/brian2/tests/test_units.py
+++ b/brian2/tests/test_units.py
@@ -977,19 +977,13 @@ def test_get_unit():
     '''
     Test get_unit
     '''
-    values = [3 * mV, np.array([1, 2]) * mV,
-              np.arange(12).reshape(4, 3) * mV]
-    for value in values:
-        unit = get_unit(value)
+    values = [(volt.dim, volt),
+              (mV.dim, volt),
+              ((amp/metre**2).dim, amp/metre**2)]
+    for dim, expected_unit in values:
+        unit = get_unit(dim)
         assert isinstance(unit, Unit)
-        assert unit == volt
-
-    values = [3 * amp/metre**2, np.array([1, 2]) * amp/metre**2,
-              np.arange(12).reshape(4, 3) * amp/metre**2]
-    for value in values:
-        unit = get_unit(value)
-        assert isinstance(unit, Unit)
-        assert unit == amp/metre**2
+        assert unit == expected_unit
         assert float(unit) == 1.
 
 

--- a/brian2/tests/test_variables.py
+++ b/brian2/tests/test_variables.py
@@ -16,12 +16,11 @@ from brian2.units.allunits import second
 @attr('codegen-independent')
 def test_construction_errors():
     # Boolean variable that isn't dimensionless
-    assert_raises(ValueError, lambda: Variable(name='name', unit=second,
+    assert_raises(ValueError, lambda: Variable(name='name', dimensions=second.dim,
                                                dtype=np.bool))
 
     # Dynamic array variable that is constant but not constant in size
     assert_raises(ValueError, lambda: DynamicArrayVariable(name='name',
-                                                           unit=Unit(1),
                                                            owner=None,
                                                            size=0,
                                                            device=None,
@@ -34,13 +33,13 @@ def test_str_repr():
     # Basic test that the str/repr methods work
     FakeGroup = namedtuple('G', ['name'])
     group = FakeGroup(name='groupname')
-    variables = [Variable(name='name', unit=second),
-                 Constant(name='name', unit=second, value=1.0),
-                 AuxiliaryVariable(name='name', unit=second),
-                 ArrayVariable(name='name', unit=second, owner=None, size=10, device=None),
-                 DynamicArrayVariable(name='name', unit=second, owner=None, size=0,
+    variables = [Variable(name='name', dimensions=second.dim),
+                 Constant(name='name', dimensions=second.dim, value=1.0),
+                 AuxiliaryVariable(name='name', dimensions=second.dim),
+                 ArrayVariable(name='name', dimensions=second.dim, owner=None, size=10, device=None),
+                 DynamicArrayVariable(name='name', dimensions=second.dim, owner=None, size=0,
                                       device=None),
-                 Subexpression(name='sub', unit=second, expr='a+b', owner=group,
+                 Subexpression(name='sub', dimensions=second.dim, expr='a+b', owner=group,
                                device=None)]
     for var in variables:
         assert len(str(var))
@@ -54,14 +53,13 @@ def test_dtype_str():
     group = FakeGroup(name='groupname')
     for d in ['int32', 'int64', 'float32', 'float64', 'bool', 'int', 'float']:
         nd = np.dtype(d)
-        for var in [Constant(name='name', unit=1,
-                             value=np.zeros(1, dtype=nd)[0]),
-                    AuxiliaryVariable(name='name', dtype=nd, unit=1),
-                    ArrayVariable(name='name', owner=None, size=10, unit=1,
+        for var in [Constant(name='name', value=np.zeros(1, dtype=nd)[0]),
+                    AuxiliaryVariable(name='name', dtype=nd),
+                    ArrayVariable(name='name', owner=None, size=10,
                                   device=None, dtype=nd),
                     DynamicArrayVariable(name='name', owner=None, dtype=nd,
-                                         size=0, device=None, unit=1),
-                    Subexpression(name='sub', expr='a+b', owner=group, unit=1,
+                                         size=0, device=None),
+                    Subexpression(name='sub', expr='a+b', owner=group,
                                   device=None, dtype=nd)]:
             assert var.dtype_str.startswith(d)
 

--- a/brian2/units/fundamentalunits.py
+++ b/brian2/units/fundamentalunits.py
@@ -130,8 +130,8 @@ def fail_for_dimension_mismatch(obj1, obj2=None, error_message=None,
     Returns
     -------
     dim1, dim2 : `Dimension`, `Dimension`
-        The dimensions of the two arguments (so that later code does not need
-        to get the dimensions again).
+        The physical dimensions of the two arguments (so that later code does
+        not need to get the dimensions again).
 
     Raises
     ------
@@ -560,9 +560,9 @@ class DimensionMismatchError(Exception):
     description : ``str``
         A description of the type of operation being performed, e.g. Addition,
         Multiplication, etc.
-    dims : ``Dimension``
-        The dimensions of the objects involved in the operation, any number of
-        them is possible
+    dims : `Dimension`
+        The physical dimensions of the objects involved in the operation, any
+        number of them is possible
     """
     def __init__(self, description, *dims):
         # Call the base class constructor to make Exception pickable, see:
@@ -632,7 +632,7 @@ def get_dimensions(obj):
     Returns
     -------
     dim: `Dimension`
-        The dimensions of the `obj`.
+        The physical dimensions of the `obj`.
     """
     try:
         return obj.dim
@@ -800,7 +800,7 @@ def quantity_with_dimensions(floatval, dims):
     floatval : `float`
         The floating point value of the quantity.
     dims : `Dimension`
-        The dimensions of the quantity.
+        The physical dimensions of the quantity.
 
     Returns
     -------
@@ -880,7 +880,7 @@ class Quantity(np.ndarray, object):
     dimensions
     is_dimensionless
     dim : Dimensions
-        The dimensions of this quantity.
+        The physical dimensions of this quantity.
 
     Methods
     -------
@@ -1112,7 +1112,7 @@ class Quantity(np.ndarray, object):
     @property
     def dimensions(self):
         '''
-        The dimensions of this quantity.
+        The physical dimensions of this quantity.
         '''
         return self.dim
 

--- a/brian2/units/fundamentalunits.py
+++ b/brian2/units/fundamentalunits.py
@@ -28,8 +28,7 @@ __all__ = [
     'DimensionMismatchError', 'get_or_create_dimension',
     'get_dimensions', 'is_dimensionless', 'have_same_dimensions',
     'in_unit', 'in_best_unit', 'Quantity', 'Unit', 'register_new_unit',
-    'check_units', 'is_scalar_type', 'get_unit', 'get_unit_fast',
-    'unit_checking'
+    'check_units', 'is_scalar_type', 'get_unit', 'unit_checking'
     ]
 
 
@@ -2297,13 +2296,6 @@ def get_unit_for_display(x):
         return '1'
     else:
         return repr(get_unit(x))
-
-def get_unit_fast(x):
-    '''
-    Return a `Quantity` with value 1 and the same dimensions.
-    '''
-    return Quantity.with_dimensions(1, get_dimensions(x))
-
 
 #### DECORATORS
 

--- a/brian2/units/fundamentalunits.py
+++ b/brian2/units/fundamentalunits.py
@@ -460,7 +460,11 @@ class Dimension(object):
 
     #### COMPARISON ####
     def __eq__(self, value):
-        return np.allclose(self._dims, value._dims)
+        try:
+            return np.allclose(self._dims, value._dims)
+        except AttributeError:
+            # Only compare equal to another Dimensions object
+            return False
 
     def __ne__(self, value):
         return not self.__eq__(value)

--- a/brian2/units/fundamentalunits.py
+++ b/brian2/units/fundamentalunits.py
@@ -1237,7 +1237,8 @@ class Quantity(np.ndarray, object):
                     pass
             return Quantity(1, self.dim)
         else:
-            return self.get_best_unit(standard_unit_register, user_unit_register,
+            return self.get_best_unit(user_unit_register,
+                                      standard_unit_register,
                                       additional_unit_register)
 
     def in_best_unit(self, precision=None, python_code=False, *regs):
@@ -2239,31 +2240,6 @@ additional_unit_register = UnitRegistry()
 #: `UnitRegistry` containing all units defined by the user
 user_unit_register = UnitRegistry()
 
-def all_registered_units(*regs):
-    """
-    Generator returning all registered units.
-    
-    Parameters
-    ----------
-    regs : any number of `UnitRegistry` objects.
-        If given, units from the given registries are returned. If none are
-        given, units are returned from the standard units, the user-registered
-        units and the "additional units" (e.g. ``newton * metre``) in that
-        order. 
-    
-    Returns
-    -------
-        u : `Unit`
-            A single unit from the registry.
-    """
-    if not len(regs):
-        regs = [standard_unit_register,
-                user_unit_register,
-                additional_unit_register]
-    for r in regs:
-        for u in r.units:
-            yield u
-
 
 def get_unit(d):
     '''
@@ -2280,9 +2256,12 @@ def get_unit(d):
         A registered unscaled `Unit` for the dimensions ``d``, or a new `Unit`
         if no unit was found.
     '''
-    for u in all_registered_units():
-        if np.array(u, copy=False) == 1 and u.dim is d:
-            return u
+    for unit_register in [user_unit_register,
+                          standard_unit_register,
+                          additional_unit_register]:
+        for u in unit_register.units_for_dimensions[d]:
+            if float(u) == 1.0:
+                return u
     return Unit(1.0, dim=d)
 
 

--- a/brian2/units/fundamentalunits.py
+++ b/brian2/units/fundamentalunits.py
@@ -178,7 +178,7 @@ def fail_for_dimension_mismatch(obj1, obj2=None, error_message=None,
             error_message = error_message.format(**error_quantities)
         # If we are comparing an object to a specific unit, we don't want to
         # restate this unit (it is probably mentioned in the text already)
-        if obj2 is None or isinstance(obj2, Unit):
+        if obj2 is None or isinstance(obj2, (Dimension, Unit)):
             raise DimensionMismatchError(error_message, dim1)
         else:
             raise DimensionMismatchError(error_message, dim1, dim2)

--- a/brian2/units/fundamentalunits.py
+++ b/brian2/units/fundamentalunits.py
@@ -257,7 +257,7 @@ def wrap_function_change_dimensions(func, change_dim_func):
 def wrap_function_remove_dimensions(func):
     '''
     Returns a new function that wraps the given function `func` so that it
-    removes any dimensions from its input. Useful for functions that are
+    removes any dim from its input. Useful for functions that are
     returning integers (indices) or booleans, irrespective of the datatype
     contained in the array.
 
@@ -1073,7 +1073,7 @@ class Quantity(np.ndarray, object):
     @staticmethod
     def with_dimensions(value, *args, **keywords):
         """
-        Create a `Quantity` object with dimensions.
+        Create a `Quantity` object with dim.
 
         Parameters
         ----------
@@ -1082,12 +1082,12 @@ class Quantity(np.ndarray, object):
         args : {`Dimension`, sequence of float}
             Either a single argument (a `Dimension`) or a sequence of 7 values.
         kwds
-            Keywords defining the dimensions, see `Dimension` for details.
+            Keywords defining the dim, see `Dimension` for details.
 
         Returns
         -------
         q : `Quantity`
-            A `Quantity` object with the given dimensions
+            A `Quantity` object with the given dim
 
         Examples
         --------
@@ -1845,7 +1845,7 @@ class Unit(Quantity):
         Parameters
         ----------
         dim : `Dimension`
-            The dimensions of the unit.
+            The dim of the unit.
         name : `str`, optional
             The full name of the unit, e.g. ``'volt'``
         dispname : `str`, optional

--- a/brian2/units/fundamentalunits.py
+++ b/brian2/units/fundamentalunits.py
@@ -783,7 +783,7 @@ def in_best_unit(x, precision=None):
             precision = np.get_printoptions()['precision']
         return str(np.round(x, precision))
     
-    u = x._get_best_unit()
+    u = x.get_best_unit()
     return x.in_unit(u, precision=precision)
 
 
@@ -1212,7 +1212,7 @@ class Quantity(np.ndarray, object):
             return '%s(%s)' % (self.__class__.__name__, s.strip())
         return s.strip()
 
-    def _get_best_unit(self, *regs):
+    def get_best_unit(self, *regs):
         """
         Return the best unit for this `Quantity`.
 
@@ -1237,8 +1237,8 @@ class Quantity(np.ndarray, object):
                     pass
             return Quantity(1, self.dim)
         else:
-            return self._get_best_unit(standard_unit_register, user_unit_register,
-                                       additional_unit_register)
+            return self.get_best_unit(standard_unit_register, user_unit_register,
+                                      additional_unit_register)
 
     def in_best_unit(self, precision=None, python_code=False, *regs):
         """
@@ -1280,7 +1280,7 @@ class Quantity(np.ndarray, object):
         --------
         in_best_unit
         """
-        u = self._get_best_unit(*regs)
+        u = self.get_best_unit(*regs)
         return self.in_unit(u, precision=precision, python_code=python_code)
 
 #==============================================================================
@@ -1573,7 +1573,7 @@ class Quantity(np.ndarray, object):
     # TODO: Use sympy's _latex method, then latex(unit) should work
     def _latex(self, expr):
         from sympy import Matrix
-        best_unit = self._get_best_unit()
+        best_unit = self.get_best_unit()
         if isinstance(best_unit, Unit):
             best_unit_latex = latex(best_unit)
         else: # A quantity

--- a/brian2/units/fundamentalunits.py
+++ b/brian2/units/fundamentalunits.py
@@ -2111,7 +2111,7 @@ class Unit(Quantity):
 
     def __eq__(self, other):
         if isinstance(other, Unit):
-            return (other.dim == self.dim and
+            return (other.dim is self.dim and
                     other.scalefactor == self.scalefactor and
                     other.scale == self.scale)
         else:

--- a/brian2/units/fundamentalunits.py
+++ b/brian2/units/fundamentalunits.py
@@ -190,7 +190,7 @@ def wrap_function_dimensionless(func):
     '''
     Returns a new function that wraps the given function `func` so that it
     raises a DimensionMismatchError if the function is called on a quantity
-    with dimensions (excluding dimensionless quantitities). Quantities are
+    with dimensions (excluding dimensionless quantities). Quantities are
     transformed to unitless numpy arrays before calling `func`.
 
     These checks/transformations apply only to the very first argument, all
@@ -256,7 +256,7 @@ def wrap_function_change_dimensions(func, change_dim_func):
 def wrap_function_remove_dimensions(func):
     '''
     Returns a new function that wraps the given function `func` so that it
-    removes any dim from its input. Useful for functions that are
+    removes any dimensions from its input. Useful for functions that are
     returning integers (indices) or booleans, irrespective of the datatype
     contained in the array.
 
@@ -306,7 +306,6 @@ class Dimension(object):
 
     Provides a subset of arithmetic operations appropriate to dimensions:
     multiplication, division and powers, and equality testing.
-
 
     Parameters
     ----------
@@ -681,10 +680,10 @@ def have_same_dimensions(obj1, obj2):
     same : `bool`
         ``True`` if `obj1` and `obj2` have the same dimensions.
     """
-    
+
     if not unit_checking:
         return True  # ignore units when unit checking is disabled
-    
+
     # If dimensions are consistently created using get_or_create_dimensions,
     # the fast "is" comparison should always return the correct result.
     # To be safe, we also do an equals comparison in case it fails. This
@@ -732,7 +731,7 @@ def in_unit(x, u, precision=None):
         ...
     DimensionMismatchError: Non-matching unit for method "in_unit",
     dimensions were (m^-2 kg^-1 s^3 A^2) (m^2 kg s^-3 A^-2)
-    
+
     See Also
     --------
     Quantity.in_unit    
@@ -757,16 +756,15 @@ def in_best_unit(x, precision=None):
     precision : `int`, optional
         The number of digits of precision (in the best unit, see Examples).
         If no value is given, numpy's `get_printoptions` value is used.            
-    
+
     Returns
     -------
     representation : `str`
         A string representation of this `Quantity`.
-    
+
     Examples
     --------
     >>> from brian2.units import *
-    
     >>> in_best_unit(0.00123456 * volt)
     '1.23456 mV'
     >>> in_best_unit(0.00123456 * volt, 2)
@@ -787,6 +785,7 @@ def in_best_unit(x, precision=None):
     
     u = x._get_best_unit()
     return x.in_unit(u, precision=precision)
+
 
 def quantity_with_dimensions(floatval, dims):
     '''
@@ -1139,7 +1138,7 @@ class Quantity(np.ndarray, object):
         """
         if not unit_checking:
             return True  # ignore units if unit checking is disabled
-        
+
         other_dim = get_dimensions(other)
         return (self.dim is other_dim) or (self.dim == other_dim) 
 
@@ -1176,7 +1175,7 @@ class Quantity(np.ndarray, object):
         '0.025 V'
         >>> x.in_unit(mV, 3)
         '25.123 mV'
-        
+
         See Also
         --------
         in_unit
@@ -1216,13 +1215,13 @@ class Quantity(np.ndarray, object):
     def _get_best_unit(self, *regs):
         """
         Return the best unit for this `Quantity`.
-        
+
         Parameters
-        ----------            
+        ----------
         regs : any number of `UnitRegistry` objects
             The registries that are searched for units. If none are provided, it
             will check the standard, user and additional unit registers in turn.
-    
+
         Returns
         -------
             u : `Quantity` or `Unit`
@@ -1259,24 +1258,24 @@ class Quantity(np.ndarray, object):
             The registries where to search for units. If none are given, the
             standard, user-defined and additional registries are searched in
             that order.
-        
+
         Returns
         -------
         representation : `str`
             A string representation of this `Quantity`.
-        
+
         Examples
         --------
         >>> from brian2.units import *
-        
+
         >>> x = 0.00123456 * volt
-        
+
         >>> x.in_best_unit()
         '1.23456 mV'
-        
+
         >>> x.in_best_unit(3)
         '1.235 mV'
-        
+
         See Also
         --------
         in_best_unit

--- a/brian2/units/fundamentalunits.py
+++ b/brian2/units/fundamentalunits.py
@@ -2265,36 +2265,46 @@ def all_registered_units(*regs):
             yield u
 
 
-def get_unit(x, *regs):
+def get_unit(d):
     '''
-    Find the most appropriate consistent unit from the unit registries.
+    Find an unscaled unit (e.g. `volt` but not `mvolt`) for a `Dimension`.
 
     Parameters
     ----------
-    x : {`Quantity`, `Dimension`, array-like, number}
-        The value to find a unit for.
+    d : `Dimension`
+        The dimension to find a unit for.
 
     Returns
     -------
-    q : `Unit`
-        The equivalent `Unit` for the quantity `x`.
+    u : `Unit`
+        A registered unscaled `Unit` for the dimensions ``d``, or a new `Unit`
+        if no unit was found.
     '''
-    for u in all_registered_units(*regs):
-        if np.array(u, copy=False) == 1 and have_same_dimensions(u, x):
+    for u in all_registered_units():
+        if np.array(u, copy=False) == 1 and u.dim is d:
             return u
-    dim = getattr(x, 'dim', DIMENSIONLESS)  # For units, get dimensions
-    return Unit(1.0, dim=dim)
+    return Unit(1.0, dim=d)
 
 
-def get_unit_for_display(x):
+def get_unit_for_display(d):
     '''
-    Return a string representation of the most appropriate unit or ``'1'`` for
-    a dimensionless quantity
+    Return a string representation of an appropriate unscaled unit or ``'1'``
+    for a dimensionless quantity.
+
+    Parameters
+    ----------
+    d : `Dimension`
+        The dimension to find a unit for.
+
+    Returns
+    -------
+    s : str
+        A string representation of the respective unit or the string ``'1'``.
     '''
-    if x is 1 or x is DIMENSIONLESS or have_same_dimensions(x, 1):
+    if d is 1 or d is DIMENSIONLESS:
         return '1'
     else:
-        return repr(get_unit(x))
+        return repr(get_unit(d))
 
 #### DECORATORS
 


### PR DESCRIPTION
This implements what I proposed in #797: `SingleEquation`, `Variable`, and `VariableView` now internally store dimensions instead of units. If I run a HH model repeatedly in a loop (with `run(0*ms)`) to coarsely matter preparation overhead, then this actually cuts the time in half! This mostly shows how inefficient `get_unit` was (which again and again went through the full registry to search for a suitable unit, checking and discarding scaled units along the way), but still. I also profiled a bit where the rest of the time is spend, and I think we can quite easily improve more with some simple caching. I might tackle this soon.
Note that you can still access a `unit` property of the above mentioned classes (since it was kind of part of our "public API" and I have already seen user code making use of this, e.g. to create equation strings programmatically), but this will raise a deprecation warning.

Fixes #797 