### PR TITLE
[MRG] Rename/deprecate state updaters

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -147,7 +147,7 @@ install:
 script:
 - if [[ $CONDA_BUILD == 'yes' ]]; then
     source deactivate;
-    for NUMPY_VERSION in 1.10 1.11 1.12 1.13; do
+    for NUMPY_VERSION in 1.12 1.13; do
       conda build --quiet -c conda-forge dev/conda-recipe --numpy $NUMPY_VERSION;
     done;
     source activate travis_conda;

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -129,7 +129,6 @@ after_test:
           %CMD_IN_ENV% python setup.py bdist_wininst &&
           %appveyor-retry CMD_IN_ENV% conda install --yes --quiet -c conda-forge conda-build pip &&
           %appveyor-retry CMD_IN_ENV% conda install --yes --quiet anaconda-client &&
-          %CMD_IN_ENV% conda build --quiet -c conda-forge dev\conda-recipe --numpy 1.11 &&
           %CMD_IN_ENV% conda build --quiet -c conda-forge dev\conda-recipe --numpy 1.12 &&
           %CMD_IN_ENV% conda build --quiet -c conda-forge dev\conda-recipe --numpy 1.13 &&
           %CMD_IN_ENV% python dev\continuous-integration\move-conda-package.py dev\conda-recipe &&

--- a/brian2/groups/neurongroup.py
+++ b/brian2/groups/neurongroup.py
@@ -369,7 +369,7 @@ class NeuronGroup(Group, SpikeSource):
     add_to_magic_network = True
 
     def __init__(self, N, model,
-                 method=('linear', 'euler', 'heun'),
+                 method=('exact', 'euler', 'heun'),
                  threshold=None,
                  reset=None,
                  refractory=False,

--- a/brian2/spatialneuron/spatialneuron.py
+++ b/brian2/spatialneuron/spatialneuron.py
@@ -226,7 +226,7 @@ class SpatialNeuron(NeuronGroup):
                  threshold_location=None,
                  dt=None, clock=None, order=0, Cm=0.9 * uF / cm ** 2, Ri=150 * ohm * cm,
                  name='spatialneuron*', dtype=None, namespace=None,
-                 method=('linear', 'exponential_euler', 'rk2', 'heun')):
+                 method=('exact', 'exponential_euler', 'rk2', 'heun')):
 
         # #### Prepare and validate equations
         if isinstance(model, basestring):

--- a/brian2/stateupdaters/__init__.py
+++ b/brian2/stateupdaters/__init__.py
@@ -7,9 +7,8 @@ from .exact import *
 from .explicit import *
 from .exponential_euler import *
 
-# Register the standard state updaters in the order in which they should be
-# chosen
 StateUpdateMethod.register('linear', linear)
+StateUpdateMethod.register('exact', exact)
 StateUpdateMethod.register('independent', independent)
 StateUpdateMethod.register('exponential_euler', exponential_euler)
 StateUpdateMethod.register('euler', euler)
@@ -17,5 +16,3 @@ StateUpdateMethod.register('rk2', rk2)
 StateUpdateMethod.register('rk4', rk4)
 StateUpdateMethod.register('milstein', milstein)
 StateUpdateMethod.register('heun', heun)
-
-

--- a/brian2/stateupdaters/exact.py
+++ b/brian2/stateupdaters/exact.py
@@ -12,9 +12,10 @@ from brian2.stateupdaters.base import (StateUpdateMethod,
                                        UnsupportedEquationsException)
 from brian2.utils.logger import get_logger
 
-__all__ = ['linear', 'independent']
+__all__ = ['linear', 'exact', 'independent']
 
 logger = get_logger(__name__)
+
 
 def get_linear_system(eqs, variables):
     '''
@@ -232,3 +233,4 @@ class LinearStateUpdater(StateUpdateMethod):
 
 independent = IndependentStateUpdater()
 linear = LinearStateUpdater()
+exact = linear

--- a/brian2/stateupdaters/exact.py
+++ b/brian2/stateupdaters/exact.py
@@ -78,9 +78,15 @@ class IndependentStateUpdater(StateUpdateMethod):
     A state update for equations that do not depend on other state variables,
     i.e. 1-dimensional differential equations. The individual equations are
     solved by sympy.
+
+    .. deprecated:: 2.1
+        This method might be removed from future versions of Brian.
     '''
 
     def __call__(self, equations, variables=None):
