### PR TITLE
[MRG] Fix numpy 1.14 compatibility issues

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -101,7 +101,9 @@ install:
   - 'python -c "import struct; print(struct.calcsize(''P'') * 8)"'
 
   # Install the build dependencies of the project via conda
-  - 'appveyor-retry conda install --yes --quiet numpy nose "sphinx<1.6.3" "sympy!=1.1.0" pyparsing jinja2 ipython setuptools cython'
+  - 'appveyor-retry conda install --yes --quiet numpy nose "sphinx<1.6.3" "sympy!=1.1.0" pyparsing jinja2 ipython setuptools cython "conda==4.3.21"'
+  # Pin conda version
+  - 'echo conda ==4.3.21 >> %PYTHON%\conda-meta\pinned'
   # Install an older version of scipy (which still has weave) on Python 2
   - 'if "%PYTHON_VERSION:~0,1%" == "2" appveyor-retry conda install --yes --quiet -c brian-team weave scipy'
   - 'if "%PYTHON_VERSION:~0,1%" == "3" appveyor-retry conda install --yes --quiet scipy'

--- a/brian2/codegen/generators/base.py
+++ b/brian2/codegen/generators/base.py
@@ -20,24 +20,6 @@ __all__ = ['CodeGenerator']
 logger = get_logger(__name__)
 
 
-def get_numpy_ABI_version():
-    # I don't see a way to get numpy's ABI version from Python,
-    # so we look it up in the numpy header file that we are using
-    # later...
-    header_name = os.path.join(numpy.get_include(), 'numpy', '_numpyconfig.h')
-    if os.path.exists(header_name):
-        with open(header_name, 'r') as f:
-            for line in f.readlines():
-                if line.startswith('#define NPY_ABI_VERSION'):
-                    elements = line.split(' ')
-                    if len(elements) == 3 and elements[2].startswith('0x'):
-                        return elements[2]
-
-    # Something went wrong, we don't want to raise an error because
-    # it might be that we'll never actually use this information
-    return 'Unknown'
-
-
 class CodeGenerator(object):
     '''
     Base class for all languages.

--- a/brian2/codegen/generators/base.py
+++ b/brian2/codegen/generators/base.py
@@ -2,10 +2,6 @@
 Base class for generating code in different programming languages, gives the
 methods which should be overridden to implement a new language.
 '''
-import os
-
-import numpy
-
 from brian2.core.variables import ArrayVariable
 from brian2.core.functions import Function
 from brian2.utils.stringtools import get_identifiers

