### PR TITLE
[MRG] Handle delay variable differently

### DIFF
--- a/brian2/equations/equations.py
+++ b/brian2/equations/equations.py
@@ -177,7 +177,7 @@ def check_identifier_reserved(identifier):
     if (identifier in ('t', 'dt', 'xi', 'i', 'N') or
             identifier.startswith('xi_')):
         raise SyntaxError(('"%s" has a special meaning in equations and cannot '
-                           ' be used as a variable name.') % identifier)
+                           'be used as a variable name.') % identifier)
 
 
 def check_identifier_units(identifier):
@@ -675,7 +675,8 @@ class Equations(collections.Hashable, collections.Mapping):
     #: `Equations.register_identifier_check` and will be automatically
     #: used when checking identifiers
     identifier_checks = {check_identifier_basic, check_identifier_reserved,
-                         check_identifier_functions, check_identifier_units}
+                         check_identifier_functions, check_identifier_constants,
+                         check_identifier_units}
 
     @staticmethod
     def register_identifier_check(func):

--- a/brian2/equations/equations.py
+++ b/brian2/equations/equations.py
@@ -133,7 +133,7 @@ def check_identifier_basic(identifier):
     
     Raises
     ------
-    ValueError    
+    SyntaxError
         If the identifier does not conform to the above rules.
     '''
 
@@ -146,14 +146,14 @@ def check_identifier_basic(identifier):
     # full identifier, if not it is an illegal identifier like "3foo" which only
     # matched on "foo"
     if len(parse_result) != 1 or parse_result[0][0][0] != identifier:
-        raise ValueError('"%s" is not a valid variable name.' % identifier)
+        raise SyntaxError('"%s" is not a valid variable name.' % identifier)
 
     if keyword.iskeyword(identifier):
-        raise ValueError(('"%s" is a Python keyword and cannot be used as a '
-                          'variable.') % identifier)
+        raise SyntaxError(('"%s" is a Python keyword and cannot be used as a '
+                           'variable.') % identifier)
 
     if identifier.startswith('_'):
-        raise ValueError(('Variable "%s" starts with an underscore, '
+        raise SyntaxError(('Variable "%s" starts with an underscore, '
                           'this is only allowed for variables used '
                           'internally') % identifier)
 
@@ -171,12 +171,13 @@ def check_identifier_reserved(identifier):
     
     Raises
     ------
-    ValueError
+    SyntaxError
         If the identifier is a special variable name.
     '''
-    if identifier in ('t', 'dt', 'xi') or identifier.startswith('xi_'):
-        raise ValueError(('"%s" has a special meaning in equations and cannot '
-                         ' be used as a variable name.') % identifier)
+    if (identifier in ('t', 'dt', 'xi', 'i', 'N') or
+            identifier.startswith('xi_')):
+        raise SyntaxError(('"%s" has a special meaning in equations and cannot '
+                           ' be used as a variable name.') % identifier)
 
 
 def check_identifier_units(identifier):
@@ -184,24 +185,26 @@ def check_identifier_units(identifier):
     Make sure that identifier names do not clash with unit names.
     '''
     if identifier in DEFAULT_UNITS:
-        raise ValueError('"%s" is the name of a unit, cannot be used as a '
-                         'variable name.' % identifier)
+        raise SyntaxError('"%s" is the name of a unit, cannot be used as a '
+                          'variable name.' % identifier)
+
 
 def check_identifier_functions(identifier):
     '''
     Make sure that identifier names do not clash with function names.
     '''
     if identifier in DEFAULT_FUNCTIONS:
-        raise ValueError('"%s" is the name of a function, cannot be used as a '
-                         'variable name.' % identifier)
+        raise SyntaxError('"%s" is the name of a function, cannot be used as a '
+                          'variable name.' % identifier)
+
 
 def check_identifier_constants(identifier):
     '''
     Make sure that identifier names do not clash with function names.
     '''
     if identifier in DEFAULT_CONSTANTS:
-        raise ValueError('"%s" is the name of a constant, cannot be used as a '
-                         'variable name.' % identifier)
+        raise SyntaxError('"%s" is the name of a constant, cannot be used as a '
+                          'variable name.' % identifier)
 
 
 _base_units_with_alternatives = None

--- a/brian2/equations/refractory.py
+++ b/brian2/equations/refractory.py
@@ -27,8 +27,10 @@ def check_identifier_refractory(identifier):
         If the identifier is a variable name used for the refractory mechanism.
     '''
     if identifier in ('not_refractory', 'refractory', 'refractory_until'):
