### PR TITLE
Implement generic typing for `_clip`

### DIFF
--- a/brian2/codegen/generators/cpp_generator.py
+++ b/brian2/codegen/generators/cpp_generator.py
@@ -438,7 +438,8 @@ DEFAULT_FUNCTIONS['abs'].implementations.add_implementation(CPPCodeGenerator,
                                                             name='_brian_abs')
 
 clip_code = '''
-        inline double _clip(const double value, const double a_min, const double a_max)
+        template <typename T>
+        inline T _clip(const T value, const double a_min, const double a_max)
         {
 	        if (value < a_min)
 	            return a_min;

--- a/brian2/codegen/generators/cython_generator.py
+++ b/brian2/codegen/generators/cython_generator.py
@@ -368,11 +368,18 @@ DEFAULT_FUNCTIONS['sign'].implementations.add_implementation(CythonCodeGenerator
                                                              name='_sign')
 
 clip_code = '''
-cdef double clip(double x, double low, double high):
-    if x<low:
-        return low
-    if x>high:
-        return high
+ctypedef fused _to_clip:
+    char
+    short
+    int
+    float
+    double
+
+cdef _to_clip clip(_to_clip x, double low, double high):
+    if x < low:
+        return <_to_clip?>low
+    if x > high:
+        return <_to_clip?>high
     return x
 '''
 DEFAULT_FUNCTIONS['clip'].implementations.add_implementation(CythonCodeGenerator,


### PR DESCRIPTION
Issue: #782

This pull request makes a more abstract version of the `_clip` function
to accommodate also for arguments of other types than `double`.

It would probably be a good idea to add test cases for each of the different
types, but I have not really looked into the internals of your test suite yet.