--- a/brian2/codegen/generators/base.py
+++ b/brian2/codegen/generators/base.py
@@ -2,6 +2,10 @@
 Base class for generating code in different programming languages, gives the
 methods which should be overridden to implement a new language.
 '''
+import os
+
+import numpy
+
 from brian2.core.variables import ArrayVariable
 from brian2.core.functions import Function
 from brian2.utils.stringtools import get_identifiers
@@ -14,6 +18,24 @@ __all__ = ['CodeGenerator']
 
 
 logger = get_logger(__name__)
+
+
+def get_numpy_ABI_version():
+    # I don't see a way to get numpy's ABI version from Python,
+    # so we look it up in the numpy header file that we are using
+    # later...
+    header_name = os.path.join(numpy.get_include(), 'numpy', '_numpyconfig.h')
+    if os.path.exists(header_name):
+        with open(header_name, 'r') as f:
+            for line in f.readlines():
+                if line.startswith('#define NPY_ABI_VERSION'):
+                    elements = line.split(' ')
+                    if len(elements) == 3 and elements[2].startswith('0x'):
+                        return elements[2]
+
+    # Something went wrong, we don't want to raise an error because
+    # it might be that we'll never actually use this information
+    return 'Unknown'
 
 
 class CodeGenerator(object):

--- a/brian2/codegen/runtime/cython_rt/extension_manager.py
+++ b/brian2/codegen/runtime/cython_rt/extension_manager.py
@@ -23,6 +23,7 @@ except ImportError:
 from distutils.core import Distribution, Extension
 from distutils.command.build_ext import build_ext
 
+import numpy
 try:
     import Cython
     import Cython.Compiler as Cython_Compiler
@@ -32,7 +33,6 @@ except ImportError:
     Cython = None
 
 from brian2.codegen.cpp_prefs import update_for_cross_compilation
-from brian2.codegen.generators.base import get_numpy_ABI_version
 from brian2.utils.logger import std_silent, get_logger
 from brian2.utils.stringtools import deindent
 from brian2.core.preferences import prefs
@@ -45,7 +45,6 @@ logger = get_logger(__name__)
 class CythonExtensionManager(object):
     def __init__(self):
         self._code_cache = {}
-        self.numpy_ABI_version = get_numpy_ABI_version()
         
     def create_extension(self, code, force=False, name=None,
                          define_macros=None,
@@ -78,7 +77,8 @@ class CythonExtensionManager(object):
                 raise IOError("Couldn't create Cython cache directory '%s', try setting the "
                               "cache directly with prefs.codegen.runtime.cython.cache_dir." % lib_dir)
 
-        key = code, sys.version_info, sys.executable, Cython.__version__, self.numpy_ABI_version
+        numpy_version = '.'.join(numpy.__version__.split('.')[:2])  # Only use major.minor version
+        key = code, sys.version_info, sys.executable, Cython.__version__, numpy_version
             
         if force:
             # Force a new module name by adding the current time to the

--- a/brian2/codegen/runtime/cython_rt/extension_manager.py
+++ b/brian2/codegen/runtime/cython_rt/extension_manager.py
@@ -32,6 +32,7 @@ except ImportError:
     Cython = None
 
 from brian2.codegen.cpp_prefs import update_for_cross_compilation
+from brian2.codegen.generators.base import get_numpy_ABI_version
 from brian2.utils.logger import std_silent, get_logger
 from brian2.utils.stringtools import deindent
 from brian2.core.preferences import prefs
@@ -44,6 +45,7 @@ logger = get_logger(__name__)
 class CythonExtensionManager(object):
     def __init__(self):
         self._code_cache = {}
+        self.numpy_ABI_version = get_numpy_ABI_version()
         
     def create_extension(self, code, force=False, name=None,
                          define_macros=None,
@@ -76,7 +78,7 @@ class CythonExtensionManager(object):
                 raise IOError("Couldn't create Cython cache directory '%s', try setting the "
                               "cache directly with prefs.codegen.runtime.cython.cache_dir." % lib_dir)
 
-        key = code, sys.version_info, sys.executable, Cython.__version__
+        key = code, sys.version_info, sys.executable, Cython.__version__, self.numpy_ABI_version
             
         if force:
             # Force a new module name by adding the current time to the

--- a/brian2/codegen/runtime/weave_rt/weave_rt.py
+++ b/brian2/codegen/runtime/weave_rt/weave_rt.py
@@ -29,6 +29,7 @@ from brian2.utils.stringtools import get_identifiers
 from ...codeobject import CodeObject, constant_or_scalar, sys_info
 from ...templates import Templater
 from ...generators.cpp_generator import CPPCodeGenerator
+from ...generators.base import get_numpy_ABI_version
 from ...targets import codegen_targets
 from ...cpp_prefs import get_compiler_and_args, update_for_cross_compilation
 
@@ -62,7 +63,6 @@ class WeaveCodeGenerator(CPPCodeGenerator):
         super(WeaveCodeGenerator, self).__init__(*args, **kwds)
         self.c_data_type = weave_data_type
 
-
 class WeaveCodeObject(CodeObject):
     '''
     Weave code object
@@ -77,6 +77,7 @@ class WeaveCodeObject(CodeObject):
                                        'constant_or_scalar': constant_or_scalar})
     generator_class = WeaveCodeGenerator
     class_name = 'weave'
+    numpy_ABI_version = get_numpy_ABI_version()
 
     def __init__(self, owner, code, variables, variable_indices,
                  template_name, template_source, name='weave_code_object*'):
@@ -135,6 +136,8 @@ include_dirs: {self.include_dirs}
 library_dirs: {self.library_dirs}
 runtime_library_dirs: {self.runtime_library_dirs}
 libraries: {self.libraries}
