### PR TITLE
[MRG] Floating point instead of integer division (elapsed time for report function)

### DIFF
--- a/brian2/devices/cpp_standalone/templates/network.cpp
+++ b/brian2/devices/cpp_standalone/templates/network.cpp
@@ -74,7 +74,7 @@ void Network::run(const double duration, void (*report_func)(const double, const
                 const double elapsed = omp_get_wtime() - start;
                 {% else %}
                 current = std::clock();
-                const double elapsed = (double)((current - start) / CLOCKS_PER_SEC);
+                const double elapsed = ((double)(current - start) / CLOCKS_PER_SEC);
                 {% endif %}
                 if (elapsed > next_report_time)
                 {

--- a/docs_sphinx/introduction/release_notes.rst
+++ b/docs_sphinx/introduction/release_notes.rst
@@ -23,6 +23,7 @@ Testing, suggestions and bug reports (ordered alphabetically, apologies to
 anyone we forgot...):
 
 * Christopher Nolan
+* Denis Alevi
 * Meng Dong
 
 Brian 2.0.1


### PR DESCRIPTION
Fixes #804