### PR TITLE
[MRG] Set up the exception hook only after the logging system has been set up

### DIFF
--- a/brian2/utils/logger.py
+++ b/brian2/utils/logger.py
@@ -202,7 +202,6 @@ def clean_up_logging():
         std_silent.close()
 
 
-sys.excepthook = brian_excepthook
 atexit.register(clean_up_logging)
 
 
@@ -584,6 +583,8 @@ class BrianLogger(object):
                        '{name} version is: {version}'.format(name=_name,
                                                              version=str(
                                                                  _version)))
+        # Handle uncaught exceptions
+        sys.excepthook = brian_excepthook
 
 
 def get_logger(module_name='brian2'):


### PR DESCRIPTION
Otherwise, errors raised during Brian's import, before the logging
system is in place, will only lead to the unhelpful error message
`No handlers could be found for logger "brian2"`

This happened to me regularly during development, but we had also cases on the mailing list where this happened to other users (because of problems with the compiled spike queue).