### PR TITLE
[MRG] Make profiling optional in standalone

### DIFF
--- a/brian2/core/network.py
+++ b/brian2/core/network.py
@@ -362,7 +362,7 @@ class Network(Nameable):
         is to allow devices (e.g. `CPPStandaloneDevice`) to overwrite this.
         '''
         if self._profiling_info is None:
-            raise ValueError('(No profiling info collected (did you run with '
+            raise ValueError('No profiling info collected (did you run with '
                              'profile=True?)')
         return sorted(self._profiling_info, key=lambda item: item[1],
                       reverse=True)

--- a/brian2/devices/cpp_standalone/device.py
+++ b/brian2/devices/cpp_standalone/device.py
@@ -1291,9 +1291,9 @@ class CPPStandaloneDevice(Device):
                                    'supported in the C++ standalone'))
 
     def network_get_profiling_info(self, net):
-        if net._profiling_info is None:
+        fname = os.path.join(self.project_dir, 'results', 'profiling_info.txt')
+        if os.path.exists(fname):
             net._profiling_info = []
-            fname = os.path.join(self.project_dir, 'results', 'profiling_info.txt')
             with open(fname) as f:
                 for line in f:
                     (key, val) = line.split()

--- a/brian2/devices/cpp_standalone/templates/common_group.cpp
+++ b/brian2/devices/cpp_standalone/templates/common_group.cpp
@@ -24,10 +24,12 @@ void _run_{{codeobj_name}}()
 {
 	using namespace brian;
 
+    {% if profiled %}
     {% if openmp_pragma('with_openmp') %}
     const double _start_time = omp_get_wtime();
     {% else %}
     const std::clock_t _start_time = std::clock();
+    {% endif %}
     {% endif %}
 
 	///// CONSTANTS ///////////
@@ -56,12 +58,14 @@ void _run_{{codeobj_name}}()
 	}
 	{% endblock %}
 
+    {% if profiled %}
     {% if openmp_pragma('with_openmp') %}
     const double _run_time = omp_get_wtime() -_start_time;
     {% else %}
     const double _run_time = (double)(std::clock() -_start_time)/CLOCKS_PER_SEC;
     {% endif %}
     {{codeobj_name}}_profiling_info += _run_time;
+    {% endif %}
 }
 
 {% block extra_functions_cpp %}

--- a/brian2/devices/cpp_standalone/templates/objects.cpp
+++ b/brian2/devices/cpp_standalone/templates/objects.cpp
@@ -64,10 +64,9 @@ Clock {{clock.name}};  // attributes will be set in run.cpp
 {% endfor %}
 
 // Profiling information for each code object
-{% for codeobj in code_objects | sort(attribute='name') %}
-double {{codeobj.name}}_profiling_info = 0.0;
+{% for codeobj in profiled_codeobjects | sort %}
+double {{codeobj}}_profiling_info = 0.0;
 {% endfor %}
-
 }
 
 void _init_arrays()
@@ -186,21 +185,21 @@ void _write_arrays()
 		std::cout << "Error writing output file for {{varname}}." << endl;
 	}
 	{% endfor %}
-
+    {% if profiled_codeobjects %}
 	// Write profiling info to disk
 	ofstream outfile_profiling_info;
 	outfile_profiling_info.open("results/profiling_info.txt", ios::out);
 	if(outfile_profiling_info.is_open())
 	{
-	{% for codeobj in code_objects | sort(attribute='name') %}
-	outfile_profiling_info << "{{codeobj.name}}\t" << {{codeobj.name}}_profiling_info << std::endl;
+	{% for codeobj in profiled_codeobjects | sort %}
+	outfile_profiling_info << "{{codeobj}}\t" << {{codeobj}}_profiling_info << std::endl;
 	{% endfor %}
 	outfile_profiling_info.close();
 	} else
 	{
 	    std::cout << "Error writing profiling info to file." << std::endl;
 	}
-
+    {% endif %}
 	// Write last run info to disk
 	ofstream outfile_last_run_info;
 	outfile_last_run_info.open("results/last_run_info.txt", ios::out);
@@ -309,8 +308,8 @@ extern SynapticPathway<double> {{path.name}};
 {% endfor %}
 
 // Profiling information for each code object
-{% for codeobj in code_objects | sort(attribute='name') %}
-extern double {{codeobj.name}}_profiling_info;
+{% for codeobj in profiled_codeobjects | sort %}
+extern double {{codeobj}}_profiling_info;
 {% endfor %}
 
 }

--- a/brian2/devices/cpp_standalone/templates/synapses_push_spikes.cpp
+++ b/brian2/devices/cpp_standalone/templates/synapses_push_spikes.cpp
@@ -12,10 +12,12 @@ void _run_{{codeobj_name}}()
 {
     using namespace brian;
 
+    {% if profiled %}
     {% if openmp_pragma('with_openmp') %}
     const double _start_time = omp_get_wtime();
     {% else %}
     const std::clock_t _start_time = std::clock();
+    {% endif %}
     {% endif %}
 
     ///// CONSTANTS ///////////
@@ -34,6 +36,7 @@ void _run_{{codeobj_name}}()
         {{owner.name}}.push({{_eventspace}}, {{_eventspace}}[_num{{eventspace_variable.name}}-1]);
     }
 
+    {% if profiled %}
     // Profiling
     {% if openmp_pragma('with_openmp') %}
     const double _run_time = omp_get_wtime() -_start_time;
@@ -41,6 +44,7 @@ void _run_{{codeobj_name}}()
     const double _run_time = (double)(std::clock() -_start_time)/CLOCKS_PER_SEC;
     {% endif %}
     {{codeobj_name}}_profiling_info += _run_time;
+    {% endif %}
 }
 {% endmacro %}
 

--- a/brian2/tests/__init__.py
+++ b/brian2/tests/__init__.py
@@ -57,6 +57,7 @@ def make_argv(dirnames, attributes, doctests=False):
              '-I', '^_',
              "-a", attributes,
              '--nologcapture',
+             '--verbose',
              '--exe'])
     if doctests:
         argv += ['--with-doctest']

--- a/brian2/tests/test_cpp_standalone.py
+++ b/brian2/tests/test_cpp_standalone.py
@@ -5,6 +5,7 @@ from numpy.testing.utils import assert_allclose, assert_equal, assert_raises
 from brian2 import *
 from brian2.devices.device import reinit_devices, set_device, reset_device
 
+
 @attr('cpp_standalone', 'standalone-only')
 @with_setup(teardown=reinit_devices)
 def test_cpp_standalone():
@@ -328,6 +329,57 @@ def test_run_with_debug():
     mon = SpikeMonitor(group)
     run(defaultclock.dt)
 
+@attr('cpp_standalone', 'standalone-only')
+@with_setup(teardown=reinit_devices)
+def test_changing_profile_arg():
+    set_device('cpp_standalone', build_on_run=False)
+    G = NeuronGroup(10000, 'v : 1')
+    op1 = G.run_regularly('v = exp(-v)', name='op1')
+    op2 = G.run_regularly('v = exp(-v)', name='op2')
+    op3 = G.run_regularly('v = exp(-v)', name='op3')
+    op4 = G.run_regularly('v = exp(-v)', name='op4')
+    # Op 1 is active only during the first profiled run
+    # Op 2 is active during both profiled runs
+    # Op 3 is active only during the second profiled run
+    # Op 4 is never active (only during the unprofiled run)
+    op1.active = True
+    op2.active = True
+    op3.active = False
+    op4.active = False
+    run(100*defaultclock.dt, profile=True)
+    op1.active = True
+    op2.active = True
+    op3.active = True
+    op4.active = True
+    run(100*defaultclock.dt, profile=False)
+    op1.active = False
+    op2.active = True
+    op3.active = True
+    op4.active = False
+    run(100*defaultclock.dt, profile=True)
+    device.build(directory=None, with_output=False)
+    profiling_dict = dict(magic_network.profiling_info)
+    # Note that for now, C++ standalone creates a new CodeObject for every run,
+    # which is most of the time unnecessary (this is partly due to the way we
+    # handle constants: they are included as literals in the code but they can
+    # change between runs). Therefore, the profiling info is potentially
+    # difficult to interpret
+    assert len(profiling_dict) == 4  # 2 during first run, 2 during last run
+    # The two code objects that were executed during the first run
+    assert ('op1_codeobject' in profiling_dict and
+            profiling_dict['op1_codeobject'] > 0*second)
+    assert ('op2_codeobject' in profiling_dict and
+            profiling_dict['op2_codeobject'] > 0*second)
+    # Four code objects were executed during the second run, but no profiling
+    # information was saved
+    for name in ['op1_codeobject_1', 'op2_codeobject_1', 'op3_codeobject',
+                 'op4_codeobject']:
+        assert name not in profiling_dict
+    # Two code objects were exectued during the third run
+    assert ('op2_codeobject_2' in profiling_dict and
+            profiling_dict['op2_codeobject_2'] > 0*second)
+    assert ('op3_codeobject_1' in profiling_dict and
+            profiling_dict['op3_codeobject_1'] > 0*second)
 
 
 if __name__=='__main__':
@@ -340,7 +392,8 @@ if __name__=='__main__':
              test_openmp_scalar_writes,
              test_time_after_run,
              test_array_cache,
-             test_run_with_debug
+             test_run_with_debug,
+             test_changing_profile_arg,
              ]:
         t()
         reinit_devices()


### PR DESCRIPTION
This is somewhat embarrassing, but in contrast to what I thought, measuring the profiling information in C++ standalone *can* take a significant amount of time. Profiling has been always optional in runtime and recently we switched the default to off for performance reasons. However, in C++ standalone switching off profiling did not change anything. With this PR, profiling becomes optional (it also fixes a minor corner-case issue, where the profiling info would not be reloaded if you reinitialize the device and re-run a s imulation).

The performance difference can be quite striking:
`cuba_openmp`: 0.26-0.27s (this PR); 0.36-0.37s (master)
`STDP_standalone`: 13.4s (this PR); 19.1s (master)
For other examples where the computation within a single code object takes a very long time (e.g. `Kremer_et_al_2011_barrel_cortex`, `COBAHH`) there's not much of a difference, though.