### PR TITLE
[MRG] Use `&` and `|` instead of `*` and `+` for logical operations in numpy

### DIFF
--- a/brian2/parsing/rendering.py
+++ b/brian2/parsing/rendering.py
@@ -145,17 +145,17 @@ class NodeRenderer(object):
         if len(node.comparators)>1:
             raise SyntaxError("Can only handle single comparisons like a<b not a<b<c")
         return self.render_BinOp_parentheses(node.left, node.comparators[0], node.ops[0])
-        
+
     def render_UnaryOp(self, node):
         return '%s %s' % (self.expression_ops[node.op.__class__.__name__],
                           self.render_element_parentheses(node.operand))
-                
+
     def render_Assign(self, node):
         if len(node.targets)>1:
             raise SyntaxError("Only support syntax like a=b not a=b=c")
         return '%s = %s' % (self.render_node(node.targets[0]),
                             self.render_node(node.value))
-        
+
     def render_AugAssign(self, node):
         target = node.target.id
         rhs = self.render_node(node.value)
@@ -163,14 +163,14 @@ class NodeRenderer(object):
         return '%s %s %s' % (target, op, rhs)
 
 
-class NumpyNodeRenderer(NodeRenderer):           
+class NumpyNodeRenderer(NodeRenderer):
     expression_ops = NodeRenderer.expression_ops.copy()
     expression_ops.update({
           # Unary ops
           # We'll handle "not" explicitly below
           # Bool ops
-          'And': '*',
-          'Or': '+',
+          'And': '&',
+          'Or': '|',
           })
 
     def render_UnaryOp(self, node):

--- a/brian2/tests/test_synapses.py
+++ b/brian2/tests/test_synapses.py
@@ -261,6 +261,18 @@ def test_connection_string_deterministic():
 
 @attr('standalone-compatible')
 @with_setup(teardown=reinit_devices)
+def test_connection_string_deterministic_multiple_and():
+    # In Brian versions 2.1.0-2.1.2, this fails on the numpy target
+    # See github issue 900
+    group = NeuronGroup(10, '')
+    synapses = Synapses(group, group)
+    synapses.connect('i>=5 and i<10 and j>=5')
+    run(0*ms)  # for standalone
+    assert len(synapses) == 25
+
+
+@attr('standalone-compatible')
+@with_setup(teardown=reinit_devices)
 def test_connection_random_with_condition():
     G = NeuronGroup(4, 'v: 1', threshold='False')
 
@@ -2355,6 +2367,7 @@ if __name__ == '__main__':
     test_name_clashes()
     test_incoming_outgoing()
     test_connection_string_deterministic()
+    test_connection_string_deterministic_multiple_and()
     test_connection_random_with_condition()
     test_connection_random_without_condition()
     test_connection_random_with_indices()


### PR DESCRIPTION
In numpy, we were using `*` and `+` to implement logical and/or. This works in general, but can become problematic when the result is used as an index because something like `[0, 0, 1]` is not equivalent to `[False, False, True]`. This could lead to incorrect creation of synapses (see #900).

Why this only manifested recently is unclear, but using arithmetic operators for boolean operations is quite fragile and simply changing the order can change the type:
```pycon
>>> True * False
0

>>> True * False * np.array([True, False])
array([0, 0])

>>> np.array([True, False]) * True * False
array([False, False], dtype=bool)
```