### PR TITLE
[MRG] Error for multiple summed vars

### DIFF
--- a/brian2/codegen/runtime/numpy_rt/templates/summed_variable.py_
+++ b/brian2/codegen/runtime/numpy_rt/templates/summed_variable.py_
@@ -17,7 +17,19 @@ _vectorisation_idx = LazyArange(N)
 
 # We write to the array, using the name provided as a keyword argument to the
 # template
-
-{{_target_var_array}}[:] = _numpy.bincount({{_index_array}},
-                                 minlength=len({{_target_var_array}}),
-                                 weights=_synaptic_var)
+# Note that for subgroups, we do not want to overwrite the full array
+{% if _target_start > 0 %}
+_indices = {{_index_array}} - {{_target_start}}
+{% else %}
+_indices = {{_index_array}}
+{% endif %}
+{# Handle the situation that the target did not have a stop variable, e.g. for synapses: #}
+{% if _target_stop < 0 %}
+_target_stop = {{constant_or_scalar(_target_size_name, variables[_target_size_name])}}
+{% else %}
+_target_stop = {{_target_stop}}
+{% endif %}
+_length = _target_stop - {{_target_start}}
+{{_target_var_array}}[{{_target_start}}:_target_stop] = _numpy.bincount(_indices,
+                                 minlength=_length,
+                                 weights=_numpy.broadcast_to(_synaptic_var, (N, )))

--- a/brian2/core/network.py
+++ b/brian2/core/network.py
@@ -13,6 +13,7 @@ import time
 from collections import defaultdict, Sequence, Counter, Mapping, namedtuple
 import cPickle as pickle
 
+from brian2.synapses.synapses import SummedVariableUpdater
 from brian2.utils.logger import get_logger
 from brian2.core.names import Nameable
 from brian2.core.base import BrianObject, brian_object_exception
@@ -214,6 +215,65 @@ class SchedulingSummary(object):
         </table>
         '''.format(rows='\n'.join(rows))
         return html_code
+
+
+def _check_multiple_summed_updaters(objects):
+    '''
+    Helper function that checks whether multiple `SummedVariableUpdater` target
+    the same target variable. Raises a `NotImplementedError` if this is the
+    case (and problematic, i.e. not when using non-overlapping subgroups).
+
+    Parameters
+    ----------
+    objects : list of `BrianObject`
+        The list of objects in the network.
+    '''
+    summed_targets = {}
+    for obj in objects:
+        if isinstance(obj, SummedVariableUpdater):
+            if obj.target_var in summed_targets:
+                other_target = summed_targets[obj.target_var]
+                if obj.target == other_target:
+                    # We raise an error, even though this could be ok in
+                    # principle (e.g. two Synapses could target different
+                    # subsets of the target groups, without using subgroups)
+                    msg = ('Multiple "summed variables" target the '
+                           'variable "{var}" in group "{target}". Use '
+                           'multiple variables in the target group '
+                           'instead.'.format(var=obj.target_var.name,
+                                             target=obj.target.name))
+                    raise NotImplementedError(msg)
+                else:
+                    # Two different targets with the same variable
+                    target1_index = other_target.variables.indices[
+                        obj.target_var]
+                    target2_index = obj.target.variables.indices[
+                        obj.target_var]
+                    if target1_index != target2_index:
+                        # The variables use non-standard indexing (e.g.
+                        # linked variables) -- this is getting too
+                        # complicated to check, so bail out.
+                        msg = ('Multiple "summed variables" target the '
+                               'variable "{var}" in groups "{target1}" and '
+                               '"{target2}" with non-standard indexing (e.g.'
+                               'via linked variables). Use separate '
+                               'variables in the target groups '
+                               'instead.'.format(var=obj.target_var.name,
+                                                 target1=other_target.name,
+                                                 target2=obj.target.name))
+                        raise NotImplementedError(msg)
+                    elif (obj.target.start < other_target.stop and
+                                  other_target.start < obj.target.stop):
+                        # Overlapping subgroups
+                        msg = ('Multiple "summed variables" target the '
+                               'variable "{var}" in overlapping groups '
+                               '"{target1}" and "{target2}". Use separate '
+                               'variables in the target groups '
+                               'instead.'.format(var=obj.target_var.name,
+                                                 target1=other_target.name,
+                                                 target2=obj.target.name))
+                        raise NotImplementedError(msg)
+            summed_targets[obj.target_var] = obj.target
 
 
 class Network(Nameable):
@@ -760,6 +820,10 @@ class Network(Nameable):
                              'names, the following name(s) were used more than '
                              'once: %s' % formatted_names)
 
+        # Check that there are no SummedVariableUpdaters targeting the same
+        # target variable
+        _check_multiple_summed_updaters(self.objects)
+
         self._stopped = False
         Network._globally_stopped = False
 
@@ -816,7 +880,7 @@ class Network(Nameable):
                         clocknames=', '.join('%s (dt=%s)' % (obj.name, obj.dt)
                                              for obj in self._clocks)),
                      "before_run")
-    
+
     @device_override('network_after_run')
     def after_run(self):
         '''

--- a/brian2/core/network.py
+++ b/brian2/core/network.py
@@ -243,36 +243,17 @@ def _check_multiple_summed_updaters(objects):
                            'instead.'.format(var=obj.target_var.name,
                                              target=obj.target.name))
                     raise NotImplementedError(msg)
