### PR TITLE
[MRG] Reduce codegen cache size

### DIFF
--- a/brian2/__init__.py
+++ b/brian2/__init__.py
@@ -97,3 +97,14 @@ for name, version in [('numpy',  '1.10'),
 
 # Initialize the logging system
 BrianLogger.initialize()
+
+
+# Check the caches
+if prefs.codegen.max_cache_dir_size > 0:
+    from brian2.codegen import check_cache
+    from brian2.codegen.runtime.weave_rt.weave_rt import get_weave_cache_dir as _get_weave_cache_dir
+    from brian2.codegen.runtime.cython_rt.extension_manager import get_cython_cache_dir as _get_cython_cache_dir
+    for target, dir in [('weave', _get_weave_cache_dir()),
+                        ('cython', _get_cython_cache_dir())]:
+        if dir is not None:
+            check_cache(target, dir)

--- a/brian2/__init__.py
+++ b/brian2/__init__.py
@@ -120,7 +120,12 @@ def check_cache(target):
     size = _get_size_recursively(cache_dir)
     size_in_mb = int(round(size/1024./1024.))
     if size_in_mb > prefs.codegen.max_cache_dir_size:
-        logger.warn('Cache size for target "%s": %s MB' % (target, size_in_mb))
+        logger.info('Cache size for target "{target}": {size} MB.\n'
+                    'You can call "clear_cache(\'{target}\')" to delete all '
+                    'files from the cache or manually delete files in the '
+                    '"{cache_dir}" directory.'.format(target=target,
+                                                      size=size_in_mb,
+                                                      cache_dir=cache_dir))
     else:
         logger.debug('Cache size for target "%s": %s MB' % (target, size_in_mb))
 

--- a/brian2/codegen/_prefs.py
+++ b/brian2/codegen/_prefs.py
@@ -55,5 +55,12 @@ prefs.register_preferences(
         optimisation is already performed by the compiler) or because the
         code generation target does not deal well with it. Defaults to ``True``.
         '''
+    ),
+    max_cache_dir_size=BrianPreference(
+      default=1000,
+      docs='''
+      The size of a directory (in MB) with cached code for weave or Cython that triggers a warning.
+      Set to 0 to never get a warning.
+      '''
     )
 )

--- a/brian2/codegen/runtime/__init__.py
+++ b/brian2/codegen/runtime/__init__.py
@@ -1,12 +1,17 @@
 '''
 Runtime targets for code generation.
 '''
+import os
+
 # Register the base category before importing the indivial codegen targets with
 # their subcategories
 from brian2.core.preferences import prefs
+from brian2.utils.logger import get_logger
 prefs.register_preferences('codegen.runtime',
                            ('Runtime codegen preferences (see subcategories '
                             'for individual targets)'))
+
+logger = get_logger(__name__)
 
 from .numpy_rt import *
 from .weave_rt import *
@@ -19,3 +24,19 @@ try:
     from .GSLcython_rt import *
 except ImportError:
     pass
+
+
+def _get_size_recursively(dirname):
+    total_size = 0
+    for dirpath, _, filenames in os.walk(dirname):
+        for fname in filenames:
+            total_size += os.path.getsize(os.path.join(dirpath, fname))
+    return total_size
+
+def check_cache(target, cache_dir):
+    size = _get_size_recursively(cache_dir)
+    size_in_mb = int(round(size/1024./1024.))
+    if size_in_mb > prefs.codegen.max_cache_dir_size:
+        logger.warn('Cache size for target "%s": %s MB' % (target, size_in_mb))
+    else:
+        logger.debug('Cache size for target "%s": %s MB' % (target, size_in_mb))

--- a/brian2/codegen/runtime/__init__.py
+++ b/brian2/codegen/runtime/__init__.py
@@ -1,7 +1,6 @@
 '''
 Runtime targets for code generation.
 '''
-import os
 
 # Register the base category before importing the indivial codegen targets with
 # their subcategories
@@ -24,19 +23,3 @@ try:
     from .GSLcython_rt import *
 except ImportError:
     pass
-
-
-def _get_size_recursively(dirname):
-    total_size = 0
-    for dirpath, _, filenames in os.walk(dirname):
-        for fname in filenames:
-            total_size += os.path.getsize(os.path.join(dirpath, fname))
-    return total_size
-
-def check_cache(target, cache_dir):
-    size = _get_size_recursively(cache_dir)
-    size_in_mb = int(round(size/1024./1024.))
-    if size_in_mb > prefs.codegen.max_cache_dir_size:
-        logger.warn('Cache size for target "%s": %s MB' % (target, size_in_mb))
-    else:
-        logger.debug('Cache size for target "%s": %s MB' % (target, size_in_mb))

--- a/brian2/codegen/runtime/cython_rt/cython_rt.py
+++ b/brian2/codegen/runtime/cython_rt/cython_rt.py
@@ -45,6 +45,16 @@ prefs.register_preferences(
         (the result of ``get_cython_cache_dir()``).
         '''
         ),
