### PR TITLE
at the moment the keywords for the support code for cpp (includes wea…

### DIFF
--- a/brian2/codegen/generators/cython_generator.py
+++ b/brian2/codegen/generators/cython_generator.py
@@ -294,7 +294,7 @@ class CythonCodeGenerator(CodeGenerator):
                 self.variables.update(func_namespace)
 
         return {'load_namespace': '\n'.join(load_namespace),
-                'support_code': '\n'.join(support_code)}
+                'support_code_lines': support_code}
 
 ###############################################################################
 # Implement functions

--- a/brian2/codegen/runtime/cython_rt/templates/common.pyx
+++ b/brian2/codegen/runtime/cython_rt/templates/common.pyx
@@ -36,7 +36,7 @@ cdef extern from "stdint_compat.h":
 
 
 # support code
-{{ support_code | autoindent }}
+{{ support_code_lines | autoindent }}
 
 # template-specific support code
 {% block template_support_code %}


### PR DESCRIPTION
…ve) templates and cython templates doesn't match. for cpp it's support_code_lines, while cython uses just support_code. It makes more sense to have them match up. I changes everything to support_code_lines in cython because this would require the least changes (only two to be precise). 