+        logger.warn("The 'independent' state updater is deprecated and might be "
+                    "removed in future versions of Brian.",
+                    'deprecated_independent', once=True)
         if equations.is_stochastic:
             raise UnsupportedEquationsException('Cannot solve stochastic '
                                                 'equations with this state '
@@ -93,9 +99,6 @@ class IndependentStateUpdater(StateUpdateMethod):
         t = Symbol('t', real=True, positive=True)
         dt = Symbol('dt', real=True, positive=True)
         t0 = Symbol('t0', real=True, positive=True)
-        f0 = Symbol('f0', real=True)
-        # TODO: Shortcut for simple linear equations? Is all this effort really
-        #       worth it?
 
         code = []
         for name, expression in diff_eqs:
@@ -230,6 +233,7 @@ class LinearStateUpdater(StateUpdateMethod):
 
     def __repr__(self):
         return '%s()' % self.__class__.__name__
+
 
 independent = IndependentStateUpdater()
 linear = LinearStateUpdater()

--- a/brian2/synapses/synapses.py
+++ b/brian2/synapses/synapses.py
@@ -640,7 +640,7 @@ class Synapses(Group):
                  namespace=None, dtype=None,
                  codeobj_class=None,
                  dt=None, clock=None, order=0,
-                 method=('linear', 'euler', 'heun'),
+                 method=('exact', 'euler', 'heun'),
                  name='synapses*'):
         if connect is not None:
             raise TypeError('The connect keyword argument is no longer '

--- a/brian2/tests/features/speed.py
+++ b/brian2/tests/features/speed.py
@@ -233,7 +233,7 @@ class STDP(SpeedTest):
 
         input = PoissonGroup(N, rates=F)
         neurons = NeuronGroup(1, eqs_neurons, threshold='v>vt', reset='v = vr',
-                              method='linear')
+                              method='exact')
         S = Synapses(input, neurons,
                      '''w : 1
                         dApre/dt = -Apre / taupre : 1 (event-driven)

--- a/brian2/tests/test_network.py
+++ b/brian2/tests/test_network.py
@@ -6,10 +6,9 @@ import os
 import uuid
 
 import numpy as np
-from numpy.testing import assert_equal, assert_raises
+from numpy.testing import assert_equal, assert_raises, assert_allclose
 from nose import with_setup
 from nose.plugins.attrib import attr
-from numpy.testing.utils import assert_allclose
 
 from brian2 import (Clock, Network, ms, us, second, BrianObject, defaultclock,
                     run, stop, NetworkOperation, network_operation,
@@ -1332,8 +1331,8 @@ def test_small_runs():
         if net_2.t >= 1*second:
             break
 
-    assert_equal(mon_1.t_[:], mon_2.t_[:])
-    assert_equal(mon_1.v_[:], mon_2.v_[:])
+    assert_allclose(mon_1.t_[:], mon_2.t_[:])
+    assert_allclose(mon_1.v_[:], mon_2.v_[:])
 
 
 @attr('codegen-independent')

--- a/brian2/tests/test_neurongroup.py
+++ b/brian2/tests/test_neurongroup.py
@@ -1142,7 +1142,7 @@ def test_scalar_subexpression():
 @with_setup(teardown=reinit_devices)
 def test_sim_with_scalar_variable():
     G = NeuronGroup(10, '''tau : second (shared)
-                           dv/dt = -v/tau : 1''', method='linear')
+                           dv/dt = -v/tau : 1''', method='exact')
     G.tau = 10*ms
     G.v = '1.0*i/N'
     run(1*ms)
@@ -1153,7 +1153,7 @@ def test_sim_with_scalar_variable():
 @with_setup(teardown=reinit_devices)
 def test_sim_with_scalar_subexpression():
     G = NeuronGroup(10, '''tau = 10*ms : second (shared)
-                           dv/dt = -v/tau : 1''', method='linear')
+                           dv/dt = -v/tau : 1''', method='exact')
     G.v = '1.0*i/N'
     run(1*ms)
     assert_allclose(G.v[:], np.exp(-0.1)*np.linspace(0, 1, 10, endpoint=False))

--- a/docs_sphinx/user/numerical_integration.rst
+++ b/docs_sphinx/user/numerical_integration.rst
@@ -33,8 +33,6 @@ the ``method`` keyword for `NeuronGroup`, `Synapses`, or `SpatialNeuron`.
 The complete list of available methods is the following:
 
 * ``'exact'``: exact integration for linear equations (alternative name: ``'linear'``)
-* ``'independent'``: exact integration for a system of independent equations,
-  where all the equations can be analytically solved independently
 * ``'exponential_euler'``: exponential Euler integration for conditionally
   linear equations
 * ``'euler'``: forward Euler integration (for additive stochastic
@@ -45,6 +43,13 @@ The complete list of available methods is the following:
   differential equations with non-diagonal multiplicative noise.
 * ``'milstein'``: derivative-free Milstein method for solving stochastic
   differential equations with diagonal multiplicative noise
+
+.. note::
+
+  The ``'independent'`` integration method (exact integration for a system of
+  independent equations, where all the equations can be analytically solved
+  independently) should no longer be used and might be removed in future
+  versions of Brian.
 
 .. admonition:: The following topics are not essential for beginners.
 

--- a/docs_sphinx/user/numerical_integration.rst
+++ b/docs_sphinx/user/numerical_integration.rst
@@ -22,7 +22,7 @@ You will get an ``INFO`` message telling you which integration method Brian deci
 together with information about how much time it took to apply the integration method
 to your equations. If other methods have been tried but were not applicable, you will
 also see the time it took to try out those other methods. In some cases, checking
-other methods (in particular the ``'linear'`` method which attempts to solve the
+other methods (in particular the ``'exact'`` method which attempts to solve the
 equations analytically) can take a considerable amount of time -- to avoid wasting
 this time, you can always chose the integration method manually (see below). You
 can also suppress the message by raising the log level or by explicitly suppressing
@@ -32,7 +32,7 @@ If you prefer to chose an integration algorithm yourself, you can do so using
 the ``method`` keyword for `NeuronGroup`, `Synapses`, or `SpatialNeuron`.
 The complete list of available methods is the following:
 
-* ``'linear'``: exact integration for linear equations
+* ``'exact'``: exact integration for linear equations (alternative name: ``'linear'``)
 * ``'independent'``: exact integration for a system of independent equations,
   where all the equations can be analytically solved independently
 * ``'exponential_euler'``: exponential Euler integration for conditionally
@@ -55,8 +55,8 @@ Technical notes
 
 Each class defines its own list of algorithms it tries to
 apply, `NeuronGroup` and `Synapses` will use the first suitable method out of
-the methods ``'linear'``, ``'euler'`` and ``'heun'`` while `SpatialNeuron`
-objects will use ``'linear'``, ``'exponential_euler'``, ``'rk2'`` or ``'heun'``.
+the methods ``'exact'``, ``'euler'`` and ``'heun'`` while `SpatialNeuron`
+objects will use ``'exact'``, ``'exponential_euler'``, ``'rk2'`` or ``'heun'``.
 
 You can also define your own numerical integrators, see
 :doc:`../advanced/state_update` for details.

--- a/examples/CUBA.py
+++ b/examples/CUBA.py
@@ -30,7 +30,7 @@ dgi/dt = -gi/taui : volt
 '''
 
 P = NeuronGroup(4000, eqs, threshold='v>Vt', reset='v = Vr', refractory=5*ms,
-                method='linear')
+                method='exact')
 P.v = 'Vr + rand() * (Vt - Vr)'
 P.ge = 0*mV
 P.gi = 0*mV