+
+numpy ABI version: {self.numpy_ABI_version}
 */
         '''.format(self=self)
 

--- a/brian2/codegen/runtime/weave_rt/weave_rt.py
+++ b/brian2/codegen/runtime/weave_rt/weave_rt.py
@@ -29,7 +29,6 @@ from brian2.utils.stringtools import get_identifiers
 from ...codeobject import CodeObject, constant_or_scalar, sys_info
 from ...templates import Templater
 from ...generators.cpp_generator import CPPCodeGenerator
-from ...generators.base import get_numpy_ABI_version
 from ...targets import codegen_targets
 from ...cpp_prefs import get_compiler_and_args, update_for_cross_compilation
 
@@ -77,7 +76,6 @@ class WeaveCodeObject(CodeObject):
                                        'constant_or_scalar': constant_or_scalar})
     generator_class = WeaveCodeGenerator
     class_name = 'weave'
-    numpy_ABI_version = get_numpy_ABI_version()
 
     def __init__(self, owner, code, variables, variable_indices,
                  template_name, template_source, name='weave_code_object*'):
@@ -119,6 +117,7 @@ class WeaveCodeObject(CodeObject):
         self.runtime_library_dirs = list(prefs['codegen.cpp.runtime_library_dirs'])
         self.libraries = list(prefs['codegen.cpp.libraries'])
         self.headers = ['<algorithm>', '<limits>', '"stdint_compat.h"'] + prefs['codegen.cpp.headers']
+        self.numpy_version = '.'.join(numpy.__version__.split('.')[:2])  # Only use major.minor version
         self.annotated_code = self.code.main+'''
 /*
 The following code is just compiler options for the call to weave.inline.
@@ -137,7 +136,7 @@ library_dirs: {self.library_dirs}
 runtime_library_dirs: {self.runtime_library_dirs}
 libraries: {self.libraries}
 
-numpy ABI version: {self.numpy_ABI_version}
+numpy version: {self.numpy_version}
 */
         '''.format(self=self)
 

--- a/brian2/core/clocks.py
+++ b/brian2/core/clocks.py
@@ -55,9 +55,9 @@ def check_dt(new_dt, old_dt, target_t):
     if abs(new_t - old_t)/new_dt > Clock.epsilon_dt:
         raise ValueError(('Cannot set dt from {old} to {new}, the '
                           'time {t} is not a multiple of '
-                          '{new}').format(old=old_dt * second,
-                                          new=new_dt * second,
-                                          t=error_t * second))
+                          '{new}').format(old=str(old_dt * second),
+                                          new=str(new_dt * second),
+                                          t=str(error_t * second)))
 
 
 class Clock(VariableOwner):

--- a/brian2/core/variables.py
+++ b/brian2/core/variables.py
@@ -171,11 +171,11 @@ class Variable(CacheKey):
 
     @property
     def is_boolean(self):
-        return np.issubdtype(np.bool, self.dtype)
+        return np.issubdtype(self.dtype, np.bool_)
 
     @property
     def is_integer(self):
-        return np.issubdtype(self.dtype, np.integer)
+        return np.issubdtype(self.dtype, np.signedinteger)
 
     @property
     def dtype_str(self):

--- a/brian2/groups/group.py
+++ b/brian2/groups/group.py
@@ -255,7 +255,7 @@ class Indexing(object):
                 index_array = np.asarray(item)
                 if index_array.dtype == np.bool:
                     index_array = np.nonzero(index_array)[0]
-                elif not np.issubdtype(index_array.dtype, np.int):
+                elif not np.issubdtype(index_array.dtype, np.signedinteger):
                     raise TypeError(('Indexing is only supported for integer '
                                      'and boolean arrays, not for type '
                                      '%s' % index_array.dtype))

--- a/brian2/monitors/statemonitor.py
+++ b/brian2/monitors/statemonitor.py
@@ -54,7 +54,7 @@ class StateMonitorView(object):
         '''
         dtype = get_dtype(item)
         # scalar value
-        if np.issubdtype(dtype, np.int) and not isinstance(item, np.ndarray):
+        if np.issubdtype(dtype, np.signedinteger) and not isinstance(item, np.ndarray):
             indices = np.nonzero(self.monitor.record == item)[0]
             if len(indices) == 0:
                 raise IndexError('Index number %d has not been recorded' % item)
@@ -284,11 +284,11 @@ class StateMonitor(Group, CodeRunner):
 
     def __getitem__(self, item):
         dtype = get_dtype(item)
-        if np.issubdtype(dtype, np.int):
+        if np.issubdtype(dtype, np.signedinteger):
             return StateMonitorView(self, item)
         elif isinstance(item, collections.Sequence):
             index_array = np.array(item)
-            if not np.issubdtype(index_array.dtype, np.int):
+            if not np.issubdtype(index_array.dtype, np.signedinteger):
                 raise TypeError('Index has to be an integer or a sequence '
                                 'of integers')
             return StateMonitorView(self, item)

--- a/brian2/synapses/synapses.py
+++ b/brian2/synapses/synapses.py
@@ -1285,7 +1285,7 @@ class Synapses(Group):
                 if hasattr(i, '_indices'):
                     i = i._indices()
                 i = np.asarray(i)
