### PR TITLE
Fix minor typo in synapses exception message

### DIFF
--- a/brian2/synapses/synapses.py
+++ b/brian2/synapses/synapses.py
@@ -864,7 +864,7 @@ class Synapses(Group):
                                   'in "_pre" or "_post".') % varname)
             if not varname in self.variables:
                 raise ValueError(('The summed variable "%s" does not refer'
-                                  'do any known variable in the '
+                                  'to any known variable in the '
                                   'target group.') % varname)
             if varname.endswith('_pre'):
                 summed_target = self.source


### PR DESCRIPTION
Just fixing (through the GH online editor) a typo that I noticed when I received an error message:
"...do any..." <- "...to any..."