+    delete_source_files = BrianPreference(
+        default=True,
+        docs='''
+        Whether to delete source files after compiling. The Cython
+        source files can take a significant amount of disk space, and
+        are not used anymore when the compiled library file exists.
+        They are therefore deleted by default, but keeping them around
+        can be useful for debugging.
+        '''
+        )
     )
 
 

--- a/brian2/codegen/runtime/cython_rt/extension_manager.py
+++ b/brian2/codegen/runtime/cython_rt/extension_manager.py
@@ -50,7 +50,7 @@ def get_cython_cache_dir():
     return cache_dir
 
 def get_cython_extensions():
-    return {'.pyx', '.pyd', '.cpp', '.so', '.o', '.o.d', '.lock'}
+    return {'.pyx', '.pyd', '.cpp', '.so', '.o', '.o.d', '.lock', '.dll', '.obj'}
 
 class CythonExtensionManager(object):
     def __init__(self):

--- a/brian2/codegen/runtime/cython_rt/extension_manager.py
+++ b/brian2/codegen/runtime/cython_rt/extension_manager.py
@@ -49,13 +49,16 @@ def get_cython_cache_dir():
         cache_dir = os.path.join(base_cython_cache_dir(), 'brian_extensions')
     return cache_dir
 
+
 def get_cython_extensions():
-    return {'.pyx', '.pyd', '.cpp', '.so', '.o', '.o.d', '.lock', '.dll', '.obj'}
+    return {'.pyx', '.pyd', '.cpp', '.so', '.o', '.o.d', '.lock', '.dll',
+            '.obj', '.exp', '.lib'}
+
 
 class CythonExtensionManager(object):
     def __init__(self):
         self._code_cache = {}
