### PR TITLE
[MRG] Do not tie conda packages to numpy version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -150,9 +150,7 @@ install:
 script:
 - if [[ $CONDA_BUILD == 'yes' ]]; then
     source deactivate;
-    for NUMPY_VERSION in 1.12 1.13; do
-      conda build --quiet -c conda-forge dev/conda-recipe --numpy $NUMPY_VERSION;
-    done;
+    conda build --quiet -c conda-forge dev/conda-recipe
     source activate travis_conda;
   fi
 # Don't run tests in parallel when reporting coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,28 +23,28 @@ matrix:
       os: linux
     # Standard tests
     - python: "2.7"
-      env: PYTHON="2.7" STANDALONE=yes CYTHON=no MINIMAL_VERSIONS=no REPORT_COVERAGE=no CONDA_BUILD='no' ARCHITECTURE="x86_64"
+      env: PYTHON="2.7" STANDALONE=yes CYTHON=no MINIMAL_VERSIONS=no REPORT_COVERAGE=no DO_CONDA_BUILD='no' ARCHITECTURE="x86_64"
       os: osx
     - python: "3.6"
-      env: PYTHON="3.6" STANDALONE=yes CYTHON=no MINIMAL_VERSIONS=no REPORT_COVERAGE=no CONDA_BUILD='no' ARCHITECTURE="x86_64"
+      env: PYTHON="3.6" STANDALONE=yes CYTHON=no MINIMAL_VERSIONS=no REPORT_COVERAGE=no DO_CONDA_BUILD='no' ARCHITECTURE="x86_64"
       os: osx
     - python: "2.7"
-      env: PYTHON="2.7" STANDALONE=no CYTHON=yes MINIMAL_VERSIONS=no  REPORT_COVERAGE=yes CONDA_PY="27" CONDA_BUILD='yes' SPLIT_RUN=1 ARCHITECTURE="x86_64"
+      env: PYTHON="2.7" STANDALONE=no CYTHON=yes MINIMAL_VERSIONS=no  REPORT_COVERAGE=yes CONDA_PY="27" DO_CONDA_BUILD='yes' SPLIT_RUN=1 ARCHITECTURE="x86_64"
       os: linux
     - python: "2.7"
-      env: PYTHON="2.7" STANDALONE=no CYTHON=yes MINIMAL_VERSIONS=no  REPORT_COVERAGE=yes CONDA_PY="27" CONDA_BUILD='no' SPLIT_RUN=2 ARCHITECTURE="x86_64"
+      env: PYTHON="2.7" STANDALONE=no CYTHON=yes MINIMAL_VERSIONS=no  REPORT_COVERAGE=yes CONDA_PY="27" DO_CONDA_BUILD='no' SPLIT_RUN=2 ARCHITECTURE="x86_64"
       os: linux
     - python: "2.7"
-      env: PYTHON="2.7" STANDALONE=no CYTHON=yes MINIMAL_VERSIONS=no  REPORT_COVERAGE=no CONDA_PY="27" CONDA_BUILD='yes' SPLIT_RUN=1 ARCHITECTURE="x86_64"
+      env: PYTHON="2.7" STANDALONE=no CYTHON=yes MINIMAL_VERSIONS=no  REPORT_COVERAGE=no CONDA_PY="27" DO_CONDA_BUILD='yes' SPLIT_RUN=1 ARCHITECTURE="x86_64"
       os: osx
     - python: "2.7"
-      env: PYTHON="2.7" STANDALONE=no CYTHON=yes MINIMAL_VERSIONS=no  REPORT_COVERAGE=no CONDA_PY="27" CONDA_BUILD='no' SPLIT_RUN=2 ARCHITECTURE="x86_64"
+      env: PYTHON="2.7" STANDALONE=no CYTHON=yes MINIMAL_VERSIONS=no  REPORT_COVERAGE=no CONDA_PY="27" DO_CONDA_BUILD='no' SPLIT_RUN=2 ARCHITECTURE="x86_64"
       os: osx
 #    - python: "2.7"