--- a/examples/IF_curve_LIF.py
+++ b/examples/IF_curve_LIF.py
@@ -15,7 +15,7 @@ dv/dt = (v0 - v) / tau : volt (unless refractory)
 v0 : volt
 '''
 group = NeuronGroup(n, eqs, threshold='v > 10*mV', reset='v = 0*mV',
-                    refractory=5*ms, method='linear')
+                    refractory=5*ms, method='exact')
 group.v = 0*mV
 group.v0 = '20*mV * i / (n-1)'
 

--- a/examples/adaptive_threshold.py
+++ b/examples/adaptive_threshold.py
@@ -14,7 +14,7 @@ vt += 3*mV
 '''
 
 IF = NeuronGroup(1, model=eqs, reset=reset, threshold='v>vt',
-                 method='linear')
+                 method='exact')
 IF.vt = 10*mV
 PG = PoissonGroup(1, 500 * Hz)
 

--- a/examples/advanced/opencv_movie.py
+++ b/examples/advanced/opencv_movie.py
@@ -101,7 +101,7 @@ G = NeuronGroup(N, '''dv/dt = (-v + I)/tau : 1
                       column : integer (constant)
                       I : 1 # input current''',
                 threshold='v>v_th', reset='v=0; v_th = 3*v_th + 1.0',
-                method='linear')
+                method='exact')
 G.v_th = 1
 G.row = 'i/width'
 G.column = 'i%width'

--- a/examples/compartmental/bipolar_with_inputs.py
+++ b/examples/compartmental/bipolar_with_inputs.py
@@ -33,7 +33,7 @@ taus = 1*ms
 w = 20*nS
 S = Synapses(stimulation, neuron, model='''dg/dt = -g/taus : siemens (clock-driven)
                                            gs_post = g : siemens (summed)''',
-             on_pre='g += w', method='linear')
+             on_pre='g += w', method='exact')
 
 S.connect(i=0, j=morpho.L[-1])
 S.connect(i=1, j=morpho.R[-1])

--- a/examples/frompapers/Clopath_et_al_2010_homeostasis.py
+++ b/examples/frompapers/Clopath_et_al_2010_homeostasis.py
@@ -121,7 +121,7 @@ Nrn_downstream = NeuronGroup(Nr_neurons, eqs_neurons, threshold='v>V_thresh',
                              method='euler')
 Nrns_input = NeuronGroup(Nr_inputs, eqs_inputs, threshold='rand()<rates*dt',
                          reset='v=V_rest;x_trace+=x_reset/(taux/ms)',
-                         method='linear')
+                         method='exact')
 
 #### create Synapses
 

--- a/examples/frompapers/Rossant_et_al_2011bis.py
+++ b/examples/frompapers/Rossant_et_al_2011bis.py
@@ -43,7 +43,7 @@ wi = (vmean-El-lambdae*ne*we*taue)/(lambdae*ni*taui)
 # NeuronGroup definition
 group = NeuronGroup(N=2, model=eqs, reset='v = El',
                     threshold='v>theta',
-                    refractory=5*ms, method='linear')
+                    refractory=5*ms, method='exact')
 group.v = El
 group.ge = group.gi = 0
 