-                if not np.issubdtype(i.dtype, np.int):
+                if not np.issubdtype(i.dtype, np.signedinteger):
                     raise TypeError(('Presynaptic indices have to be given as '
                                      'integers, are type %s '
                                      'instead.') % i.dtype)
@@ -1293,7 +1293,7 @@ class Synapses(Group):
                 if hasattr(j, '_indices'):
                     j = j._indices()
                 j = np.asarray(j)
-                if not np.issubdtype(j.dtype, np.int):
+                if not np.issubdtype(j.dtype, np.signedinteger):
                     raise TypeError(('Presynaptic indices can only be combined '
                                      'with postsynaptic integer indices))'))
                 if isinstance(n, basestring):

--- a/brian2/tests/__init__.py
+++ b/brian2/tests/__init__.py
@@ -219,6 +219,13 @@ def run(codegen_targets=None, long_tests=False, test_codegen_independent=True,
             # Some doctests do actually use code generation, use numpy for that
             prefs.codegen.target = 'numpy'
             prefs._backup()
+            # Print output changed in numpy 1.14, stick with the old format to
+            # avoid doctest failures
+            import numpy as np
+            try:
+                np.set_printoptions(legacy='1.13')
+            except TypeError:
+                pass  # using a numpy version < 1.14
             argv = make_argv(dirnames, "codegen-independent", doctests=True)
             if 'codegen_independent' in test_in_parallel:
                 argv.extend(multiprocess_arguments)

--- a/brian2/tests/test_codegen.py
+++ b/brian2/tests/test_codegen.py
@@ -169,7 +169,7 @@ def test_apply_loop_invariant_optimisation():
     scalar, vector = optimise_statements([], statements, variables)
     # The optimisation should pull out at least exp(-dt / tau)
     assert len(scalar) >= 1
-    assert np.issubdtype(scalar[0].dtype, (np.floating, float))
+    assert np.issubdtype(scalar[0].dtype, np.floating)
     assert scalar[0].var == '_lio_1'
     assert len(vector) == 2
     assert all('_lio_' in stmt.expr for stmt in vector)
@@ -192,15 +192,15 @@ def test_apply_loop_invariant_optimisation_integer():
                   ]
     scalar, vector = optimise_statements([], statements, variables)
     assert len(scalar) == 3
-    assert np.issubdtype(scalar[0].dtype, (np.integer, int))
+    assert np.issubdtype(scalar[0].dtype, np.signedinteger)
     assert scalar[0].var == '_lio_1'
     expr = scalar[0].expr.replace(' ', '')
     assert expr=='6*N' or expr=='N*6'
-    assert np.issubdtype(scalar[1].dtype, (np.integer, int))
+    assert np.issubdtype(scalar[1].dtype, np.signedinteger)
     assert scalar[1].var == '_lio_2'
     expr = scalar[1].expr.replace(' ', '')
     assert expr=='b/(c/d)'
-    assert np.issubdtype(scalar[2].dtype, (np.float, float))
+    assert np.issubdtype(scalar[2].dtype, np.floating)
     assert scalar[2].var == '_lio_3'
     expr = scalar[2].expr.replace(' ', '')
     assert expr=='(y*w)/z' or expr=='(w*y)/z'


### PR DESCRIPTION
This PR fixes three issues, the first two directly about the [recent numpy 1.14 release](https://github.com/numpy/numpy/releases/tag/v1.14.0) (~3 weeks ago) and the last a bit more general:
* Our use of `np.issubdtype` raised warnings because of a potential future incompatibility (if I understood correctly that incompatibility does not concern us, but the warning was annoying either way): 
* numpy's print output improved (less unnecessary spaces, etc.), but this of course makes almost all of our doctests fail. For the doctests, I therefore enabled the "legacy mode". Note that the tests only work correctly when run with `brian2.test()` or with one of our scripts, running something like `nosetests --with-doctests brian2` manually will fail (with numpy 1.14).
* Switching between numpy versions (as I did for testing these changes) can lead to runtime or link errors when weave/Cython reuse code compiled against a different numpy version. I now embed the ABI version directly in the code comment where we also put compiler options etc. (for weave), respectively consider the ABI version part of the key that we use for hashing (Cython). Unfortunately, I did not find an elegant way to ask for this ABI version from Python, so I directly read it out from numpy's header file... If this is too hacky, an alternative would be to embed the full numpy version, even though it would mean to recompile everything (e.g. for tests) after each minor numpy update.