-#      env: PYTHON="2.7" STANDALONE=no CYTHON=yes MINIMAL_VERSIONS=no  REPORT_COVERAGE=no  CONDA_PY="27" CONDA_BUILD='no' SPLIT_RUN=1 ARCHITECTURE="x86"
+#      env: PYTHON="2.7" STANDALONE=no CYTHON=yes MINIMAL_VERSIONS=no  REPORT_COVERAGE=no  CONDA_PY="27" DO_CONDA_BUILD='no' SPLIT_RUN=1 ARCHITECTURE="x86"
 #      os: linux
 #    - python: "2.7"
-#      env: PYTHON="2.7" STANDALONE=no CYTHON=yes MINIMAL_VERSIONS=no  REPORT_COVERAGE=no  CONDA_PY="27" CONDA_BUILD='yes' SPLIT_RUN=2 ARCHITECTURE="x86"
+#      env: PYTHON="2.7" STANDALONE=no CYTHON=yes MINIMAL_VERSIONS=no  REPORT_COVERAGE=no  CONDA_PY="27" DO_CONDA_BUILD='yes' SPLIT_RUN=2 ARCHITECTURE="x86"
 #      os: linux
     - python: "2.7"
       env: PYTHON="2.7" STANDALONE=no CYTHON=yes MINIMAL_VERSIONS=yes REPORT_COVERAGE=no  SPLIT_RUN=1 ARCHITECTURE="x86_64"
@@ -53,29 +53,29 @@ matrix:
       env: PYTHON="2.7" STANDALONE=no CYTHON=yes MINIMAL_VERSIONS=yes REPORT_COVERAGE=no  SPLIT_RUN=2 ARCHITECTURE="x86_64"
       os: linux
     - python: "3.5"
-      env: PYTHON="3.5" STANDALONE=no CYTHON=yes MINIMAL_VERSIONS=no  REPORT_COVERAGE=no  CONDA_PY="35" CONDA_BUILD='yes' ARCHITECTURE="x86_64"
+      env: PYTHON="3.5" STANDALONE=no CYTHON=yes MINIMAL_VERSIONS=no  REPORT_COVERAGE=no  CONDA_PY="35" DO_CONDA_BUILD='yes' ARCHITECTURE="x86_64"
       os: linux
     - python: "3.5"
-      env: PYTHON="3.5" STANDALONE=no CYTHON=yes MINIMAL_VERSIONS=no  REPORT_COVERAGE=no  CONDA_PY="35" CONDA_BUILD='yes' ARCHITECTURE="x86_64"
+      env: PYTHON="3.5" STANDALONE=no CYTHON=yes MINIMAL_VERSIONS=no  REPORT_COVERAGE=no  CONDA_PY="35" DO_CONDA_BUILD='yes' ARCHITECTURE="x86_64"
       os: osx
 #    - python: "3.5"
-#      env: PYTHON="3.5" STANDALONE=no CYTHON=yes MINIMAL_VERSIONS=no  REPORT_COVERAGE=no  CONDA_PY="35" CONDA_BUILD='yes' ARCHITECTURE="x86"
+#      env: PYTHON="3.5" STANDALONE=no CYTHON=yes MINIMAL_VERSIONS=no  REPORT_COVERAGE=no  CONDA_PY="35" DO_CONDA_BUILD='yes' ARCHITECTURE="x86"
 #      os: linux
     - python: "3.6"
-      env: PYTHON="3.6" STANDALONE=no CYTHON=yes MINIMAL_VERSIONS=no  REPORT_COVERAGE=no  CONDA_PY="36" CONDA_BUILD='yes' ARCHITECTURE="x86_64"
+      env: PYTHON="3.6" STANDALONE=no CYTHON=yes MINIMAL_VERSIONS=no  REPORT_COVERAGE=no  CONDA_PY="36" DO_CONDA_BUILD='yes' ARCHITECTURE="x86_64"
       os: linux
     - python: "3.6"
-      env: PYTHON="3.6" STANDALONE=no CYTHON=yes MINIMAL_VERSIONS=no  REPORT_COVERAGE=no  CONDA_PY="36" CONDA_BUILD='yes' ARCHITECTURE="x86_64"
+      env: PYTHON="3.6" STANDALONE=no CYTHON=yes MINIMAL_VERSIONS=no  REPORT_COVERAGE=no  CONDA_PY="36" DO_CONDA_BUILD='yes' ARCHITECTURE="x86_64"
       os: osx
     # test standalone
     - python: "2.7"