--- a/examples/frompapers/Stimberg_et_al_2018/example_2_gchi_astrocyte.py
+++ b/examples/frompapers/Stimberg_et_al_2018/example_2_gchi_astrocyte.py
@@ -87,7 +87,7 @@ synapses_eqs = 'dY_S/dt = -Omega_c * Y_S : mmolar (clock-driven)'
 synapses_action = 'Y_S += rho_c * Y_T'
 synapses = Synapses(source_neurons, target_neurons,
                     model=synapses_eqs, on_pre=synapses_action,
-                    method='linear')
+                    method='exact')
 synapses.connect()
 
 ### Astrocytes

--- a/examples/frompapers/Stimberg_et_al_2018/example_3_io_synapse.py
+++ b/examples/frompapers/Stimberg_et_al_2018/example_3_io_synapse.py
@@ -114,7 +114,7 @@ Y_S += rho_c * Y_T * r_S
 '''
 synapses = Synapses(source_neurons, target_neurons,
                     model=synapses_eqs, on_pre=synapses_action,
-                    method='linear')
+                    method='exact')
 # We create three synapses, only the second and third ones are modulated by astrocytes
 synapses.connect(True, n=3)
 

--- a/examples/frompapers/Stimberg_et_al_2018/example_4_rsmean.py
+++ b/examples/frompapers/Stimberg_et_al_2018/example_4_rsmean.py
@@ -120,7 +120,7 @@ Y_S += rho_c * Y_T * r_S
 '''
 synapses = Synapses(source_neurons, target_neurons,
                     model=synapses_eqs, on_pre=synapses_action,
-                    method='linear')
+                    method='exact')
 # We create three synapses per connection: only the first two are modulated by
 # the astrocyte however. Note that we could also create three synapses per
 # connection with a single connect call by using connect(j='i', n=3), but this

--- a/examples/frompapers/Stimberg_et_al_2018/example_4_synrel.py
+++ b/examples/frompapers/Stimberg_et_al_2018/example_4_synrel.py
@@ -124,7 +124,7 @@ Y_S += rho_c * Y_T * r_S
 '''
 synapses = Synapses(source_neurons, target_neurons,
                     model=synapses_eqs, on_pre=synapses_action,
-                    method='linear')
+                    method='exact')
 # We create three synapses per connection: only the first two are modulated by
 # the astrocyte however. Note that we could also create three synapses per
 # connection with a single connect call by using connect(j='i', n=3), but this

--- a/examples/frompapers/Stimberg_et_al_2018/example_6_COBA_with_astro.py
+++ b/examples/frompapers/Stimberg_et_al_2018/example_6_COBA_with_astro.py
@@ -163,12 +163,12 @@ Y_S += rho_c * Y_T * r_S
 '''
 exc_syn = Synapses(exc_neurons, neurons, model=synapses_eqs,
                    on_pre=synapses_action+'g_e_post += w_e*r_S',
-                   method='linear')
+                   method='exact')
 exc_syn.connect(True, p=0.05)
 exc_syn.x_S = 1.0
 inh_syn = Synapses(inh_neurons, neurons, model=synapses_eqs,
                    on_pre=synapses_action+'g_i_post += w_i*r_S',
-                   method='linear')
+                   method='exact')
 inh_syn.connect(True, p=0.2)
 inh_syn.x_S = 1.0
 # Connect excitatory synapses to an astrocyte depending on the position of the

--- a/examples/frompapers/Sturzl_et_al_2000.py
+++ b/examples/frompapers/Sturzl_et_al_2000.py
@@ -59,7 +59,7 @@ dx/dt = (y - x)/taus : 1 # alpha currents
 dy/dt = -y/taus : 1
 '''
 neurons = NeuronGroup(8, model=eqs_neuron, threshold='v>1', reset='v=0',
-                      method='linear')
+                      method='exact')
 synapses_ex = Synapses(legs, neurons, on_pre='y+=wex')
 synapses_ex.connect(j='i')
 synapses_inh = Synapses(legs, neurons, on_pre='y+=winh', delay=deltaI)

--- a/examples/standalone/STDP_standalone.py
+++ b/examples/standalone/STDP_standalone.py
@@ -33,7 +33,7 @@ dge/dt = -ge / taue : 1
 
 input = PoissonGroup(N, rates=F)
 neurons = NeuronGroup(1, eqs_neurons, threshold='v>vt', reset='v = vr',
-                      method='linear')
+                      method='exact')
 S = Synapses(input, neurons,
              '''w : 1
                 dApre/dt = -Apre / taupre : 1 (event-driven)

--- a/examples/standalone/cuba_openmp.py
+++ b/examples/standalone/cuba_openmp.py
@@ -21,7 +21,7 @@ dgi/dt = -gi/taui : volt (unless refractory)
 '''
 
 P = NeuronGroup(4000, eqs, threshold='v>Vt', reset='v = Vr', refractory=5*ms,
-                method='linear')
+                method='exact')
 P.v = 'Vr + rand() * (Vt - Vr)'
 P.ge = 0*mV
 P.gi = 0*mV

--- a/examples/synapses/STDP.py
+++ b/examples/synapses/STDP.py
@@ -28,7 +28,7 @@ dge/dt = -ge / taue : 1
 
 input = PoissonGroup(N, rates=F)
 neurons = NeuronGroup(1, eqs_neurons, threshold='v>vt', reset='v = vr',
-                      method='linear')
+                      method='exact')
 S = Synapses(input, neurons,
              '''w : 1
                 dApre/dt = -Apre / taupre : 1 (event-driven)

