### PR TITLE
[MRG] Avoid sympy 1.1 for now

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -124,7 +124,7 @@ install:
   - if [[ $MINIMAL_VERSIONS == 'yes' ]]; then
     travis_retry conda create -n travis_conda --yes --quiet pip python=$PYTHON numpy==1.9 scipy==0.14 libgfortran==1 nose sphinx ipython sympy==0.7.6 jinja2==2.7 pyparsing setuptools coverage;
     else
-    travis_retry conda create -n travis_conda --yes --quiet pip python=$PYTHON numpy nose sphinx ipython sympy pyparsing jinja2 setuptools coverage;
+    travis_retry conda create -n travis_conda --yes --quiet pip python=$PYTHON numpy nose sphinx ipython "sympy<1.1" pyparsing jinja2 setuptools coverage;
     fi
   - source activate travis_conda
   # On Python 2: Install an older version of scipy that still has weave

--- a/.travis.yml
+++ b/.travis.yml
@@ -129,7 +129,7 @@ install:
   - source activate travis_conda
   # On Python 2: Install an older version of scipy that still has weave
   - if [ ${PYTHON:0:1} == "2" ]; then
-      travis_retry conda install --yes --quiet scipy==0.18;
+      travis_retry conda install --yes --quiet -c brian-team weave scipy;
       travis_retry conda install --yes --quiet bsddb;
     else
       travis_retry conda install --yes --quiet scipy;

--- a/.travis.yml
+++ b/.travis.yml
@@ -124,7 +124,7 @@ install:
   - if [[ $MINIMAL_VERSIONS == 'yes' ]]; then
     travis_retry conda create -n travis_conda --yes --quiet pip python=$PYTHON numpy==1.9 scipy==0.14 libgfortran==1 nose sphinx ipython sympy==0.7.6 jinja2==2.7 pyparsing setuptools coverage;
     else
-    travis_retry conda create -n travis_conda --yes --quiet pip python=$PYTHON numpy nose sphinx ipython "sympy<1.1" pyparsing jinja2 setuptools coverage;
+    travis_retry conda create -n travis_conda --yes --quiet pip python=$PYTHON numpy nose sphinx ipython sympy pyparsing jinja2 setuptools coverage;
     fi
   - source activate travis_conda
   # On Python 2: Install an older version of scipy that still has weave

--- a/.travis.yml
+++ b/.travis.yml
@@ -124,7 +124,7 @@ install:
   - if [[ $MINIMAL_VERSIONS == 'yes' ]]; then
     travis_retry conda create -n travis_conda --yes --quiet pip python=$PYTHON numpy==1.9 scipy==0.14 libgfortran==1 nose sphinx ipython sympy==0.7.6 jinja2==2.7 pyparsing setuptools coverage;
     else
-    travis_retry conda create -n travis_conda --yes --quiet pip python=$PYTHON numpy nose sphinx ipython sympy pyparsing jinja2 setuptools coverage;
+    travis_retry conda create -n travis_conda --yes --quiet pip python=$PYTHON numpy nose sphinx ipython "sympy!=1.1.0" pyparsing jinja2 setuptools coverage;
     fi
   - source activate travis_conda
   # On Python 2: Install an older version of scipy that still has weave

--- a/.travis.yml
+++ b/.travis.yml
@@ -148,7 +148,7 @@ script:
 - if [[ $CONDA_BUILD == 'yes' ]]; then
     source deactivate;
     for NUMPY_VERSION in 1.10 1.11 1.12 1.13; do
-      conda build --quiet -c brian-team dev/conda-recipe --numpy $NUMPY_VERSION;
+      conda build --quiet -c conda-forge dev/conda-recipe --numpy $NUMPY_VERSION;
     done;
     source activate travis_conda;
   fi

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -101,7 +101,7 @@ install:
   - 'python -c "import struct; print(struct.calcsize(''P'') * 8)"'
 
   # Install the build dependencies of the project via conda