-      env: PYTHON="2.7" STANDALONE=yes CYTHON=no MINIMAL_VERSIONS=no REPORT_COVERAGE=yes CONDA_BUILD='no' ARCHITECTURE="x86_64"
+      env: PYTHON="2.7" STANDALONE=yes CYTHON=no MINIMAL_VERSIONS=no REPORT_COVERAGE=yes DO_CONDA_BUILD='no' ARCHITECTURE="x86_64"
       os: linux
 #    - python: "2.7"
-#      env: PYTHON="2.7" STANDALONE=yes CYTHON=no MINIMAL_VERSIONS=no REPORT_COVERAGE=no CONDA_BUILD='no' ARCHITECTURE="x86"
+#      env: PYTHON="2.7" STANDALONE=yes CYTHON=no MINIMAL_VERSIONS=no REPORT_COVERAGE=no DO_CONDA_BUILD='no' ARCHITECTURE="x86"
 #      os: linux
     - python: "3.6"
-      env: PYTHON="3.6" STANDALONE=yes CYTHON=no MINIMAL_VERSIONS=no REPORT_COVERAGE=no CONDA_BUILD='no' ARCHITECTURE="x86_64"
+      env: PYTHON="3.6" STANDALONE=yes CYTHON=no MINIMAL_VERSIONS=no REPORT_COVERAGE=no DO_CONDA_BUILD='no' ARCHITECTURE="x86_64"
       os: linux
     # test without installed cython
     - python: "2.7"
@@ -116,9 +116,9 @@ install:
   - travis_retry conda update --yes conda
   # For faster tests, only build conda packages for the master branch or pull requests
   - if [[ $TRAVIS_PULL_REQUEST == 'false' ]] && [[ $TRAVIS_BRANCH != 'master' ]]; then
-       CONDA_BUILD='no';
+       DO_CONDA_BUILD='no';
     fi
-  - if [[ $CONDA_BUILD == 'yes' ]]; then
+  - if [[ $DO_CONDA_BUILD == 'yes' ]]; then
        conda install --yes --quiet anaconda-client conda-build jinja2 pip setuptools;
     fi
   - if [[ $MINIMAL_VERSIONS == 'yes' ]]; then
@@ -147,7 +147,7 @@ install:
 
 # command to run tests (make sure to not run it from the source directory)
 script:
-- if [[ $CONDA_BUILD == 'yes' ]]; then
+- if [[ $DO_CONDA_BUILD == 'yes' ]]; then
     source deactivate;
     conda build --quiet -c conda-forge dev/conda-recipe
     source activate travis_conda;
@@ -169,7 +169,7 @@ script:
 
 after_success:
 # We only upload to binstar for commits merged into the master branch
-- if [[ $CONDA_BUILD == 'yes' && $TRAVIS_PULL_REQUEST == 'false' && $TRAVIS_REPO_SLUG == 'brian-team/brian2' && $TRAVIS_BRANCH == 'master' ]]; then
+- if [[ $DO_CONDA_BUILD == 'yes' && $TRAVIS_PULL_REQUEST == 'false' && $TRAVIS_REPO_SLUG == 'brian-team/brian2' && $TRAVIS_BRANCH == 'master' ]]; then
     cd $SRCDIR;
     source deactivate;
     python dev/continuous-integration/move-conda-package.py dev/conda-recipe &&

--- a/.travis.yml
+++ b/.travis.yml
@@ -113,8 +113,7 @@ before_install:
 
 # command to install dependencies
 install:
-  # - conda update --yes conda
-  - echo "conda ==4.3.21" >> ~/miniconda/conda-meta/pinned  # Pin conda as workaround for conda/conda#6030
+  - travis_retry conda update --yes conda
   # For faster tests, only build conda packages for the master branch or pull requests
   - if [[ $TRAVIS_PULL_REQUEST == 'false' ]] && [[ $TRAVIS_BRANCH != 'master' ]]; then
        CONDA_BUILD='no';

--- a/.travis.yml
+++ b/.travis.yml
@@ -114,6 +114,8 @@ before_install:
 # command to install dependencies
 install:
   - travis_retry conda update --yes conda
