### PR TITLE
[MRG] Avoid standalone recompilations

### DIFF
--- a/brian2/codegen/runtime/cython_rt/templates/spikemonitor.pyx
+++ b/brian2/codegen/runtime/cython_rt/templates/spikemonitor.pyx
@@ -9,7 +9,7 @@
 
     cdef int _num_events = {{_eventspace}}[_num{{_eventspace}}-1]
     cdef int _start_idx, _end_idx, _curlen, _newlen, _j
-    {% for varname, var in record_variables.items() %}
+    {% for varname, var in record_variables | dictsort %}
     cdef {{cpp_dtype(var.dtype)}}[:] _{{varname}}_view
     {% endfor %}
     if _num_events > 0:
@@ -37,7 +37,7 @@
             # Resize the arrays
             _owner.resize(_newlen)
             {{N}} = _newlen
-            {% for varname, var in record_variables.items() %}
+            {% for varname, var in record_variables | dictsort %}
             _{{varname}}_view = {{get_array_name(var, access_data=False)}}.data
             {% endfor %}
             # Copy the values across
@@ -45,7 +45,7 @@
                 _idx = {{_eventspace}}[_j]
                 _vectorisation_idx = _idx
                 {{ vector_code|autoindent }}
-                {% for varname in record_variables %}
+                {% for varname in record_variables | sort %}
                 _{{varname}}_view [_curlen + _j - _start_idx] = _to_record_{{varname}}
                 {% endfor %}
                 {{count}}[_idx - _source_start] += 1

--- a/brian2/codegen/runtime/cython_rt/templates/statemonitor.pyx
+++ b/brian2/codegen/runtime/cython_rt/templates/statemonitor.pyx
@@ -16,7 +16,7 @@
 
     cdef int _i
 
-    {% for varname, var in _recorded_variables.items() %}
+    {% for varname, var in _recorded_variables | dictsort %}
     {% set c_type = cpp_dtype(variables[varname].dtype) %}
     {% set np_type = numpy_dtype(variables[varname].dtype) %}
     # Resize the recorded variable "{{varname}}" and get the (potentially

--- a/brian2/codegen/runtime/weave_rt/templates/spikemonitor.cpp
+++ b/brian2/codegen/runtime/weave_rt/templates/spikemonitor.cpp
@@ -42,7 +42,7 @@
             _owner.mcall("resize", _newlen_tuple);
             // Set N explicitly (it is referenced with a restricted pointer)
             {{N}} = _newlen;
-            {% for varname, var in record_variables.items() %}
+            {% for varname, var in record_variables | dictsort %}
             {{c_data_type(var.dtype)}}* _{{varname}}_data = ({{c_data_type(var.dtype)}}*)(((PyArrayObject*)(PyObject*){{get_array_name(var, access_data=False)}}.attr("data"))->data);
             {% endfor %}
             // Copy the values across

--- a/brian2/codegen/runtime/weave_rt/templates/statemonitor.cpp
+++ b/brian2/codegen/runtime/weave_rt/templates/statemonitor.cpp
@@ -17,7 +17,7 @@
 	const int _vectorisation_idx = 1;
 	{{scalar_code|autoindent}}
 
