### PR TITLE
[MRG] Use the standard names in error messages for unknown units

### DIFF
--- a/brian2/core/namespace.py
+++ b/brian2/core/namespace.py
@@ -59,7 +59,7 @@ def _get_default_unit_namespace():
     namespace : dict
         The unit namespace
     '''
-    namespace = dict(standard_unit_register.units)
+    namespace = collections.OrderedDict(standard_unit_register.units)
     namespace.update(stdunits)
     # Include all "simple" units from additional_units, i.e. units like mliter
     # but not "newton * metre"

--- a/brian2/units/fundamentalunits.py
+++ b/brian2/units/fundamentalunits.py
@@ -2118,7 +2118,7 @@ class UnitRegistry(object):
     __getitem__
     """
     def __init__(self):
-        self.units = {}
+        self.units = collections.OrderedDict()
         self.units_for_dimensions = collections.defaultdict(dict)
 
     def add(self, u):


### PR DESCRIPTION
Just a small follow-up to the unit-related changes in #821: I noticed that the display for unknown units was not optimal:
```pycon
>>> Equations('dv/dt = -v/tau : volta')
...
EquationError: Error parsing the unit specification for variable "v": Unit specification refers to "volta", but
this is not a base unit. The following base units are allowed: ampere, coulomb, farad, henry, hertz,
joule, katal, kelvin, kgram, klitre, lumen, lux, metre, mmolar, mole, newton, ohm, pascal, radian, second,
siemens, sievert, tesla, volt, watt, weber (plus some variants of these, e.g. "Hz" instead of "hertz", or
"meter" instead of "metre").
```
This error message uses some non-standard forms ("ampere", "kgram") and the "plus some variants" bit is maybe a bit vague. With this PR we'd get:
```pycon
>>> Equations('dv/dt = -v/tau : volta')
...
EquationError: Error parsing the unit specification for variable "v": Unit specification refers to "volta", but
this is not a base unit. The following base units are allowed: amp (ampere), candle (lumen), coulomb,
farad, gray (sievert), henry, hertz (Hz, becquerel), joule, katal, kelvin, kilogram (kilogramme, kgram,
kgramme), klitre (kliter), lux, metre (meter), mmolar (mM), mole (mol), newton, ohm, pascal, radian
(steradian), second, siemens, tesla, volt, watt, weber.
```

I promise to stop tweaking this error message any further ;)