+  # Use the conda-forge channel
+  - conda config --append channels conda-forge
   # For faster tests, only build conda packages for the master branch or pull requests
   - if [[ $TRAVIS_PULL_REQUEST == 'false' ]] && [[ $TRAVIS_BRANCH != 'master' ]]; then
        DO_CONDA_BUILD='no';
@@ -122,24 +124,23 @@ install:
        conda install --yes --quiet anaconda-client conda-build jinja2 pip setuptools;
     fi
   - if [[ $MINIMAL_VERSIONS == 'yes' ]]; then
-    travis_retry conda create -n travis_conda --yes --quiet pip python=$PYTHON numpy==1.10 scipy==0.16 libgfortran==1 nose "sphinx<1.6.3" ipython sympy==0.7.6 jinja2==2.7 pyparsing setuptools coverage;
+    travis_retry conda create -n travis_conda --yes --quiet python=$PYTHON numpy==1.10 scipy==0.16 libgfortran==1 nose "sphinx<1.6.3" ipython sympy==0.7.6 jinja2==2.7 pyparsing setuptools coverage;
     else
-    travis_retry conda create -n travis_conda --yes --quiet pip python=$PYTHON numpy nose "sphinx<1.6.3" ipython "sympy!=1.1.0" pyparsing jinja2 setuptools coverage;
+    travis_retry conda create -n travis_conda --yes --quiet python=$PYTHON numpy nose "sphinx<1.6.3" ipython "sympy!=1.1.0" pyparsing jinja2 setuptools coverage;
     fi
   - source activate travis_conda
-  # On Python 2: Install an older version of scipy that still has weave
+  # On Python 2: Install the weave package explicitly
   - if [ ${PYTHON:0:1} == "2" ]; then
       if [[ $MINIMAL_VERSIONS != 'yes' ]]; then
-        travis_retry conda install --yes --quiet -c brian-team weave scipy;
+        travis_retry conda install --yes --quiet weave scipy;
       fi;
       travis_retry conda install --yes --quiet bsddb;
     else
       travis_retry conda install --yes --quiet scipy;
     fi
-  - travis_retry conda install --yes --quiet -c brian-team py-cpuinfo  # install cpuinfo from our own channel
-  - travis_retry conda install --yes --quiet -c conda-forge "gsl>1.15"  # install gsl from conda-forge
+  - travis_retry conda install --yes --quiet py-cpuinfo "gsl>1.15"  # install cpuinfo and gsl from conda-forge
   - if [[ $CYTHON == 'yes' ]]; then travis_retry conda install --yes cython; SETUP_ARGS=--with-cython; else SETUP_ARGS=''; fi
-  - if [[ $REPORT_COVERAGE == 'yes' ]]; then travis_retry pip install -q coveralls; fi
+  - if [[ $REPORT_COVERAGE == 'yes' ]]; then travis_retry conda install --yes --quiet coveralls; fi
   - python setup.py install $SETUP_ARGS --fail-on-error --single-version-externally-managed --record=record.txt
   - if [[ $DOCS_ONLY == 'yes' ]]; then
       python setup.py sdist;

--- a/.travis.yml
+++ b/.travis.yml
@@ -150,10 +150,9 @@ install:
 script:
 - if [[ $DO_CONDA_BUILD == 'yes' ]]; then
     source deactivate;
-    conda build --quiet -c conda-forge dev/conda-recipe
+    conda build --quiet -c conda-forge dev/conda-recipe;
     source activate travis_conda;
   fi
-# Don't run tests in parallel when reporting coverage
 - if [[ $DOCS_ONLY == 'yes' ]]; then
     cd dist;
     tar xvzf *.tar.gz;

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -132,8 +132,7 @@ after_test:
           %CMD_IN_ENV% python setup.py bdist_wininst &&
           %appveyor-retry CMD_IN_ENV% conda install --yes --quiet -c conda-forge conda-build pip &&
           %appveyor-retry CMD_IN_ENV% conda install --yes --quiet anaconda-client &&