-    {% for varname, var in _recorded_variables.items() %}
+    {% for varname, var in _recorded_variables | dictsort %}
     {%set c_type = c_data_type(variables[varname].dtype) %}
     {
         // Resize the recorded variable "{{varname}}" and get the (potentially

--- a/brian2/codegen/templates.py
+++ b/brian2/codegen/templates.py
@@ -43,6 +43,15 @@ def autoindent_postfilter(code):
         outlines.append(' '*addspaces+line)
     return '\n'.join(outlines)
 
+
+def variables_to_array_names(variables, access_data=True):
+    from brian2.devices.device import get_device
+    device = get_device()
+    names = [device.get_array_name(var, access_data=access_data)
+             for var in variables]
+    return names
+
+
 class LazyTemplateLoader(object):
     '''
     Helper object to load templates only when they are needed.
@@ -98,6 +107,7 @@ class Templater(object):
                                lstrip_blocks=True, undefined=StrictUndefined)
         self.env.globals['autoindent'] = autoindent
         self.env.filters['autoindent'] = autoindent
+        self.env.filters['variables_to_array_names'] = variables_to_array_names
         if env_globals is not None:
             self.env.globals.update(env_globals)
         else:

--- a/brian2/devices/cpp_standalone/device.py
+++ b/brian2/devices/cpp_standalone/device.py
@@ -831,10 +831,17 @@ class CPPStandaloneDevice(Device):
                     x = os.system('%s >>winmake.log 2>&1 && %s %s>>winmake.log 2>&1' % (vcvars_cmd,
                                                                                         make_cmd,
                                                                                         make_args))
-                    if x!=0:
+                    if x != 0:
                         if os.path.exists('winmake.log'):
                             print open('winmake.log', 'r').read()
-                        raise RuntimeError("Project compilation failed")
+                        raise RuntimeError("Project compilation failed. "
+                                           "Note that this can happen when you "
+                                           "repeat the same simulation but "
+                                           "change details of the compilation "
+                                           "(e.g. OpenMP, optimization flags, "
+                                           "...). Use 'clean=True' in the "
+                                           "build or set_device call to "
+                                           "re-compile the full project.")
             else:
                 with std_silent(debug):
                     if clean:
@@ -844,8 +851,15 @@ class CPPStandaloneDevice(Device):
                     else:
                         make_args = ' '.join(prefs.devices.cpp_standalone.extra_make_args_unix)
                         x = os.system('make %s' % (make_args, ))
-                    if x!=0:
-                        raise RuntimeError("Project compilation failed")
+                    if x != 0:
+                        raise RuntimeError("Project compilation failed. "
+                                           "Note that this can happen when you "
+                                           "repeat the same simulation but "
+                                           "change details of the compilation "
+                                           "(e.g. OpenMP, optimization flags, "
+                                           "...). Use 'clean=True' in the "
+                                           "build or set_device call to "
+                                           "re-compile the full project.")
 
     def seed(self, seed=None):
         '''

--- a/brian2/devices/cpp_standalone/device.py
+++ b/brian2/devices/cpp_standalone/device.py
@@ -834,14 +834,13 @@ class CPPStandaloneDevice(Device):
                     if x != 0:
                         if os.path.exists('winmake.log'):
                             print open('winmake.log', 'r').read()
-                        raise RuntimeError("Project compilation failed. "
-                                           "Note that this can happen when you "
-                                           "repeat the same simulation but "
-                                           "change details of the compilation "
-                                           "(e.g. OpenMP, optimization flags, "
-                                           "...). Use 'clean=True' in the "
-                                           "build or set_device call to "
-                                           "re-compile the full project.")
+                        error_message = ('Project compilation failed (error '
+                                         'code: %u).') % x
+                        if not clean:
+                            error_message += (' Consider running with ' 
+                                             '"clean=True" to force a complete '
+                                              'rebuild.')
+                        raise RuntimeError(error_message)
             else:
                 with std_silent(debug):
                     if clean:
@@ -852,14 +851,13 @@ class CPPStandaloneDevice(Device):
                         make_args = ' '.join(prefs.devices.cpp_standalone.extra_make_args_unix)
                         x = os.system('make %s' % (make_args, ))
                     if x != 0:
-                        raise RuntimeError("Project compilation failed. "
-                                           "Note that this can happen when you "
-                                           "repeat the same simulation but "
-                                           "change details of the compilation "
-                                           "(e.g. OpenMP, optimization flags, "
-                                           "...). Use 'clean=True' in the "
-                                           "build or set_device call to "
-                                           "re-compile the full project.")
+                        error_message = ('Project compilation failed (error '
+                                         'code: %u).') % x
+                        if not clean:
+                            error_message += (' Consider running with ' 
+                                             '"clean=True" to force a complete '
+                                              'rebuild.')
+                        raise RuntimeError(error_message)
 
     def seed(self, seed=None):
         '''

--- a/brian2/devices/cpp_standalone/device.py
+++ b/brian2/devices/cpp_standalone/device.py
@@ -909,7 +909,7 @@ class CPPStandaloneDevice(Device):
 
 
     def build(self, directory='output',
-              compile=True, run=True, debug=False, clean=True,
+              compile=True, run=True, debug=False, clean=False,
               with_output=True, additional_source_files=None,
               run_args=None, direct_call=True, **kwds):
         '''
@@ -939,7 +939,7 @@ class CPPStandaloneDevice(Device):
             Defaults to ``True``.
         clean : bool, optional
             Whether or not to clean the project before building. Defaults to
-            ``True``.
+            ``False``.
         additional_source_files : list of str, optional
             A list of additional ``.cpp`` files to include in the build.
         direct_call : bool, optional

--- a/brian2/devices/cpp_standalone/templates/common_group.cpp
+++ b/brian2/devices/cpp_standalone/templates/common_group.cpp
@@ -8,7 +8,7 @@
 #include<fstream>
 {% block extra_headers %}
 {% endblock %}
-{% for name in user_headers %}
+{% for name in user_headers | sort %}
 #include {{name}}
 {% endfor %}
 
@@ -21,7 +21,7 @@ namespace {
 {{hashdefine_lines|autoindent}}
 
 void _run_{{codeobj_name}}()
-{	
+{
 	using namespace brian;
 
     {% if openmp_pragma('with_openmp') %}

--- a/brian2/devices/cpp_standalone/templates/group_variable_set_conditional.cpp
+++ b/brian2/devices/cpp_standalone/templates/group_variable_set_conditional.cpp
@@ -7,7 +7,7 @@
 #include<fstream>
 {% block extra_headers %}
 {% endblock %}
-{% for name in user_headers %}
+{% for name in user_headers | sort %}
 #include {{name}}
 {% endfor %}
 

--- a/brian2/devices/cpp_standalone/templates/main.cpp
+++ b/brian2/devices/cpp_standalone/templates/main.cpp
@@ -7,11 +7,11 @@
 #include "brianlib/common_math.h"
 #include "randomkit.h"
 
-{% for codeobj in code_objects %}
+{% for codeobj in code_objects | sort(attribute='name') %}
 #include "code_objects/{{codeobj.name}}.h"
 {% endfor %}
 
-{% for name in user_headers %}
+{% for name in user_headers | sort %}
 #include {{name}}
 {% endfor %}
 

--- a/brian2/devices/cpp_standalone/templates/makefile
+++ b/brian2/devices/cpp_standalone/templates/makefile
@@ -19,7 +19,7 @@ debug: $(PROGRAM)
 
 .PHONY: all debug clean
 
-$(PROGRAM): $(OBJS) $(DEPS)
+$(PROGRAM): $(OBJS) $(DEPS) makefile
 	$(CC) $(OBJS) -o $(PROGRAM) $(LFLAGS)
 
 clean:
@@ -32,5 +32,5 @@ ifneq ($(wildcard $(DEPS)), )
 include $(DEPS)
 endif
 
-%.o : %.cpp
+%.o : %.cpp makefile
 	$(CC) $(CFLAGS) $< -o $@

--- a/brian2/devices/cpp_standalone/templates/makefile
+++ b/brian2/devices/cpp_standalone/templates/makefile
@@ -10,16 +10,16 @@ CFLAGS = -c -Wno-write-strings $(OPTIMISATIONS) -I. {{ openmp_pragma('compilatio
 LFLAGS = {{ openmp_pragma('compilation') }} {{ linker_flags }}
 DEPS = make.deps
 
-all: executable
+all: $(PROGRAM)
 
 # Adds debug flags
 debug: CFLAGS += $(DEBUG)
 debug: LFLAGS += $(DEBUG)
-debug: executable
+debug: $(PROGRAM)
 
-.PHONY: all debug executable clean
+.PHONY: all debug clean
 
-executable: $(OBJS) $(DEPS)
+$(PROGRAM): $(OBJS) $(DEPS)
 	$(CC) $(OBJS) -o $(PROGRAM) $(LFLAGS)
 
 clean:

--- a/brian2/devices/cpp_standalone/templates/objects.cpp
+++ b/brian2/devices/cpp_standalone/templates/objects.cpp
@@ -278,12 +278,12 @@ namespace brian {
 extern std::vector< rk_state* > _mersenne_twister_states;
 
 //////////////// clocks ///////////////////
-{% for clock in clocks %}
+{% for clock in clocks | sort(attribute='name') %}
 extern Clock {{clock.name}};
 {% endfor %}
 
 //////////////// networks /////////////////
-{% for net in networks %}
+{% for net in networks | sort(attribute='name') %}
 extern Network {{net.name}};
 {% endfor %}
 
@@ -306,7 +306,7 @@ extern DynamicArray2D<{{c_data_type(var.dtype)}}> {{varname}};
 {% endfor %}
 
 /////////////// static arrays /////////////
-{% for (name, dtype_spec, N, filename) in static_array_specs | sort %}
+{% for (name, dtype_spec, N, filename) in static_array_specs | sort(attribute='0') %}
 {# arrays that are initialized from static data are already declared #}
 {% if not (name in array_specs.values() or name in dynamic_array_specs.values() or name in dynamic_array_2d_specs.values())%}
 extern {{dtype_spec}} *{{name}};

--- a/brian2/devices/cpp_standalone/templates/objects.cpp
+++ b/brian2/devices/cpp_standalone/templates/objects.cpp
@@ -282,7 +282,6 @@ extern Clock {{clock.name}};
 {% endfor %}
 
 //////////////// networks /////////////////
-extern Network magicnetwork;
 {% for net in networks %}
 extern Network {{net.name}};
 {% endfor %}

--- a/brian2/devices/cpp_standalone/templates/objects.cpp
+++ b/brian2/devices/cpp_standalone/templates/objects.cpp
@@ -75,30 +75,25 @@ void _init_arrays()
 	using namespace brian;
 
     // Arrays initialized to 0
-	{% for var in zero_arrays | sort(attribute='name') %}
-	{% if var in dynamic_array_specs %}
-	{% set varname = '_dynamic'+array_specs[var] %}
-	{% else %}
-	{% set varname = array_specs[var] %}
-	{% endif %}
+	{% for var, varname in zero_arrays | sort(attribute='1') %}
 	{% if varname in dynamic_array_specs.values() %}
 	{{varname}}.resize({{var.size}});
 	{% else %}
 	{{varname}} = new {{c_data_type(var.dtype)}}[{{var.size}}];
 	{% endif %}
-	{{ openmp_pragma('parallel-static') }}
+	{{ openmp_pragma('parallel-static') -}}
 	for(int i=0; i<{{var.size}}; i++) {{varname}}[i] = 0;
+
 	{% endfor %}
 
 	// Arrays initialized to an "arange"
-	{% for var, start in arange_arrays %}
-	{% set varname = array_specs[var] %}
+	{% for var, varname, start in arange_arrays | sort(attribute='1')%}
 	{% if varname in dynamic_array_specs.values() %}
 	{{varname}}.resize({{var.size}});
 	{% else %}
 	{{varname}} = new {{c_data_type(var.dtype)}}[{{var.size}}];
 	{% endif %}
-	{{ openmp_pragma('parallel-static') }}
+	{{ openmp_pragma('parallel-static') -}}
 	for(int i=0; i<{{var.size}}; i++) {{varname}}[i] = {{start}} + i;
 	{% endfor %}
 

--- a/brian2/devices/cpp_standalone/templates/objects.cpp
+++ b/brian2/devices/cpp_standalone/templates/objects.cpp
@@ -81,7 +81,7 @@ void _init_arrays()
 	{% else %}
 	{{varname}} = new {{c_data_type(var.dtype)}}[{{var.size}}];
 	{% endif %}
-	{{ openmp_pragma('parallel-static') -}}
+    {{ openmp_pragma('parallel-static')}}
 	for(int i=0; i<{{var.size}}; i++) {{varname}}[i] = 0;
 
 	{% endfor %}
@@ -93,8 +93,9 @@ void _init_arrays()
 	{% else %}
 	{{varname}} = new {{c_data_type(var.dtype)}}[{{var.size}}];
 	{% endif %}
-	{{ openmp_pragma('parallel-static') -}}
+    {{ openmp_pragma('parallel-static')}}
 	for(int i=0; i<{{var.size}}; i++) {{varname}}[i] = {{start}} + i;
+
 	{% endfor %}
 
 	// static arrays

--- a/brian2/devices/cpp_standalone/templates/run.cpp
+++ b/brian2/devices/cpp_standalone/templates/run.cpp
@@ -8,7 +8,7 @@
 #include "code_objects/{{codeobj.name}}.h"
 {% endfor %}
 
-{% for name in user_headers %}
+{% for name in user_headers | sort %}
 #include {{name}}
 {% endfor %}
 

--- a/brian2/devices/cpp_standalone/templates/spikemonitor.cpp
+++ b/brian2/devices/cpp_standalone/templates/spikemonitor.cpp
@@ -38,7 +38,7 @@
                 const int _idx = {{_eventspace}}[_j];
                 const int _vectorisation_idx = _idx;
                 {{vector_code|autoindent}}
-                {% for varname, var in record_variables.items() %}
+                {% for varname, var in record_variables | dictsort %}
                 {{get_array_name(var, access_data=False)}}.push_back(_to_record_{{varname}});
                 {% endfor %}
                 {{count}}[_idx-_source_start]++;

--- a/brian2/devices/cpp_standalone/templates/synapses.cpp
+++ b/brian2/devices/cpp_standalone/templates/synapses.cpp
@@ -12,7 +12,7 @@
 
 	// This is only needed for the _debugmsg function below	
 	{# USES_VARIABLES { _synaptic_pre } #}	
-	
+
 	// scalar code
 	const int _vectorisation_idx = -1;
 	{{scalar_code|autoindent}}

--- a/brian2/devices/cpp_standalone/templates/synapses_create_array.cpp
+++ b/brian2/devices/cpp_standalone/templates/synapses_create_array.cpp
@@ -34,15 +34,8 @@ for (int _idx=0; _idx<_numsources; _idx++) {
 
 // now we need to resize all registered variables
 const int newsize = {{_dynamic__synaptic_pre}}.size();
-{% set varnames %}
-{%- for variable in owner._registered_variables -%}
-{{ get_array_name(variable, access_data=False) }}
-{% endfor -%}
-{% endset %}
-{% for varname in varnames.split('\n') | sort %}
-{% if varname %}
+{% for varname in owner._registered_variables | variables_to_array_names(access_data=False) | sort %}
 {{varname}}.resize(newsize);
-{% endif %}
 {% endfor %}
 // Also update the total number of synapses
 {{N}} = newsize;

--- a/brian2/devices/cpp_standalone/templates/synapses_create_array.cpp
+++ b/brian2/devices/cpp_standalone/templates/synapses_create_array.cpp
@@ -34,9 +34,15 @@ for (int _idx=0; _idx<_numsources; _idx++) {
 
 // now we need to resize all registered variables
 const int newsize = {{_dynamic__synaptic_pre}}.size();
-{% for variable in owner._registered_variables | sort(attribute='name') %}
-{% set varname = get_array_name(variable, access_data=False) %}
+{% set varnames %}
+{%- for variable in owner._registered_variables -%}
+{{ get_array_name(variable, access_data=False) }}
+{% endfor -%}
+{% endset %}
+{% for varname in varnames.split('\n') | sort %}
+{% if varname %}
 {{varname}}.resize(newsize);
+{% endif %}
 {% endfor %}
 // Also update the total number of synapses
 {{N}} = newsize;

--- a/brian2/devices/cpp_standalone/templates/synapses_create_generator.cpp
+++ b/brian2/devices/cpp_standalone/templates/synapses_create_generator.cpp
@@ -132,9 +132,15 @@
 
 	// now we need to resize all registered variables
 	const int32_t newsize = {{_dynamic__synaptic_pre}}.size();
-	{% for variable in owner._registered_variables | sort(attribute='name') %}
-	{% set varname = get_array_name(variable, access_data=False) %}
+	{% set varnames %}
+	{%- for variable in owner._registered_variables -%}
+	{{ get_array_name(variable, access_data=False) }}
+	{% endfor -%}
+	{% endset %}
+	{% for varname in varnames.split('\n') | sort %}
+	{% if varname %}
 	{{varname}}.resize(newsize);
+	{% endif %}
 	{% endfor %}
 	// Also update the total number of synapses
 	{{N}} = newsize;

--- a/brian2/devices/cpp_standalone/templates/synapses_create_generator.cpp
+++ b/brian2/devices/cpp_standalone/templates/synapses_create_generator.cpp
@@ -132,16 +132,9 @@
 
 	// now we need to resize all registered variables
 	const int32_t newsize = {{_dynamic__synaptic_pre}}.size();
-	{% set varnames %}
-	{%- for variable in owner._registered_variables -%}
-	{{ get_array_name(variable, access_data=False) }}
-	{% endfor -%}
-	{% endset %}
-	{% for varname in varnames.split('\n') | sort %}
-	{% if varname %}
-	{{varname}}.resize(newsize);
-	{% endif %}
-	{% endfor %}
+    {% for varname in owner._registered_variables | variables_to_array_names(access_data=False) | sort%}
+    {{varname}}.resize(newsize);
+    {% endfor %}
 	// Also update the total number of synapses
 	{{N}} = newsize;
 

--- a/brian2/devices/cpp_standalone/templates/win_makefile
+++ b/brian2/devices/cpp_standalone/templates/win_makefile
@@ -4,12 +4,12 @@ clean:
     del *.obj /s
     del *.exe /s
 
-{% for fname, base in zip(source_files, source_bases) %}
+{% for fname, base in zip(source_files, source_bases) | sort(attribute='0')%}
 {{base}}.obj: win_makefile
     cl /c /EHsc /I. {{compiler_flags}} {{openmp_flag}} {{fname}} /Fo{{base}}.obj
     
 {% endfor %}
 
-main.exe: {% for base in source_bases %}{{base}}.obj {% endfor %} win_makefile
+main.exe: {% for base in source_bases | sort%}{{base}}.obj {% endfor %} win_makefile
 
-    link {% for base in source_bases %}{{base}}.obj {% endfor %} {{linker_flags}} /OUT:main.exe
+    link {% for base in source_bases | sort %}{{base}}.obj {% endfor %} {{linker_flags}} /OUT:main.exe

--- a/brian2/devices/cpp_standalone/templates/win_makefile
+++ b/brian2/devices/cpp_standalone/templates/win_makefile
@@ -5,11 +5,11 @@ clean:
     del *.exe /s
 
 {% for fname, base in zip(source_files, source_bases) %}
-{{base}}.obj:
+{{base}}.obj: win_makefile
     cl /c /EHsc /I. {{compiler_flags}} {{openmp_flag}} {{fname}} /Fo{{base}}.obj
     
 {% endfor %}
 
-main.exe: {% for base in source_bases %}{{base}}.obj {% endfor %}
+main.exe: {% for base in source_bases %}{{base}}.obj {% endfor %} win_makefile
 
     link {% for base in source_bases %}{{base}}.obj {% endfor %} {{linker_flags}} /OUT:main.exe

--- a/brian2/devices/cpp_standalone/templates/win_makefile
+++ b/brian2/devices/cpp_standalone/templates/win_makefile
@@ -11,5 +11,4 @@ clean:
 {% endfor %}
 
 main.exe: {% for base in source_bases | sort%}{{base}}.obj {% endfor %} win_makefile
-
     link {% for base in source_bases | sort %}{{base}}.obj {% endfor %} {{linker_flags}} /OUT:main.exe

--- a/docs_sphinx/introduction/release_notes.rst
+++ b/docs_sphinx/introduction/release_notes.rst
@@ -37,6 +37,15 @@ Backwards-incompatible changes
   Celsius to Kelvin, add the `zero_celsius` constant from
   `brian2.units.constants` (#817).
 
+Changes to default settings
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+* In C++ standalone mode, the ``clean`` argument now defaults to ``False``,
+  meaning that ``make clean`` will not be executed by default before building
+  the simulation. This avoids recompiling all files for unchanged simulations
+  that are executed repeatedly. To return to the previous behaviour, specify
+  ``clean=True`` in the ``device.build`` call (or in ``set_device`` if your
+  script does not have an explicit ``device.build``).
+
 Contributions
 ~~~~~~~~~~~~~
 Code and documentation contributions (ordered by the number of commits):


### PR DESCRIPTION
On Linux, standalone's `main` file was always re-compilated, since it was not mentioned by name (instead there was an `executable` target). Also, the ordering of arrays in `object.cpp` was not completely deterministic: it was sorted by "name", but this was just the name of the variable (e.g. many variables have the name "i"). I changed all this, and also changed the default for `clean` to `False`. I am not 100% about this one, because it can actually lead to compilation errors if you re-run the same simulation but change compilation parameters (or activate OpenMP). I mention this in the error message now. Either way, I'm not seeing any recompilation if I run the same script twice.

So, should stay with `clean=True` by default for safety or switch to `clean=False`? I rarely have compilation times that are longer than 1 or 2 seconds, and adding `clean=False` is not very difficult. But with the new error message, I am happy either way.

Maybe an alternative solution: we keep `clean=True` by default, but when it is activated, we display an `INFO` message at the start of the run, telling the user that they can turn it off.