### PR TITLE
[MRG] Simplify SpatialNeuron

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -101,7 +101,9 @@ install:
   - 'python -c "import struct; print(struct.calcsize(''P'') * 8)"'
 
   # Install the build dependencies of the project via conda
-  - 'appveyor-retry conda install --yes --quiet numpy nose "sphinx<1.6.3" "sympy!=1.1.0" pyparsing jinja2 ipython setuptools cython "conda<4.4"'
+  - 'appveyor-retry conda install --yes --quiet numpy nose "sphinx<1.6.3" "sympy!=1.1.0" pyparsing jinja2 ipython setuptools cython "conda==4.3.21"'
+  # Pin conda version
+  - 'echo "conda ==4.3.21" >> %PYTHON%\conda-meta\pinned'
   # Install an older version of scipy (which still has weave) on Python 2
   - 'if "%PYTHON_VERSION:~0,1%" == "2" appveyor-retry conda install --yes --quiet -c brian-team weave scipy'
   - 'if "%PYTHON_VERSION:~0,1%" == "3" appveyor-retry conda install --yes --quiet scipy'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -103,7 +103,7 @@ install:
   # Install the build dependencies of the project via conda
   - 'appveyor-retry conda install --yes --quiet numpy nose "sphinx<1.6.3" "sympy!=1.1.0" pyparsing jinja2 ipython setuptools cython "conda==4.3.21"'
   # Pin conda version
-  - 'echo "conda ==4.3.21" >> %PYTHON%\conda-meta\pinned'
+  - 'echo conda ==4.3.21 >> %PYTHON%\conda-meta\pinned'
   # Install an older version of scipy (which still has weave) on Python 2
   - 'if "%PYTHON_VERSION:~0,1%" == "2" appveyor-retry conda install --yes --quiet -c brian-team weave scipy'
   - 'if "%PYTHON_VERSION:~0,1%" == "3" appveyor-retry conda install --yes --quiet scipy'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -101,7 +101,7 @@ install:
   - 'python -c "import struct; print(struct.calcsize(''P'') * 8)"'
 
   # Install the build dependencies of the project via conda
-  - 'appveyor-retry conda install --yes --quiet numpy nose "sphinx<1.6.3" "sympy!=1.1.0" pyparsing jinja2 ipython setuptools cython'
+  - 'appveyor-retry conda install --yes --quiet numpy nose "sphinx<1.6.3" "sympy!=1.1.0" pyparsing jinja2 ipython setuptools cython "conda<4.4"'
   # Install an older version of scipy (which still has weave) on Python 2
   - 'if "%PYTHON_VERSION:~0,1%" == "2" appveyor-retry conda install --yes --quiet -c brian-team weave scipy'
   - 'if "%PYTHON_VERSION:~0,1%" == "3" appveyor-retry conda install --yes --quiet scipy'

--- a/brian2/codegen/runtime/cython_rt/templates/spatialneuron_prepare.pyx
+++ b/brian2/codegen/runtime/cython_rt/templates/spatialneuron_prepare.pyx
@@ -3,8 +3,6 @@
 {% block maincode %}
     {# USES_VARIABLES { N, _invr, Ri, Cm, dt, area, r_length_1, r_length_2,
                         _ab_star0, _ab_star1, _ab_star2,
-                        _a_plus0, _a_plus1, _a_plus2,
-                        _a_minus0, _a_minus1, _a_minus2,
                         _starts, _ends, _invr0, _invrn, _b_plus, _b_minus } #}
     cdef int _i
     cdef int _counter
@@ -31,14 +29,6 @@
         {{_ab_star0}}[_i] = {{_invr}}[_i] / {{area}}[_i-1]
         {{_ab_star2}}[_i-1] = {{_invr}}[_i] / {{area}}[_i]
         {{_ab_star1}}[_i-1] -= {{_invr}}[_i] / {{area}}[_i-1]
-    for _i in range(N):
-        # Homogeneous solutions
-        {{_a_plus0}}[_i] = {{_ab_star0}}[_i]
-        {{_a_minus0}}[_i] = {{_ab_star0}}[_i]
-        {{_a_plus1}}[_i] = {{_ab_star1}}[_i]
-        {{_a_minus1}}[_i] = {{_ab_star1}}[_i]
-        {{_a_plus2}}[_i] = {{_ab_star2}}[_i]
-        {{_a_minus2}}[_i] = {{_ab_star2}}[_i]
 
     # Set the boundary conditions
     for _counter in range(_num{{_starts}}):
@@ -52,10 +42,6 @@
         # Correction for boundary conditions
         {{_ab_star1}}[_first] -= (__invr0 / {{area}}[_first])
         {{_ab_star1}}[_last] -= (__invrn / {{area}}[_last])
-        {{_a_plus1}}[_first] -= (__invr0 / {{area}}[_first])
-        {{_a_plus1}}[_last] -= (__invrn / {{area}}[_last])
-        {{_a_minus1}}[_first] -= (__invr0 / {{area}}[_first])
-        {{_a_minus1}}[_last] -= (__invrn / {{area}}[_last])
         # RHS for homogeneous solutions
         {{_b_plus}}[_last] = -(__invrn / {{area}}[_last])
         {{_b_minus}}[_first] = -(__invr0 / {{area}}[_first])