-          %CMD_IN_ENV% conda build --quiet -c conda-forge dev\conda-recipe --numpy 1.12 &&
-          %CMD_IN_ENV% conda build --quiet -c conda-forge dev\conda-recipe --numpy 1.13 &&
+          %CMD_IN_ENV% conda build --quiet -c conda-forge dev\conda-recipe
           %CMD_IN_ENV% python dev\continuous-integration\move-conda-package.py dev\conda-recipe &&
           if "%APPVEYOR_PULL_REQUEST_NUMBER%" == "" if "%APPVEYOR_REPO_NAME%" == "brian-team/brian2" if "%APPVEYOR_REPO_BRANCH%" == "master" %CMD_IN_ENV% python dev\continuous-integration\conda-server-push.py
      )'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -101,9 +101,8 @@ install:
   - 'python -c "import struct; print(struct.calcsize(''P'') * 8)"'
 
   # Install the build dependencies of the project via conda
-  - 'appveyor-retry conda install --yes --quiet numpy nose "sphinx<1.6.3" "sympy!=1.1.0" pyparsing jinja2 ipython setuptools cython "conda==4.3.21"'
-  # Pin conda version
-  - 'echo conda ==4.3.21 >> %PYTHON%\conda-meta\pinned'
+  - 'appveyor-retry conda update --yes conda'
+  - 'appveyor-retry conda install --yes --quiet numpy nose "sphinx<1.6.3" "sympy!=1.1.0" pyparsing jinja2 ipython setuptools cython'
   # Install an older version of scipy (which still has weave) on Python 2
   - 'if "%PYTHON_VERSION:~0,1%" == "2" appveyor-retry conda install --yes --quiet -c brian-team weave scipy'
   - 'if "%PYTHON_VERSION:~0,1%" == "3" appveyor-retry conda install --yes --quiet scipy'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -108,7 +108,7 @@ install:
   # Install the weave package for Python 2
   - 'if "%PYTHON_VERSION:~0,1%" == "2" appveyor-retry conda install --yes --quiet weave scipy'
   - 'if "%PYTHON_VERSION:~0,1%" == "3" appveyor-retry conda install --yes --quiet scipy'
-  - 'appveyor-retry conda install --yes --quiet py-cpuinfo "gsl>1.15"'  # install cpuinfo and gsl from conda-forge
+  - 'appveyor-retry conda install --yes --quiet py-cpuinfo=3 "gsl>1.15"'  # install cpuinfo and gsl from conda-forge
   # For faster tests, only build conda packages for the master branch or pull requests
   - 'if "%APPVEYOR_PULL_REQUEST_NUMBER%" == "" if not "%APPVEYOR_REPO_BRANCH%" == "master" set DO_CONDA_BUILD=FALSE'
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -102,12 +102,13 @@ install:
 
   # Install the build dependencies of the project via conda
   - 'appveyor-retry conda update --yes conda'
+  # Use the conda-forge channel
+  - 'conda config --append channels conda-forge'
   - 'appveyor-retry conda install --yes --quiet numpy nose "sphinx<1.6.3" "sympy!=1.1.0" pyparsing jinja2 ipython setuptools cython'
-  # Install an older version of scipy (which still has weave) on Python 2
-  - 'if "%PYTHON_VERSION:~0,1%" == "2" appveyor-retry conda install --yes --quiet -c brian-team weave scipy'
+  # Install the weave package for Python 2
+  - 'if "%PYTHON_VERSION:~0,1%" == "2" appveyor-retry conda install --yes --quiet weave scipy'
   - 'if "%PYTHON_VERSION:~0,1%" == "3" appveyor-retry conda install --yes --quiet scipy'
-  - 'appveyor-retry conda install --yes --quiet -c brian-team py-cpuinfo'
-  - 'appveyor-retry conda install --yes --quiet -c conda-forge "gsl>1.15"'  # install gsl from conda-forge
+  - 'appveyor-retry conda install --yes --quiet py-cpuinfo "gsl>1.15"'  # install cpuinfo and gsl from conda-forge
   # For faster tests, only build conda packages for the master branch or pull requests
   - 'if "%APPVEYOR_PULL_REQUEST_NUMBER%" == "" if not "%APPVEYOR_REPO_BRANCH%" == "master" set DO_CONDA_BUILD=FALSE'
 
