### PR TITLE
[MRG] Standalone debug output

### DIFF
--- a/brian2/devices/cpp_standalone/templates/makefile
+++ b/brian2/devices/cpp_standalone/templates/makefile
@@ -1,23 +1,18 @@
 PROGRAM = main
+
 SRCS = {{source_files}}
 H_SRCS = {{header_files}}
 OBJS = ${SRCS:.cpp=.o}
 OBJS := ${OBJS:.c=.o}
 CC = @g++
-DEBUG = -g
 OPTIMISATIONS = {{ compiler_flags }}
-CFLAGS = -c -Wno-write-strings $(OPTIMISATIONS) -I. {{ openmp_pragma('compilation') }}
-LFLAGS = {{ openmp_pragma('compilation') }} {{ linker_flags }}
+CFLAGS = -c -Wno-write-strings $(OPTIMISATIONS) -I. {{ openmp_pragma('compilation') }} {{ compiler_debug_flags }}
+LFLAGS = {{ openmp_pragma('compilation') }} {{ linker_flags }} {{ linker_debug_flags }}
 DEPS = make.deps
 
 all: $(PROGRAM)
 
-# Adds debug flags
-debug: CFLAGS += $(DEBUG)
-debug: LFLAGS += $(DEBUG)
-debug: $(PROGRAM)
-
-.PHONY: all debug clean
+.PHONY: all clean
 
 $(PROGRAM): $(OBJS) $(DEPS) makefile
 	$(CC) $(OBJS) -o $(PROGRAM) $(LFLAGS)

--- a/brian2/devices/cpp_standalone/templates/spikemonitor.cpp
+++ b/brian2/devices/cpp_standalone/templates/spikemonitor.cpp
@@ -65,5 +65,7 @@ void _debugmsg_{{codeobj_name}}();
 {% endblock %}
 
 {% macro main_finalise() %}
+#ifdef DEBUG
 _debugmsg_{{codeobj_name}}();
+#endif
 {% endmacro %}

--- a/brian2/devices/cpp_standalone/templates/synapses.cpp
+++ b/brian2/devices/cpp_standalone/templates/synapses.cpp
@@ -62,6 +62,8 @@ void _debugmsg_{{codeobj_name}}()
 void _debugmsg_{{codeobj_name}}();
 {% endblock %}
 
-{% macro main_finalise() %}
+{% macro main_finalise() -%}
+#ifdef DEBUG
 _debugmsg_{{codeobj_name}}();
+#endif
 {% endmacro %}

--- a/brian2/devices/cpp_standalone/templates/win_makefile
+++ b/brian2/devices/cpp_standalone/templates/win_makefile
@@ -1,4 +1,3 @@
-
 all: main.exe
 
 clean:
@@ -8,9 +7,9 @@ clean:
 
 {% for fname, base in zip(source_files, source_bases) | sort(attribute='0')%}
 {{base}}.obj: win_makefile
-    cl /c /EHsc /I. {{compiler_flags}} {{openmp_flag}} {{fname}} /Fo{{base}}.obj
+    cl /c /EHsc /I. {{compiler_flags}} {{openmp_flag}} {{fname}} /Fo{{base}}.obj {{compiler_debug_flags}}
     
 {% endfor %}
 
 main.exe: {% for base in source_bases | sort%}{{base}}.obj {% endfor %} win_makefile sourcefiles.txt
-    link @sourcefiles.txt {{linker_flags}} /OUT:main.exe
+    link @sourcefiles.txt {{linker_flags}} /OUT:main.exe {{linker_debug_flags}}

--- a/brian2/tests/test_cpp_standalone.py
+++ b/brian2/tests/test_cpp_standalone.py
@@ -314,6 +314,21 @@ def test_array_cache():
     assert_allclose(G.i, np.arange(10))
     assert_allclose(S.weight, 7)
 
+@attr('cpp_standalone', 'standalone-only')
+@with_setup(teardown=reinit_devices)
+def test_run_with_debug():
+    # We just want to make sure that it works for now (i.e. not fails with a
+    # compilation or runtime error), capturing the output is actually
+    # a bit involved to get right.
+    set_device('cpp_standalone', build_on_run=True, debug=True,
+               directory=None)
+    group = NeuronGroup(1, 'v: 1', threshold='False')
+    syn = Synapses(group, group, on_pre='v += 1')
+    syn.connect()
+    mon = SpikeMonitor(group)
+    run(defaultclock.dt)
+
+
 
 if __name__=='__main__':
     for t in [
@@ -325,6 +340,7 @@ if __name__=='__main__':
              test_openmp_scalar_writes,
              test_time_after_run,
              test_array_cache,
+             test_run_with_debug
              ]:
         t()
         reinit_devices()


### PR DESCRIPTION
This branch fixes #882 by only showing the "Number of synapses/spikes" messages in standalone mode when called with `debug=True`. It also changes the approach to debug compilation on UNIX, and enables it for Windows (where previously it only raised a warning).
The change in approach for UNIX: previously, there was a separate debug target in the make file, and compiling in debug mode meant to call `make debug` instead of `make`. Now, using debug mode means creating a make file that includes debug options in the compiler options (i.e., `make` will compile with debug options). The reason is that two separate targets are problematic when they lead to the same output file (in our case `main`), in particular with our new `clean=False` default. If you run the same simulation twice, first with `debug=False` and then with `debug=True`, then the second run will not re-compile anything since the `main` file is up-to-date with respect to the dependencies. We could work around this in various ways, but just building a different make file depending on the `debug` variable seems to be a reasonably simple solution and is also easily implemented for Windows.

The change in this PR also defines a `DEBUG` preprocessor macro in debug mode, which is useful to deal with the "Number of synapses/spikes" issue (when we create the code for the code objects, we do not yet know whether `device.build` will activate the debug mode or not) and is a fairly common thing to do, anyway.