### PR TITLE
[MRG] Fix subexpression statements

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -127,7 +127,8 @@ after_test:
           cd %SRC_DIR% &&
           %CMD_IN_ENV% python setup.py bdist_wheel &&
           %CMD_IN_ENV% python setup.py bdist_wininst &&
-          %appveyor-retry CMD_IN_ENV% conda install --yes --quiet -c conda-forge conda-build anaconda-client pip &&
+          %appveyor-retry CMD_IN_ENV% conda install --yes --quiet -c conda-forge conda-build pip &&
+          %appveyor-retry CMD_IN_ENV% conda install --yes --quiet anaconda-client &&
           %CMD_IN_ENV% conda build --quiet -c conda-forge dev\conda-recipe --numpy 1.11 &&
           %CMD_IN_ENV% conda build --quiet -c conda-forge dev\conda-recipe --numpy 1.12 &&
           %CMD_IN_ENV% conda build --quiet -c conda-forge dev\conda-recipe --numpy 1.13 &&

--- a/brian2/codegen/translation.py
+++ b/brian2/codegen/translation.py
@@ -224,6 +224,11 @@ def make_statements(code, variables, dtype, optimise=True, blockname=''):
         statement = None
         # parse statement into "var op expr"
         var, op, expr, comment = parse_statement(line.code)
+        if var in variables and isinstance(variables[var], Subexpression):
+            raise SyntaxError("Illegal line '{line}' in abstract code. "
+                              "Cannot write to subexpression "
+                              "'{var}'.".format(line=line.code,
+                                                var=var))
         if op == '=':
             if var not in defined:
                 op = ':='

--- a/brian2/tests/test_codegen.py
+++ b/brian2/tests/test_codegen.py
@@ -1,6 +1,7 @@
 from collections import namedtuple
 
 import numpy as np
+from numpy.testing.utils import assert_raises
 from nose.plugins.attrib import attr
 
 from brian2.codegen.optimisation import optimise_statements
@@ -64,6 +65,20 @@ def test_get_identifiers_recursively():
     identifiers = get_identifiers_recursively(['_x = sub1 + x'],
                                               variables)
     assert identifiers == {'x', '_x', 'y', 'z', 'sub1', 'sub2'}
+
+
+@attr('codegen-independent')
+def test_write_to_subexpression():
+    variables = {
+        'a': Subexpression(name='a', dtype=np.float32,
+                           owner=FakeGroup(variables={}), device=None,
+                           expr='2*z'),
+        'z': Variable(name='z')
+    }
+
+    # Writing to a subexpression is not allowed
+    code = 'a = z'
+    assert_raises(SyntaxError, make_statements, code, variables, np.float32)
 
 
 @attr('codegen-independent')
@@ -397,6 +412,7 @@ if __name__ == '__main__':
     test_auto_target()
     test_analyse_identifiers()
     test_get_identifiers_recursively()
+    test_write_to_subexpression()
     test_repeated_subexpressions()
     test_nested_subexpressions()
     test_apply_loop_invariant_optimisation()

--- a/brian2/tests/test_synapses.py
+++ b/brian2/tests/test_synapses.py
@@ -2049,6 +2049,14 @@ def test_synapse_generator_deterministic():
     for source in xrange(4):
         expected_diverging[source, np.arange(4) + source*4] = 1
 
+    # Diverging connection pattern within population (no self-connections)
+    S11b = Synapses(G2, G2, 'w:1', 'v+=w')
+    S11b.connect(j='k for k in range(i-3, i+4) if i!=k', skip_if_invalid=True)
+    expected_diverging_b = np.zeros((len(G2), len(G2)), dtype=np.int32)
+    for source in xrange(len(G2)):
+        expected_diverging_b[source, np.clip(np.arange(-3, 4) + source, 0, len(G2)-1)] = 1
+        expected_diverging_b[source, source] = 0
+
     # Converging connection pattern
     S12 = Synapses(G, G2, 'w:1', 'v+=w')
     S12.connect(j='int(i/4)')
@@ -2084,6 +2092,7 @@ def test_synapse_generator_deterministic():
     _compare(S9, expected_one_to_one)
     _compare(S10, expected_ring)
     _compare(S11, expected_diverging)
+    _compare(S11b, expected_diverging_b)
     _compare(S12, expected_converging)
     _compare(S13, expected_offdiagonal)
     _compare(S14, expected_converging_restricted)


### PR DESCRIPTION
For the bug description, see #880.

Previously, we redefined a subexpression every time when it was used (just changing between the use of `:=` and `=`). Now, the `subdefined` dictionary does no longer contain `True`/`False` values, but one out of `None`, `'constant'`, `'variable'` instead. If it is already defined *and* constant, then we don't redefine it.
Note that there are some corner cases where we could define a subexpression as constant where we currently don't do it: if the variables on which a subexpression depends change, but the subexpression is not used after that change. I don't think it's worth complicating the logic much just for getting the `const` flag 100% right.

I just fixed another thing I realized while fixing the above bug: you were allowed to write to a subexpression variable which does not make much sense as in our view, a subexpression is not an "lvalue", but rather a shorthand for its right-hand side. Either way, the written value would not even be used later, because we'd redefine the subexpression variable for each use in the generated code. With my changes, `make_statements` will now raise a `SyntaxError` if you try to write to a subexpression (IIRC from the mailing list, some users actually tried doing this and were not aware that it did not have any effect).