### PR TITLE
[MRG] Reduce the number of supported data types for `brian_mod`

### DIFF
--- a/brian2/codegen/generators/cpp_generator.py
+++ b/brian2/codegen/generators/cpp_generator.py
@@ -89,8 +89,7 @@ prefs.register_preferences(
 
 
 mod_support_code = ''
-typestrs = ['unsigned char', 'char', 'unsigned short', 'short', 'unsigned int', 'int', 'unsigned long', 'long',
-            'unsigned long long', 'long long', 'float', 'double', 'long double']
+typestrs = ['int', 'long', 'long long', 'float', 'double', 'long double']
 floattypestrs = ['float', 'double', 'long double']
 for ix, xtype in enumerate(typestrs):
     for iy, ytype in enumerate(typestrs):

--- a/brian2/core/clocks.py
+++ b/brian2/core/clocks.py
@@ -49,8 +49,8 @@ def check_dt(new_dt, old_dt, target_t):
     ...
     ValueError: Cannot set dt from 100. us to 200. us, the time 10.1 ms is not a multiple of 200. us
     '''
-    old_t = np.uint64(np.round(target_t / old_dt)) * old_dt
-    new_t = np.uint64(np.round(target_t / new_dt)) * new_dt
+    old_t = np.int64(np.round(target_t / old_dt)) * old_dt
+    new_t = np.int64(np.round(target_t / new_dt)) * new_dt
     error_t = target_t
     if abs(new_t - old_t)/new_dt > Clock.epsilon_dt:
         raise ValueError(('Cannot set dt from {old} to {new}, the '
@@ -86,7 +86,7 @@ class Clock(VariableOwner):
         Nameable.__init__(self, name=name)
         self._old_dt = None
         self.variables = Variables(self)
-        self.variables.add_array('timestep', size=1, dtype=np.uint64,
+        self.variables.add_array('timestep', size=1, dtype=np.int64,
                                  read_only=True, scalar=True)
         self.variables.add_array('t', dimensions=second.dim, size=1,
                                  dtype=np.double, read_only=True, scalar=True)
@@ -133,13 +133,13 @@ class Clock(VariableOwner):
         timestep : int
             The target time in integers (based on dt)
         '''
-        new_i = np.uint64(np.round(target_t / self.dt_))
+        new_i = np.int64(np.round(target_t / self.dt_))
         new_t = new_i * self.dt_
         if (new_t == target_t or
                         np.abs(new_t - target_t)/self.dt_ <= Clock.epsilon_dt):
             new_timestep = new_i
         else:
-            new_timestep = np.uint64(np.ceil(target_t / self.dt_))
+            new_timestep = np.int64(np.ceil(target_t / self.dt_))
         return new_timestep
 
     def __repr__(self):

--- a/brian2/devices/cpp_standalone/brianlib/clocks.h
+++ b/brian2/devices/cpp_standalone/brianlib/clocks.h
@@ -17,7 +17,7 @@ class Clock
 public:
 	double epsilon;
 	double *dt;
-	uint64_t *timestep;
+	int64_t *timestep;
 	double *t;
 	Clock(double _epsilon=1e-14) : epsilon(_epsilon) { i_end = 0;};
     inline void tick()
@@ -45,7 +45,7 @@ public:
         }
 	}
 private:
-	uint64_t i_end;
+	int64_t i_end;
 };
 
 #endif

--- a/brian2/devices/cpp_standalone/templates/synapses_classes.cpp
+++ b/brian2/devices/cpp_standalone/templates/synapses_classes.cpp
@@ -39,7 +39,7 @@ public:
 			delete(queue[_idx]);
 	}
 
-	void push(int *spikes, unsigned int nspikes)
+	void push(int *spikes, int nspikes)
     {
     	queue[{{ openmp_pragma('get_thread_num') }}]->push(spikes, nspikes);
     }
@@ -65,20 +65,20 @@ public:
     	return &all_peek;
     }
 
-    void prepare(int n_source, int n_target, scalar *real_delays, unsigned int n_delays,
-                 int *sources, unsigned int n_synapses, double _dt)
+    void prepare(int n_source, int n_target, scalar *real_delays, int n_delays,
+                 int *sources, int n_synapses, double _dt)
     {
         Nsource = n_source;
         Ntarget = n_target;
     	{{ openmp_pragma('parallel') }}
     	{
-            unsigned int length;
+            int length;
             if ({{ openmp_pragma('get_thread_num') }} == _nb_threads - 1) 
-                length = n_synapses - (unsigned int) {{ openmp_pragma('get_thread_num') }}*(n_synapses/_nb_threads);
+                length = n_synapses - (int){{ openmp_pragma('get_thread_num') }}*(n_synapses/_nb_threads);
             else
-                length = (unsigned int) n_synapses/_nb_threads;
+                length = (int) n_synapses/_nb_threads;
 
-            unsigned int padding  = {{ openmp_pragma('get_thread_num') }}*(n_synapses/_nb_threads);
+            int padding  = {{ openmp_pragma('get_thread_num') }}*(n_synapses/_nb_threads);
 
             queue[{{ openmp_pragma('get_thread_num') }}]->openmp_padding = padding;
             if (n_delays > 1)

--- a/brian2/synapses/cythonspikequeue.pyx
+++ b/brian2/synapses/cythonspikequeue.pyx
@@ -20,13 +20,13 @@ cdef extern from "stdint_compat.h":
     ctypedef signed int int32_t
     ctypedef signed long int64_t
 
-ctypedef pair[unsigned int, vector[vector[int32_t]]] state_pair
+ctypedef pair[int, vector[vector[int32_t]]] state_pair
 
 cdef extern from "cspikequeue.cpp":
     cdef cppclass CSpikeQueue[T]:
         CSpikeQueue(int, int) except +
-        void prepare(T*, int, int32_t*, unsigned int, double)
-        void push(int32_t *, unsigned int)
+        void prepare(T*, int, int32_t*, int, double)
+        void push(int32_t *, int)
         state_pair _full_state()
         void _restore_from_full_state(state_pair)
         vector[int32_t]* peek()

--- a/dev/conda-recipe/meta.yaml
+++ b/dev/conda-recipe/meta.yaml
@@ -72,6 +72,5 @@ about:
   dev_url: https://github.com/brian-team/brian2
   doc_url: http://brian2.readthedocs.io/
   license: CeCILL-2.1
-  license_family: Other
   license_file: LICENSE
   summary: 'A clock-driven simulator for spiking neural networks'


### PR DESCRIPTION
In current master, we generate a whopping 169 variants of `brian_mod`, even though you cannot generate variables (or number literals) with data types such as `unsigned int` or `short` at the moment. This clutters the generated code quite a bit (#594 would of course deal with this as well) without a clear gain. This PR is still quite generous by allowing for six data types (i.e. a total of 36 variants), but we probably rather want to err on the side of caution here.