### PR TITLE
[MRG] Don't pass all source files on the command line (C++ standalone on Windows)

### DIFF
--- a/brian2/devices/cpp_standalone/device.py
+++ b/brian2/devices/cpp_standalone/device.py
@@ -718,6 +718,13 @@ class CPPStandaloneDevice(Device):
                 openmp_flag=openmp_flag,
                 )
             writer.write('win_makefile', win_makefile_tmp)
+            # write the list of sources
+            source_list = ' '.join(source_bases)
+            source_list_fname = os.path.join(self.project_dir, 'sourcefiles.txt')
+            if os.path.exists(source_list_fname):
+                if open(source_list_fname, 'r').read() == source_list:
+                    return
+            open(source_list_fname, 'w').write(source_list)
         else:
             # Generate the makefile
             if os.name=='nt':

--- a/brian2/devices/cpp_standalone/templates/win_makefile
+++ b/brian2/devices/cpp_standalone/templates/win_makefile
@@ -1,8 +1,10 @@
+
 all: main.exe
 
 clean:
     del *.obj /s
     del *.exe /s
+    del sourcefiles.txt
 
 {% for fname, base in zip(source_files, source_bases) | sort(attribute='0')%}
 {{base}}.obj: win_makefile
@@ -10,5 +12,5 @@ clean:
     
 {% endfor %}
 
-main.exe: {% for base in source_bases | sort%}{{base}}.obj {% endfor %} win_makefile
-    link {% for base in source_bases | sort %}{{base}}.obj {% endfor %} {{linker_flags}} /OUT:main.exe
+main.exe: {% for base in source_bases | sort%}{{base}}.obj {% endfor %} win_makefile sourcefiles.txt
+    link @sourcefiles.txt {{linker_flags}} /OUT:main.exe


### PR DESCRIPTION
Fixes #787

I did not include a specific test because (at least on my Windows VM), it needs many objects to trigger this problem, and then the compilation time is also crazily long. I manually verified with one example that had many objects that it failed before and now works. 