--- a/examples/synapses/gapjunctions.py
+++ b/examples/synapses/gapjunctions.py
@@ -14,7 +14,7 @@ Igap : 1 # gap junction current
 '''
 
 neurons = NeuronGroup(n, eqs, threshold='v > 1', reset='v = 0',
-                      method='linear')
+                      method='exact')
 neurons.v = 'i * 1.0 / (n-1)'
 trace = StateMonitor(neurons, 'v', record=[0, 5])
 

--- a/examples/synapses/nonlinear.py
+++ b/examples/synapses/nonlinear.py
@@ -11,7 +11,7 @@ c = 1 / (10*ms)
 input = NeuronGroup(2, 'dv/dt = 1/(10*ms) : 1', threshold='v>1', reset='v = 0',
                     method='euler')
 neurons = NeuronGroup(1, """dv/dt = (g-v)/(10*ms) : 1
-                            g : 1""", method='linear')
+                            g : 1""", method='exact')
 S = Synapses(input, neurons,'''
                 dg_syn/dt = -a*g_syn+b*x*(1-g_syn) : 1 (clock-driven)
                 g_post = g_syn : 1 (summed)

--- a/examples/synapses/synapses.py
+++ b/examples/synapses/synapses.py
@@ -4,10 +4,10 @@ A simple example of using `Synapses`.
 from brian2 import *
 
 G1 = NeuronGroup(10, 'dv/dt = -v / (10*ms) : 1',
-                 threshold='v > 1', reset='v=0.', method='linear')
+                 threshold='v > 1', reset='v=0.', method='exact')
 G1.v = 1.2
 G2 = NeuronGroup(10, 'dv/dt = -v / (10*ms) : 1',
-                 threshold='v > 1', reset='v=0', method='linear')
+                 threshold='v > 1', reset='v=0', method='exact')
  
 syn = Synapses(G1, G2, 'dw/dt = -w / (50*ms): 1 (event-driven)', on_pre='v += w')
 

