### PR TITLE
[MRG] Fix handling of linked variables that are scalar in the referring but not in the source group

### DIFF
--- a/brian2/groups/subgroup.py
+++ b/brian2/groups/subgroup.py
@@ -82,8 +82,13 @@ class Subgroup(Group, SpikeSource):
         # special indexing for subgroups
         self._indices = Indexing(self, self.variables['_sub_idx'])
 
+        # Deal with special indices
         for key, value in self.source.variables.indices.iteritems():
-            if value not in ('_idx', '0'):
+            if value == '0':
+                self.variables.indices[key] = '0'
+            elif value == '_idx':
+                continue  # nothing to do, already uses _sub_idx correctly
+            else:
                 raise ValueError(('Do not know how to deal with variable %s '
                                   'using  index %s in a subgroup') % (key,
                                                                       value))

--- a/brian2/tests/test_neurongroup.py
+++ b/brian2/tests/test_neurongroup.py
@@ -237,12 +237,19 @@ def test_linked_variable_scalar():
     mon = StateMonitor(G2, 'y', record=True)
     # We don't test anything for now, except that it runs without raising an
     # error
-    run(10*ms)
+    run(defaultclock.dt)
     # Make sure that printing the variable values works
     assert len(str(G2.x)) > 0
     assert len(repr(G2.x)) > 0
     assert len(str(G2.x[:])) > 0
     assert len(repr(G2.x[:])) > 0
+    assert np.isscalar(G2.x[:])
+    # Check that subgroups work correctly (see github issue #916)
+    sg1 = G2[:5]
+    sg2 = G2[5:]
+    assert sg1.x == G2.x
+    assert sg2.x == G2.x
+
 
 @attr('codegen-independent')
 def test_linked_variable_indexed():


### PR DESCRIPTION
See #916 for an explanation of the issue.

The fix is not exactly what I had proposed: we cannot actually change the `scalar` attribute of the variable, because the `variables` dictionary of the referring group only holds a reference to the original `Variable` object. Instead, I added some code to handle this specific situation in subgroups. This is a bit of an ad-hoc fix, but we have to rewrite things quite substantially at some point anyway to deal with the issues described in #276.
