### PR TITLE
argument goes to diameter param if argument name is not specified int…

### DIFF
--- a/docs_sphinx/user/multicompartmental.rst
+++ b/docs_sphinx/user/multicompartmental.rst
@@ -206,7 +206,7 @@ Morphologies with coordinates can also be created section by section, following 
 morphologies::
 
     soma = Soma(diameter=30*um, x=50*um, y=20*um)
-    cylinder = Cylinder(10, x=[0, 100]*um, diameter=1*um)
+    cylinder = Cylinder(n=10, x=[0, 100]*um, diameter=1*um)
     section = Section(5,
                       x=[0, 10, 20, 30, 40, 50]*um,
                       y=[0, 10, 20, 30, 40, 50]*um,

--- a/docs_sphinx/user/multicompartmental.rst
+++ b/docs_sphinx/user/multicompartmental.rst
@@ -56,7 +56,7 @@ start of the section represents the parent compartment with diameter 15 μm, no
 |**Cylinder** |  ::                                                                               |
 |             |                                                                                   |
 |             |     # Each compartment has fixed length and diameter                              |
-|             |     Cylinder(5, diameter=10*um, length=50*um)                                     |
+|             |     Cylinder(n=5, diameter=10*um, length=50*um)                                   |
 |             |                                                                                   |
 |             | .. image:: images/cylinder.*                                                      |
 |             |                                                                                   |
@@ -65,7 +65,7 @@ start of the section represents the parent compartment with diameter 15 μm, no
 |             |                                                                                   |
 |             |     # Length and diameter individually defined for each compartment (at start     |
 |             |     # and end)                                                                    |
-|             |     Section(5, diameter=[15, 5, 10, 5, 10, 5]*um,                                 |
+|             |     Section(n=5, diameter=[15, 5, 10, 5, 10, 5]*um,                               |
 |             |             length=[10, 20, 5, 5, 10]*um)                                         |
 |             |                                                                                   |
 |             | .. image:: images/section.*                                                       |

--- a/docs_sphinx/user/multicompartmental.rst
+++ b/docs_sphinx/user/multicompartmental.rst
@@ -207,11 +207,11 @@ morphologies::
 
     soma = Soma(diameter=30*um, x=50*um, y=20*um)
     cylinder = Cylinder(n=10, x=[0, 100]*um, diameter=1*um)
-    section = Section(5,
+    section = Section(n=5,
                       x=[0, 10, 20, 30, 40, 50]*um,
                       y=[0, 10, 20, 30, 40, 50]*um,
                       z=[0, 10, 10, 10, 10, 10]*um,
-                      diameter=[6, 5, 4, 3, 2, 1])*um
+                      diameter=[6, 5, 4, 3, 2, 1]*um)
 
 Note that the ``x``, ``y``, ``z`` attributes of `Morphology` and `SpatialNeuron` will return the coordinates at the
 midpoint of each compartment (as for all other attributes that vary over the length of a compartment, e.g. ``diameter``


### PR DESCRIPTION
In this implementation of `Cylinder` function, first argument is unnamed and it tries to get attached with param `diameter`, which is already defined.
It throws
```
---------------------------------------------------------------------------
DimensionMismatchError                    Traceback (most recent call last)
<ipython-input-34-4d594a6997e6> in <module>()
      1 # biophsical properties and their potential representation is in attached file
      2 
----> 3 Cylinder(10, x=[0, 100]*um, diameter=1*um)

~/anaconda3/envs/brian2/lib/python3.6/site-packages/brian2/units/fundamentalunits.py in new_f(*args, **kwds)
   2356                                                            value=newkeyset[k])
   2357                         raise DimensionMismatchError(error_message,
-> 2358                                                      get_dimensions(newkeyset[k]))
   2359 
   2360             result = f(*args, **kwds)

DimensionMismatchError: Function "__init__" expected a quantitity with unit meter for argument "diameter" but got 10. (unit is 1).

```

fixing it by naming that argument correctly