### PR TITLE
[MRG] Fix an error in numpy template, triggered when assigning to a variable with an unfulfilled scalar condition

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -137,6 +137,7 @@ install:
   - travis_retry conda install --yes --quiet -c brian-team py-cpuinfo  # install cpuinfo from our own channel
   - if [[ $CYTHON == 'yes' ]]; then travis_retry conda install --yes cython; SETUP_ARGS=--with-cython; else SETUP_ARGS=''; fi
   - if [[ $REPORT_COVERAGE == 'yes' ]]; then travis_retry pip install -q coveralls; fi
+  - python -c 'import sysconfig, pprint; pprint.pprint(sysconfig.get_config_vars())'
   - python setup.py install $SETUP_ARGS --fail-on-error --single-version-externally-managed --record=record.txt
   - if [[ $DOCS_ONLY == 'yes' ]]; then
       python setup.py sdist;

--- a/.travis.yml
+++ b/.travis.yml
@@ -114,6 +114,7 @@ before_install:
 # command to install dependencies
 install:
   # - conda update --yes conda
+  - echo "conda ==4.3.21" >> ~/miniconda/conda-meta/pinned  # Pin conda as workaround for conda/conda#6030
   # For faster tests, only build conda packages for the master branch or pull requests
   - if [[ $TRAVIS_PULL_REQUEST == 'false' ]] && [[ $TRAVIS_BRANCH != 'master' ]]; then
        CONDA_BUILD='no';

--- a/.travis.yml
+++ b/.travis.yml
@@ -113,7 +113,7 @@ before_install:
 
 # command to install dependencies
 install:
-  - conda update --yes conda
+  # - conda update --yes conda
   # For faster tests, only build conda packages for the master branch or pull requests
   - if [[ $TRAVIS_PULL_REQUEST == 'false' ]] && [[ $TRAVIS_BRANCH != 'master' ]]; then
        CONDA_BUILD='no';
@@ -137,7 +137,6 @@ install:
   - travis_retry conda install --yes --quiet -c brian-team py-cpuinfo  # install cpuinfo from our own channel
   - if [[ $CYTHON == 'yes' ]]; then travis_retry conda install --yes cython; SETUP_ARGS=--with-cython; else SETUP_ARGS=''; fi
   - if [[ $REPORT_COVERAGE == 'yes' ]]; then travis_retry pip install -q coveralls; fi
-  - python -c 'import sysconfig, pprint; pprint.pprint(sysconfig.get_config_vars())'
   - python setup.py install $SETUP_ARGS --fail-on-error --single-version-externally-managed --record=record.txt
   - if [[ $DOCS_ONLY == 'yes' ]]; then
       python setup.py sdist;

--- a/brian2/codegen/runtime/numpy_rt/templates/group_variable_set_conditional.py_
+++ b/brian2/codegen/runtime/numpy_rt/templates/group_variable_set_conditional.py_
@@ -38,7 +38,7 @@ if _cond is True or _cond is numpy_True:
     _vectorisation_idx = LazyArange(N)
 elif _cond is False or _cond is numpy_False:
     _idx = []
-    _vectorisation_idx = np.array([], dtype=np.int32)
+    _vectorisation_idx = _numpy.array([], dtype=_numpy.int32)
 else:
     _vectorisation_idx = _idx = _numpy.nonzero(_cond)[0]
 

--- a/brian2/tests/test_neurongroup.py
+++ b/brian2/tests/test_neurongroup.py
@@ -912,8 +912,12 @@ def test_state_variable_set_strings():
                            v5  : volt
                            v6  : volt
                            v7  : volt
+                           v7b : volt
+                           v7c : volt
                            v8  : volt
                            v9  : volt
