### PR TITLE
[MRG] Fix subgroups and summed variables with C-based codegen targets

### DIFF
--- a/brian2/codegen/runtime/cython_rt/templates/summed_variable.pyx
+++ b/brian2/codegen/runtime/cython_rt/templates/summed_variable.pyx
@@ -9,7 +9,7 @@
 
     # Set all the target variable values to zero
     for _target_idx in range({{_target_size_name}}):
-        {{_target_var_array}}[_target_idx] = 0
+        {{_target_var_array}}[_target_idx + {{_target_start}}] = 0
 
     # scalar code
     _vectorisation_idx = 1

--- a/brian2/codegen/runtime/weave_rt/templates/summed_variable.cpp
+++ b/brian2/codegen/runtime/weave_rt/templates/summed_variable.cpp
@@ -10,7 +10,7 @@
 
 	// Set all the target variable values to zero
 	for (int _target_idx=0; _target_idx<_target_size; _target_idx++)
-	    {{_target_var_array}}[_target_idx] = 0;
+	    {{_target_var_array}}[_target_idx + {{_target_start}}] = 0;
 
     // scalar code
 	const int _vectorisation_idx = 1;

--- a/brian2/devices/cpp_standalone/templates/summed_variable.cpp
+++ b/brian2/devices/cpp_standalone/templates/summed_variable.cpp
@@ -12,7 +12,7 @@
     {{ openmp_pragma('parallel-static') }}
     for (int _target_idx=0; _target_idx<_target_size; _target_idx++)
     {
-        {{_target_var_array}}[_target_idx] = 0;
+        {{_target_var_array}}[_target_idx + {{_target_start}}] = 0;
     }
 
     // scalar code


### PR DESCRIPTION
As detailed in #925, C-based codegen targets were not correctly setting the values of the target variable to 0 before doing the summation when the target was a subgroup. The fix is straightforward, all that was needed is to add the start index of the target group (which is 0 for standard groups, but potentially >0 for subgroups).
Fixes #925