-                else:
-                    # Two different targets with the same variable
-                    target1_index = other_target.variables.indices[
-                        obj.target_var]
-                    target2_index = obj.target.variables.indices[
-                        obj.target_var]
-                    if target1_index != target2_index:
-                        # The variables use non-standard indexing (e.g.
-                        # linked variables) -- this is getting too
-                        # complicated to check, so bail out.
-                        msg = ('Multiple "summed variables" target the '
-                               'variable "{var}" in groups "{target1}" and '
-                               '"{target2}" with non-standard indexing (e.g.'
-                               'via linked variables). Use separate '
-                               'variables in the target groups '
-                               'instead.'.format(var=obj.target_var.name,
-                                                 target1=other_target.name,
-                                                 target2=obj.target.name))
-                        raise NotImplementedError(msg)
-                    elif (obj.target.start < other_target.stop and
-                                  other_target.start < obj.target.stop):
-                        # Overlapping subgroups
-                        msg = ('Multiple "summed variables" target the '
-                               'variable "{var}" in overlapping groups '
-                               '"{target1}" and "{target2}". Use separate '
-                               'variables in the target groups '
-                               'instead.'.format(var=obj.target_var.name,
-                                                 target1=other_target.name,
-                                                 target2=obj.target.name))
-                        raise NotImplementedError(msg)
+                elif (obj.target.start < other_target.stop and
+                              other_target.start < obj.target.stop):
+                    # Overlapping subgroups
+                    msg = ('Multiple "summed variables" target the '
+                           'variable "{var}" in overlapping groups '
+                           '"{target1}" and "{target2}". Use separate '
+                           'variables in the target groups '
+                           'instead.'.format(var=obj.target_var.name,
+                                             target1=other_target.name,
+                                             target2=obj.target.name))
+                    raise NotImplementedError(msg)
             summed_targets[obj.target_var] = obj.target
 
 

--- a/brian2/groups/subgroup.py
+++ b/brian2/groups/subgroup.py
@@ -32,6 +32,11 @@ class Subgroup(Group, SpikeSource):
         else:
             self.source = weakproxy_with_fallback(source)
 
+        # Store a reference to the source's equations (if any)
+        self.equations = None
+        if hasattr(self.source, 'equations'):
+            self.equations = weakproxy_with_fallback(self.source.equations)
+
         if name is None:
             name = source.name + '_subgroup*'
         # We want to update the spikes attribute after it has been updated