--- a/brian2/codegen/runtime/cython_rt/templates/spatialstateupdate.pyx
+++ b/brian2/codegen/runtime/cython_rt/templates/spatialstateupdate.pyx
@@ -1,7 +1,6 @@
 {# USES_VARIABLES { Cm, dt, v, N, Ic,
-                  _ab_star0, _ab_star1, _ab_star2, _b_plus,
-                  _a_plus0, _a_plus1, _a_plus2, _b_minus,
-                  _a_minus0, _a_minus1, _a_minus2, _v_star, _u_plus, _u_minus,
+                  _ab_star0, _ab_star1, _ab_star2, _b_plus, _b_minus,
+                  _v_star, _u_plus, _u_minus,
                   _v_previous,
                   _gtot_all, _I0_all,
                   _c1, _c2, _c3,
@@ -78,11 +77,11 @@
         # upper triangularization of tridiagonal system for _u_plus
         for _j in range(_j_start, _j_end):
             {{_u_plus}}[_j]={{_b_plus}}[_j] # RHS -> _u_plus (solution)
-            _bi={{_a_plus1}}[_j]-{{_gtot_all}}[_j] # main diagonal
+            _bi={{_ab_star1}}[_j]-{{_gtot_all}}[_j] # main diagonal
             if _j < N-1:
-                {{_c2}}[_j]={{_a_plus0}}[_j+1] # superdiagonal
+                {{_c2}}[_j]={{_ab_star0}}[_j+1] # superdiagonal
             if _j > 0:
-                _ai={{_a_plus2}}[_j-1] # subdiagonal
+                _ai={{_ab_star2}}[_j-1] # subdiagonal
                 _m=1.0/(_bi-_ai*{{_c2}}[_j-1])
                 {{_c2}}[_j]={{_c2}}[_j]*_m
                 {{_u_plus}}[_j]=({{_u_plus}}[_j] - _ai*{{_u_plus}}[_j-1])*_m
@@ -101,11 +100,11 @@
         # upper triangularization of tridiagonal system for _u_minus
         for _j in range(_j_start, _j_end):
             {{_u_minus}}[_j]={{_b_minus}}[_j] # RHS -> _u_minus (solution)
-            _bi={{_a_minus1}}[_j]-{{_gtot_all}}[_j] # main diagonal
+            _bi={{_ab_star1}}[_j]-{{_gtot_all}}[_j] # main diagonal
             if _j < N-1:
-                {{_c3}}[_j]={{_a_minus0}}[_j+1] # superdiagonal
+                {{_c3}}[_j]={{_ab_star0}}[_j+1] # superdiagonal
             if _j > 0:
-                _ai={{_a_minus2}}[_j-1] # subdiagonal
+                _ai={{_ab_star2}}[_j-1] # subdiagonal
                 _m=1.0/(_bi-_ai*{{_c3}}[_j-1])
                 {{_c3}}[_j]={{_c3}}[_j]*_m
                 {{_u_minus}}[_j]=({{_u_minus}}[_j] - _ai*{{_u_minus}}[_j-1])*_m

--- a/brian2/codegen/runtime/cython_rt/templates/spatialstateupdate.pyx
+++ b/brian2/codegen/runtime/cython_rt/templates/spatialstateupdate.pyx
@@ -3,7 +3,7 @@
                   _v_star, _u_plus, _u_minus,
                   _v_previous,
                   _gtot_all, _I0_all,
-                  _c1, _c2, _c3,
+                  _c,
                   _P_diag, _P_parent, _P_children,
                   _B, _morph_parent_i, _starts, _ends,
                   _morph_children, _morph_children_num, _morph_idxchild,
@@ -51,69 +51,31 @@
         _j_start = {{_starts}}[_i]
         _j_end = {{_ends}}[_i]
 
-        # upper triangularization of tridiagonal system for _v_star
+        # upper triangularization of tridiagonal system for _v_star, _u_plus, and _u_minus
         for _j in range(_j_start, _j_end):
             {{_v_star}}[_j]=-({{Cm}}[_j]/{{dt}}*{{v}}[_j])-{{_I0_all}}[_j] # RHS -> _v_star (solution)
-            _bi={{_ab_star1}}[_j]-{{_gtot_all}}[_j] # main diagonal
-            if _j < N-1:
-                {{_c1}}[_j]={{_ab_star0}}[_j+1] # superdiagonal
-            if _j > 0:
-                _ai={{_ab_star2}}[_j-1] # subdiagonal
-                _m=1.0/(_bi-_ai*{{_c1}}[_j-1])
-                {{_c1}}[_j]={{_c1}}[_j]*_m
-                {{_v_star}}[_j]=({{_v_star}}[_j] - _ai*{{_v_star}}[_j-1])*_m
-            else:
-                {{_c1}}[0]={{_c1}}[0]/_bi
-                {{_v_star}}[0]={{_v_star}}[0]/_bi
-        # backwards substitution of the upper triangularized system for _v_star
-        for _j in range(_j_end-2, _j_start-1, -1):
-            {{_v_star}}[_j]={{_v_star}}[_j] - {{_c1}}[_j]*{{_v_star}}[_j+1]
-
-    for _i in range(0, _num{{_B}} - 1):
-        # first and last index of the i-th section
-        _j_start = {{_starts}}[_i]
-        _j_end = {{_ends}}[_i]
-
-        # upper triangularization of tridiagonal system for _u_plus
-        for _j in range(_j_start, _j_end):
             {{_u_plus}}[_j]={{_b_plus}}[_j] # RHS -> _u_plus (solution)
-            _bi={{_ab_star1}}[_j]-{{_gtot_all}}[_j] # main diagonal
-            if _j < N-1:
-                {{_c2}}[_j]={{_ab_star0}}[_j+1] # superdiagonal
-            if _j > 0:
-                _ai={{_ab_star2}}[_j-1] # subdiagonal
-                _m=1.0/(_bi-_ai*{{_c2}}[_j-1])
-                {{_c2}}[_j]={{_c2}}[_j]*_m
-                {{_u_plus}}[_j]=({{_u_plus}}[_j] - _ai*{{_u_plus}}[_j-1])*_m
-            else:
-                {{_c2}}[0]={{_c2}}[0]/_bi
-                {{_u_plus}}[0]={{_u_plus}}[0]/_bi
-        # backwards substitution of the upper triangularized system for _u_plus
-        for _j in range(_j_end-2, _j_start-1, -1):
-            {{_u_plus}}[_j]={{_u_plus}}[_j] - {{_c2}}[_j]*{{_u_plus}}[_j+1]
-
-    for _i in range(0, _num{{_B}} - 1):
-        # first and last index of the i-th section
-        _j_start = {{_starts}}[_i]
-        _j_end = {{_ends}}[_i]
-
-        # upper triangularization of tridiagonal system for _u_minus
-        for _j in range(_j_start, _j_end):
             {{_u_minus}}[_j]={{_b_minus}}[_j] # RHS -> _u_minus (solution)
             _bi={{_ab_star1}}[_j]-{{_gtot_all}}[_j] # main diagonal
             if _j < N-1:
-                {{_c3}}[_j]={{_ab_star0}}[_j+1] # superdiagonal
+                {{_c}}[_j]={{_ab_star0}}[_j+1] # superdiagonal
             if _j > 0:
                 _ai={{_ab_star2}}[_j-1] # subdiagonal
-                _m=1.0/(_bi-_ai*{{_c3}}[_j-1])
-                {{_c3}}[_j]={{_c3}}[_j]*_m
+                _m=1.0/(_bi-_ai*{{_c}}[_j-1])
+                {{_c}}[_j]={{_c}}[_j]*_m
+                {{_v_star}}[_j]=({{_v_star}}[_j] - _ai*{{_v_star}}[_j-1])*_m
+                {{_u_plus}}[_j]=({{_u_plus}}[_j] - _ai*{{_u_plus}}[_j-1])*_m
                 {{_u_minus}}[_j]=({{_u_minus}}[_j] - _ai*{{_u_minus}}[_j-1])*_m
             else:
-                {{_c3}}[0]={{_c3}}[0]/_bi
+                {{_c}}[0]={{_c}}[0]/_bi
+                {{_v_star}}[0]={{_v_star}}[0]/_bi
+                {{_u_plus}}[0]={{_u_plus}}[0]/_bi
                 {{_u_minus}}[0]={{_u_minus}}[0]/_bi
-        # backwards substitution of the upper triangularized system for _u_minus
+        # backwards substitution of the upper triangularized system for _v_star
         for _j in range(_j_end-2, _j_start-1, -1):
-            {{_u_minus}}[_j]={{_u_minus}}[_j] - {{_c3}}[_j]*{{_u_minus}}[_j+1]
+            {{_v_star}}[_j]={{_v_star}}[_j] - {{_c}}[_j]*{{_v_star}}[_j+1]
+            {{_u_plus}}[_j]={{_u_plus}}[_j] - {{_c}}[_j]*{{_u_plus}}[_j+1]
+            {{_u_minus}}[_j]={{_u_minus}}[_j] - {{_c}}[_j]*{{_u_minus}}[_j+1]
 
     # STEP 3: solve the coupling system
 

--- a/brian2/codegen/runtime/numpy_rt/templates/spatialneuron_prepare.py_
+++ b/brian2/codegen/runtime/numpy_rt/templates/spatialneuron_prepare.py_
@@ -1,7 +1,5 @@
 {# USES_VARIABLES { _invr, Ri, Cm, dt, area, r_length_1, r_length_2,
                     _ab_star0, _ab_star1, _ab_star2,
-                    _a_plus0, _a_plus1, _a_plus2,
-                    _a_minus0, _a_minus1, _a_minus2,
                     _starts, _ends, _invr0, _invrn, _b_plus, _b_minus } #}
 import numpy as _numpy
 from numpy import pi
@@ -20,13 +18,6 @@ for _first in {{_starts}}:
 {{_ab_star2}}[:-1] = {{_invr}}[1:] / {{area}}[1:]
 {{_ab_star1}}[:] = (-({{Cm}} / {{dt}}) - {{_invr}} / {{area}})
 {{_ab_star1}}[:-1] -= {{_invr}}[1:] / {{area}}[:-1]
-# Homogeneous solutions
-{{_a_plus0}}[:] = {{_ab_star0}}
-{{_a_minus0}}[:] = {{_ab_star0}}
-{{_a_plus1}}[:] = {{_ab_star1}}
-{{_a_minus1}}[:] = {{_ab_star1}}
-{{_a_plus2}}[:] = {{_ab_star2}}
-{{_a_minus2}}[:] = {{_ab_star2}}
 
 # Set the boundary conditions
 for _counter, (_first, _last) in enumerate(zip({{_starts}},
@@ -38,10 +29,6 @@ for _counter, (_first, _last) in enumerate(zip({{_starts}},
     # Correction for boundary conditions
     {{_ab_star1}}[_first] -= (_invr0 / {{area}}[_first])
     {{_ab_star1}}[_last] -= (_invrn / {{area}}[_last])
-    {{_a_plus1}}[_first] -= (_invr0 / {{area}}[_first])
-    {{_a_plus1}}[_last] -= (_invrn / {{area}}[_last])
-    {{_a_minus1}}[_first] -= (_invr0 / {{area}}[_first])
-    {{_a_minus1}}[_last] -= (_invrn / {{area}}[_last])
     # RHS for homogeneous solutions
     {{_b_plus}}[_last] = -(_invrn / {{area}}[_last])
     {{_b_minus}}[_first] = -(_invr0 / {{area}}[_first])

--- a/brian2/codegen/runtime/numpy_rt/templates/spatialstateupdate.py_
+++ b/brian2/codegen/runtime/numpy_rt/templates/spatialstateupdate.py_
@@ -3,7 +3,7 @@
                   _v_star, _u_plus, _u_minus,
                   _v_previous,
                   _gtot_all, _I0_all, v
-                  _c1, _c2, _c3,
+                  _c,
                   _P_diag, _P_parent, _P_children,
                   _B, _morph_parent_i, _starts, _ends,
                   _morph_children, _morph_children_num, _morph_idxchild,
@@ -34,22 +34,19 @@ from scipy.linalg import solve_banded
 _b=-({{Cm}}/{{dt}}*{{v}})-_I0
 _ab = zeros((3,N))
 _ab[0,:] = {{_ab_star0}}
-_ab[1,:] = {{_ab_star1}}
+_ab[1,:] = {{_ab_star1}} - _gtot
 _ab[2,:] = {{_ab_star2}}
-_ab[1,:] -= _gtot
 {{_v_star}}[:] = solve_banded((1,1),_ab,_b,overwrite_ab=True,overwrite_b=True)
 # Homogeneous solutions
 _b[:] = {{_b_plus}}
 _ab[0,:] = {{_ab_star0}}
-_ab[1,:] = {{_ab_star1}}
+_ab[1,:] = {{_ab_star1}} - _gtot
 _ab[2,:] = {{_ab_star2}}
-_ab[1,:] -= _gtot
 {{_u_plus}}[:] = solve_banded((1,1),_ab,_b,overwrite_ab=True,overwrite_b=True)
 _b[:] = {{_b_minus}}
 _ab[0,:] = {{_ab_star0}}
-_ab[1,:] = {{_ab_star1}}
+_ab[1,:] = {{_ab_star1}} - _gtot
 _ab[2,:] = {{_ab_star2}}
-_ab[1,:] -= _gtot
 {{_u_minus}}[:] = solve_banded((1,1),_ab,_b,overwrite_ab=True,overwrite_b=True)
 {% else %}
 # Pure numpy solution, very slow because it needs forward and backward passes
@@ -59,62 +56,30 @@ _b = -({{Cm}} / {{dt}}*{{v}}) - _I0
 # Tridiagonal solving
 _forward = range(1, N)
 _backward = range(N-2, -1, -1)
-_c = zeros(N)
 
-# Pass 1
 _bi = {{_ab_star1}} - _gtot  # main diagonal
 
 # First compartment
-_c[0] = {{_ab_star0}}[1] / _bi[0]
+{{_c}}[0] = {{_ab_star0}}[1] / _bi[0]
 {{_v_star}}[0] = _b[0] / _bi[0]
-
-# Other compartments
-_c[1:-1] = {{_ab_star0}}[2:]
-for _i in _forward:
-    _ai = {{_ab_star2}}[_i-1]  # subdiagonal
-    _m = 1.0/(_bi[_i]-_ai*_c[_i-1])
-    _c[_i] *= _m
-    {{_v_star}}[_i] = (_b[_i] - _ai*{{_v_star}}[_i-1])*_m
-
-for _i in _backward:
-    {{_v_star}}[_i] -= _c[_i]*{{_v_star}}[_i+1]
-
-# Pass 2
-_bi = {{_ab_star1}} - _gtot  # main diagonal
-
-# First compartment
-_c[0] = {{_ab_star0}}[1]/_bi[0]
 {{_u_plus}}[0] = {{_b_plus}}[0]/_bi[0]
-
-# Other compartments
-_c[1:-1] = {{_ab_star0}}[2:]  # superdiagonal
-
-for _i in _forward:
-    _ai = {{_ab_star2}}[_i-1]  # subdiagonal
-    _m = 1.0/(_bi[_i]-_ai*_c[_i-1])
-    _c[_i] *= _m
-    {{_u_plus}}[_i] = ({{_b_plus}}[_i] - _ai*{{_u_plus}}[_i-1])*_m
-
-for _i in _backward:
-    {{_u_plus}}[_i] -= _c[_i]*{{_u_plus}}[_i+1]
-
-# Pass 3
-_bi = {{_ab_star1}} - _gtot  # main diagonal
-
-# First compartment
-_c[0] = {{_ab_star0}}[1]/_bi[0]
 {{_u_minus}}[0] = {{_b_minus}}[0]/_bi[0]
 
 # Other compartments
-_c[1:-1] = {{_ab_star0}}[2:]  # superdiagonal
+{{_c}}[1:-1] = {{_ab_star0}}[2:]
 for _i in _forward:
     _ai = {{_ab_star2}}[_i-1]  # subdiagonal
-    _m = 1.0/(_bi[_i]-_ai*_c[_i-1]);
-    _c[_i] *= _m
+    _m = 1.0/(_bi[_i]-_ai*{{_c}}[_i-1])
+    {{_c}}[_i] *= _m
+    {{_v_star}}[_i] = (_b[_i] - _ai*{{_v_star}}[_i-1])*_m
+    {{_u_plus}}[_i] = ({{_b_plus}}[_i] - _ai*{{_u_plus}}[_i-1])*_m
     {{_u_minus}}[_i] = ({{_b_minus}}[_i] - _ai*{{_u_minus}}[_i-1])*_m
 
 for _i in _backward:
-    {{_u_minus}}[_i] -= _c[_i]*{{_u_minus}}[_i+1]
+    {{_v_star}}[_i] -= {{_c}}[_i]*{{_v_star}}[_i+1]
+    {{_u_plus}}[_i] -= {{_c}}[_i]*{{_u_plus}}[_i+1]
+    {{_u_minus}}[_i] -= {{_c}}[_i]*{{_u_minus}}[_i+1]
+
 {% endif %}
 
 # indexing for _P_children which contains the elements above the diagonal of the coupling matrix _P

--- a/brian2/codegen/runtime/numpy_rt/templates/spatialstateupdate.py_
+++ b/brian2/codegen/runtime/numpy_rt/templates/spatialstateupdate.py_
@@ -1,7 +1,6 @@
 {# USES_VARIABLES { Cm, dt, v, N, Ic,
-                  _ab_star0, _ab_star1, _ab_star2, _b_plus,
-                  _a_plus0, _a_plus1, _a_plus2, _b_minus,
-                  _a_minus0, _a_minus1, _a_minus2, _v_star, _u_plus, _u_minus,
+                  _ab_star0, _ab_star1, _ab_star2, _b_plus, _b_minus,
+                  _v_star, _u_plus, _u_minus,
                   _v_previous,
                   _gtot_all, _I0_all, v
                   _c1, _c2, _c3,
@@ -41,15 +40,15 @@ _ab[1,:] -= _gtot
 {{_v_star}}[:] = solve_banded((1,1),_ab,_b,overwrite_ab=True,overwrite_b=True)
 # Homogeneous solutions
 _b[:] = {{_b_plus}}
-_ab[0,:] = {{_a_plus0}}
-_ab[1,:] = {{_a_plus1}}
-_ab[2,:] = {{_a_plus2}}
+_ab[0,:] = {{_ab_star0}}
+_ab[1,:] = {{_ab_star1}}
+_ab[2,:] = {{_ab_star2}}
 _ab[1,:] -= _gtot
 {{_u_plus}}[:] = solve_banded((1,1),_ab,_b,overwrite_ab=True,overwrite_b=True)
 _b[:] = {{_b_minus}}
-_ab[0,:] = {{_a_minus0}}
-_ab[1,:] = {{_a_minus1}}
-_ab[2,:] = {{_a_minus2}}
+_ab[0,:] = {{_ab_star0}}
+_ab[1,:] = {{_ab_star1}}
+_ab[2,:] = {{_ab_star2}}
 _ab[1,:] -= _gtot
 {{_u_minus}}[:] = solve_banded((1,1),_ab,_b,overwrite_ab=True,overwrite_b=True)
 {% else %}
@@ -81,17 +80,17 @@ for _i in _backward:
     {{_v_star}}[_i] -= _c[_i]*{{_v_star}}[_i+1]
 
 # Pass 2
-_bi = {{_a_plus1}} - _gtot  # main diagonal
+_bi = {{_ab_star1}} - _gtot  # main diagonal
 
 # First compartment
-_c[0] = {{_a_plus0}}[1]/_bi[0]
+_c[0] = {{_ab_star0}}[1]/_bi[0]
 {{_u_plus}}[0] = {{_b_plus}}[0]/_bi[0]
 
 # Other compartments
-_c[1:-1] = {{_a_plus0}}[2:]  # superdiagonal
+_c[1:-1] = {{_ab_star0}}[2:]  # superdiagonal
 
 for _i in _forward:
-    _ai = {{_a_plus2}}[_i-1]  # subdiagonal
+    _ai = {{_ab_star2}}[_i-1]  # subdiagonal
     _m = 1.0/(_bi[_i]-_ai*_c[_i-1])
     _c[_i] *= _m
     {{_u_plus}}[_i] = ({{_b_plus}}[_i] - _ai*{{_u_plus}}[_i-1])*_m
@@ -100,16 +99,16 @@ for _i in _backward:
     {{_u_plus}}[_i] -= _c[_i]*{{_u_plus}}[_i+1]
 
 # Pass 3
-_bi = {{_a_minus1}} - _gtot  # main diagonal
+_bi = {{_ab_star1}} - _gtot  # main diagonal
 
 # First compartment
-_c[0] = {{_a_minus0}}[1]/_bi[0]
+_c[0] = {{_ab_star0}}[1]/_bi[0]
 {{_u_minus}}[0] = {{_b_minus}}[0]/_bi[0]
 
 # Other compartments
-_c[1:-1] = {{_a_minus0}}[2:]  # superdiagonal
+_c[1:-1] = {{_ab_star0}}[2:]  # superdiagonal
 for _i in _forward:
-    _ai = {{_a_minus2}}[_i-1]  # subdiagonal
+    _ai = {{_ab_star2}}[_i-1]  # subdiagonal
     _m = 1.0/(_bi[_i]-_ai*_c[_i-1]);
     _c[_i] *= _m
     {{_u_minus}}[_i] = ({{_b_minus}}[_i] - _ai*{{_u_minus}}[_i-1])*_m

--- a/brian2/codegen/runtime/weave_rt/templates/spatialneuron_prepare.cpp
+++ b/brian2/codegen/runtime/weave_rt/templates/spatialneuron_prepare.cpp
@@ -1,7 +1,5 @@
 {# USES_VARIABLES { N, _invr, Ri, Cm, dt, area, r_length_1, r_length_2,
                     _ab_star0, _ab_star1, _ab_star2,
-                    _a_plus0, _a_plus1, _a_plus2,
-                    _a_minus0, _a_minus1, _a_minus2,
                     _starts, _ends, _invr0, _invrn, _b_plus, _b_minus } #}
 {% import 'common_macros.cpp' as common with context %}
 {% macro main() %}
@@ -26,16 +24,6 @@
         {{_ab_star2}}[_i-1] = {{_invr}}[_i] / {{area}}[_i];
         {{_ab_star1}}[_i-1] -= {{_invr}}[_i] / {{area}}[_i-1];
     }
-    for (int _i=0; _i<N; _i++)
-    {
-        // Homogeneous solutions
-        {{_a_plus0}}[_i] = {{_ab_star0}}[_i];
-        {{_a_minus0}}[_i] = {{_ab_star0}}[_i];
-        {{_a_plus1}}[_i] = {{_ab_star1}}[_i];
-        {{_a_minus1}}[_i] = {{_ab_star1}}[_i];
-        {{_a_plus2}}[_i] = {{_ab_star2}}[_i];
-        {{_a_minus2}}[_i] = {{_ab_star2}}[_i];
-    }
 
     // Set the boundary conditions
     for (int _counter=0; _counter<_num_starts; _counter++)
@@ -50,10 +38,6 @@
         // Correction for boundary conditions
         {{_ab_star1}}[_first] -= (_invr0 / {{area}}[_first]);
         {{_ab_star1}}[_last] -= (_invrn / {{area}}[_last]);
-        {{_a_plus1}}[_first] -= (_invr0 / {{area}}[_first]);
-        {{_a_plus1}}[_last] -= (_invrn / {{area}}[_last]);
-        {{_a_minus1}}[_first] -= (_invr0 / {{area}}[_first]);
-        {{_a_minus1}}[_last] -= (_invrn / {{area}}[_last]);
         // RHS for homogeneous solutions
         {{_b_plus}}[_last] = -(_invrn / {{area}}[_last]);
         {{_b_minus}}[_first] = -(_invr0 / {{area}}[_first]);

--- a/brian2/codegen/runtime/weave_rt/templates/spatialstateupdate.cpp
+++ b/brian2/codegen/runtime/weave_rt/templates/spatialstateupdate.cpp
@@ -5,7 +5,7 @@
                   _v_star, _u_plus, _u_minus,
                   _v_previous,
                   _gtot_all, _I0_all,
-                  _c1, _c2, _c3,
+                  _c,
                   _P_diag, _P_parent, _P_children,
                   _B, _morph_parent_i, _starts, _ends,
                   _morph_children, _morph_children_num, _morph_idxchild,
@@ -34,7 +34,6 @@
 
     // STEP 2: for each section: solve three tridiagonal systems
 
-    // system 2a: solve for _v_star
     for (int _i=0; _i<_num_B - 1; _i++)
     {
         // first and last index of the i-th section
@@ -47,87 +46,33 @@
         for(int _j=_j_start; _j<_j_end; _j++)
         {
             {{_v_star}}[_j]=-({{Cm}}[_j]/{{dt}}*{{v}}[_j])-{{_I0_all}}[_j]; // RHS -> _v_star (solution)
-            _bi={{_ab_star1}}[_j]-{{_gtot_all}}[_j]; // main diagonal
-            if (_j<N-1)
-                {{_c1}}[_j]={{_ab_star0}}[_j+1]; // superdiagonal
-            if (_j>0)
-            {
-                _ai={{_ab_star2}}[_j-1]; // subdiagonal
-                _m=1.0/(_bi-_ai*{{_c1}}[_j-1]);
-                {{_c1}}[_j]={{_c1}}[_j]*_m;
-                {{_v_star}}[_j]=({{_v_star}}[_j] - _ai*{{_v_star}}[_j-1])*_m;
-            } else
-            {
-                {{_c1}}[0]={{_c1}}[0]/_bi;
-                {{_v_star}}[0]={{_v_star}}[0]/_bi;
-            }
-        }
-        // backwards substitution of the upper triangularized system for _v_star
-        for(int _j=_j_end-2; _j>=_j_start; _j--)
-            {{_v_star}}[_j]={{_v_star}}[_j] - {{_c1}}[_j]*{{_v_star}}[_j+1];
-    }
-    for (int _i=0; _i<_num_B - 1; _i++)
-    {
-        // first and last index of the i-th section
-        const int _j_start = {{_starts}}[_i];
-        const int _j_end = {{_ends}}[_i];  // the compartment indices are in the interval [starts, ends[
-
-        double _ai, _bi, _m; // helper variables
-
-        // upper triangularization of tridiagonal system for _u_plus
-        for(int _j=_j_start; _j<_j_end; _j++)
-        {
             {{_u_plus}}[_j]={{_b_plus}}[_j]; // RHS -> _u_plus (solution)
-            _bi={{_ab_star1}}[_j]-{{_gtot_all}}[_j]; // main diagonal
-            if (_j<N-1)
-                {{_c2}}[_j]={{_ab_star0}}[_j+1]; // superdiagonal
-            if (_j>0)
-            {
-                _ai={{_ab_star2}}[_j-1]; // subdiagonal
-                _m=1.0/(_bi-_ai*{{_c2}}[_j-1]);
-                {{_c2}}[_j]={{_c2}}[_j]*_m;
-                {{_u_plus}}[_j]=({{_u_plus}}[_j] - _ai*{{_u_plus}}[_j-1])*_m;
-            } else
-            {
-                {{_c2}}[0]={{_c2}}[0]/_bi;
-                {{_u_plus}}[0]={{_u_plus}}[0]/_bi;
-            }
-        }
-        // backwards substitution of the upper triangularized system for _u_plus
-        for(int _j=_j_end-2; _j>=_j_start; _j--)
-            {{_u_plus}}[_j]={{_u_plus}}[_j] - {{_c2}}[_j]*{{_u_plus}}[_j+1];
-    }
-
-    for (int _i=0; _i<_num_B - 1; _i++)
-    {
-        // first and last index of the i-th section
-        const int _j_start = {{_starts}}[_i];
-        const int _j_end = {{_ends}}[_i];
-
-        double _ai, _bi, _m; // helper variables
-
-        // upper triangularization of tridiagonal system for _u_minus
-        for(int _j=_j_start; _j<_j_end; _j++)
-        {
             {{_u_minus}}[_j]={{_b_minus}}[_j]; // RHS -> _u_minus (solution)
             _bi={{_ab_star1}}[_j]-{{_gtot_all}}[_j]; // main diagonal
             if (_j<N-1)
-                {{_c3}}[_j]={{_ab_star0}}[_j+1]; // superdiagonal
+                {{_c}}[_j]={{_ab_star0}}[_j+1]; // superdiagonal
             if (_j>0)
             {
                 _ai={{_ab_star2}}[_j-1]; // subdiagonal
-                _m=1.0/(_bi-_ai*{{_c3}}[_j-1]);
-                {{_c3}}[_j]={{_c3}}[_j]*_m;
+                _m=1.0/(_bi-_ai*{{_c}}[_j-1]);
+                {{_c}}[_j]={{_c}}[_j]*_m;
+                {{_v_star}}[_j]=({{_v_star}}[_j] - _ai*{{_v_star}}[_j-1])*_m;
+                {{_u_plus}}[_j]=({{_u_plus}}[_j] - _ai*{{_u_plus}}[_j-1])*_m;
                 {{_u_minus}}[_j]=({{_u_minus}}[_j] - _ai*{{_u_minus}}[_j-1])*_m;
             } else
             {
-                {{_c3}}[0]={{_c3}}[0]/_bi;
+                {{_c}}[0]={{_c}}[0]/_bi;
+                {{_v_star}}[0]={{_v_star}}[0]/_bi;
+                {{_u_plus}}[0]={{_u_plus}}[0]/_bi;
                 {{_u_minus}}[0]={{_u_minus}}[0]/_bi;
             }
         }
-        // backwards substitution of the upper triangularized system for _u_minus
-        for(int _j=_j_end-2; _j>=_j_start; _j--)
-            {{_u_minus}}[_j]={{_u_minus}}[_j] - {{_c3}}[_j]*{{_u_minus}}[_j+1];
+        // backwards substitution of the upper triangularized system for _v_star
+        for(int _j=_j_end-2; _j>=_j_start; _j--) {
+            {{_v_star}}[_j]={{_v_star}}[_j] - {{_c}}[_j]*{{_v_star}}[_j+1];
+            {{_u_plus}}[_j]={{_u_plus}}[_j] - {{_c}}[_j]*{{_u_plus}}[_j+1];
+            {{_u_minus}}[_j]={{_u_minus}}[_j] - {{_c}}[_j]*{{_u_minus}}[_j+1];
+        }
     }
 
     // STEP 3: solve the coupling system

--- a/brian2/codegen/runtime/weave_rt/templates/spatialstateupdate.cpp
+++ b/brian2/codegen/runtime/weave_rt/templates/spatialstateupdate.cpp
@@ -1,9 +1,8 @@
 ////////////////////////////////////////////////////////////////////////////
 //// MAIN CODE /////////////////////////////////////////////////////////////
 {# USES_VARIABLES { Cm, dt, v, N, Ic,
-                  _ab_star0, _ab_star1, _ab_star2, _b_plus,
-                  _a_plus0, _a_plus1, _a_plus2, _b_minus,
-                  _a_minus0, _a_minus1, _a_minus2, _v_star, _u_plus, _u_minus,
+                  _ab_star0, _ab_star1, _ab_star2, _b_plus, _b_minus,
+                  _v_star, _u_plus, _u_minus,
                   _v_previous,
                   _gtot_all, _I0_all,
                   _c1, _c2, _c3,
@@ -79,12 +78,12 @@
         for(int _j=_j_start; _j<_j_end; _j++)
         {
             {{_u_plus}}[_j]={{_b_plus}}[_j]; // RHS -> _u_plus (solution)
-            _bi={{_a_plus1}}[_j]-{{_gtot_all}}[_j]; // main diagonal
+            _bi={{_ab_star1}}[_j]-{{_gtot_all}}[_j]; // main diagonal
             if (_j<N-1)
-                {{_c2}}[_j]={{_a_plus0}}[_j+1]; // superdiagonal
+                {{_c2}}[_j]={{_ab_star0}}[_j+1]; // superdiagonal
             if (_j>0)
             {
-                _ai={{_a_plus2}}[_j-1]; // subdiagonal
+                _ai={{_ab_star2}}[_j-1]; // subdiagonal
                 _m=1.0/(_bi-_ai*{{_c2}}[_j-1]);
                 {{_c2}}[_j]={{_c2}}[_j]*_m;
                 {{_u_plus}}[_j]=({{_u_plus}}[_j] - _ai*{{_u_plus}}[_j-1])*_m;
@@ -111,12 +110,12 @@
         for(int _j=_j_start; _j<_j_end; _j++)
         {
             {{_u_minus}}[_j]={{_b_minus}}[_j]; // RHS -> _u_minus (solution)
-            _bi={{_a_minus1}}[_j]-{{_gtot_all}}[_j]; // main diagonal
+            _bi={{_ab_star1}}[_j]-{{_gtot_all}}[_j]; // main diagonal
             if (_j<N-1)
-                {{_c3}}[_j]={{_a_minus0}}[_j+1]; // superdiagonal
+                {{_c3}}[_j]={{_ab_star0}}[_j+1]; // superdiagonal
             if (_j>0)
             {
-                _ai={{_a_minus2}}[_j-1]; // subdiagonal
+                _ai={{_ab_star2}}[_j-1]; // subdiagonal
                 _m=1.0/(_bi-_ai*{{_c3}}[_j-1]);
                 {{_c3}}[_j]={{_c3}}[_j]*_m;
                 {{_u_minus}}[_j]=({{_u_minus}}[_j] - _ai*{{_u_minus}}[_j-1])*_m;

--- a/brian2/devices/cpp_standalone/device.py
+++ b/brian2/devices/cpp_standalone/device.py
@@ -58,17 +58,9 @@ prefs.register_preferences(
         default=None,
         validator=lambda val: val in [None, 'branches', 'systems'],
         docs='''
-        Which strategy to chose for solving the three tridiagonal systems with
-        OpenMP: `'branches'` means to solve the three systems sequentially, but
-        for all the branches in parallel, `'systems'` means to solve the three
-        systems in parallel, but all the branches within each system
-        sequentially. The `'branches'` approach is usually better for
-        morphologies with many branches and a large number of threads, while the
-        `'systems'` strategy should be better for morphologies with few
-        branches (e.g. cables) and/or simulations with no more than three
-        threads. If not specified (the default), the `'systems'` strategy will
-        be used when using no more than three threads or when the morphology
-        has less than three branches in total.
+        DEPRECATED. Previously used to chose the strategy to parallelize the
+        solution of the three tridiagonal systems for multicompartmental
+        neurons. Now, its value is ignored.
         '''
         ),
     extra_make_args_unix=BrianPreference(
@@ -572,7 +564,12 @@ class CPPStandaloneDevice(Device):
         if nb_threads > 0:
             logger.warn("OpenMP code is not yet well tested, and may be inaccurate.", "openmp", once=True)
             logger.diagnostic("Using OpenMP with %d threads " % nb_threads)
-    
+            if prefs.devices.cpp_standalone.openmp_spatialneuron_strategy != None:
+                logger.warn("The devices.cpp_standalone.openmp_spatialneuron_strategy "
+                            "preference is no longer used and will be removed in "
+                            "future versions of Brian.", "openmp_spatialneuron_strategy",
+                            once=True)
+
     def generate_objects_source(self, writer, arange_arrays, synapses, static_array_specs, networks):
         arr_tmp = CPPStandaloneCodeObject.templater.objects(
                         None, None,

--- a/brian2/devices/cpp_standalone/device.py
+++ b/brian2/devices/cpp_standalone/device.py
@@ -564,7 +564,7 @@ class CPPStandaloneDevice(Device):
         if nb_threads > 0:
             logger.warn("OpenMP code is not yet well tested, and may be inaccurate.", "openmp", once=True)
             logger.diagnostic("Using OpenMP with %d threads " % nb_threads)
-            if prefs.devices.cpp_standalone.openmp_spatialneuron_strategy != None:
+            if prefs.devices.cpp_standalone.openmp_spatialneuron_strategy is not None:
                 logger.warn("The devices.cpp_standalone.openmp_spatialneuron_strategy "
                             "preference is no longer used and will be removed in "
                             "future versions of Brian.", "openmp_spatialneuron_strategy",

--- a/brian2/devices/cpp_standalone/templates/spatialneuron_prepare.cpp
+++ b/brian2/devices/cpp_standalone/templates/spatialneuron_prepare.cpp
@@ -1,7 +1,5 @@
-{# USES_VARIABLES { N, _invr, Ri, Cm, dt, area, r_length_1, r_length_2
+{# USES_VARIABLES { N, _invr, Ri, Cm, dt, area, r_length_1, r_length_2,
                     _ab_star0, _ab_star1, _ab_star2,
-                    _a_plus0, _a_plus1, _a_plus2,
-                    _a_minus0, _a_minus1, _a_minus2,
                     _starts, _ends, _invr0, _invrn, _b_plus, _b_minus } #}
 {% extends 'common_group.cpp' %}
 {% block maincode %}
@@ -29,17 +27,6 @@
         {{_ab_star2}}[_i-1] = {{_invr}}[_i] / {{area}}[_i];
         {{_ab_star1}}[_i-1] -= {{_invr}}[_i] / {{area}}[_i-1];
     }
-    {{ openmp_pragma('parallel-static') }}
-    for (int _i=0; _i<N; _i++)
-    {
-        // Homogeneous solutions
-        {{_a_plus0}}[_i] = {{_ab_star0}}[_i];
-        {{_a_minus0}}[_i] = {{_ab_star0}}[_i];
-        {{_a_plus1}}[_i] = {{_ab_star1}}[_i];
-        {{_a_minus1}}[_i] = {{_ab_star1}}[_i];
-        {{_a_plus2}}[_i] = {{_ab_star2}}[_i];
-        {{_a_minus2}}[_i] = {{_ab_star2}}[_i];
-    }
 
     // Set the boundary conditions
     for (int _counter=0; _counter<_num_starts; _counter++)
@@ -54,10 +41,6 @@
         // Correction for boundary conditions
         {{_ab_star1}}[_first] -= (_invr0 / {{area}}[_first]);
         {{_ab_star1}}[_last] -= (_invrn / {{area}}[_last]);
-        {{_a_plus1}}[_first] -= (_invr0 / {{area}}[_first]);
-        {{_a_plus1}}[_last] -= (_invrn / {{area}}[_last]);
-        {{_a_minus1}}[_first] -= (_invr0 / {{area}}[_first]);
-        {{_a_minus1}}[_last] -= (_invrn / {{area}}[_last]);
         // RHS for homogeneous solutions
         {{_b_plus}}[_last] = -(_invrn / {{area}}[_last]);
         {{_b_minus}}[_first] = -(_invr0 / {{area}}[_first]);

--- a/brian2/devices/cpp_standalone/templates/spatialstateupdate.cpp
+++ b/brian2/devices/cpp_standalone/templates/spatialstateupdate.cpp
@@ -6,23 +6,14 @@
                   _v_star, _u_plus, _u_minus,
                   _v_previous,
                   _gtot_all, _I0_all,
-                  _c1, _c2, _c3,
+                  _c,
                   _P_diag, _P_parent, _P_children,
                   _B, _morph_parent_i, _starts, _ends,
                   _morph_children, _morph_children_num, _morph_idxchild,
                   _invr0, _invrn} #}
-                  
+
 {% extends 'common_group.cpp' %}
 {% block maincode %}
-
-    {% set strategy = prefs.devices.cpp_standalone.openmp_spatialneuron_strategy %}
-    {% if strategy == None %}
-        {% if prefs.devices.cpp_standalone.openmp_threads <= 3 or number_sections < 3%}
-            {% set strategy = 'systems' %}
-        {% else %}
-            {% set strategy = 'branches' %}
-        {% endif %}
-    {% endif %}
 
     int _vectorisation_idx = 1;
 
@@ -44,133 +35,50 @@
     }
 
     // STEP 2: for each section: solve three tridiagonal systems
-    // (independent: branches and also the three tridiagonal systems)
+    // (independent: branches)
 
-    {% if strategy == 'systems' %}
-    {{ openmp_pragma('parallel') }}
+    {{ openmp_pragma('parallel-static') }}
+    for (int _i=0; _i<_num_B - 1; _i++)
     {
-    {% endif %}
-    {{ openmp_pragma('sections') }}
-    {
-    // system 2a: solve for _v_star
-    {{ openmp_pragma('section') }}
-    {
-        {% if strategy == 'branches' %}
-        {{ openmp_pragma('parallel-static') }}
-        {% endif %}
-        for (int _i=0; _i<_num_B - 1; _i++)
+        // first and last index of the i-th section
+        const int _j_start = {{_starts}}[_i];
+        const int _j_end = {{_ends}}[_i];
+
+        double _ai, _bi, _m; // helper variables
+
+        // upper triangularization of tridiagonal system for _v_star, _u_plus, and _u_minus
+        for(int _j=_j_start; _j<_j_end; _j++)
         {
-            // first and last index of the i-th section
-            const int _j_start = {{_starts}}[_i];
-            const int _j_end = {{_ends}}[_i];
-            
-            double _ai, _bi, _m; // helper variables
-
-            // upper triangularization of tridiagonal system for _v_star
-            for(int _j=_j_start; _j<_j_end; _j++)
+            {{_v_star}}[_j]=-({{Cm}}[_j]/{{dt}}*{{v}}[_j])-{{_I0_all}}[_j]; // RHS -> _v_star (solution)
+            {{_u_plus}}[_j]={{_b_plus}}[_j]; // RHS -> _u_plus (solution)
+            {{_u_minus}}[_j]={{_b_minus}}[_j]; // RHS -> _u_minus (solution)
+            _bi={{_ab_star1}}[_j]-{{_gtot_all}}[_j]; // main diagonal
+            if (_j<N-1)
+                {{_c}}[_j]={{_ab_star0}}[_j+1]; // superdiagonal
+            if (_j>0)
             {
-                {{_v_star}}[_j]=-({{Cm}}[_j]/{{dt}}*{{v}}[_j])-{{_I0_all}}[_j]; // RHS -> _v_star (solution)
-                _bi={{_ab_star1}}[_j]-{{_gtot_all}}[_j]; // main diagonal
-                if (_j<N-1)
-                    {{_c1}}[_j]={{_ab_star0}}[_j+1]; // superdiagonal
-                if (_j>0)
-                {
-                    _ai={{_ab_star2}}[_j-1]; // subdiagonal
-                    _m=1.0/(_bi-_ai*{{_c1}}[_j-1]);
-                    {{_c1}}[_j]={{_c1}}[_j]*_m;
-                    {{_v_star}}[_j]=({{_v_star}}[_j] - _ai*{{_v_star}}[_j-1])*_m;
-                } else
-                {
-                    {{_c1}}[0]={{_c1}}[0]/_bi;
-                    {{_v_star}}[0]={{_v_star}}[0]/_bi;
-                }
+                _ai={{_ab_star2}}[_j-1]; // subdiagonal
+                _m=1.0/(_bi-_ai*{{_c}}[_j-1]);
+                {{_c}}[_j]={{_c}}[_j]*_m;
+                {{_v_star}}[_j]=({{_v_star}}[_j] - _ai*{{_v_star}}[_j-1])*_m;
+                {{_u_plus}}[_j]=({{_u_plus}}[_j] - _ai*{{_u_plus}}[_j-1])*_m;
+                {{_u_minus}}[_j]=({{_u_minus}}[_j] - _ai*{{_u_minus}}[_j-1])*_m;
+            } else
+            {
+                {{_c}}[0]={{_c}}[0]/_bi;
+                {{_v_star}}[0]={{_v_star}}[0]/_bi;
+                {{_u_plus}}[0]={{_u_plus}}[0]/_bi;
+                {{_u_minus}}[0]={{_u_minus}}[0]/_bi;
             }
-            // backwards substituation of the upper triangularized system for _v_star
-            for(int _j=_j_end-2; _j>=_j_start; _j--)
-                {{_v_star}}[_j]={{_v_star}}[_j] - {{_c1}}[_j]*{{_v_star}}[_j+1];
+        }
+        // backwards substituation of the upper triangularized system for _v_star
+        for(int _j=_j_end-2; _j>=_j_start; _j--)
+        {
+            {{_v_star}}[_j]={{_v_star}}[_j] - {{_c}}[_j]*{{_v_star}}[_j+1];
+            {{_u_plus}}[_j]={{_u_plus}}[_j] - {{_c}}[_j]*{{_u_plus}}[_j+1];
+            {{_u_minus}}[_j]={{_u_minus}}[_j] - {{_c}}[_j]*{{_u_minus}}[_j+1];
         }
     }
-    // system 2b: solve for _u_plus
-    {{ openmp_pragma('section') }}
-    {
-        {% if strategy == 'branches' %}
-        {{ openmp_pragma('parallel-static') }}
-        {% endif %}
-        for (int _i=0; _i<_num_B - 1; _i++)
-        {
-            // first and last index of the i-th section
-            const int _j_start = {{_starts}}[_i];
-            const int _j_end = {{_ends}}[_i];
-            
-            double _ai, _bi, _m; // helper variables
-
-            // upper triangularization of tridiagonal system for _u_plus
-            for(int _j=_j_start; _j<_j_end; _j++)
-            {
-                {{_u_plus}}[_j]={{_b_plus}}[_j]; // RHS -> _u_plus (solution)
-                _bi={{_ab_star1}}[_j]-{{_gtot_all}}[_j]; // main diagonal
-                if (_j<N-1)
-                    {{_c2}}[_j]={{_ab_star0}}[_j+1]; // superdiagonal
-                if (_j>0)
-                {
-                    _ai={{_ab_star2}}[_j-1]; // subdiagonal
-                    _m=1.0/(_bi-_ai*{{_c2}}[_j-1]);
-                    {{_c2}}[_j]={{_c2}}[_j]*_m;
-                    {{_u_plus}}[_j]=({{_u_plus}}[_j] - _ai*{{_u_plus}}[_j-1])*_m;
-                } else
-                {
-                    {{_c2}}[0]={{_c2}}[0]/_bi;
-                    {{_u_plus}}[0]={{_u_plus}}[0]/_bi;
-                }
-            }
-            // backwards substituation of the upper triangularized system for _u_plus
-            for(int _j=_j_end-2; _j>=_j_start; _j--)
-                {{_u_plus}}[_j]={{_u_plus}}[_j] - {{_c2}}[_j]*{{_u_plus}}[_j+1];
-        }
-    }
-    // system 2c: solve for _u_minus
-    {{ openmp_pragma('section') }}
-    {
-        {% if strategy == 'branches' %}
-        {{ openmp_pragma('parallel-static') }}
-        {% endif %}
-        for (int _i=0; _i<_num_B - 1; _i++)
-        {
-            // first and last index of the i-th section
-            const int _j_start = {{_starts}}[_i];
-            const int _j_end = {{_ends}}[_i];
-
-            double _ai, _bi, _m; // helper variables
-            
-            // upper triangularization of tridiagonal system for _u_minus
-            for(int _j=_j_start; _j<_j_end; _j++)
-            {
-                {{_u_minus}}[_j]={{_b_minus}}[_j]; // RHS -> _u_minus (solution)
-                _bi={{_ab_star1}}[_j]-{{_gtot_all}}[_j]; // main diagonal
-                if (_j<N-1)
-                    {{_c3}}[_j]={{_ab_star0}}[_j+1]; // superdiagonal
-                if (_j>0)
-                {
-                    _ai={{_ab_star2}}[_j-1]; // subdiagonal
-                    _m=1.0/(_bi-_ai*{{_c3}}[_j-1]);
-                    {{_c3}}[_j]={{_c3}}[_j]*_m;
-                    {{_u_minus}}[_j]=({{_u_minus}}[_j] - _ai*{{_u_minus}}[_j-1])*_m;
-                } else
-                {
-                    {{_c3}}[0]={{_c3}}[0]/_bi;
-                    {{_u_minus}}[0]={{_u_minus}}[0]/_bi;
-                }
-            }
-            // backwards substituation of the upper triangularized system for _u_minus
-            for(int _j=_j_end-2; _j>=_j_start; _j--)
-                {{_u_minus}}[_j]={{_u_minus}}[_j] - {{_c3}}[_j]*{{_u_minus}}[_j+1];
-        }
-    } // (OpenMP section)
-    } // (OpenMP sections)
-    {% if strategy == 'systems' %}
-    } // (OpenMP parallel)
-    {% endif %}
-
 
     // STEP 3: solve the coupling system
 

--- a/brian2/devices/cpp_standalone/templates/spatialstateupdate.cpp
+++ b/brian2/devices/cpp_standalone/templates/spatialstateupdate.cpp
@@ -2,9 +2,8 @@
 //// MAIN CODE /////////////////////////////////////////////////////////////
 
 {# USES_VARIABLES { Cm, dt, v, N, Ic,
-                  _ab_star0, _ab_star1, _ab_star2, _b_plus,
-                  _a_plus0, _a_plus1, _a_plus2, _b_minus,
-                  _a_minus0, _a_minus1, _a_minus2, _v_star, _u_plus, _u_minus,
+                  _ab_star0, _ab_star1, _ab_star2, _b_plus, _b_minus,
+                  _v_star, _u_plus, _u_minus,
                   _v_previous,
                   _gtot_all, _I0_all,
                   _c1, _c2, _c3,
@@ -109,12 +108,12 @@
             for(int _j=_j_start; _j<_j_end; _j++)
             {
                 {{_u_plus}}[_j]={{_b_plus}}[_j]; // RHS -> _u_plus (solution)
-                _bi={{_a_plus1}}[_j]-{{_gtot_all}}[_j]; // main diagonal
+                _bi={{_ab_star1}}[_j]-{{_gtot_all}}[_j]; // main diagonal
                 if (_j<N-1)
-                    {{_c2}}[_j]={{_a_plus0}}[_j+1]; // superdiagonal
+                    {{_c2}}[_j]={{_ab_star0}}[_j+1]; // superdiagonal
                 if (_j>0)
                 {
-                    _ai={{_a_plus2}}[_j-1]; // subdiagonal
+                    _ai={{_ab_star2}}[_j-1]; // subdiagonal
                     _m=1.0/(_bi-_ai*{{_c2}}[_j-1]);
                     {{_c2}}[_j]={{_c2}}[_j]*_m;
                     {{_u_plus}}[_j]=({{_u_plus}}[_j] - _ai*{{_u_plus}}[_j-1])*_m;
@@ -147,12 +146,12 @@
             for(int _j=_j_start; _j<_j_end; _j++)
             {
                 {{_u_minus}}[_j]={{_b_minus}}[_j]; // RHS -> _u_minus (solution)
-                _bi={{_a_minus1}}[_j]-{{_gtot_all}}[_j]; // main diagonal
+                _bi={{_ab_star1}}[_j]-{{_gtot_all}}[_j]; // main diagonal
                 if (_j<N-1)
-                    {{_c3}}[_j]={{_a_minus0}}[_j+1]; // superdiagonal
+                    {{_c3}}[_j]={{_ab_star0}}[_j+1]; // superdiagonal
                 if (_j>0)
                 {
-                    _ai={{_a_minus2}}[_j-1]; // subdiagonal
+                    _ai={{_ab_star2}}[_j-1]; // subdiagonal
                     _m=1.0/(_bi-_ai*{{_c3}}[_j-1]);
                     {{_c3}}[_j]={{_c3}}[_j]*_m;
                     {{_u_minus}}[_j]=({{_u_minus}}[_j] - _ai*{{_u_minus}}[_j-1])*_m;

--- a/brian2/spatialneuron/spatialneuron.py
+++ b/brian2/spatialneuron/spatialneuron.py
@@ -370,8 +370,6 @@ class SpatialNeuron(NeuronGroup):
         # since these variables should never be used in user code, we don't
         # assign them any units
         self.variables.add_arrays(['_ab_star0', '_ab_star1', '_ab_star2',
-                                   '_a_minus0', '_a_minus1', '_a_minus2',
-                                   '_a_plus0', '_a_plus1', '_a_plus2',
                                    '_b_plus', '_b_minus',
                                    '_v_star', '_u_plus', '_u_minus',
                                    '_v_previous',

--- a/brian2/spatialneuron/spatialneuron.py
+++ b/brian2/spatialneuron/spatialneuron.py
@@ -372,10 +372,7 @@ class SpatialNeuron(NeuronGroup):
         self.variables.add_arrays(['_ab_star0', '_ab_star1', '_ab_star2',
                                    '_b_plus', '_b_minus',
                                    '_v_star', '_u_plus', '_u_minus',
-                                   '_v_previous',
-                                   # The following three are for solving the
-                                   # three tridiag systems in parallel
-                                   '_c1', '_c2', '_c3',
+                                   '_v_previous', '_c',
                                    # The following two are only necessary for
                                    # C code where we cannot deal with scalars
                                    # and arrays interchangeably:

--- a/brian2/tests/test_spatialneuron.py
+++ b/brian2/tests/test_spatialneuron.py
@@ -757,6 +757,7 @@ def test_spatialneuron_morphology_assignment():
 @attr('standalone-compatible', 'multiple-runs')
 @with_setup(teardown=reinit_devices)
 def test_spatialneuron_capacitive_currents():
+    defaultclock.dt = 0.1*ms
     morpho = Cylinder(x=[0, 10]*cm, diameter=2*238*um, n=200, type='axon')
 
     El = 10.613* mV


### PR DESCRIPTION
Big thanks to @moritzaugustin for pointing out that our three arrays `_ab_star`, `_a_minus` and `_a_plus` (the LHS of the three systems of equations that we solve at every time step) were actually identical! So instead of solving three systems (with a lot of redundant code), we now solve only one (for three RHSs). This simplifies the code quite a bit and also makes things a bit faster.

We previously optionally parallelized over these 3 systems with OpenMP. There was a preference and a heuristic to chose between this parallelization and a parallelization over the branches of the morphology (which should be more efficient with more than 3 branches and more then 3 threads). Since the three systems are now basically solved as one, this choice is obsolete and I documented the preference accordingly (+ raise a warning when someone is actually changing its value from `"auto"` -- I doubt that many users did that...).