### PR TITLE
[MRG] Re-add stateupdate caching

### DIFF
--- a/brian2/stateupdaters/base.py
+++ b/brian2/stateupdaters/base.py
@@ -137,8 +137,11 @@ class StateUpdateMethod(object):
         StateUpdateMethod.stateupdaters[name] = stateupdater
 
     @staticmethod
+    @cached
     def apply_stateupdater(equations, variables, method, method_options=None, group_name=None):
         '''
+        apply_stateupdater(equations, variables, method, method_options=None, group_name=None)
+
         Applies a given state updater to equations. If a `method` is given, the
         state updater with the given name is used or if is a callable, then it
         is used directly. If a `method` is a list of names, all the

--- a/brian2/utils/caching.py
+++ b/brian2/utils/caching.py
@@ -116,6 +116,9 @@ def _hashable(obj):
     elif isinstance(obj, collections.Mapping):
         return frozenset((_hashable(key), _hashable(value))
                          for key, value in obj.iteritems())
+    elif hasattr(obj, 'dim') and getattr(obj, 'shape', None) == ():
+        # Scalar Quantity object
+        return float(obj), obj.dim
     else:
         raise AssertionError('Do not know how to handle object of type '
                              '%s' % type(obj))

--- a/brian2/utils/caching.py
+++ b/brian2/utils/caching.py
@@ -82,9 +82,17 @@ def cached(func):
 
     @functools.wraps(func)
     def cached_func(*args, **kwds):
-        cache_key = tuple([_hashable(arg) for arg in args] +
-                          [(key, _hashable(value))
-                           for key, value in sorted(kwds.iteritems())])
+        try:
+            cache_key = tuple([_hashable(arg) for arg in args] +
+                              [(key, _hashable(value))
+                               for key, value in sorted(kwds.iteritems())])
+        except TypeError:
+            # If we cannot handle a type here, that most likely means that the
+            # user provided an argument of a type we don't handle. This will
+            # lead to an error message later that is most likely more meaningful
+            # to the user than an error message by the caching system
+            # complaining about an unsupported type.
+            return func(*args, **kwds)
         if cache_key in func._cache:
             func._cache_statistics.hits += 1
         else:
@@ -120,5 +128,5 @@ def _hashable(obj):
         # Scalar Quantity object
         return float(obj), obj.dim
     else:
-        raise AssertionError('Do not know how to handle object of type '
-                             '%s' % type(obj))
+        raise TypeError('Do not know how to handle object of type '
+                        '%s' % type(obj))


### PR DESCRIPTION
Gnarg, I just realized that a small but important line got lost when resolving the merge conflicts between the GSL branch and master: the results of the state update code generation were actually no longer cached ;-( This is particularly annoying as it had the most noticeable effect on the runtime improvements for repeated runs. I think it would therefore be good to do a "hotfix" release as soon as possible, hopefully not too many users already tested the performance and were disappointed :-/