@@ -129,7 +130,7 @@ after_test:
           cd %SRC_DIR% &&
           %CMD_IN_ENV% python setup.py bdist_wheel &&
           %CMD_IN_ENV% python setup.py bdist_wininst &&
-          %appveyor-retry CMD_IN_ENV% conda install --yes --quiet -c conda-forge conda-build pip &&
+          %appveyor-retry CMD_IN_ENV% conda install --yes --quiet  conda-build pip &&
           %appveyor-retry CMD_IN_ENV% conda install --yes --quiet anaconda-client &&
           %CMD_IN_ENV% conda build --quiet -c conda-forge dev\conda-recipe &&
           %CMD_IN_ENV% python dev\continuous-integration\move-conda-package.py dev\conda-recipe &&

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,7 +22,7 @@ environment:
       platform: x86
       STANDALONE: "FALSE"
       CONDA_PY: "35"
-      CONDA_BUILD: "TRUE"
+      DO_CONDA_BUILD: "TRUE"
       SPLIT_RUN: "FALSE"
 
     - PYTHON: "C:\\Miniconda35-x64"
@@ -31,7 +31,7 @@ environment:
       platform: x64
       STANDALONE: "FALSE"
       CONDA_PY: "35"
-      CONDA_BUILD: "TRUE"
+      DO_CONDA_BUILD: "TRUE"
       SPLIT_RUN: "FALSE"
 
     - PYTHON: "C:\\Miniconda36"
@@ -40,7 +40,7 @@ environment:
       platform: x86
       STANDALONE: "FALSE"
       CONDA_PY: "36"
-      CONDA_BUILD: "TRUE"
+      DO_CONDA_BUILD: "TRUE"
       SPLIT_RUN: "FALSE"
 
     - PYTHON: "C:\\Miniconda36-x64"
@@ -49,7 +49,7 @@ environment:
       platform: x64
       STANDALONE: "FALSE"
       CONDA_PY: "36"
-      CONDA_BUILD: "TRUE"
+      DO_CONDA_BUILD: "TRUE"
       SPLIT_RUN: "FALSE"
 
     - PYTHON: "C:\\Miniconda"
@@ -58,7 +58,7 @@ environment:
       platform: x86
       STANDALONE: "FALSE"
       CONDA_PY: "27"
-      CONDA_BUILD: "TRUE"
+      DO_CONDA_BUILD: "TRUE"
       SPLIT_RUN: "1"
 
     - PYTHON: "C:\\Miniconda"
@@ -66,7 +66,7 @@ environment:
       PYTHON_ARCH: "32"
       platform: x86
       STANDALONE: "FALSE"
-      CONDA_BUILD: "FALSE"
+      DO_CONDA_BUILD: "FALSE"
       SPLIT_RUN: "2"
 
     - PYTHON: "C:\\Miniconda-x64"
@@ -75,7 +75,7 @@ environment:
       platform: x64
       STANDALONE: "FALSE"
       CONDA_PY: "27"
-      CONDA_BUILD: "TRUE"
+      DO_CONDA_BUILD: "TRUE"
       SPLIT_RUN: "1"
 
     - PYTHON: "C:\\Miniconda-x64"
@@ -83,7 +83,7 @@ environment:
       PYTHON_ARCH: "64"
       platform: x64
       STANDALONE: "FALSE"
-      CONDA_BUILD: "FALSE"
+      DO_CONDA_BUILD: "FALSE"
       SPLIT_RUN: "2"
 
     - PYTHON: "C:\\Miniconda-x64"
@@ -109,7 +109,7 @@ install:
   - 'appveyor-retry conda install --yes --quiet -c brian-team py-cpuinfo'
   - 'appveyor-retry conda install --yes --quiet -c conda-forge "gsl>1.15"'  # install gsl from conda-forge
   # For faster tests, only build conda packages for the master branch or pull requests
-  - 'if "%APPVEYOR_PULL_REQUEST_NUMBER%" == "" if not "%APPVEYOR_REPO_BRANCH%" == "master" set CONDA_BUILD=FALSE'
+  - 'if "%APPVEYOR_PULL_REQUEST_NUMBER%" == "" if not "%APPVEYOR_REPO_BRANCH%" == "master" set DO_CONDA_BUILD=FALSE'
 
 build: false  # Not a C# project, build stuff at the test step instead.
 
