### PR TITLE
[MRG] Fix `_vectorisation_idx` for numpy target

### DIFF
--- a/brian2/codegen/generators/numpy_generator.py
+++ b/brian2/codegen/generators/numpy_generator.py
@@ -305,27 +305,19 @@ for func_name, func in [('sin', np.sin), ('cos', np.cos), ('tan', np.tan),
 def randn_func(vectorisation_idx):
     try:
         N = len(vectorisation_idx)
+        return np.random.randn(N)
     except TypeError:
-        N = int(vectorisation_idx)
-
-    numbers = np.random.randn(N)
-    if N == 1:
-        return numbers[0]
-    else:
-        return numbers
+        # scalar value
+        return np.random.randn()
 
 
 def rand_func(vectorisation_idx):
     try:
         N = len(vectorisation_idx)
+        return np.random.rand(N)
     except TypeError:
-        N = int(vectorisation_idx)
-
-    numbers = np.random.rand(N)
-    if N == 1:
-        return numbers[0]
-    else:
-        return numbers
+        # scalar value
+        return np.random.rand()
 
 
 DEFAULT_FUNCTIONS['randn'].implementations.add_implementation(NumpyCodeGenerator,

--- a/brian2/codegen/generators/numpy_generator.py
+++ b/brian2/codegen/generators/numpy_generator.py
@@ -239,6 +239,9 @@ class NumpyCodeGenerator(CodeGenerator):
             # all newly created vars are arrays and will need indexing
             for varname in created_vars:
                 subs[varname] = varname + '[' + repl_string + ']'
+            # Also index _vectorisation_idx so that e.g. rand() works correctly
+            subs['_vectorisation_idx'] = '_vectorisation_idx' + '[' + repl_string + ']'
+
             line = word_substitute(line, subs)
             line = line.replace(repl_string, index)
         return line

--- a/brian2/codegen/runtime/numpy_rt/templates/group_get_indices.py_
+++ b/brian2/codegen/runtime/numpy_rt/templates/group_get_indices.py_
@@ -1,13 +1,15 @@
 {# USES_VARIABLES { N } #}
 import numpy as _numpy
 
+from brian2.codegen.runtime.numpy_rt.numpy_rt import LazyArange
+
 # scalar code
 _vectorisation_idx = 1
 {{scalar_code|autoindent}}
 
 # vector code
-_idx = _numpy.arange(N)
-_vectorisation_idx = N
+_idx = LazyArange(N)
+_vectorisation_idx = _idx
 
 {{vector_code|autoindent}}
 
@@ -16,5 +18,4 @@ if _cond is True:
 if _cond is False:
     _cond = []
 
-# _indices is set in the abstract code, see IndexWrapper.__getitem__
-_return_values = _idx[_cond]
+_return_values = _numpy.array(_idx[_cond])

--- a/brian2/codegen/runtime/numpy_rt/templates/group_variable_get_conditional.py_
+++ b/brian2/codegen/runtime/numpy_rt/templates/group_variable_get_conditional.py_
@@ -2,12 +2,14 @@
 {# USES_VARIABLES { N } #}
 import numpy as _numpy
 
+from brian2.codegen.runtime.numpy_rt.numpy_rt import LazyArange
+
 # scalar code
 _vectorisation_idx = 1
 {{scalar_code|autoindent}}
 
 # vector code
-_vectorisation_idx = {{constant_or_scalar('N', variables['N'])}}
+_vectorisation_idx = LazyArange({{constant_or_scalar('N', variables['N'])}})
 {{vector_code|autoindent}}
 
 if _cond is True:

--- a/brian2/codegen/runtime/numpy_rt/templates/group_variable_set.py_
+++ b/brian2/codegen/runtime/numpy_rt/templates/group_variable_set.py_
@@ -1,6 +1,8 @@
-{# USES_VARIABLES { _group_idx } #}
+{# USES_VARIABLES { _group_idx, N } #}
 {# ITERATE_ALL { _target_idx } #}
 import numpy as _numpy
+
+from brian2.codegen.runtime.numpy_rt.numpy_rt import LazyArange
 
 # scalar code
 _vectorisation_idx = 1

--- a/brian2/codegen/runtime/numpy_rt/templates/group_variable_set_conditional.py_
+++ b/brian2/codegen/runtime/numpy_rt/templates/group_variable_set_conditional.py_
@@ -2,6 +2,8 @@
 {# ALLOWS_SCALAR_WRITE #}
 import numpy as _numpy
 
+from brian2.codegen.runtime.numpy_rt.numpy_rt import LazyArange
+
 numpy_False = _numpy.bool_(False)
 numpy_True = _numpy.bool_(True)
 
@@ -15,7 +17,7 @@ _vectorisation_idx = 1
 
 # vector code
 _idx = slice(None)
-_vectorisation_idx = {{constant_or_scalar('N', variables['N'])}}
+_vectorisation_idx = LazyArange({{constant_or_scalar('N', variables['N'])}})
 {{vector_code['condition']|autoindent}}
 
 # Phase 2: having computed _cond, the boolean array of points where
@@ -33,10 +35,10 @@ _vectorisation_idx = 1
 # vector code
 if _cond is True or _cond is numpy_True:
     _idx = slice(None)
-    _vectorisation_idx = N
+    _vectorisation_idx = LazyArange(N)
 elif _cond is False or _cond is numpy_False:
     _idx = []
-    _vectorisation_idx = 0
+    _vectorisation_idx = np.array([], dtype=np.int32)
 else:
     _vectorisation_idx = _idx = _numpy.nonzero(_cond)[0]
 

--- a/brian2/codegen/runtime/numpy_rt/templates/spatialstateupdate.py_
+++ b/brian2/codegen/runtime/numpy_rt/templates/spatialstateupdate.py_
@@ -16,12 +16,14 @@ This is where most time-consuming time computations are done.
 '''
 from numpy import zeros
 
+from brian2.codegen.runtime.numpy_rt.numpy_rt import LazyArange
+
 # scalar code
 _vectorisation_idx = 1
 {{scalar_code|autoindent}}
 
 # vector code
-_vectorisation_idx = N
+_vectorisation_idx = LazyArange(N)
 {{vector_code|autoindent}}
 
 {%if _scipy_available %}

--- a/brian2/codegen/runtime/numpy_rt/templates/spikemonitor.py_
+++ b/brian2/codegen/runtime/numpy_rt/templates/spikemonitor.py_
@@ -19,7 +19,7 @@ if _n_events > 0:
         _newlen = _curlen + _n_events
         _owner.resize(_newlen)
         {{N}} = _newlen
-        _vectorisation_idx = _n_events
+        _vectorisation_idx = _events
         _idx = _events
         {{vector_code|autoindent}}
         {% for varname, var in record_variables.items() %}

--- a/brian2/codegen/runtime/numpy_rt/templates/stateupdate.py_
+++ b/brian2/codegen/runtime/numpy_rt/templates/stateupdate.py_
@@ -3,10 +3,12 @@
 {# ALLOWS_SCALAR_WRITE #}
 import numpy as _numpy
 
+from brian2.codegen.runtime.numpy_rt.numpy_rt import LazyArange
+
 # scalar code
 _vectorisation_idx = 1
 {{scalar_code|autoindent}}
 
 # vector code
-_vectorisation_idx = N
+_vectorisation_idx = LazyArange(N)
 {{vector_code|autoindent}}

--- a/brian2/codegen/runtime/numpy_rt/templates/summed_variable.py_
+++ b/brian2/codegen/runtime/numpy_rt/templates/summed_variable.py_
@@ -2,6 +2,8 @@
 {# ITERATE_ALL { _idx } #}
 import numpy as _numpy
 
+from brian2.codegen.runtime.numpy_rt.numpy_rt import LazyArange
+
 {% set _target_var_array = get_array_name(_target_var) %}
 {% set _index_array = get_array_name(_index_var) %}
 
@@ -10,7 +12,7 @@ _vectorisation_idx = 1
 {{scalar_code|autoindent}}
 
 # vector code
-_vectorisation_idx = N
+_vectorisation_idx = LazyArange(N)
 {{vector_code|autoindent}}
 
 # We write to the array, using the name provided as a keyword argument to the

--- a/brian2/codegen/runtime/numpy_rt/templates/threshold.py_
+++ b/brian2/codegen/runtime/numpy_rt/templates/threshold.py_
@@ -7,6 +7,8 @@
 {# ITERATE_ALL { _idx } #}
 import numpy as _numpy
 
+from brian2.codegen.runtime.numpy_rt.numpy_rt import LazyArange
+
 numpy_True = _numpy.bool_(True)
 numpy_False = _numpy.bool_(False)
 
@@ -15,11 +17,11 @@ _vectorisation_idx = 1
 {{scalar_code|autoindent}}
 
 # vector code
-_vectorisation_idx = N
+_vectorisation_idx = LazyArange(N)
 
 {{vector_code|autoindent}}
 if _cond is True or _cond is numpy_True:
-    _events = _numpy.arange(_vectorisation_idx)
+    _events = _numpy.arange(N)
 elif _cond is False or _cond is numpy_False:
     _events = _numpy.array([])
 else:

--- a/brian2/tests/__init__.py
+++ b/brian2/tests/__init__.py
@@ -33,7 +33,7 @@ except ImportError:
     nose = None
 
 
-def make_argv(dirnames, attributes):
+def make_argv(dirnames, attributes, doctests=False):
     '''
     Create the list of arguments for the ``nosetests`` call.
 
@@ -58,6 +58,8 @@ def make_argv(dirnames, attributes):
              "-a", attributes,
              '--nologcapture',
              '--exe'])
+    if doctests:
+        argv += ['--with-doctest']
     return argv
 
 
@@ -217,7 +219,7 @@ def run(codegen_targets=None, long_tests=False, test_codegen_independent=True,
             # Some doctests do actually use code generation, use numpy for that
             prefs.codegen.target = 'numpy'
             prefs._backup()
-            argv = make_argv(dirnames, "codegen-independent")
+            argv = make_argv(dirnames, "codegen-independent", doctests=True)
             if 'codegen_independent' in test_in_parallel:
                 argv.extend(multiprocess_arguments)
             success.append(nose.run(argv=argv,

--- a/brian2/tests/test_monitor.py
+++ b/brian2/tests/test_monitor.py
@@ -543,6 +543,7 @@ if __name__ == '__main__':
     test_event_monitor()
     test_event_monitor_no_record()
     test_spike_trains()
+    test_synapses_state_monitor()
     test_state_monitor()
     test_state_monitor_record_single_timestep()
     test_state_monitor_get_states()


### PR DESCRIPTION
Previously, the `_vectorisation_idx` variable in numpy templates was allowed to be a scalar variable which would *directly* be interpreted as the number of values that e.g. `rand()` should produce, or a vector whose *length* would determine the number of values. In addition, `rand()` would return a scalar value if the `_vectorisation_idx` had the value 1 or was of length 1, and an array otherwise.
This was a bit of mess, I now made this (hopefully) a bit clearer:
* `rand()` will return a scalar value if it receives a scalar value (remember, in the long run, we want to use `_vectorisation_idx` to get reproducible random numbers, so we might need the freedom to have different values for `_vectorisation_idx`, even though we do not need to determine how many numbers to produce.)
* If `rand()` receives an array (or rather: anything with a length), it will use the length of this array to determine how many values to produce.

In many cases (e.g. `group.Vm = 'Vr + randn()*5*mV'`), `_vectorisation_idx` needs to be "the size of the group". For neurons, we actually already have an array storing the values from 0 to `N` in the variable `i`, but we don't have the equivalent for synapses -- in the general case, we do not want to waste memory like this. This is why previously in this situation we used `_vectorisation_idx = N`. We cannot do this anymore with the approach outlines above, but we don't want to do an `np.arange(N)` for synapses, either. Therefore, this PR introduces a new `LazyArange` class that we can use as a replacement for `arange`. You can query its length and it also allows some slicing/indexing, but it is not meant to be a super-general all-purpose class. It does everything that we need for the numpy templates, all tests and examples run fine with it.
With this change, the fix for #761 became trivial, we only have to replace ``_vectorisation_idx`` by ``vectorisation_idx[not_refractory]`` (i.e., treat it like all other variables) in the "conditional write" code used for refractoriness.