### PR TITLE
[WIP] Use filelocking module for locking in Cython

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -124,9 +124,9 @@ install:
        conda install --yes --quiet anaconda-client conda-build jinja2 pip setuptools;
     fi
   - if [[ $MINIMAL_VERSIONS == 'yes' ]]; then
-    travis_retry conda create -n travis_conda --yes --quiet python=$PYTHON numpy==1.10 scipy==0.16 libgfortran==1 nose "sphinx<1.6.3" ipython sympy==0.7.6 jinja2==2.7 pyparsing setuptools coverage;
+    travis_retry conda create -n travis_conda --yes --quiet python=$PYTHON numpy==1.10 scipy==0.16 libgfortran==1 nose "sphinx<1.6.3" ipython sympy==0.7.6 jinja2==2.7 pyparsing setuptools coverage filelock==2.0.6;
     else
-    travis_retry conda create -n travis_conda --yes --quiet python=$PYTHON numpy nose "sphinx<1.6.3" ipython "sympy!=1.1.0" pyparsing jinja2 setuptools coverage;
+    travis_retry conda create -n travis_conda --yes --quiet python=$PYTHON numpy nose "sphinx<1.6.3" ipython "sympy!=1.1.0" pyparsing jinja2 setuptools coverage filelock;
     fi
   - source activate travis_conda
   # On Python 2: Install the weave package explicitly

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -104,7 +104,7 @@ install:
   - 'appveyor-retry conda update --yes conda'
   # Use the conda-forge channel
   - 'conda config --append channels conda-forge'
-  - 'appveyor-retry conda install --yes --quiet numpy nose "sphinx<1.6.3" "sympy!=1.1.0" pyparsing jinja2 ipython setuptools cython'
+  - 'appveyor-retry conda install --yes --quiet numpy nose "sphinx<1.6.3" "sympy!=1.1.0" pyparsing jinja2 ipython setuptools cython filelock'
   # Install the weave package for Python 2
   - 'if "%PYTHON_VERSION:~0,1%" == "2" appveyor-retry conda install --yes --quiet weave scipy'
   - 'if "%PYTHON_VERSION:~0,1%" == "3" appveyor-retry conda install --yes --quiet scipy'

--- a/dev/conda-recipe/meta.yaml
+++ b/dev/conda-recipe/meta.yaml
@@ -60,7 +60,7 @@ test:
 
   commands:
     # Run a simple test that uses some of the main simulation elements
-    - python -c 'from brian2.tests.test_synapses import test_transmission_simple; test_transmission_simple()'
+    - 'python -c "from brian2.tests.test_synapses import test_transmission_simple; test_transmission_simple()"'
 
   requires:
     - nose

--- a/dev/conda-recipe/meta.yaml
+++ b/dev/conda-recipe/meta.yaml
@@ -28,6 +28,7 @@ requirements:
     - jinja2 >=2.7
     - setuptools >=6.0
     - py-cpuinfo >=0.1.6
+    - filelock >=2.0
 
 test:
   # Python imports

--- a/setup.py
+++ b/setup.py
@@ -167,6 +167,7 @@ setup(name='Brian2',
                         'pyparsing',
                         'jinja2>=2.7',
                         'py-cpuinfo>=0.1.6',
+                        'filelock>=2.0.0',
                         'setuptools>=6.0'  # FIXME: setuptools>=6.0 is only needed for Windows
                        ],
       setup_requires=['numpy>=1.10',


### PR DESCRIPTION
We regularly had one specific travis test hang during the Cython tests (e.g. [this one](https://travis-ci.org/brian-team/brian2/jobs/382208904)) and I think it has to due with our file locking implementation for Cython that we need to make running things with parallel processes work. In this PR, I use the [filelock](https://pypi.org/project/filelock/) module to do the locking as a replacement for our own implementation. I decided to declare it as a dependency (it is available both via pypi and conda, and installing it should always work given that it is a Python-only package), but if you run directly from source, it should only fail when you actually use Cython. An alternative would be to include the module directly in our code (it is a single file and public domain), but I think it could be useful to benefit from future enhancements and bug fixes. I don't feel strongly about this, though.

Note that I used a timeout of 9min for aquiring the lock which is quite long, but during testing I saw that e.g. a timeout of 1min is not enough in all cases (we might want to investigate why this is the case at some point, though...). Either way, we cannot do much useful with the timeout information anyway, I simply added it so that we can distinguish hangs due to lock acquisition from other problems on travis/appveyor (where tests will fail after 10min without output).