### PR TITLE
[MRG] Forbid "..._pre"/"..._post" variable names

### DIFF
--- a/brian2/groups/neurongroup.py
+++ b/brian2/groups/neurongroup.py
@@ -76,6 +76,18 @@ def _guess_membrane_potential(equations):
     return None
 
 
+# Note that we do not register this function with
+# Equations.register_identifier_check, because we do not want this check to
+# apply unconditionally to all equation objects ("x_post = ... : ... (summed)"
+# needs to be allowed)
+def check_identifier_pre_post(identifier):
+    'Do not allow names ending in ``_pre`` or ``_post`` to avoid confusion.'
+    if identifier.endswith('_pre') or identifier.endswith('_post'):
+        raise ValueError('"%s" cannot be used as a variable name, the "_pre" '
+                         'and "_post" suffixes are used to refer to pre- and '
+                         'post-synaptic variables in synapses.' % identifier)
+
+
 class StateUpdater(CodeRunner):
     '''
     The `CodeRunner` that updates the state variables of a `NeuronGroup`
@@ -724,7 +736,7 @@ class NeuronGroup(Group, SpikeSource):
 
         for eq in self.equations.itervalues():
             dtype = get_dtype(eq, user_dtype)
-
+            check_identifier_pre_post(eq.varname)
             if eq.type in (DIFFERENTIAL_EQUATION, PARAMETER):
                 if 'linked' in eq.flags:
                     # 'linked' cannot be combined with other flags

--- a/brian2/synapses/synapses.py
+++ b/brian2/synapses/synapses.py
@@ -23,7 +23,8 @@ from brian2.equations.equations import (Equations, SingleEquation,
                                         check_subexpressions)
 from brian2.groups.group import Group, CodeRunner, get_dtype
 from brian2.groups.neurongroup import (extract_constant_subexpressions,
-                                       SubexpressionUpdater)
+                                       SubexpressionUpdater,
+                                       check_identifier_pre_post)
 from brian2.stateupdaters.base import (StateUpdateMethod,
                                        UnsupportedEquationsException)
 from brian2.stateupdaters.exact import linear, independent
@@ -1013,6 +1014,7 @@ class Synapses(Group):
         for eq in equations.itervalues():
             dtype = get_dtype(eq, user_dtype)
             if eq.type in (DIFFERENTIAL_EQUATION, PARAMETER):
+                check_identifier_pre_post(eq.varname)
                 constant = 'constant' in eq.flags
                 shared = 'shared' in eq.flags
                 if shared:
@@ -1034,6 +1036,7 @@ class Synapses(Group):
                     # target variable
                     varname = '_summed_'+eq.varname
                 else:
+                    check_identifier_pre_post(eq.varname)
                     varname = eq.varname
                 self.variables.add_subexpression(varname, dimensions=eq.dim,
                                                  expr=str(eq.expr),

--- a/brian2/tests/test_synapses.py
+++ b/brian2/tests/test_synapses.py
@@ -80,6 +80,17 @@ def test_name_clashes():
     assert_raises(ValueError, lambda: Synapses(G1, G2, 'a : 1'))
     assert_raises(ValueError, lambda: Synapses(G1, G2, 'b : 1'))
 
+    # Using _pre or _post as variable names is confusing (even if it is non-
+    # ambiguous in unconnected NeuronGroups)
+    assert_raises(ValueError, lambda: Synapses(G1, G2, 'x_pre : 1'))
+    assert_raises(ValueError, lambda: Synapses(G1, G2, 'x_post : 1'))
+    assert_raises(ValueError, lambda: Synapses(G1, G2, 'x_pre = 1 : 1'))
+    assert_raises(ValueError, lambda: Synapses(G1, G2, 'x_post = 1 : 1'))
+    assert_raises(ValueError, lambda: NeuronGroup(1, 'x_pre : 1'))
+    assert_raises(ValueError, lambda: NeuronGroup(1, 'x_post : 1'))
+    assert_raises(ValueError, lambda: NeuronGroup(1, 'x_pre = 1 : 1'))
+    assert_raises(ValueError, lambda: NeuronGroup(1, 'x_post = 1 : 1'))
+
     # this should all be ok
     Synapses(G1, G2, 'c : 1')
     Synapses(G1, G2, 'a_syn : 1')

--- a/examples/frompapers/Vogels_et_al_2011.py
+++ b/examples/frompapers/Vogels_et_al_2011.py
@@ -69,18 +69,18 @@ con_ii.connect(p=epsilon)
 
 eqs_stdp_inhib = '''
 w : 1
-dA_pre/dt=-A_pre/tau_stdp : 1 (event-driven)
-dA_post/dt=-A_post/tau_stdp : 1 (event-driven)
+dApre/dt=-Apre/tau_stdp : 1 (event-driven)
+dApost/dt=-Apost/tau_stdp : 1 (event-driven)
 '''
 alpha = 3*Hz*tau_stdp*2  # Target rate parameter
 gmax = 100               # Maximum inhibitory weight
 
 con_ie = Synapses(Pi, Pe, model=eqs_stdp_inhib,
-                  on_pre='''A_pre += 1.
-                         w = clip(w+(A_post-alpha)*eta, 0, gmax)
+                  on_pre='''Apre += 1.
+                         w = clip(w+(Apost-alpha)*eta, 0, gmax)
                          g_gaba += w*nS''',
-                  on_post='''A_post += 1.
-                          w = clip(w+A_pre*eta, 0, gmax)
+                  on_post='''Apost += 1.
+                          w = clip(w+Apre*eta, 0, gmax)
                        ''')
 con_ie.connect(p=epsilon)
 con_ie.w = 1e-10


### PR DESCRIPTION
As discussed in #818: raise an error if a user calls their variables "..._pre" or "..._post", to avoid confusion with the `_pre`/`_post` suffix in synapses.