-  - 'appveyor-retry conda install --yes --quiet numpy nose sphinx sympy pyparsing jinja2 ipython setuptools cython'
+  - 'appveyor-retry conda install --yes --quiet numpy nose sphinx "sympy<1.1" pyparsing jinja2 ipython setuptools cython'
   # Install an older version of scipy (which still has weave) on Python 2
   - 'if "%PYTHON_VERSION:~0,1%" == "2" appveyor-retry conda install --yes --quiet scipy==0.18'
   - 'if "%PYTHON_VERSION:~0,1%" == "3" appveyor-retry conda install --yes --quiet scipy'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -101,7 +101,7 @@ install:
   - 'python -c "import struct; print(struct.calcsize(''P'') * 8)"'
 
   # Install the build dependencies of the project via conda
-  - 'appveyor-retry conda install --yes --quiet numpy nose sphinx sympy pyparsing jinja2 ipython setuptools cython'
+  - 'appveyor-retry conda install --yes --quiet numpy nose sphinx "sympy!=1.1.0" pyparsing jinja2 ipython setuptools cython'
   # Install an older version of scipy (which still has weave) on Python 2
   - 'if "%PYTHON_VERSION:~0,1%" == "2" appveyor-retry conda install --yes --quiet scipy==0.18'
   - 'if "%PYTHON_VERSION:~0,1%" == "3" appveyor-retry conda install --yes --quiet scipy'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -128,9 +128,9 @@ after_test:
           %CMD_IN_ENV% python setup.py bdist_wheel &&
           %CMD_IN_ENV% python setup.py bdist_wininst &&
           %appveyor-retry CMD_IN_ENV% conda install --yes --quiet -c conda-forge conda-build anaconda-client pip &&
-          %CMD_IN_ENV% conda build --quiet -c brian-team dev\conda-recipe --numpy 1.11 &&
-          %CMD_IN_ENV% conda build --quiet -c brian-team dev\conda-recipe --numpy 1.12 &&
-          %CMD_IN_ENV% conda build --quiet -c brian-team dev\conda-recipe --numpy 1.13 &&
+          %CMD_IN_ENV% conda build --quiet -c conda-forge dev\conda-recipe --numpy 1.11 &&
+          %CMD_IN_ENV% conda build --quiet -c conda-forge dev\conda-recipe --numpy 1.12 &&
+          %CMD_IN_ENV% conda build --quiet -c conda-forge dev\conda-recipe --numpy 1.13 &&
           %CMD_IN_ENV% python dev\continuous-integration\move-conda-package.py dev\conda-recipe &&
           if "%APPVEYOR_PULL_REQUEST_NUMBER%" == "" if "%APPVEYOR_REPO_NAME%" == "brian-team/brian2" if "%APPVEYOR_REPO_BRANCH%" == "master" %CMD_IN_ENV% python dev\continuous-integration\conda-server-push.py
      )'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -127,7 +127,7 @@ after_test:
           cd %SRC_DIR% &&
           %CMD_IN_ENV% python setup.py bdist_wheel &&
           %CMD_IN_ENV% python setup.py bdist_wininst &&
-          %appveyor-retry CMD_IN_ENV% conda install --yes --quiet conda-build anaconda-client pip &&
+          %appveyor-retry CMD_IN_ENV% conda install --yes --quiet -c conda-forge conda-build anaconda-client pip &&
           %CMD_IN_ENV% conda build --quiet -c brian-team dev\conda-recipe --numpy 1.11 &&
           %CMD_IN_ENV% conda build --quiet -c brian-team dev\conda-recipe --numpy 1.12 &&
           %CMD_IN_ENV% conda build --quiet -c brian-team dev\conda-recipe --numpy 1.13 &&

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -103,7 +103,7 @@ install:
   # Install the build dependencies of the project via conda
   - 'appveyor-retry conda install --yes --quiet numpy nose sphinx "sympy!=1.1.0" pyparsing jinja2 ipython setuptools cython'
   # Install an older version of scipy (which still has weave) on Python 2
