### PR TITLE
[MRG] Fix the meaning of `i` and `j` in synapses connecting to/from other synapses

### DIFF
--- a/brian2/synapses/synapses.py
+++ b/brian2/synapses/synapses.py
@@ -973,10 +973,6 @@ class Synapses(Group):
                                          dtype=np.int32)
         self.variables.add_dynamic_array('_synaptic_post', size=0,
                                          dtype=np.int32)
-        self.variables.add_reference('i', self.source, 'i',
-                                     index='_presynaptic_idx')
-        self.variables.add_reference('j', self.target, 'i',
-                                     index='_postsynaptic_idx')
         self.variables.create_clock_variables(self._clock,
                                               prefix='_clock_')
         if '_offset' in self.target.variables:
@@ -1010,6 +1006,30 @@ class Synapses(Group):
         self.variables.add_reference('_postsynaptic_idx',
                                      self,
                                      '_synaptic_post')
+
+        # Except for subgroups (which potentially add an offset), the "i" and
+        # "j" variables are simply equivalent to `_synaptic_pre` and
+        # `_synaptic_post`
+        if getattr(self.source, 'start', 0) == 0:
+            self.variables.add_reference('i', self, '_synaptic_pre')
+        else:
+            self.variables.add_reference('_source_i', self.source.source, 'i',
+                                         index='_presynaptic_idx')
+            self.variables.add_reference('_source_offset', self.source, '_offset')
+            self.variables.add_subexpression('i',
+                                             dtype=self.source.source.variables['i'].dtype,
+                                             expr='_source_i - _source_offset',
+                                             index='_presynaptic_idx')
+        if getattr(self.target, 'start', 0) == 0:
+            self.variables.add_reference('j', self, '_synaptic_post')
+        else:
+            self.variables.add_reference('_target_j', self.target.source, 'i',
+                                         index='_postsynaptic_idx')
+            self.variables.add_reference('_target_offset', self.target, '_offset')
+            self.variables.add_subexpression('j',
+                                             dtype=self.target.source.variables['i'].dtype,
+                                             expr='_target_j - _target_offset',
+                                             index='_postsynaptic_idx')
 
         # Add the standard variables
         self.variables.add_array('N',  dtype=np.int32, size=1, scalar=True,
@@ -1462,7 +1482,14 @@ class Synapses(Group):
         if additional_indices is None:
             additional_indices = {}
         for varname in get_identifiers_recursively([expr], self.variables):
-            if varname in additional_indices:
+            # Special handling of i and j -- they do not actually use pre-/
+            # postsynaptic indices (except for subgroups), they *are* the
+            # pre-/postsynaptic indices
+            if varname == 'i':
+                deps.add('_presynaptic_idx')
+            elif varname == 'j':
+                deps.add('_postsynaptic_idx')
+            elif varname in additional_indices:
                 deps.add(additional_indices[varname])
             else:
                 deps.add(self.variables.indices[varname])
@@ -1566,6 +1593,13 @@ class Synapses(Group):
                 variable_indices[varname] = '_raw_pre_idx'
             elif self.variables.indices[varname] == '_postsynaptic_idx':
                 variable_indices[varname] = '_raw_post_idx'
+
+        if self.variables['i'] is self.variables['_synaptic_pre']:
+            variables.add_subexpression('i', '_i',
+                                        dtype=self.variables['i'].dtype)
+        if self.variables['j'] is self.variables['_synaptic_post']:
+            variables.add_subexpression('j', '_j',
+                                        dtype=self.variables['j'].dtype)
 
         logger.debug(("Creating synapses from group '%s' to group '%s', "
                       "using generator '%s'") % (self.source.name,

--- a/brian2/tests/test_subgroup.py
+++ b/brian2/tests/test_subgroup.py
@@ -429,17 +429,19 @@ def test_synapses_access_subgroups_problematic():
     S = Synapses(G1, G2, 'w:1')
     S.connect()
 
+    # Note that "j" is not ambiguous, because the equivalent in the target group
+    # is called "i" (this previously raised a warning)
     tests = [
         ((SG1, slice(None)), 'i', 1),
         ((SG1, slice(None)), 'i + N_pre', 2),
         ((SG1, slice(None)), 'N_pre', 1),
-        ((slice(None), SG2), 'j', 1),
+        ((slice(None), SG2), 'j', 0),
         ((slice(None), SG2), 'N_post', 1),
         ((slice(None), SG2), 'N', 1),
         ((SG1, SG2), 'i', 1),
-        ((SG1, SG2), 'i + j', 2),
+        ((SG1, SG2), 'i + j', 1),
         ((SG1, SG2), 'N_pre', 1),
-        ((SG1, SG2), 'j', 1),
+        ((SG1, SG2), 'j', 0),
         ((SG1, SG2), 'N_post', 1),
         ((SG1, SG2), 'N', 1),
         # These should not raise a warning

--- a/brian2/tests/test_synapses.py
+++ b/brian2/tests/test_synapses.py
@@ -1822,7 +1822,11 @@ def test_synapses_to_synapses_statevar_access():
     run(0*ms)
     assert_equal(modulator_to_conn.i, np.arange(40))
     assert_equal(modulator_to_conn.j, np.repeat(np.arange(20), 2))
+    assert_equal(modulator_to_conn.i_post, np.repeat(np.arange(10), 4))
+    assert_equal(modulator_to_conn.j_post, np.repeat(np.arange(10), 4))
     assert_equal(conn_to_modulator.i, np.hstack([np.arange(20), np.arange(20)]))
+    assert_equal(conn_to_modulator.i_pre, np.hstack([np.repeat(np.arange(10), 2), np.repeat(np.arange(10), 2)]))
+    assert_equal(conn_to_modulator.j_pre, np.hstack([np.repeat(np.arange(10), 2), np.repeat(np.arange(10), 2)]))
     assert_equal(conn_to_modulator.j, np.arange(40))
 
 

--- a/brian2/tests/test_synapses.py
+++ b/brian2/tests/test_synapses.py
@@ -1808,6 +1808,26 @@ def test_synapses_to_synapses():
 
 @attr('standalone-compatible')
 @with_setup(teardown=reinit_devices)
+def test_synapses_to_synapses_statevar_access():
+    source = NeuronGroup(10, 'v:1')
+    modulator = NeuronGroup(40, '')
+    target = NeuronGroup(10, 'v:1')
+    conn = Synapses(source, target)
+    conn.connect(j='i', n=2)
+    modulator_to_conn = Synapses(modulator, conn)
+    modulator_to_conn.connect(j='int(i/2)')
+    conn_to_modulator = Synapses(conn, modulator)
+    conn_to_modulator.connect(j='i')
+    conn_to_modulator.connect(j='i + 20')
+    run(0*ms)
+    assert_equal(modulator_to_conn.i, np.arange(40))
+    assert_equal(modulator_to_conn.j, np.repeat(np.arange(20), 2))
+    assert_equal(conn_to_modulator.i, np.hstack([np.arange(20), np.arange(20)]))
+    assert_equal(conn_to_modulator.j, np.arange(40))
+
+
+@attr('standalone-compatible')
+@with_setup(teardown=reinit_devices)
 def test_synapses_to_synapses_different_sizes():
     prefs.codegen.target = 'numpy'
     source = NeuronGroup(100, 'v : 1', threshold='False')
@@ -2349,6 +2369,7 @@ if __name__ == '__main__':
     test_synaptic_equations()
     test_synapse_with_run_regularly()
     test_synapses_to_synapses()
+    test_synapses_to_synapses_statevar_access()
     test_synapses_to_synapses_different_sizes()
     test_synapses_to_synapses_summed_variable()
     try:


### PR DESCRIPTION
This is a rather marginal use case, but in our astrocyte modeling, we need `Synapses` that connect to or from other `Synapses` objects. This works fine in principle, but currently you cannot use `i` and `j` in such `Synapses`, e.g. in `connect` calls. In most cases, you should not use them directly anyway (because the "index" of a synapse is not very meaningful), but currently it might raise an error or do something completely wrong. The reason is that for a connection from a `Synapses` object, `i` will refer to `i` of the source `Synapses` which itself refers to `i` of the synapses's source. This will however be indexed as if it were a variable of the "source synapse". This will do the right thing only by accident, and most of the time will raise an error about incorrect indexing.

This PR fixes this by making `i` and `j` not refer to `i` of the source/target group, but instead just make them an alias for the pre-/postsynaptic indices. We did something like this before but this approach unfortunately does not work when connecting from/to subgroups, so there's a bit of special handling code for that. Also, `i` and `j` are now indexed as "synaptic variables", which throws off some analysis code which I had to fix accordingly.

All in all this is not the elegant solution I hoped for, but I think it is still reasonably clean and worth having.