### PR TITLE
Added a python script that uses `doc2dash` to build a `Dash.app`-compatible docset for Brian2

### DIFF
--- a/dev/tools/docs/build_dash_docset.py
+++ b/dev/tools/docs/build_dash_docset.py
@@ -1,0 +1,13 @@
+import brian2
+import sphinx
+import doc2dash
+import sys
+import os
+
+# - Build documentation with Sphinx
+os.chdir('../../../docs_sphinx')
+sphinx.main(['sphinx-build', '-b', 'html', '-d', '_build/doctrees', '.', '_build/html'])
+
+# - Run doc2dash on the built documentation
+os.system('doc2dash _build/html/ -n Brian2 -I index.html -d ..')
+


### PR DESCRIPTION
This script builds a nice docset from the Brian2 docs, which can be used in `Dash.app` or similar clones.