--- a/tutorials/1-intro-to-brian-neurons.ipynb
+++ b/tutorials/1-intro-to-brian-neurons.ipynb
@@ -38,7 +38,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "%matplotlib inline"
@@ -192,7 +194,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "G = NeuronGroup(1, eqs)"
@@ -267,7 +271,7 @@
    "source": [
     "start_scope()\n",
     "\n",
-    "G = NeuronGroup(1, eqs, method='linear')\n",
+    "G = NeuronGroup(1, eqs, method='exact')\n",
     "print('Before v = %s' % G.v[0])\n",
     "run(100*ms)\n",
     "print('After v = %s' % G.v[0])"
@@ -306,7 +310,7 @@
    "source": [
     "start_scope()\n",
     "\n",
-    "G = NeuronGroup(1, eqs, method='linear')\n",
+    "G = NeuronGroup(1, eqs, method='exact')\n",
     "M = StateMonitor(G, 'v', record=True)\n",
     "\n",
     "run(30*ms)\n",
@@ -333,7 +337,7 @@
    "source": [
     "start_scope()\n",
     "\n",
-    "G = NeuronGroup(1, eqs, method='linear')\n",
+    "G = NeuronGroup(1, eqs, method='exact')\n",
     "M = StateMonitor(G, 'v', record=0)\n",
     "\n",
     "run(30*ms)\n",
@@ -407,7 +411,7 @@
     "dv/dt = (1-v)/tau : 1\n",
     "'''\n",
     "\n",
-    "G = NeuronGroup(1, eqs, threshold='v>0.8', reset='v = 0', method='linear')\n",
+    "G = NeuronGroup(1, eqs, threshold='v>0.8', reset='v = 0', method='exact')\n",
     "\n",
     "M = StateMonitor(G, 'v', record=0)\n",
     "run(50*ms)\n",
@@ -433,7 +437,7 @@
    "source": [
     "start_scope()\n",
     "\n",
-    "G = NeuronGroup(1, eqs, threshold='v>0.8', reset='v = 0', method='linear')\n",
+    "G = NeuronGroup(1, eqs, threshold='v>0.8', reset='v = 0', method='exact')\n",
     "\n",
     "spikemon = SpikeMonitor(G)\n",
     "\n",
@@ -457,7 +461,7 @@
    "source": [
     "start_scope()\n",
     "\n",
-    "G = NeuronGroup(1, eqs, threshold='v>0.8', reset='v = 0', method='linear')\n",
+    "G = NeuronGroup(1, eqs, threshold='v>0.8', reset='v = 0', method='exact')\n",
     "\n",
     "statemon = StateMonitor(G, 'v', record=0)\n",
     "spikemon = SpikeMonitor(G)\n",
@@ -505,7 +509,7 @@
     "dv/dt = (1-v)/tau : 1 (unless refractory)\n",
     "'''\n",
     "\n",
-    "G = NeuronGroup(1, eqs, threshold='v>0.8', reset='v = 0', refractory=5*ms, method='linear')\n",
+    "G = NeuronGroup(1, eqs, threshold='v>0.8', reset='v = 0', refractory=5*ms, method='exact')\n",
     "\n",
     "statemon = StateMonitor(G, 'v', record=0)\n",
     "spikemon = SpikeMonitor(G)\n",
@@ -541,7 +545,7 @@
     "dv/dt = (1-v)/tau : 1\n",
     "'''\n",
     "\n",
-    "G = NeuronGroup(1, eqs, threshold='v>0.8', reset='v = 0', refractory=15*ms, method='linear')\n",
+    "G = NeuronGroup(1, eqs, threshold='v>0.8', reset='v = 0', refractory=15*ms, method='exact')\n",
     "\n",
     "statemon = StateMonitor(G, 'v', record=0)\n",
     "spikemon = SpikeMonitor(G)\n",
@@ -592,7 +596,7 @@
     "dv/dt = (2-v)/tau : 1\n",
     "'''\n",
     "\n",
-    "G = NeuronGroup(N, eqs, threshold='v>1', reset='v=0', method='linear')\n",
+    "G = NeuronGroup(N, eqs, threshold='v>1', reset='v=0', method='exact')\n",
     "G.v = 'rand()'\n",
     "\n",
     "spikemon = SpikeMonitor(G)\n",
@@ -643,7 +647,7 @@
     "v0 : 1\n",
     "'''\n",
     "\n",
-    "G = NeuronGroup(N, eqs, threshold='v>1', reset='v=0', refractory=5*ms, method='linear')\n",
+    "G = NeuronGroup(N, eqs, threshold='v>1', reset='v=0', refractory=5*ms, method='exact')\n",
     "M = SpikeMonitor(G)\n",
     "\n",
     "G.v0 = 'i*v0_max/(N-1)'\n",
@@ -684,7 +688,7 @@
     "## Stochastic neurons\n",
     "\n",
     "Often when making models of neurons, we include a random element to model the effect of various forms of neural noise. In Brian, we can do this by using the symbol ``xi`` in differential equations. Strictly speaking, this symbol is a \"stochastic differential\" but you can sort of thinking of it as just a Gaussian random variable with mean 0 and standard deviation 1. We do have to take into account the way stochastic differentials scale with time, which is why we multiply it by ``tau**-0.5`` in the equations below (see a textbook on stochastic differential equations for more details).\n",
-    "Note that we also changed the ``method`` keyword argument to use ``'euler'`` (which stands for the [Euler-Maruyama method](https://en.wikipedia.org/wiki/Euler%E2%80%93Maruyama_method)); the ``'linear'`` method that we used earlier is not applicable to stochastic differential equations."
+    "Note that we also changed the ``method`` keyword argument to use ``'euler'`` (which stands for the [Euler-Maruyama method](https://en.wikipedia.org/wiki/Euler%E2%80%93Maruyama_method)); the ``'exact'`` method that we used earlier is not applicable to stochastic differential equations."
    ]
   },
   {
@@ -806,7 +810,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython2",
-   "version": "2.7.12"
+   "version": "2.7.3"
   }
  },
  "nbformat": 4,

--- a/tutorials/2-intro-to-brian-synapses.ipynb
+++ b/tutorials/2-intro-to-brian-synapses.ipynb
@@ -46,9 +46,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "start_scope()\n",
@@ -58,7 +56,7 @@
     "I : 1\n",
     "tau : second\n",
     "'''\n",
-    "G = NeuronGroup(2, eqs, threshold='v>1', reset='v = 0', method='linear')\n",
+    "G = NeuronGroup(2, eqs, threshold='v>1', reset='v = 0', method='exact')\n",
     "G.I = [2, 0]\n",
     "G.tau = [10, 100]*ms\n",
     "\n",
@@ -105,9 +103,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "start_scope()\n",
@@ -117,7 +113,7 @@
     "I : 1\n",
     "tau : second\n",
     "'''\n",
-    "G = NeuronGroup(3, eqs, threshold='v>1', reset='v = 0', method='linear')\n",
+    "G = NeuronGroup(3, eqs, threshold='v>1', reset='v = 0', method='exact')\n",
     "G.I = [2, 0, 0]\n",
     "G.tau = [10, 100, 100]*ms\n",
     "\n",
@@ -160,9 +156,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "start_scope()\n",
@@ -172,7 +166,7 @@
     "I : 1\n",
     "tau : second\n",
     "'''\n",
-    "G = NeuronGroup(3, eqs, threshold='v>1', reset='v = 0', method='linear')\n",
+    "G = NeuronGroup(3, eqs, threshold='v>1', reset='v = 0', method='exact')\n",
     "G.I = [2, 0, 0]\n",
     "G.tau = [10, 100, 100]*ms\n",
     "\n",
@@ -240,9 +234,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "def visualise_connectivity(S):\n",
@@ -280,9 +272,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "start_scope()\n",
@@ -307,9 +297,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "start_scope()\n",
@@ -341,9 +329,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "start_scope()\n",
@@ -368,9 +354,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "start_scope()\n",
@@ -395,9 +379,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "start_scope()\n",
@@ -448,9 +430,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "tau_pre = tau_post = 20*ms\n",
@@ -546,9 +526,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "start_scope()\n",
@@ -607,9 +585,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "start_scope()\n",

--- a/tutorials/3-intro-to-brian-simulations.ipynb
+++ b/tutorials/3-intro-to-brian-simulations.ipynb
@@ -37,9 +37,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# remember, this is here for running separate simulations in the same notebook\n",
@@ -59,7 +57,7 @@
     "    eqs = '''\n",
     "    dv/dt = -v/tau : 1\n",
     "    '''\n",
-    "    G = NeuronGroup(1, eqs, threshold='v>1', reset='v=0', method='linear')\n",
+    "    G = NeuronGroup(1, eqs, threshold='v>1', reset='v=0', method='exact')\n",
     "    S = Synapses(P, G, on_pre='v += weight')\n",
     "    S.connect()\n",
     "    M = SpikeMonitor(G)\n",
@@ -82,9 +80,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "start_scope() \n",
@@ -98,7 +94,7 @@
     "eqs = '''\n",
     "dv/dt = -v/tau : 1\n",
     "'''\n",
-    "G = NeuronGroup(1, eqs, threshold='v>1', reset='v=0', method='linear')\n",
+    "G = NeuronGroup(1, eqs, threshold='v>1', reset='v=0', method='exact')\n",
     "S = Synapses(P, G, on_pre='v += weight')\n",
     "S.connect()\n",
     "M = SpikeMonitor(G)\n",
@@ -127,9 +123,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "start_scope() \n",
@@ -154,7 +148,7 @@
     "eqs = '''\n",
     "dv/dt = -v/tau : 1\n",
     "'''\n",
-    "G = NeuronGroup(1, eqs, threshold='v>1', reset='v=0', method='linear')\n",
+    "G = NeuronGroup(1, eqs, threshold='v>1', reset='v=0', method='exact')\n",
     "S = Synapses(SGG, G, on_pre='v += weight')\n",
     "S.connect()\n",
     "M = SpikeMonitor(G)\n",
@@ -186,9 +180,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "start_scope() \n",
@@ -204,7 +196,7 @@
     "tau : second\n",
     "'''\n",
     "# And we have num_tau output neurons, each with a different tau\n",
-    "G = NeuronGroup(num_tau, eqs, threshold='v>1', reset='v=0', method='linear')\n",
+    "G = NeuronGroup(num_tau, eqs, threshold='v>1', reset='v=0', method='exact')\n",
     "G.tau = tau_range\n",
     "S = Synapses(P, G, on_pre='v += weight')\n",
     "S.connect()\n",
@@ -229,19 +221,17 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "trains = M.spike_trains()\n",
     "isi_mu = full(num_tau, nan)*second\n",
     "isi_std = full(num_tau, nan)*second\n",
-    "for i in range(num_tau):\n",
-    "    train = diff(trains[i])\n",
+    "for idx in range(num_tau):\n",
+    "    train = diff(trains[idx])\n",
     "    if len(train)>1:\n",
-    "        isi_mu[i] = mean(train)\n",
-    "        isi_std[i] = std(train)\n",
+    "        isi_mu[idx] = mean(train)\n",
+    "        isi_std[idx] = std(train)\n",
     "errorbar(tau_range/ms, isi_mu/ms, yerr=isi_std/ms)\n",
     "xlabel(r'$\\tau$ (ms)')\n",
     "ylabel('Interspike interval (ms)');"
@@ -261,9 +251,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "start_scope()\n",
@@ -296,10 +284,10 @@
     "statemon = StateMonitor(group, 'v', record=True)\n",
     "spikemon = SpikeMonitor(group, variables='v')\n",
     "figure(figsize=(9, 4))\n",
-    "for i in range(5):\n",
+    "for l in range(5):\n",
     "    group.I = rand()*50*nA\n",
     "    run(10*ms)\n",
-    "    axvline(i*10, ls='--', c='k')\n",
+    "    axvline(l*10, ls='--', c='k')\n",
     "axhline(El/mV, ls='-', c='lightgray', lw=3)\n",
     "plot(statemon.t/ms, statemon.v[0]/mV, '-b')\n",
     "plot(spikemon.t/ms, spikemon.v/mV, 'ob')\n",
@@ -317,9 +305,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "start_scope()\n",
@@ -335,8 +321,8 @@
     "run(50*ms)\n",
     "figure(figsize=(9, 4))\n",
     "# we keep the loop just to draw the vertical lines\n",
-    "for i in range(5):\n",
-    "    axvline(i*10, ls='--', c='k')\n",
+    "for l in range(5):\n",
+    "    axvline(l*10, ls='--', c='k')\n",
     "axhline(El/mV, ls='-', c='lightgray', lw=3)\n",
     "plot(statemon.t/ms, statemon.v[0]/mV, '-b')\n",
     "plot(spikemon.t/ms, spikemon.v/mV, 'ob')\n",
@@ -354,9 +340,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "start_scope()\n",
@@ -373,8 +357,8 @@
     "    group.I = rand()*50*nA\n",
     "run(50*ms)\n",
     "figure(figsize=(9, 4))\n",
-    "for i in range(5):\n",
-    "    axvline(i*10, ls='--', c='k')\n",
+    "for l in range(5):\n",
+    "    axvline(l*10, ls='--', c='k')\n",
     "axhline(El/mV, ls='-', c='lightgray', lw=3)\n",
     "plot(statemon.t/ms, statemon.v[0]/mV, '-b')\n",
     "plot(spikemon.t/ms, spikemon.v/mV, 'ob')\n",
@@ -392,9 +376,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "start_scope()\n",
@@ -422,8 +404,8 @@
     "group.run_regularly('I = rand()*50*nA', dt=10*ms)\n",
     "run(50*ms)\n",
     "figure(figsize=(9, 4))\n",
-    "for i in range(5):\n",
-    "    axvline(i*10, ls='--', c='k')\n",
+    "for l in range(5):\n",
+    "    axvline(l*10, ls='--', c='k')\n",
     "axhline(El/mV, ls='-', c='lightgray', lw=3)\n",
     "plot(statemon.t/ms, statemon.v.T/mV, '-')\n",
     "xlabel('Time (ms)')\n",
@@ -440,9 +422,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "plot(statemon.t/ms, statemon.I.T/nA, '-')\n",
@@ -460,9 +440,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "start_scope()\n",
@@ -488,8 +466,8 @@
     "group.run_regularly('I = rand()*50*nA', dt=10*ms)\n",
     "run(50*ms)\n",
     "figure(figsize=(9, 4))\n",
-    "for i in range(5):\n",
-    "    axvline(i*10, ls='--', c='k')\n",
+    "for l in range(5):\n",
+    "    axvline(l*10, ls='--', c='k')\n",
     "axhline(El/mV, ls='-', c='lightgray', lw=3)\n",
     "plot(statemon.t/ms, statemon.v.T/mV, '-')\n",
     "xlabel('Time (ms)')\n",
@@ -510,9 +488,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "start_scope()\n",
@@ -543,9 +519,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "start_scope()\n",
@@ -559,7 +533,7 @@
     "dv/dt = (I-v)/tau : 1\n",
     "I = I_recorded(t) : 1\n",
     "'''\n",
-    "G = NeuronGroup(1, eqs, threshold='v>1', reset='v=0', method='linear')\n",
+    "G = NeuronGroup(1, eqs, threshold='v>1', reset='v=0', method='exact')\n",
     "M = StateMonitor(G, variables=True, record=True)\n",
     "run(200*ms)\n",
     "plot(M.t/ms, M.v[0], label='v')\n",
@@ -573,7 +547,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Note that for the example where we put the ``sin`` function directly in the equations, we had to use the ``method='euler'`` argument because the linear integrator wouldn't work here (try it!). However, ``TimedArray`` is considered to be constant over its time step and so the linear integrator can be used. This means you won't get the same behaviour from these two methods for two reasons. Firstly, the numerical integration methods ``linear`` and ``euler`` give slightly different results. Secondly, ``sin`` is not constant over a timestep whereas ``TimedArray`` is.\n",
+    "Note that for the example where we put the ``sin`` function directly in the equations, we had to use the ``method='euler'`` argument because the exact integrator wouldn't work here (try it!). However, ``TimedArray`` is considered to be constant over its time step and so the linear integrator can be used. This means you won't get the same behaviour from these two methods for two reasons. Firstly, the numerical integration methods ``exact`` and ``euler`` give slightly different results. Secondly, ``sin`` is not constant over a timestep whereas ``TimedArray`` is.\n",
     "\n",
     "Now just to show that ``TimedArray`` works for arbitrary currents, let's make a weird \"recorded\" current and run it on that."
    ]
@@ -581,9 +555,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "start_scope()\n",
@@ -602,7 +574,7 @@
     "dv/dt = (I-v)/tau : 1\n",
     "I = I_recorded(t) : 1\n",
     "'''\n",
-    "G = NeuronGroup(1, eqs, threshold='v>1', reset='v=0', method='linear')\n",
+    "G = NeuronGroup(1, eqs, threshold='v>1', reset='v=0', method='exact')\n",
     "M = StateMonitor(G, variables=True, record=True)\n",
     "run(200*ms)\n",
     "plot(M.t/ms, M.v[0], label='v')\n",
@@ -622,9 +594,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "start_scope()\n",
@@ -651,7 +621,7 @@
  "metadata": {
   "hide_input": false,
   "kernelspec": {
-   "display_name": "Python [default]",
+   "display_name": "Python 2",
    "language": "python",
    "name": "python2"
   },
@@ -665,7 +635,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython2",
-   "version": "2.7.13"
+   "version": "2.7.3"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This branch:
* renames the `'linear'` state updater to `'exact'` (#877), but still accepts `'linear'`, without raising a warning (I think we should keep the annoyance to a minimum for such a "cosmetic" change)
* deprecates the `'independent'` state updater (#878), its use now raises a warning (note that the state updater gets never chosen automatically, so that should only affect users that chose it manually -- if there are any...)