--- a/brian2/synapses/synapses.py
+++ b/brian2/synapses/synapses.py
@@ -92,7 +92,9 @@ class SummedVariableUpdater(CodeRunner):
         self.target = target
         template_kwds = {'_target_var': self.target_var,
                          '_target_size_name': target_size_name,
-                         '_index_var': synapses.variables[index_var]}
+                         '_index_var': synapses.variables[index_var],
+                         '_target_start': getattr(target, 'start', 0),
+                         '_target_stop': getattr(target, 'stop', -1)}
 
         CodeRunner.__init__(self, group=synapses,
                             template='summed_variable',

--- a/brian2/synapses/synapses.py
+++ b/brian2/synapses/synapses.py
@@ -88,8 +88,10 @@ class SummedVariableUpdater(CodeRunner):
         '''.format(expression=expression,
                    target_varname=target_varname)
 
-        template_kwds = {'_target_var': synapses.variables[target_varname],
-                         '_target_size_name' : target_size_name,
+        self.target_var = synapses.variables[target_varname]
+        self.target = target
+        template_kwds = {'_target_var': self.target_var,
+                         '_target_size_name': target_size_name,
                          '_index_var': synapses.variables[index_var]}
 
         CodeRunner.__init__(self, group=synapses,

--- a/brian2/tests/test_synapses.py
+++ b/brian2/tests/test_synapses.py
@@ -1174,6 +1174,7 @@ def test_multiple_summed_variables():
     assert_raises(NotImplementedError, net.run, 0*ms)
 
 @attr('standalone-compatible')
+@with_setup(teardown=reinit_devices)
 def test_summed_variables_subgroups():
     source = NeuronGroup(1, '')
     target = NeuronGroup(10, 'v : 1')

--- a/docs_sphinx/introduction/release_notes.rst
+++ b/docs_sphinx/introduction/release_notes.rst
@@ -31,6 +31,8 @@ Improvements and bug fixes
   unit registration system.
 * Numpy target: fix an indexing error for a `SpikeMonitor` that records from a
   subgroup (#824)
+* Summed variables targeting the same post-synaptic variable now raise an error
+  (previously, only the one executed last was taken into account, see #766).
 
 Backwards-incompatible changes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -63,6 +65,7 @@ anyone we forgot...):
 * Denis Alevi
 * Meng Dong
 * Oleg Strikov
+* Regimantas Jurkus
 * Shailesh Appukuttan
 
 Brian 2.0.1

--- a/docs_sphinx/user/synapses.rst
+++ b/docs_sphinx/user/synapses.rst
@@ -299,15 +299,13 @@ Summed variables
 In many cases, the postsynaptic neuron has a variable that represents a sum of variables over all
 its synapses. This is called a "summed variable". An example is nonlinear synapses (e.g. NMDA)::
 
-	neurons = NeuronGroup(1, model="""dv/dt=(gtot-v)/(10*ms) : 1
-	                                  gtot : 1""")
-	S=Synapses(input,neurons,
-	           model='''dg/dt=-a*g+b*x*(1-g) : 1
-	                    gtot_post = g : 1  (summed)
-	                    dx/dt=-c*x : 1
-	                    w : 1 # synaptic weight
-	                 ''',
-	           on_pre='x+=w')
+    neurons = NeuronGroup(1, model='''dv/dt=(gtot-v)/(10*ms) : 1
+                                      gtot : 1''')
+    S = Synapses(input, neurons,
+                 model='''dg/dt=-a*g+b*x*(1-g) : 1
+                          gtot_post = g : 1  (summed)
+                          dx/dt=-c*x : 1
+                          w : 1 # synaptic weight''', on_pre='x+=w')
 
 Here, each synapse has a conductance ``g`` with nonlinear dynamics. The neuron's total conductance
 is ``gtot``. The line stating ``gtot_post = g : 1  (summed)`` specifies the link
@@ -322,6 +320,27 @@ result is copied to the variable ``gtot``. Another example is gap junctions::
                                 Igap_post = w*(v_pre-v_post): 1 (summed)''')
 
 Here, ``Igap`` is the total gap junction current received by the postsynaptic neuron.
+
+Note that you cannot target the same post-synaptic variable from more than one
+`Synapses` object. To work around this restriction, use multiple post-synaptic
+variables that ar then summed up:
+
+    neurons = NeuronGroup(1, model='''dv/dt=(gtot-v)/(10*ms) : 1
+                                      gtot = gtot1 + gtot2: 1
+                                      gtot1 : 1
+                                      gtot2 : 1''')
+    S1 = Synapses(input, neurons,
+                  model='''dg/dt=-a*g+b*x*(1-g) : 1
+                           gtot1_post = g : 1  (summed)
+                           dx/dt=-c*x : 1
+                           w : 1 # synaptic weight
+                        ''', on_pre='x+=w')
+    S2 = Synapses(input, neurons,
+                  model='''dg/dt=-a*g+b*x*(1-g) : 1
+                           gtot2_post = g : 1  (summed)
+                           dx/dt=-c*x : 1
+                           w : 1 # synaptic weight
+                        ''', on_pre='x+=w')
 
 Creating multi-synapses
 -----------------------

--- a/docs_sphinx/user/synapses.rst
+++ b/docs_sphinx/user/synapses.rst
@@ -323,22 +323,22 @@ Here, ``Igap`` is the total gap junction current received by the postsynaptic ne
 
 Note that you cannot target the same post-synaptic variable from more than one
 `Synapses` object. To work around this restriction, use multiple post-synaptic
-variables that ar then summed up:
+variables that ar then summed up::
 
     neurons = NeuronGroup(1, model='''dv/dt=(gtot-v)/(10*ms) : 1
                                       gtot = gtot1 + gtot2: 1
                                       gtot1 : 1
                                       gtot2 : 1''')
     S1 = Synapses(input, neurons,
-                  model='''dg/dt=-a*g+b*x*(1-g) : 1
+                  model='''dg/dt=-a1*g+b1*x*(1-g) : 1
                            gtot1_post = g : 1  (summed)
-                           dx/dt=-c*x : 1
+                           dx/dt=-c1*x : 1
                            w : 1 # synaptic weight
                         ''', on_pre='x+=w')
     S2 = Synapses(input, neurons,
-                  model='''dg/dt=-a*g+b*x*(1-g) : 1
+                  model='''dg/dt=-a2*g+b2*x*(1-g) : 1
                            gtot2_post = g : 1  (summed)
-                           dx/dt=-c*x : 1
+                           dx/dt=-c2*x : 1
                            w : 1 # synaptic weight
                         ''', on_pre='x+=w')
 


### PR DESCRIPTION
I think we consider this as fixing #766 -- it is a bit hacky (goes through the list of all objects in `Network.before_run`) but does its job.

Connecting to two non-overlapping subgroups is allowed:
```Python
    source = NeuronGroup(1, '')
    target = NeuronGroup(10, 'v : 1')
    subgroup1 = target[:6]
    subgroup2 = target[6:]
    syn1 = Synapses(source, subgroup1, 'v_post = 1 : 1 (summed)')
    syn2 = Synapses(source, subgroup2, 'v_post = 1 : 1 (summed)')
```
(Previously, this was actually raising a confusing error because you could not access the equations from a subgroup. After fixing this, it needed a bit of work to make the numpy target behave correctly).

If the two subgroups overlap you'll get an error:
> NotImplementedError: Multiple "summed variables" target the variable "v" in overlapping groups "neurongroup_1_subgroup_1" and "neurongroup_1_subgroup". Use separate variables in the target groups instead.

This error actually also applies to the following situation with linked variables:
```Python
    source = NeuronGroup(1, '')
    target1 = NeuronGroup(10, 'v : 1')
    target2 = NeuronGroup(10, 'v : 1 (linked)')
    target2.v = linked_var(target1.v)
    # Seemingly independent targets, but the variable is the same
    syn1 = Synapses(source, target1, 'v_post = 1 : 1 (summed)')
    syn2 = Synapses(source, target2, 'v_post = 1 : 1 (summed)')
```
(I initially also added a check for more complicated linked variables, i.e. those with manually defined indices, but these cannot be used with synapses anyway, see #276)

And of course the main point of #766 was to deal with the situation without any subgroups:
```Python
    source = NeuronGroup(1, '')
    target = NeuronGroup(10, 'v : 1')
    syn1 = Synapses(source, target, 'v_post = 1 : 1 (summed)')
    syn2 = Synapses(source, target, 'v_post = 1 : 1 (summed)')
```
> NotImplementedError: Multiple "summed variables" target the variable "v" in group "neurongroup_1". Use multiple variables in the target group instead.