-        
+
     def create_extension(self, code, force=False, name=None,
                          define_macros=None,
                          include_dirs=None,

--- a/brian2/codegen/runtime/cython_rt/extension_manager.py
+++ b/brian2/codegen/runtime/cython_rt/extension_manager.py
@@ -49,6 +49,8 @@ def get_cython_cache_dir():
         cache_dir = os.path.join(base_cython_cache_dir(), 'brian_extensions')
     return cache_dir
 
+def get_cython_extensions():
+    return {'.pyx', '.pyd', '.cpp', '.so', '.o', '.o.d', '.lock'}
 
 class CythonExtensionManager(object):
     def __init__(self):

--- a/brian2/codegen/runtime/cython_rt/extension_manager.py
+++ b/brian2/codegen/runtime/cython_rt/extension_manager.py
@@ -29,7 +29,7 @@ try:
     import Cython
     import Cython.Compiler as Cython_Compiler
     import Cython.Build as Cython_Build
-    from Cython.Utils import get_cython_cache_dir
+    from Cython.Utils import get_cython_cache_dir as base_cython_cache_dir
 except ImportError:
     Cython = None
 
@@ -41,6 +41,13 @@ from brian2.core.preferences import prefs
 __all__ = ['cython_extension_manager']
 
 logger = get_logger(__name__)
+
+
+def get_cython_cache_dir():
+    cache_dir = prefs.codegen.runtime.cython.cache_dir
+    if cache_dir is None and Cython is not None:
+        cache_dir = os.path.join(base_cython_cache_dir(), 'brian_extensions')
+    return cache_dir
 
 
 class CythonExtensionManager(object):
@@ -66,9 +73,7 @@ class CythonExtensionManager(object):
 
         code = deindent(code)
 
-        lib_dir = prefs.codegen.runtime.cython.cache_dir
-        if lib_dir is None:
-            lib_dir = os.path.join(get_cython_cache_dir(), 'brian_extensions')
+        lib_dir = get_cython_cache_dir()
         if '~' in lib_dir:
             lib_dir = os.path.expanduser(lib_dir)
         try:

--- a/brian2/codegen/runtime/cython_rt/extension_manager.py
+++ b/brian2/codegen/runtime/cython_rt/extension_manager.py
@@ -4,6 +4,7 @@ Cython automatic extension builder/manager
 Inspired by IPython's Cython cell magics, see:
 https://github.com/ipython/ipython/blob/master/IPython/extensions/cythonmagic.py
 '''
+import glob
 import imp
 import os
 import sys
@@ -242,6 +243,18 @@ class CythonExtensionManager(object):
                     build_extension.build_temp = os.path.dirname(pyx_file)
                     build_extension.build_lib = lib_dir
                     build_extension.run()
+                    if prefs['codegen.runtime.cython.delete_source_files']:
+                        # we can delete the source files to save disk space
+                        cpp_file = os.path.join(lib_dir, module_name + '.cpp')
+                        try:
+                            os.remove(pyx_file)
+                            os.remove(cpp_file)
+                            temp_dir = os.path.join(lib_dir, os.path.dirname(pyx_file)[1:], module_name + '.*')
+                            for fname in glob.glob(temp_dir):
+                                os.remove(fname)
+                        except (OSError, IOError) as ex:
+                            logger.debug('Deleting Cython source files failed with error: %s' % str(ex))
+
             except Cython_Compiler.Errors.CompileError:
                 return
 

--- a/brian2/codegen/runtime/weave_rt/weave_rt.py
+++ b/brian2/codegen/runtime/weave_rt/weave_rt.py
@@ -47,7 +47,7 @@ def get_weave_cache_dir():
 
 
 def get_weave_extensions():
-    return {'compiled_catalog', 'cpp', '.so', '.pyd'}
+    return {'compiled_catalog', 'cpp', '.so', '.pyd', '.dll', '.obj'}
 
 
 def weave_data_type(dtype):

--- a/brian2/codegen/runtime/weave_rt/weave_rt.py
+++ b/brian2/codegen/runtime/weave_rt/weave_rt.py
@@ -9,11 +9,13 @@ try:
     from scipy import weave
     from scipy.weave.c_spec import num_to_c_types
     from scipy.weave.inline_tools import function_cache
+    from scipy.weave.catalog import default_dir
 except ImportError:
     try:  # weave as an independent package
         import weave
         from weave.c_spec import num_to_c_types
         from weave.inline_tools import function_cache
+        from weave.catalog import default_dir
     except ImportError:
         # No weave for Python 3
         weave = None
@@ -37,6 +39,11 @@ __all__ = ['WeaveCodeObject', 'WeaveCodeGenerator']
 
 logger = get_logger(__name__)
 
+def get_weave_cache_dir():
+    if weave is not None:
+        return default_dir()
+    else:
+        return None
 
 def weave_data_type(dtype):
     '''

--- a/brian2/codegen/runtime/weave_rt/weave_rt.py
+++ b/brian2/codegen/runtime/weave_rt/weave_rt.py
@@ -39,6 +39,7 @@ __all__ = ['WeaveCodeObject', 'WeaveCodeGenerator']
 
 logger = get_logger(__name__)
 
+
 def get_weave_cache_dir():
     if weave is not None:
         return default_dir()
@@ -47,7 +48,8 @@ def get_weave_cache_dir():
 
 
 def get_weave_extensions():
-    return {'compiled_catalog', 'cpp', '.so', '.pyd', '.dll', '.obj'}
+    return {'compiled_catalog', 'cpp', '.so', '.pyd', '.dll', '.obj', '.exp',
+            '.lib'}
 
 
 def weave_data_type(dtype):

--- a/brian2/codegen/runtime/weave_rt/weave_rt.py
+++ b/brian2/codegen/runtime/weave_rt/weave_rt.py
@@ -45,6 +45,11 @@ def get_weave_cache_dir():
     else:
         return None
 
+
+def get_weave_extensions():
+    return {'compiled_catalog', 'cpp', '.so', '.pyd'}
+
+
 def weave_data_type(dtype):
     '''
     Gives the C language specifier for numpy data types using weave. For example,


### PR DESCRIPTION
As discussed in #914, this PR improves Cython's and (to a lesser extent) weave's code generation cache:
1. After successful compilation of a library file for Cython we now delete the corresponding `.cpp` and `.pyx` files, plus any additional temporary library files (I still need to check whether this is working correctly on Windows as well). The library file (e.g. `.so` on Linux) is the only file that we'll ever need later. When I run the Cython test suite with an empty cache, I now get 166MB of cached files instead of 774MB before the change. Quite an improvement! I did not see any noticeable slowdown, and the deletion can be switched off with a preference for debugging (`codegen.runtime.cython.delete_source_files`).
2. When importing Brian 2, if the Cython or weave cache directory take up more than 1GB (`codegen.max_cache_dir_size` preference), the user gets an INFO message like this:
```
INFO       Cache size for target "cython": 1584 MB.
You can call "clear_cache('cython')" to delete all files from the cache or manually
delete files in the "/home/marcel/.cython/brian_extensions" directory. [brian2]
```
3. As the message suggests, `clear_cache('cython')` or `clear_cache('weave')` can be used to delete the respective cache directory.

[Unrelated to the changes here, I had to bump up the numpy dependency to version 1.10, we were actually already using a numpy function in one place that did not exist in numpy 1.9. **EDIT**: I pushed this change directly to master, as tests on all branches were failing because of a related issue]