-        raise ValueError(('The name "%s" is used in the refractory mechanism '
-                         ' and should not be used as a variable name.' % identifier))
+        raise SyntaxError('The name "%s" is used in the refractory mechanism '
+                          ' and should not be used as a variable '
+                          'name.' % identifier)
+
 
 Equations.register_identifier_check(check_identifier_refractory)
 

--- a/brian2/synapses/synapses.py
+++ b/brian2/synapses/synapses.py
@@ -718,9 +718,12 @@ class Synapses(Group):
                                               ('summed', 'shared',
                                                'constant over dt')])
 
+        for name in ['j', 'lastupdate', 'delay']:
+            if name in model.names:
+                raise SyntaxError('"%s" is a reserved name that cannot be '
+                                  'used as a variable name.' % name)
+
         # Add the lastupdate variable, needed for event-driven updates
-        if 'lastupdate' in model.names:
-            raise SyntaxError('lastupdate is a reserved name.')
         model = model + Equations('lastupdate : second')
         # Add the "multisynaptic index", if desired
         self.multisynaptic_index = multisynaptic_index

--- a/brian2/synapses/synapses.py
+++ b/brian2/synapses/synapses.py
@@ -4,6 +4,7 @@ Module providing the `Synapses` class and related helper classes/functions.
 
 import collections
 from collections import defaultdict
+import functools
 import weakref
 import re
 import numbers
@@ -253,6 +254,11 @@ class SynapticPathway(CodeRunner, Group):
         self.variables.add_references(synapses, synaptic_vars)
         self.variables.indices.update(synaptic_idcs)
         self._enable_group_attributes()
+
+    def check_variable_write(self, variable):
+        # Forward the check to the `Synapses` object (raises an error if no
+        # synapse has been created yet)
+        self.synapses.check_variable_write(variable)
 
     @device_override('synaptic_pathway_update_abstract_code')
     def update_abstract_code(self, run_namespace=None, level=0):
@@ -826,12 +832,6 @@ class Synapses(Group):
                 raise ValueError(('Cannot set the delay for pathway '
                                   '"%s": unknown pathway.') % pathway)
 
-        # If we have a pathway called "pre" (the most common use case), provide
-        # direct access to its delay via a delay attribute (instead of having
-        # to use pre.delay)
-        if 'pre' in self._synaptic_updaters:
-            self.variables.add_reference('delay', self.pre)
-
         #: Performs numerical integration step
         self.state_updater = None
 
@@ -910,6 +910,38 @@ class Synapses(Group):
     def __getitem__(self, item):
         indices = self.indices[item]
         return SynapticSubgroup(self, indices)
+
+    def _set_delay(self, delay, with_unit):
+        if 'pre' not in self._synaptic_updaters:
+            raise AttributeError("Synapses do not have a 'pre' pathway, "
+                                 "do not know what 'delay' refers to.")
+        # Note that we cannot simply say: "self.pre.delay = delay" because this
+        # would not correctly deal with references to external constants
+        var = self.pre.variables['delay']
+        if with_unit:
+            reference = var.get_addressable_value_with_unit('delay', self.pre)
+        else:
+            reference = var.get_addressable_value('delay', self.pre)
+        reference.set_item('True', delay, level=2)
+
+    def _get_delay(self, with_unit):
+        if 'pre' not in self._synaptic_updaters:
+            raise AttributeError("Synapses do not have a 'pre' pathway, "
+                                 "do not know what 'delay' refers to.")
+        var = self.pre.variables['delay']
+        if with_unit:
+            return var.get_addressable_value_with_unit('delay', self.pre)
+        else:
+            return var.get_addressable_value('delay', self.pre)
+
+    delay = property(functools.partial(_get_delay, with_unit=True),
+                     functools.partial(_set_delay, with_unit=True),
+                     doc='The presynaptic delay (if a pre-synaptic pathway '
+                         'exists).')
+    delay_ = property(functools.partial(_get_delay, with_unit=False),
+                      functools.partial(_set_delay, with_unit=False),
+                      doc='The presynaptic delay without unit information (if a'
+                          'pre-synaptic pathway exists).')
 
     def _add_updater(self, code, prepost, objname=None, delay=None,
                      event='spike'):

