### PR TITLE
[MRG] Allow the use of "if" in the shorthand generator syntax

### DIFF
--- a/brian2/synapses/synapses.py
+++ b/brian2/synapses/synapses.py
@@ -1305,8 +1305,18 @@ class Synapses(Group):
                     raise ValueError("Generator syntax cannot be combined with "
                                      "p argument")
                 if not re.search(r'\bfor\b', j):
-                    j = '{j} for _ in range(1)'.format(j=j)
-                # will now call standard generator syntax (see below)
+                    if_split = j.split(' if ')
+                    if len(if_split) == 1:
+                        j = '{j} for _ in range(1)'.format(j=j)
+                    elif len(if_split) == 2:
+                        j = '{target} for _ in range(1) if {cond}'.format(target=if_split[0],
+                                                                          cond=if_split[1])
+                    else:
+                        raise SyntaxError("Error parsing expression '{j}'. "
+                                          "Expression must have generator "
+                                          "syntax, for example 'k for k in "
+                                          "range(i-10, i+10)'".format(j=j))
+                    # will now call standard generator syntax (see below)
             else:
                 raise ValueError("Must specify at least one of condition, i or "
                                  "j arguments")

--- a/brian2/tests/test_synapses.py
+++ b/brian2/tests/test_synapses.py
@@ -2063,6 +2063,13 @@ def test_synapse_generator_deterministic():
     expected_offdiagonal[np.arange(len(G2)-1), np.arange(len(G2)-1)+1] = 1
     expected_offdiagonal[np.arange(len(G2)-1)+1, np.arange(len(G2)-1)] = 1
 
+    # Converging connection pattern with restriction
+    S14 = Synapses(G, G2, 'w:1', 'v+=w')
+    S14.connect(j='int(i/4) if i % 2 == 0')
+    expected_converging_restricted = np.zeros((len(G), len(G2)), dtype=np.int32)
+    for target in xrange(4):
+        expected_converging_restricted[np.arange(4, step=2) + target * 4, target] = 1
+
     with catch_logs() as _:  # Ignore warnings about empty synapses
         run(0*ms)  # for standalone
 
@@ -2079,7 +2086,7 @@ def test_synapse_generator_deterministic():
     _compare(S11, expected_diverging)
     _compare(S12, expected_converging)
     _compare(S13, expected_offdiagonal)
-
+    _compare(S14, expected_converging_restricted)
 
 @attr('standalone-compatible')
 @with_setup(teardown=reinit_devices)

--- a/docs_sphinx/user/synapses.rst
+++ b/docs_sphinx/user/synapses.rst
@@ -172,6 +172,12 @@ simplest way to give a 1-to-1 connection would be::
 
     S.connect(j='i')
 
+This mapping can also use a restricting condition with ``if``, e.g. to connect
+neurons 0, 2, 4, 6, ... to neurons 0, 1, 2, 3, ... you could write::
+
+    S.connect(j='int(i/2) if i % 2 == 0')
+
+
 Accessing synaptic variables
 ----------------------------
 Synaptic variables can be accessed in a similar way as `NeuronGroup` variables. They can be indexed
@@ -247,9 +253,6 @@ the synapses have not yet been created at this point, so Brian cannot calculate
 the indices.
 
 .. admonition:: The following topics are not essential for beginners.
-
-    |
-
 
 Creating synapses with the generator syntax
 -------------------------------------------


### PR DESCRIPTION
I noticed this a while ago but never got around fixing it.
At the moment, the short-hand generator syntax (for single targets per source) does not work with `if`, because something like `connect(j='i if i % 2 == 0')` is translated into `i if i % 2 == 0 for _ in range(1)`.
My commit is a bit of a quick fix, I think we should probably include the parsing of the short-hand code into the `parse_generator_syntax` function in the long run to make the code easier to follow.

Either way, I'd be happy if this could be merged as a short-term solution, I have a use case for this and writing `for _ in range(1)` is really ugly...