### PR TITLE
Fix cache memory use

### DIFF
--- a/brian2/core/variables.py
+++ b/brian2/core/variables.py
@@ -525,8 +525,8 @@ class DynamicArrayVariable(ArrayVariable):
     '''
     # The size of a dynamic variable can of course change and changes in
     # size should not invalidate the cache
-    cache_irrelevant_attributes = (ArrayVariable._cache_irrelevant_attributes |
-                                   {'size'})
+    _cache_irrelevant_attributes = (ArrayVariable._cache_irrelevant_attributes |
+                                    {'size'})
 
     def __init__(self, name, owner, size, device, dimensions=DIMENSIONLESS,
                  dtype=None, constant=False, needs_reference_update=False,

--- a/brian2/devices/device.py
+++ b/brian2/devices/device.py
@@ -89,6 +89,8 @@ class Device(object):
 
         self._maximum_run_time = None
 
+        self._state_tuple = (self.__module__, self.__class__.__name__)
+
     def _set_maximum_run_time(self, maximum_run_time):
         '''
         Sets a maximum time for a run before it will break. Used primarily for testing purposes. Not guaranteed to be

--- a/brian2/synapses/cythonspikequeue.pyx
+++ b/brian2/synapses/cythonspikequeue.pyx
@@ -35,9 +35,13 @@ cdef extern from "cspikequeue.cpp":
 cdef class SpikeQueue:
     # TODO: Currently, the data type for dt and delays is fixed
     cdef CSpikeQueue[double] *thisptr
+    cdef readonly tuple _state_tuple
 
     def __cinit__(self, int source_start, int source_end):
         self.thisptr = new CSpikeQueue[double](source_start, source_end)
+
+    def __init__(self, source_start, source_end):
+        self._state_tuple = (source_start, source_end, np.int32)
 
     def __dealloc__(self):
         del self.thisptr

--- a/brian2/synapses/spikequeue.py
+++ b/brian2/synapses/spikequeue.py
@@ -63,6 +63,8 @@ class SpikeQueue(object):
         #: The dt used for storing the spikes (will be set in `prepare`)
         self._dt = None
 
+        self._state_tuple = (self._source_start, self._source_end, self.dtype)
+
     def prepare(self, delays, dt, synapse_sources):
         '''
         Prepare the data structures


### PR DESCRIPTION
This fixes the memory leak discussed in #933. It turned out that the biggest issue was the way the `SpikeQueue` was handled. Whenever code referenced to the `SpikeQueue` (all `on_pre`/`on_post` code), then the caching mechanism used an explicit reference to the `SpikeQueue` as part of the "cache key". This led to two problems:
1. Recreating exactly the same network with the same code would not use the cache at all for all synaptic statements, because the `SpikeQueue` was no longer the same.
2. The reference to the `SpikeQueue` prevented it from getting garbage collected (since the `SpikeQueue` stores synaptic delays for each synapse, it can take quite a bit of memory).

This was fixed by using our existing mechanism (the `_state_tuple` attribute), to replace the `SpikeQueue` reference by a simple tuple with all information relevant to code generation. I also made the caching mechanism use weak references if possible to avoid the problem in a more general way. There were some other smaller issues (e.g. our `_hasheable` function did not recurse down into tuples) that I fixed as well, together with some minor performance optimisation (which became necessary because the `_hasheable` function is now called more often than before).

Performance/memory usage looks pretty good now.

Recreated objects (see #933 for code):
![full_mem_comparison](https://user-images.githubusercontent.com/1381982/38094052-08d023b0-336d-11e8-9310-c1242292484b.png)

Store/Restore mechanism:
![full_mem_comparison_restore](https://user-images.githubusercontent.com/1381982/38094066-0d4011a8-336d-11e8-9fd0-a6f58c1399aa.png)



Fixes #933