### PR TITLE
[MRG] Minor runtime improvements (mostly for tests)

### DIFF
--- a/brian2/core/magic.py
+++ b/brian2/core/magic.py
@@ -225,7 +225,7 @@ class MagicNetwork(Network):
         gc.collect()  # Make sure that all unused objects are cleared
 
     def run(self, duration, report=None, report_period=10*second,
-            namespace=None, profile=True, level=0):
+            namespace=None, profile=False, level=0):
         self._update_magic_objects(level=level+1)
         Network.run(self, duration, report=report, report_period=report_period,
                     namespace=namespace, profile=profile, level=level+1)
@@ -307,7 +307,7 @@ def collect(level=0):
 
 @check_units(duration=second, report_period=second)
 def run(duration, report=None, report_period=10*second, namespace=None,
-        profile=True, level=0):
+        profile=False, level=0):
     '''
     run(duration, report=None, report_period=10*second, namespace=None, level=0)
     

--- a/brian2/core/network.py
+++ b/brian2/core/network.py
@@ -912,7 +912,7 @@ class Network(Nameable):
             and globals around the run function will be used.
         profile : bool, optional
             Whether to record profiling information (see
-            `Network.profiling_info`). Defaults to ``True``.
+            `Network.profiling_info`). Defaults to ``False``.
         level : int, optional
             How deep to go up the stack frame to look for the locals/global
             (see `namespace` argument). Only used by run functions that call

--- a/brian2/core/network.py
+++ b/brian2/core/network.py
@@ -885,7 +885,7 @@ class Network(Nameable):
     @device_override('network_run')
     @check_units(duration=second, report_period=second)
     def run(self, duration, report=None, report_period=10*second,
-            namespace=None, profile=True, level=0):
+            namespace=None, profile=False, level=0):
         '''
         run(duration, report=None, report_period=60*second, namespace=None, level=0)
         

--- a/brian2/core/network.py
+++ b/brian2/core/network.py
@@ -18,7 +18,7 @@ from brian2.utils.logger import get_logger
 from brian2.core.names import Nameable
 from brian2.core.base import BrianObject, brian_object_exception
 from brian2.core.clocks import Clock, defaultclock
-from brian2.devices.device import device
+from brian2.devices.device import get_device, all_devices
 from brian2.groups.group import Group
 from brian2.units.fundamentalunits import check_units, Quantity
 from brian2.units.allunits import second, msecond
@@ -786,8 +786,6 @@ class Network(Nameable):
             A namespace in which objects which do not define their own
             namespace will be run.
         '''
-        from brian2.devices.device import get_device, all_devices
-
         prefs.check_all_validated()
 
         # Check names in the network for uniqueness
@@ -926,6 +924,7 @@ class Network(Nameable):
         The simulation can be stopped by calling `Network.stop` or the
         global `stop` function.
         '''
+        device = get_device()  # Do not use the ProxyDevice -- slightly faster
         self._clocks = set([obj.clock for obj in self.objects])
         single_clock = len(self._clocks) == 1
 
@@ -1240,7 +1239,6 @@ def schedule_propagation_offset(net=None):
     This function always returns ``0*ms`` or ``defaultclock.dt`` -- no attempt
     is made to deal with other clocks.
     '''
-    from brian2.devices.device import get_device
     from brian2.core.magic import magic_network
 
     device = get_device()

--- a/brian2/devices/cpp_standalone/device.py
+++ b/brian2/devices/cpp_standalone/device.py
@@ -1102,7 +1102,7 @@ class CPPStandaloneDevice(Device):
                 self.run(directory, with_output, run_args)
 
     def network_run(self, net, duration, report=None, report_period=10*second,
-                    namespace=None, profile=True, level=0, **kwds):
+                    namespace=None, profile=False, level=0, **kwds):
         if kwds:
             logger.warn(('Unsupported keyword argument(s) provided for run: '
                          '%s') % ', '.join(kwds.keys()))

--- a/brian2/tests/test_network.py
+++ b/brian2/tests/test_network.py
@@ -1343,6 +1343,7 @@ def test_long_run_dt_change():
     group = NeuronGroup(1, '')  # does nothing...
     defaultclock.dt = 0.1*ms
     run(100*second)
+    # print profiling_summary()
     defaultclock.dt = 0.01*ms
     run(1*second)
 

--- a/brian2/tests/test_spatialneuron.py
+++ b/brian2/tests/test_spatialneuron.py
@@ -301,7 +301,7 @@ def test_rallpack2():
     '''
     Rallpack 2
     '''
-    defaultclock.dt = 0.05*ms
+    defaultclock.dt = 0.1*ms
 
     # Morphology
     diameter = 32*um
@@ -332,22 +332,24 @@ def test_rallpack2():
     Im = gL*(EL - v) : amp/meter**2
     I : amp (point current, constant)
     '''
