### PR TITLE
[MRG] Workaround glibc bug

### DIFF
--- a/brian2/devices/cpp_standalone/device.py
+++ b/brian2/devices/cpp_standalone/device.py
@@ -82,6 +82,13 @@ prefs.register_preferences(
         Additional flags to pass to the nmake command on Windows. By default, no
         additional flags are passed.
         '''
+        ),
+    run_environment_variables=BrianPreference(
+        default={'LD_BIND_NOW': '1'},
+        docs='''
+        Dictionary of environment variables and their values that will be set
+        during the execution of the standalone code.
+        '''
         )
     )
 
@@ -847,6 +854,13 @@ class CPPStandaloneDevice(Device):
 
     def run(self, directory, with_output, run_args):
         with in_directory(directory):
+            # Set environment variables
+            for key, value in prefs.devices.cpp_standalone.run_environment_variables.iteritems():
+                if key in os.environ and os.environ[key] != value:
+                    logger.info('Overwriting environment variable '
+                                '"{key}"'.format(key=key),
+                                name_suffix='overwritten_env_var', once=True)
+                os.environ[key] = value
             if not with_output:
                 stdout = open('results/stdout.txt', 'w')
             else:

--- a/docs_sphinx/introduction/known_issues.rst
+++ b/docs_sphinx/introduction/known_issues.rst
@@ -56,11 +56,11 @@ are not affected by this problem.
 Slow standalone simulations
 ---------------------------
 
-While we are not yet sure about the exact reason, we have observed that some
-simulations run very slow on modern hardware when compiled with the gcc
-compiler in C++ standalone mode (see #803). Workarounds are to switch to a
-different compiler (e.g. clang, see :ref:`standalone_custom_build` for details)
-or to enable "unsafe" math optimisations by adding ``-ffinite-math-only`` to
-the compiler preferences (see :ref:`compiler_settings`). Note that this option
-may lead to incorrect simulation results if NaN or infinity values are
-encountered during the simulation.
+Some versions of the GNU standard library (in particular those used by recent
+Ubuntu versions) have a bug that can dramatically slow down simulations in
+C++ standalone mode on modern hardware (see #803). As a workaround, Brian will
+set an environment variable ``LD_BIND_NOW`` during the execution of standalone
+stimulations which changes the way the library is linked so that it does not
+suffer from this problem. If this environment variable leads to unwanted
+behaviour on your machine, change the
+`prefs.devices.cpp_standalone.run_environment_variables` preference.

--- a/docs_sphinx/introduction/release_notes.rst
+++ b/docs_sphinx/introduction/release_notes.rst
@@ -9,6 +9,10 @@ New features
 
 Improvements and bug fixes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
+* Work around low performance for certain C++ standalone simulations on Linux,
+  due to a bug in glibc (see #803). Thanks to Oleg Strikov
+  (`@xj8z <https://github.com/xj8z>`_) for debugging this
+  issue and providing the workaround that is now in use.
 * Make exact integration of ``event-driven`` synaptic variables use the `linear`
   numerical integration algorithm (instead of `independent`), fixing rare
   occasions where integration failed despite the equations being linear (#801).
@@ -25,6 +29,7 @@ anyone we forgot...):
 * Christopher Nolan
 * Denis Alevi
 * Meng Dong
+* Oleg Strikov
 * Shailesh Appukuttan
 
 Brian 2.0.1


### PR DESCRIPTION
This fixes #803 by introducing a new preference for environment variables that will be set during the execution of standalone simulations which defaults to `LD_BIND_NOW=1`. I did not bother introducing different preferences for Windows and *nix, I don't think having a non-relevant environment variable (such as `LD_BIND_NOW` on Windows) should hurt.