### PR TITLE
[MRG] Fix bug in Equation's variable substitution mechanism

### DIFF
--- a/brian2/equations/codestrings.py
+++ b/brian2/equations/codestrings.py
@@ -30,8 +30,7 @@ class CodeString(collections.Hashable):
     '''
 
     def __init__(self, code):
-
-        self._code = code
+        self._code = code.strip()
 
         # : Set of identifiers in the code string
         self.identifiers = get_identifiers(code)
@@ -181,6 +180,17 @@ class Expression(CodeString):
             raise AssertionError('Cyclical call of CodeString._repr_pretty')
         # Make use of sympy's pretty printing
         p.pretty(str_to_sympy(self.code))
+
+    def __eq__(self, other):
+        if not isinstance(other, Expression):
+            return NotImplemented
+        return self.code == other.code
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
+    def __hash__(self):
+        return hash(self.code)
 
 
 def is_constant_over_dt(expression, variables, dt_value):

--- a/brian2/equations/equations.py
+++ b/brian2/equations/equations.py
@@ -626,7 +626,7 @@ class Equations(collections.Hashable, collections.Mapping):
                                               '(' + repr(replacement) + ')',
                                               new_code)
                         try:
-                            eq.expr = Expression(new_code)
+                            Expression(new_code)
                         except ValueError as ex:
                             raise ValueError(
                                 ('Replacing "%s" with "%r" failed: %s') %

--- a/brian2/tests/test_equations.py
+++ b/brian2/tests/test_equations.py
@@ -216,6 +216,22 @@ def test_wrong_replacements():
 
 
 @attr('codegen-independent')
+def test_substitute():
+    # Check that Equations.substitute returns an independent copy
+    eqs = Equations('dx/dt = x : 1')
+    eqs2 = eqs.substitute(x='y')
+
+    # First equation should be unaffected
+    assert len(eqs) == 1 and 'x' in eqs
+    assert eqs['x'].expr == Expression('x')
+
+    # Second equation should have x substituted by y
+    assert len(eqs2) == 1 and 'y' in eqs2
+    assert eqs2['y'].expr == Expression('y')
+
+
+
+@attr('codegen-independent')
 def test_construction_errors():
     '''
     Test that the Equations constructor raises errors correctly
@@ -433,6 +449,18 @@ def test_extract_subexpressions():
 
 
 @attr('codegen-independent')
+def test_repeated_construction():
+    eqs1 = Equations('dx/dt = x : 1')
+    eqs2 = Equations('dx/dt = x : 1', x='y')
+    assert len(eqs1) == 1
+    assert 'x' in eqs1
+    assert eqs1['x'].expr == Expression('x')
+    assert len(eqs2) == 1
+    assert 'y' in eqs2
+    assert eqs2['y'].expr == Expression('y')
+
+
+@attr('codegen-independent')
 def test_str_repr():
     '''
     Test the string representation (only that it does not throw errors).
@@ -471,10 +499,12 @@ if __name__ == '__main__':
     test_identifier_checks()
     test_parse_equations()
     test_correct_replacements()
+    test_substitute()
     test_wrong_replacements()
     test_construction_errors()
     test_concatenation()
     test_unit_checking()
     test_properties()
     test_extract_subexpressions()
+    test_repeated_construction()
     test_str_repr()

--- a/brian2/units/fundamentalunits.py
+++ b/brian2/units/fundamentalunits.py
@@ -479,6 +479,11 @@ class Dimension(object):
     def __setstate__(self, state):
         self._dims = state
 
+    ### Dimension objects are singletons and deepcopy is therefore not necessary
+    def __deepcopy__(self, memodict):
+        return self
+
+
 #: The singleton object for dimensionless Dimensions.
 DIMENSIONLESS = Dimension((0, 0, 0, 0, 0, 0, 0))
 

--- a/brian2/utils/caching.py
+++ b/brian2/utils/caching.py
@@ -3,7 +3,6 @@ Module to support caching of function results to memory (used to cache results
 of parsing, generation of state update code, etc.). Provides the `cached`
 decorator.
 '''
-import copy
 import functools
 import collections
 
@@ -98,7 +97,7 @@ def cached(func):
         else:
             func._cache_statistics.misses += 1
             func._cache[cache_key] = func(*args, **kwds)
-        return copy.deepcopy(func._cache[cache_key])
+        return func._cache[cache_key]
 
     return cached_func
 

--- a/brian2/utils/caching.py
+++ b/brian2/utils/caching.py
@@ -3,7 +3,7 @@ Module to support caching of function results to memory (used to cache results
 of parsing, generation of state update code, etc.). Provides the `cached`
 decorator.
 '''
-
+import copy
 import functools
 import collections
 
@@ -98,7 +98,7 @@ def cached(func):
         else:
             func._cache_statistics.misses += 1
             func._cache[cache_key] = func(*args, **kwds)
-        return func._cache[cache_key]
+        return copy.deepcopy(func._cache[cache_key])
 
     return cached_func
 

--- a/docs_sphinx/introduction/release_notes.rst
+++ b/docs_sphinx/introduction/release_notes.rst
@@ -1,6 +1,11 @@
 Release notes
 =============
 
+Brian 2.1.2
+-----------
+This is another bug fix release that fixes a major bug in `Equations`'
+substitution mechanism (#896). Thanks to Teo Stocco for reporting this issue.
+
 Brian 2.1.1
 -----------
 This is a bug fix release that re-activates parts of the caching mechanism for


### PR DESCRIPTION
Substituting variables in `Equations` should create a new `Equations` object and leave the original object completely untouched. In violation of this principle, the `Expression` object of the original `SingleEquation` object was replaced (without being used later, probably a left-over from some earlier cleaning up).

This PR fixes this issue (a tiny fix in one line) and adds two tests that failed before the fix (one is about using `Equations.substitute`, the other is triggered by the new caching mechanism). I also tried adding another safeguard to the caching mechanism (returning deep copies of the cached values instead of the values themselves), but it turned out that this itself is fragile (deep copies fail for some sympy objects on some versions) and I therefore removed it again.