### PR TITLE
Do not unnecessarily set values in dynamic arrays to 0

### DIFF
--- a/brian2/memory/dynamicarray.py
+++ b/brian2/memory/dynamicarray.py
@@ -121,8 +121,9 @@ class DynamicArray(object):
                 slices = getslices(self._data.shape)
                 newdata[slices] = self._data
                 self._data = newdata
-        # If we reduced the size, set the no longer used memory to 0
-        self._data[getslices(newshape, from_start=False)] = 0
+        elif (newshapearr < self.shape).any():
+            # If we reduced the size, set the no longer used memory to 0
+            self._data[getslices(newshape, from_start=False)] = 0
         # Reduce our view to the requested size if necessary
         self.data = self._data[getslices(newshape, from_start=True)]
         self.shape = self.data.shape
@@ -142,8 +143,9 @@ class DynamicArray(object):
                 slices = getslices(self._data.shape)
                 newdata[slices] = self._data
                 self._data = newdata
-        # If we reduced the size, set the no longer used memory to 0
-        self._data[new_dimension:] = 0
+        elif newshape < self.shape:
+            # If we reduced the size, set the no longer used memory to 0
+            self._data[new_dimension:] = 0
         # Reduce our view to the requested size if necessary
         self. data = self._data[:new_dimension]
         self.shape = newshape


### PR DESCRIPTION
Fixes a performance regression introduced by commit 9c99e87e279 (a fix for #906; also see comment in #928).

The problem is that when you have a growing data structure such as a `StateMonitor`, it will call `DynamicArray.resize_along_first_dimension`  at every time step to make sure we have sufficient space to store new values. Because we double the underlying array size whenever we run out of space, actual resizing (with data copy) happens rarely. However, with the fix introduced in 9c99e87e, we set the unused part of the underlying array to 0 every time. This was introduced to deal with the case when a resize operation (e.g. in `restore`) *reduces* the size of the array. However, we applied this unconditionally, leading to a large slow-down for long-running simulations with monitors (in runtime only).