-    neuron = SpatialNeuron(morphology=morpho, model=eqs, Cm=Cm, Ri=Ri)
+    neuron = SpatialNeuron(morphology=morpho, model=eqs, Cm=Cm, Ri=Ri,
+                           method='rk4')
     neuron.v = EL
 
     neuron.I[0] = 0.1*nA  # injecting at the origin
 
     endpoint_indices = [endpoint.indices[0] for endpoint in endpoints]
     mon = StateMonitor(neuron, 'v', record=[0] + endpoint_indices,
-                       when='start', dt=0.05*ms)
+                       when='start', dt=0.1*ms)
 
     run(250*ms + defaultclock.dt)
 
     # Load the theoretical results
     basedir = os.path.join(os.path.abspath(os.path.dirname(__file__)),
                            'rallpack_data')
-    data_0 = np.loadtxt(os.path.join(basedir, 'ref_branch.0'))
-    data_x = np.loadtxt(os.path.join(basedir, 'ref_branch.x'))
+    # Only use very second time step, since we run with 0.1ms instead of 0.05ms
+    data_0 = np.loadtxt(os.path.join(basedir, 'ref_branch.0'))[::2]
+    data_x = np.loadtxt(os.path.join(basedir, 'ref_branch.x'))[::2]
 
     # sanity check: times are the same
     assert_allclose(mon.t/second, data_0[:, 0])
@@ -784,7 +786,7 @@ def test_spatialneuron_capacitive_currents():
 
     neuron = SpatialNeuron(morphology=morpho, model=eqs, Cm=1*uF/cm**2,
                            Ri=35.4*ohm*cm, method="exponential_euler")
-    mon = StateMonitor(neuron,['Im','Ic'],record=True, when='end')
+    mon = StateMonitor(neuron, ['Im', 'Ic'], record=True, when='end')
     run(10*ms)
     neuron.I[0] = 1*uA  # current injection at one end
     run(3*ms)


### PR DESCRIPTION
Tests are running quite slow, so I looked a bit into the long-running tests and made some improvements to run them faster. The changes I did don't change much for the total test runtime, but I think they are nevertheless worth having. I made a specific change about integration method/time for the Rallpack2 test (i.e., multicompartmental models), but the other changes are more general:
* I switch off the profiling by default. For tests that don't do much each time step (like many of our tests), it added a considerable overhead. Most of our documentation actually suggested that it was off by default, and if you use `profiling_summary` without switching it on, you get an error message telling you what to do.
* I did some micro-optimisations to the run loop, special-casing simulations with a single clock. I'm not sure I hit the best trade off between performance and readability (the fastest solution would be to have one complete run loop for each of the 6 combinations of "single clock?", "profiling?", "progress report?" to avoid any `if` statements within the loop, but I don't feel like this is worth the horrible redundancy in code -- maybe we should actually generate code for the run loop...?).

Well, that's it. As I said, I don't think this will have a noticeable impact on the total test runtime, but for some tests it makes a big difference: the most extreme case is `test_long_run_dt_change()` which runs an empty simulation for 100s -- its runtime went down from ~12s to ~3s on my machine.