--- a/brian2/synapses/synapses.py
+++ b/brian2/synapses/synapses.py
@@ -162,6 +162,9 @@ class SynapticPathway(CodeRunner, Group):
             raise ValueError('prepost argument has to be either "pre" or '
                              '"post"')
         self.synapses = weakref.proxy(synapses)
+        # Allow to use the same indexing of the delay variable  as in the parent
+        # Synapses object (e.g. 2d indexing with pre- and post-synaptic indices)
+        self._indices = self.synapses._indices
 
         if objname is None:
             objname = prepost
@@ -789,6 +792,9 @@ class Synapses(Group):
                 # it gets automatically resized
                 self.register_variable(var)
 
+        # Support 2d indexing
+        self._indices = SynapticIndexing(self)
+
         if delay is None:
             delay = {}
 
@@ -903,9 +909,6 @@ class Synapses(Group):
                                             summed_var_index)
             self.summed_updaters[varname] = updater
             self.contained_objects.append(updater)
-
-        # Support 2d indexing
-        self._indices = SynapticIndexing(self)
 
         # Activate name attribute access
         self._enable_group_attributes()

--- a/brian2/tests/test_GSL.py
+++ b/brian2/tests/test_GSL.py
@@ -421,7 +421,7 @@ def test_GSL_fixed_timestep_big_dt_small_error():
 @attr('codegen-independent')
 @skip_if_not_implemented
 def test_GSL_internal_variable():
-    assert_raises(ValueError, Equations, 'd_p/dt = 300*Hz : 1')
+    assert_raises(SyntaxError, Equations, 'd_p/dt = 300*Hz : 1')
 
 
 @attr('standalone-compatible')

--- a/brian2/tests/test_equations.py
+++ b/brian2/tests/test_equations.py
@@ -82,19 +82,19 @@ def test_identifier_checks():
                                  'identifier "%s": %s' % (identifier, ex))
 
     for identifier in illegal_identifiers:
-        assert_raises(ValueError, lambda: check_identifier_basic(identifier))
+        assert_raises(SyntaxError, lambda: check_identifier_basic(identifier))
 
-    for identifier in ('t', 'dt', 'xi'):
-        assert_raises(ValueError, lambda: check_identifier_reserved(identifier))
+    for identifier in ('t', 'dt', 'xi', 'i', 'N'):
+        assert_raises(SyntaxError, lambda: check_identifier_reserved(identifier))
 
     for identifier in ('not_refractory', 'refractory', 'refractory_until'):
-        assert_raises(ValueError, lambda: check_identifier_refractory(identifier))
+        assert_raises(SyntaxError, lambda: check_identifier_refractory(identifier))
 
     for identifier in ('exp', 'sin', 'sqrt'):
-        assert_raises(ValueError, lambda: check_identifier_functions(identifier))
+        assert_raises(SyntaxError, lambda: check_identifier_functions(identifier))
 
     for identifier in ('volt', 'second', 'mV', 'nA'):
-        assert_raises(ValueError, lambda: check_identifier_units(identifier))
+        assert_raises(SyntaxError, lambda: check_identifier_units(identifier))
 
     # Check identifier registry
     assert check_identifier_basic in Equations.identifier_checks
@@ -107,16 +107,17 @@ def test_identifier_checks():
     # gaba_123 (that is otherwise valid)
     def disallow_gaba_123(identifier):
         if identifier == 'gaba_123':
-            raise ValueError('I do not like this name')
+            raise SyntaxError('I do not like this name')
 
     Equations.check_identifier('gaba_123')
     old_checks = set(Equations.identifier_checks)
     Equations.register_identifier_check(disallow_gaba_123)
-    assert_raises(ValueError, lambda: Equations.check_identifier('gaba_123'))
+    assert_raises(SyntaxError, lambda: Equations.check_identifier('gaba_123'))
     Equations.identifier_checks = old_checks
 