@@ -124,14 +124,14 @@ test_script:
   - 'cmd /E:ON /V:ON /C %SRC_DIR%\dev\continuous-integration\appveyor\run_with_env.cmd python %SRC_DIR%\dev\continuous-integration\run_test_suite.py'
 
 after_test:
-  - 'IF "%CONDA_BUILD%" == "TRUE" (
+  - 'IF "%DO_CONDA_BUILD%" == "TRUE" (
           appveyor-retry pip install wheel &&
           cd %SRC_DIR% &&
           %CMD_IN_ENV% python setup.py bdist_wheel &&
           %CMD_IN_ENV% python setup.py bdist_wininst &&
           %appveyor-retry CMD_IN_ENV% conda install --yes --quiet -c conda-forge conda-build pip &&
           %appveyor-retry CMD_IN_ENV% conda install --yes --quiet anaconda-client &&
-          %CMD_IN_ENV% conda build --quiet -c conda-forge dev\conda-recipe
+          %CMD_IN_ENV% conda build --quiet -c conda-forge dev\conda-recipe &&
           %CMD_IN_ENV% python dev\continuous-integration\move-conda-package.py dev\conda-recipe &&
           if "%APPVEYOR_PULL_REQUEST_NUMBER%" == "" if "%APPVEYOR_REPO_NAME%" == "brian-team/brian2" if "%APPVEYOR_REPO_BRANCH%" == "master" %CMD_IN_ENV% python dev\continuous-integration\conda-server-push.py
      )'

--- a/dev/conda-recipe/meta.yaml
+++ b/dev/conda-recipe/meta.yaml
@@ -8,11 +8,11 @@ requirements:
     - python
     - cython >=0.18
     - setuptools >=6.0
-    - numpy x.x
+    - numpy 1.10  # we build against the oldest supported version
 
   run:
     - python
-    - numpy x.x
+    - numpy >=1.10  # newer versions are still ABI-compatible
     - sympy >=0.7.6,!=1.1.0
     - pyparsing
     - scipy >=0.13.3

--- a/dev/conda-recipe/meta.yaml
+++ b/dev/conda-recipe/meta.yaml
@@ -58,7 +58,8 @@ test:
     - brian2.utils
 
   commands:
-    #- python -c 'import brian2; brian2.test()'
+    # Run a simple test that uses some of the main simulation elements
+    - python -c 'from brian2.tests.test_synapses import test_transmission_simple; test_transmission_simple()'
 
   requires:
     - nose

--- a/dev/conda-recipe/meta.yaml
+++ b/dev/conda-recipe/meta.yaml
@@ -8,11 +8,16 @@ requirements:
     - python
     - cython >=0.18
     - setuptools >=6.0
-    - numpy 1.10  # we build against the oldest supported version
+    # we build against the oldest supported numpy version
+    - numpy 1.10  # [not py36]
+    - numpy 1.11  # [py36]
 
   run:
     - python
-    - numpy >=1.10  # newer versions are still ABI-compatible
+    # we don't need the same version as during the build, newer versions are
+    # still ABI-compatible
+    - numpy >=1.10  # [not py36]
+    - numpy >=1.11  # [py36]
     - sympy >=0.7.6,!=1.1.0
     - pyparsing
     - scipy >=0.13.3


### PR DESCRIPTION
As discussed earlier (https://github.com/brian-team/brian2/pull/913#issuecomment-360494739), this PR changes our conda packaging to a single package for each architecture, independent of the numpy version. The advantage is that numpy can be updated independently of Brian, and we won't run into problems when anaconda updates to a numpy version that did not exist at the time of our release (currently, this seems to prevent users from installing Brian on top of a recent full Anaconda distribution, see #930, #945). The disadvantage is that nothing prevents a user to run Brian with a new and untested numpy version -- on the other hand, that's already the case when they don't use conda for installation.

Note that in this branch (as in master) the Cython tests still hang sometimes for a certain combination of packages -- I thought I fixed it by explicitly unlocking the Cython lock files, but this does not seem to be enough. I'm currently testing using the [filelock](https://pypi.org/project/filelock/) package in a separate branch and will open another PR if that is successful.

Closes #915 