+                           v9b : volt
+                           v9c : volt
                            v10 : volt
                            v11 : volt
                            dv_ref/dt = -v_ref/(10*ms) : 1 (unless refractory)''',
@@ -952,6 +956,14 @@ def test_state_variable_set_strings():
     # String index referring to i and setting to a scalar value
     G.v7['i>=5'] = 0*mV
 
+    G.v7b = np.arange(10) * volt
+    # String index referring to i and setting to a scalar value (no effect)
+    G.v7b['i>=10'] = 0*mV
+
+    G.v7c = np.arange(10) * volt
+    # String index referring to i and setting to a scalar value (no effect)
+    G.v7c['False'] = 0*mV
+
     G.v8[:5] = np.arange(5) * volt
     # String index referring to a state variable
     G.v8['v8<3*volt'] = 0*mV
@@ -962,7 +974,15 @@ def test_state_variable_set_strings():
     G.v9 = np.arange(10) * volt
     # Strings for both condition and values
     G.v9['i>=5'] = 'v9*2'
-    G.v9['v9>=5*volt'] = 'i*volt'
+    G.v9['v9<5*volt'] = '3*i*volt'
+
+    G.v9b = np.arange(10) * volt
+    # Strings for both condition and values (no effect)
+    G.v9b['i<0'] = 'v9 + 100*volt'
+
+    G.v9c = np.arange(10) * volt
+    # Strings for both condition and values (no effect)
+    G.v9c['False'] = 'v9 + 100*volt'
 
     G.v10 = np.arange(10)*volt
     G.v10['i<=5'] = '(100 + rand())*volt'
@@ -974,18 +994,19 @@ def test_state_variable_set_strings():
     G.v11[3] = 'inf*volt'
     G.v11[4] = 'rand()*volt'
     run(0*ms)
-    assert_equal(G.v1[:],
-                 np.array([0, 3, 6, 9, 12, 10, 12, 14, 16, 18])*volt)
+    assert_equal(G.v1[:], [0, 3, 6, 9, 12, 10, 12, 14, 16, 18]*volt)
     assert_equal(G.v_ref[:], 2 * np.arange(10))
-    assert_equal(G.v2[:],
-                 np.array([0, 4, 8, 12, 16, 10, 12, 14, 16, 18])*volt)
+    assert_equal(G.v2[:], [0, 4, 8, 12, 16, 10, 12, 14, 16, 18]*volt)
     assert_equal(G.v3[:], 2 * np.arange(10) * volt + 15 * volt)
-    assert_equal(G.v4[:],
-                 np.array([15, 17, 19, 21, 23, 5, 6, 7, 8, 9])*volt)
+    assert_equal(G.v4[:], [15, 17, 19, 21, 23, 5, 6, 7, 8, 9]*volt)
     assert_equal(G.v6[:], np.zeros(10) * volt)
-    assert_equal(G.v7[:], np.array([0, 1, 2, 3, 4, 0, 0, 0, 0, 0]) * volt)
-    assert_equal(G.v8[:], np.array([0, 0, 0, 3, 0, 0, 0, 0, 0, 0]) * volt)
-    assert_equal(G.v9[:], np.arange(10) * volt)
+    assert_equal(G.v7[:], [0, 1, 2, 3, 4, 0, 0, 0, 0, 0]*volt)
+    assert_equal(G.v7b[:], np.arange(10)*volt)
+    assert_equal(G.v7c[:], np.arange(10) * volt)
+    assert_equal(G.v8[:], [0, 0, 0, 3, 0, 0, 0, 0, 0, 0]*volt)
+    assert_equal(G.v9[:], [0, 3, 6, 9, 12, 10, 12, 14, 16, 18]*volt)
+    assert_equal(G.v9b[:], np.arange(10)*volt)
+    assert_equal(G.v9c[:], np.arange(10) * volt)
     assert_equal(G.v10[6:], np.arange(4)*volt + 6*volt)  # unchanged
     assert all(G.v10[:6] >= 100*volt)
     assert all(G.v10[:6] <= 101*volt)


### PR DESCRIPTION
This is a trivial fix, the code in the template still used `np` for numpy while we replaced it everywhere else by `_numpy` -- apparently that part of the template was never triggered by our test suite (it now is).

To trigger the code and therefore the bug you needed to assign with a condition that evaluated to `False` "in a scalar sense", i.e. not like in `i < 0` which evaluates to `False` for each neuron, but rather like `N < 0`. The simplest example is of course to directly use `False`, i.e.:
```Python
group.v['False'] = 10*mV
```