-  - 'if "%PYTHON_VERSION:~0,1%" == "2" appveyor-retry conda install --yes --quiet scipy==0.18'
+  - 'if "%PYTHON_VERSION:~0,1%" == "2" appveyor-retry conda install --yes --quiet -c brian-team weave scipy'
   - 'if "%PYTHON_VERSION:~0,1%" == "3" appveyor-retry conda install --yes --quiet scipy'
   - 'appveyor-retry conda install --yes --quiet -c brian-team py-cpuinfo'
   # For faster tests, only build conda packages for the master branch or pull requests

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -101,7 +101,7 @@ install:
   - 'python -c "import struct; print(struct.calcsize(''P'') * 8)"'
 
   # Install the build dependencies of the project via conda
-  - 'appveyor-retry conda install --yes --quiet numpy nose sphinx "sympy<1.1" pyparsing jinja2 ipython setuptools cython'
+  - 'appveyor-retry conda install --yes --quiet numpy nose sphinx sympy pyparsing jinja2 ipython setuptools cython'
   # Install an older version of scipy (which still has weave) on Python 2
   - 'if "%PYTHON_VERSION:~0,1%" == "2" appveyor-retry conda install --yes --quiet scipy==0.18'
   - 'if "%PYTHON_VERSION:~0,1%" == "3" appveyor-retry conda install --yes --quiet scipy'

--- a/dev/conda-recipe/meta.yaml
+++ b/dev/conda-recipe/meta.yaml
@@ -18,7 +18,7 @@ requirements:
   run:
     - python
     - numpy x.x
-    - sympy >=0.7.6,<1.1
+    - sympy >=0.7.6,!=1.1.0
     - pyparsing
     - scipy >=0.13.3,<0.19 # [py2k]
     - bsddb # [py2k and not win]

--- a/dev/conda-recipe/meta.yaml
+++ b/dev/conda-recipe/meta.yaml
@@ -21,7 +21,7 @@ requirements:
     - sympy >=0.7.6,!=1.1.0
     - pyparsing
     - scipy >=0.13.3
-    - weave # [py2k and not linux32]
+    - weave # [py2k]
     - bsddb # [py2k and not win]
     - cython >=0.18
     - jinja2 >=2.7

--- a/dev/conda-recipe/meta.yaml
+++ b/dev/conda-recipe/meta.yaml
@@ -20,7 +20,8 @@ requirements:
     - numpy x.x
     - sympy >=0.7.6,!=1.1.0
     - pyparsing
-    - scipy >=0.13.3,<0.19 # [py2k]
+    - scipy >=0.13.3
+    - weave # [py2k and not linux32]
     - bsddb # [py2k and not win]
     - cython >=0.18
     - jinja2 >=2.7

--- a/dev/conda-recipe/meta.yaml
+++ b/dev/conda-recipe/meta.yaml
@@ -18,7 +18,7 @@ requirements:
   run:
     - python
     - numpy x.x
-    - sympy >=0.7.6
+    - sympy >=0.7.6,<1.1
     - pyparsing
     - scipy >=0.13.3,<0.19 # [py2k]
     - bsddb # [py2k and not win]

--- a/setup.py
+++ b/setup.py
@@ -161,7 +161,7 @@ setup(name='Brian2',
                     'brian2': ['default_preferences']
                     },
       install_requires=['numpy>=1.9',
-                        'sympy>=0.7.6, <1.1',
+                        'sympy>=0.7.6, !=1.1.0',
                         'pyparsing',
                         'jinja2>=2.7',
                         'py-cpuinfo>=0.1.6',

--- a/setup.py
+++ b/setup.py
@@ -161,7 +161,7 @@ setup(name='Brian2',
                     'brian2': ['default_preferences']
                     },
       install_requires=['numpy>=1.9',
-                        'sympy>=0.7.6',
+                        'sympy>=0.7.6, <1.1',
                         'pyparsing',
                         'jinja2>=2.7',
                         'py-cpuinfo>=0.1.6',


### PR DESCRIPTION
Require sympy < 1.1 as a workaround for #856 