### PR TITLE
Complex eigenvalues bug

### DIFF
--- a/brian2/stateupdaters/exact.py
+++ b/brian2/stateupdaters/exact.py
@@ -4,7 +4,7 @@ Exact integration for linear equations.
 import itertools
 
 import sympy as sp
-from sympy import Wild, Symbol
+from sympy import Wild, Symbol, I
 
 from brian2.equations.codestrings import is_constant_over_dt
 from brian2.parsing.sympytools import sympy_to_str, str_to_sympy
@@ -211,6 +211,12 @@ class LinearStateUpdater(StateUpdateMethod):
         abstract_code = []
         for idx, (variable, update) in enumerate(zip(varnames, updates)):
             rhs = update
+
+            if len(rhs.atoms(I)) > 0:
+                raise UnsupportedEquationsException('The solution to the linear system '
+                                                    'contains complex values '
+                                                    'which is currently not implemented.')
+
             for row_idx, varname in enumerate(varnames):
                 rhs = rhs.subs(_S[row_idx, 0], varname)
 

--- a/brian2/stateupdaters/exact.py
+++ b/brian2/stateupdaters/exact.py
@@ -211,12 +211,10 @@ class LinearStateUpdater(StateUpdateMethod):
         abstract_code = []
         for idx, (variable, update) in enumerate(zip(varnames, updates)):
             rhs = update
-
             if len(rhs.atoms(I)) > 0:
                 raise UnsupportedEquationsException('The solution to the linear system '
                                                     'contains complex values '
                                                     'which is currently not implemented.')
-
             for row_idx, varname in enumerate(varnames):
                 rhs = rhs.subs(_S[row_idx, 0], varname)
 

--- a/brian2/tests/test_stateupdaters.py
+++ b/brian2/tests/test_stateupdaters.py
@@ -349,7 +349,25 @@ def test_priority():
             if able:
                 raise AssertionError('Should be able to integrate these '
                                      'equations')
-    
+
+    # Equations resulting in complex linear solution (unsupported)
+    eqs = Equations('''dv/dt      = (ge+gi-(v+49*mV))/(20*ms) : volt
+            dge/dt     = -ge/(5*ms) : volt
+            dgi/dt     = Dgi/(5*ms) : volt
+            dDgi/dt    = ((-2./5) * Dgi - (1./5**2)*gi)/(10*ms) : volt''')
+    can_integrate = {linear: False, euler: True, rk2: True, rk4: True,
+                     heun: True, milstein: True}
+    for integrator, able in can_integrate.iteritems():
+        try:
+            integrator(eqs, variables)
+            if not able:
+                raise AssertionError('Should not be able to integrate these '
+                                     'equations')
+        except UnsupportedEquationsException:
+            if able:
+                raise AssertionError('Should be able to integrate these '
+                                     'equations')
+
     # Equation with additive noise
     eqs = Equations('dv/dt = -v / (10*ms) + xi/(10*ms)**.5 : 1')
     assert_raises(UnsupportedEquationsException,


### PR DESCRIPTION
The equations 
```Python
eqs = '''dv/dt      = (ge+gi-(v+49*mV))/(20*ms) : volt
         dge/dt     = -ge/(5*ms) : volt
         dgi/dt     = Dgi/(5*ms) : volt
         dDgi/dt    = ((-2./5) * Dgi - (1./5**2)*gi)/(10*ms) : volt''' 
```
now fail with an error message (if the method is specified).
I guess I also have to add this somewhere as a test case? in the test_stateupdaters.py file?