-    # registering a non-function should now work
-    assert_raises(ValueError, lambda: Equations.register_identifier_check('no function'))
+    # registering a non-function should not work
+    assert_raises(ValueError,
+                  lambda: Equations.register_identifier_check('no function'))
 
 @attr('codegen-independent')
 def test_parse_equations():
@@ -192,12 +193,12 @@ def test_correct_replacements():
 def test_wrong_replacements():
     '''Tests for replacements that should not work'''
     # Replacing a variable name with an illegal new name
-    assert_raises(ValueError, lambda: Equations('dv/dt = -v / tau : 1',
-                                                v='illegal name'))
-    assert_raises(ValueError, lambda: Equations('dv/dt = -v / tau : 1',
-                                                v='_reserved'))
-    assert_raises(ValueError, lambda: Equations('dv/dt = -v / tau : 1',
-                                                v='t'))
+    assert_raises(SyntaxError, lambda: Equations('dv/dt = -v / tau : 1',
+                                                 v='illegal name'))
+    assert_raises(SyntaxError, lambda: Equations('dv/dt = -v / tau : 1',
+                                                 v='_reserved'))
+    assert_raises(SyntaxError, lambda: Equations('dv/dt = -v / tau : 1',
+                                                 v='t'))
 
     # Replacing a variable name with a value that already exists
     assert_raises(EquationError, lambda: Equations('''
@@ -262,13 +263,13 @@ def test_construction_errors():
     assert_raises(EquationError, lambda: Equations(eqs))
 
     # illegal variable names
-    assert_raises(ValueError, lambda: Equations('ddt/dt = -dt / tau : volt'))
-    assert_raises(ValueError, lambda: Equations('dt/dt = -t / tau : volt'))
-    assert_raises(ValueError, lambda: Equations('dxi/dt = -xi / tau : volt'))
-    assert_raises(ValueError, lambda: Equations('for : volt'))
-    assert_raises((EquationError, ValueError),
+    assert_raises(SyntaxError, lambda: Equations('ddt/dt = -dt / tau : volt'))
+    assert_raises(SyntaxError, lambda: Equations('dt/dt = -t / tau : volt'))
+    assert_raises(SyntaxError, lambda: Equations('dxi/dt = -xi / tau : volt'))
+    assert_raises(SyntaxError, lambda: Equations('for : volt'))
+    assert_raises((EquationError, SyntaxError),
                   lambda: Equations('d1a/dt = -1a / tau : volt'))
-    assert_raises(ValueError, lambda: Equations('d_x/dt = -_x / tau : volt'))
+    assert_raises(SyntaxError, lambda: Equations('d_x/dt = -_x / tau : volt'))
 
     # xi in a subexpression
     assert_raises(EquationError,

--- a/brian2/tests/test_equations.py
+++ b/brian2/tests/test_equations.py
@@ -1,5 +1,4 @@
 # encoding: utf8
-from collections import namedtuple
 import sys
 from StringIO import StringIO
 
@@ -12,16 +11,15 @@ except ImportError:
 from nose import SkipTest
 from nose.plugins.attrib import attr
 
-from brian2 import volt, amp, mV, second, ms, Hz, farad, metre, cm
-from brian2 import Unit, Equations, Expression, sin
+from brian2 import volt, mV, second, ms, Hz, farad, metre
+from brian2 import Unit, Equations, Expression
 from brian2.units.fundamentalunits import (DIMENSIONLESS, get_dimensions,
-                                           have_same_dimensions,
                                            DimensionMismatchError)
 from brian2.core.namespace import DEFAULT_UNITS
-from brian2.core.preferences import prefs
 from brian2.equations.equations import (check_identifier_basic,
                                         check_identifier_reserved,
                                         check_identifier_functions,
+                                        check_identifier_constants,
                                         check_identifier_units,
                                         parse_string_equations,
                                         dimensions_and_type_from_string,
@@ -29,7 +27,8 @@ from brian2.equations.equations import (check_identifier_basic,
                                         DIFFERENTIAL_EQUATION, SUBEXPRESSION,
                                         PARAMETER, FLOAT, BOOLEAN, INTEGER,
                                         EquationError,
-                                        extract_constant_subexpressions)
+                                        extract_constant_subexpressions
+                                        )
 from brian2.equations.refractory import check_identifier_refractory
 from brian2.groups.group import Group
 
@@ -93,6 +92,9 @@ def test_identifier_checks():
     for identifier in ('exp', 'sin', 'sqrt'):
         assert_raises(SyntaxError, lambda: check_identifier_functions(identifier))
 
+    for identifier in ('e', 'pi', 'inf'):
+        assert_raises(SyntaxError, lambda: check_identifier_constants(identifier))
+
     for identifier in ('volt', 'second', 'mV', 'nA'):
         assert_raises(SyntaxError, lambda: check_identifier_units(identifier))
 
@@ -101,6 +103,7 @@ def test_identifier_checks():
     assert check_identifier_reserved in Equations.identifier_checks
     assert check_identifier_refractory in Equations.identifier_checks
     assert check_identifier_functions in Equations.identifier_checks
+    assert check_identifier_constants in Equations.identifier_checks
     assert check_identifier_units in Equations.identifier_checks
 
     # Set up a dummy identifier check that disallows the variable name

--- a/brian2/tests/test_synapses.py
+++ b/brian2/tests/test_synapses.py
@@ -721,15 +721,21 @@ def test_delay_specification():
     assert_equal(S.delay[:], abs(G.x - (10 - G.i)*mmeter)/velocity)
     S.delay = 5*ms
     assert_equal(S.delay[:], np.ones(len(G))*5*ms)
+    # Setting delays without units
+    S.delay_ = float(7*ms)
+    assert_equal(S.delay[:], np.ones(len(G))*7*ms)
 
     # Scalar delay
     S = Synapses(G, G, 'w:1', on_pre='v+=w', delay=5*ms)
     assert_equal(S.delay[:], 5*ms)
     S.connect(j='i')
-    S.delay = 10*ms
-    assert_equal(S.delay[:], 10*ms)
     S.delay = '3*ms'
     assert_equal(S.delay[:], 3*ms)
+    S.delay = 10 * ms
+    assert_equal(S.delay[:], 10 * ms)
+    # Without units
+    S.delay_ = float(20*ms)
+    assert_equal(S.delay[:], 20 * ms)
 
     # Invalid arguments
     assert_raises(DimensionMismatchError, lambda: Synapses(G, G, 'w:1',

--- a/brian2/tests/test_synapses.py
+++ b/brian2/tests/test_synapses.py
@@ -772,6 +772,16 @@ def test_delays_pathways():
     assert_equal(S.pre1.delay[:], np.ones(len(G)) * 5*ms)
     assert_equal(S.pre2.delay[:], np.ones(len(G)) * 10*ms)
     assert_equal(S.post.delay[:], np.ones(len(G)) * 1*ms)
+    # Indexing with strings
+    assert len(S.pre1.delay['j<5']) == 5
+    assert_equal(S.pre1.delay['j<5'], 5*ms)
+    # Indexing with 2d indices
+    assert len(S.post.delay[[3, 4], :]) == 2
+    assert_equal(S.post.delay[[3, 4], :], 1*ms)
+    assert len(S.pre2.delay[:, 7]) == 1
+    assert_equal(S.pre2.delay[:, 7], 10*ms)
+    assert len(S.pre1.delay[[1, 2], [1, 2]]) == 2
+    assert_equal(S.pre1.delay[[1, 2], [1, 2]], 5*ms)
 
     # Scalar delay
     S = Synapses(G, G, 'w:1', on_pre={'pre1':'v+=w',


### PR DESCRIPTION
As discussed in #927 , this PR changes two things:
* `delay` can no longer be used as a variable name in `Synapses`
* The pre-synaptic delay can still be set/accessed using the shorthand `synapses.delay` (instead of `synapses.pre.delay`), but you can no longer reference `delay` in code.

I'm not 100% sure about the latter change: I don't see much use of accessing it in code, but in the long-term we want to have access to it for models of "delay plastiticity" (#355). However, we'd still have to be unambiguous about the syntax to distinguish `pre` and `post` delay. We could simply use `delay_pre` and `delay_post` but then this would be confusing with respect to other `_pre` and `_post` variables which refer neuronal and not synaptic variables. But I think this is something that we should discuss/fix independent of this PR.