### PR TITLE
[MRG] Introduce timestep function to avoid rounding issues in refractoriness

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -149,6 +149,7 @@ install:
 
 # command to run tests (make sure to not run it from the source directory)
 script:
+- export MACOSX_DEPLOYMENT_TARGET=10.9  # Prevents build errors linked when using isinf
 - if [[ $DO_CONDA_BUILD == 'yes' ]]; then
     source deactivate;
     conda build --quiet -c conda-forge dev/conda-recipe;

--- a/brian2/codegen/generators/GSL_generator.py
+++ b/brian2/codegen/generators/GSL_generator.py
@@ -723,7 +723,7 @@ class GSLCodeGenerator(object):
                 continue
             if var in variables_in_scalar.keys():
                 code += [line]
-            if var in variables_in_vector.keys():
+            elif var in variables_in_vector.keys():
                 if var == 't':
                     continue
                 try:
@@ -930,6 +930,7 @@ class GSLCodeGenerator(object):
         kwds['support_code_lines'] += GSL_support_code.split('\n')
         kwds['t_array'] = self.get_array_name(self.variables['t']) + '[0]'
         kwds['dt_array'] = self.get_array_name(self.variables['dt']) + '[0]'
+        kwds['define_dt'] = 'dt' not in variables_in_scalar
         kwds['cpp_standalone'] = self.is_cpp_standalone()
         for key, value in pointer_names.items():
             kwds[key] = value

--- a/brian2/codegen/generators/cpp_generator.py
+++ b/brian2/codegen/generators/cpp_generator.py
@@ -453,7 +453,7 @@ DEFAULT_FUNCTIONS['sign'].implementations.add_implementation(CPPCodeGenerator,
 timestep_code = '''
         static inline int _timestep(double t, double dt)
         {
-            if (std::isinf(t))
+            if (isinf(t))
             {
                 if (t < 0)
                     return INT_MIN;

--- a/brian2/codegen/generators/cpp_generator.py
+++ b/brian2/codegen/generators/cpp_generator.py
@@ -428,7 +428,7 @@ DEFAULT_FUNCTIONS['abs'].implementations.add_implementation(CPPCodeGenerator,
 
 clip_code = '''
         template <typename T>
-        inline T _clip(const T value, const double a_min, const double a_max)
+        static inline T _clip(const T value, const double a_min, const double a_max)
         {
 	        if (value < a_min)
 	            return a_min;
@@ -442,10 +442,27 @@ DEFAULT_FUNCTIONS['clip'].implementations.add_implementation(CPPCodeGenerator,
                                                              name='_clip')
 
 sign_code = '''
-        template <typename T> inline int sign_(T val) {
+        template <typename T> static inline int _sign(T val) {
             return (T(0) < val) - (val < T(0));
         }
         '''
 DEFAULT_FUNCTIONS['sign'].implementations.add_implementation(CPPCodeGenerator,
                                                              code=sign_code,
-                                                             name='sign_')
+                                                             name='_sign')
+
+timestep_code = '''
+        static inline int _timestep(double t, double dt)
+        {
+            if (isinf(t))
+            {
+                if (t < 0)
+                    return INT_MIN;
+                else
+                    return INT_MAX;
+            }
+            return (int)((t + 1e-3*dt)/dt); 
+        }
+        '''
+DEFAULT_FUNCTIONS['timestep'].implementations.add_implementation(CPPCodeGenerator,
+                                                                 code=timestep_code,
+                                                                 name='_timestep')

--- a/brian2/codegen/generators/cpp_generator.py
+++ b/brian2/codegen/generators/cpp_generator.py
@@ -451,9 +451,21 @@ DEFAULT_FUNCTIONS['sign'].implementations.add_implementation(CPPCodeGenerator,
                                                              name='_sign')
 
 timestep_code = '''
+// Adapted from npy_math.h and https://www.christophlassner.de/collection-of-msvc-gcc-compatibility-tricks.html
+#ifndef _BRIAN_REPLACE_ISINF_MSVC
+#define _BRIAN_REPLACE_ISINF_MSVC
+#if defined(_MSC_VER)
+#if _MSC_VER < 1900
+namespace std {
+  template <typename T>
+  bool isinf(const T &x) { return (!_finite(x))&&(!_isnan(x)); }
+}
+#endif
+#endif
+#endif
         static inline int _timestep(double t, double dt)
         {
-            if (isinf(t))
+            if (std::isinf(t))
             {
                 if (t < 0)
                     return INT_MIN;

--- a/brian2/codegen/generators/cpp_generator.py
+++ b/brian2/codegen/generators/cpp_generator.py
@@ -453,7 +453,7 @@ DEFAULT_FUNCTIONS['sign'].implementations.add_implementation(CPPCodeGenerator,
 timestep_code = '''
         static inline int _timestep(double t, double dt)
         {
-            if (isinf(t))
+            if (std::isinf(t))
             {
                 if (t < 0)
                     return INT_MIN;

--- a/brian2/codegen/generators/cython_generator.py
+++ b/brian2/codegen/generators/cython_generator.py
@@ -389,7 +389,7 @@ DEFAULT_FUNCTIONS['clip'].implementations.add_implementation(CythonCodeGenerator
 
 timestep_code = '''
 cdef int _timestep(double t, double dt):
-    if isinf(t):
+    if npy_isinf(t):
         if t < 0:
             return INT_MIN
         else:

--- a/brian2/codegen/generators/cython_generator.py
+++ b/brian2/codegen/generators/cython_generator.py
@@ -376,7 +376,7 @@ ctypedef fused _to_clip:
     float
     double
 
-cdef _to_clip clip(_to_clip x, double low, double high):
+cdef _to_clip _clip(_to_clip x, double low, double high):
     if x < low:
         return <_to_clip?>low
     if x > high:
@@ -385,5 +385,17 @@ cdef _to_clip clip(_to_clip x, double low, double high):
 '''
 DEFAULT_FUNCTIONS['clip'].implementations.add_implementation(CythonCodeGenerator,
                                                              code=clip_code,
-                                                             name='clip')
+                                                             name='_clip')
 
+timestep_code = '''
+cdef int _timestep(double t, double dt):
+    if isinf(t):
+        if t < 0:
+            return INT_MIN
+        else:
+            return INT_MAX
+    return <int>((t + 1e-3*dt)/dt)
+'''
+DEFAULT_FUNCTIONS['timestep'].implementations.add_implementation(CythonCodeGenerator,
+                                                                 code=timestep_code,
+                                                                 name='_timestep')

--- a/brian2/codegen/runtime/GSLcython_rt/templates/stateupdate.pyx
+++ b/brian2/codegen/runtime/GSLcython_rt/templates/stateupdate.pyx
@@ -73,8 +73,9 @@ cdef extern from "gsl/gsl_odeiv2.h":
 
     # scalar code
     _vectorisation_idx = 1
+    {% if define_dt %}
     dt = {{dt_array}}
-
+    {% endif %}
     cdef double t1
     cdef _dataholder * _GSL_dataholder = <_dataholder *>malloc(sizeof(_dataholder))
 

--- a/brian2/codegen/runtime/GSLweave_rt/templates/stateupdate.cpp
+++ b/brian2/codegen/runtime/GSLweave_rt/templates/stateupdate.cpp
@@ -23,8 +23,9 @@ gsl_odeiv2_driver_set_hmax(_GSL_driver, {{GSL_settings['dt_start']}});
 const int _N = {{constant_or_scalar('N', variables['N'])}};
 // scalar code
 const int _vectorisation_idx = 1;
+{% if define_dt %}
 const double dt = {{dt_array}};
-
+{% endif %}
 {{scalar_code['GSL']|autoindent}}
 
 for(int _idx=0; _idx<_N; _idx++)

--- a/brian2/codegen/runtime/cython_rt/templates/common.pyx
+++ b/brian2/codegen/runtime/cython_rt/templates/common.pyx
@@ -19,6 +19,9 @@ cdef extern from "numpy/ndarraytypes.h":
     void PyArray_CLEARFLAGS(_numpy.PyArrayObject *arr, int flags)
 from libc.stdlib cimport free
 
+cdef extern from "numpy/npy_math.h":
+    bint npy_isinf(double x)
+
 cdef extern from "stdint_compat.h":
     # Longness only used for type promotion
     # Actual compile time size used for conversion

--- a/brian2/codegen/runtime/cython_rt/templates/common.pyx
+++ b/brian2/codegen/runtime/cython_rt/templates/common.pyx
@@ -5,12 +5,13 @@
 
 import numpy as _numpy
 cimport numpy as _numpy
-from libc.math cimport sin, cos, tan, sinh, cosh, tanh, exp, log, log10, sqrt, asin, acos, atan, fmod, floor, ceil
+from libc.math cimport sin, cos, tan, sinh, cosh, tanh, exp, log, log10, sqrt, asin, acos, atan, fmod, floor, ceil, isinf
 cdef extern from "math.h":
     double M_PI
 # Import the two versions of std::abs
 from libc.stdlib cimport abs  # For integers
 from libc.math cimport abs  # For floating point values
+from libc.limits cimport INT_MIN, INT_MAX
 from libcpp cimport bool
 
 _numpy.import_array()

--- a/brian2/codegen/runtime/weave_rt/weave_rt.py
+++ b/brian2/codegen/runtime/weave_rt/weave_rt.py
@@ -130,7 +130,7 @@ class WeaveCodeObject(CodeObject):
                                      self.extra_link_args, logger=logger)
         self.runtime_library_dirs = list(prefs['codegen.cpp.runtime_library_dirs'])
         self.libraries = list(prefs['codegen.cpp.libraries'])
-        self.headers = ['<algorithm>', '<limits>', '"stdint_compat.h"'] + prefs['codegen.cpp.headers']
+        self.headers = ['<math.h>','<algorithm>', '<limits>', '"stdint_compat.h"'] + prefs['codegen.cpp.headers']
         self.numpy_version = '.'.join(numpy.__version__.split('.')[:2])  # Only use major.minor version
         self.annotated_code = self.code.main+'''
 /*

--- a/brian2/core/core_preferences.py
+++ b/brian2/core/core_preferences.py
@@ -37,5 +37,17 @@ prefs.register_preferences('core', 'Core Brian preferences',
         Whether to raise an error for outdated dependencies (``True``) or just
         a warning (``False``).
         '''
-        )
+        ),
+    legacy_refractory_timing=BrianPreference(
+        default=False,
+        docs='''
+        Whether to use the semantics for checking the refractoriness condition
+        that were in place up until (including) version 2.1.2. In that
+        implementation, refractory periods that were multiples of dt could lead
+        to a varying number of refractory timesteps due to the nature of
+        floating point comparisons). This preference is only provided for exact
+        reproducibility of previously obtained results, new simulations should
+        use the improved mechanism which uses a more robust mechanism to
+        convert refractoriness into timesteps. Defaults to ``False``.
+        ''')
     )

--- a/brian2/core/core_preferences.py
+++ b/brian2/core/core_preferences.py
@@ -37,8 +37,11 @@ prefs.register_preferences('core', 'Core Brian preferences',
         Whether to raise an error for outdated dependencies (``True``) or just
         a warning (``False``).
         '''
-        ),
-    legacy_refractory_timing=BrianPreference(
+        )
+    )
+
+prefs.register_preferences('legacy', 'Preferences to enable legacy behaviour',
+    refractory_timing=BrianPreference(
         default=False,
         docs='''
         Whether to use the semantics for checking the refractoriness condition

--- a/brian2/core/functions.py
+++ b/brian2/core/functions.py
@@ -544,6 +544,34 @@ class log10(sympy_Function):
 _infinity_int = np.iinfo(int).max//2
 
 def timestep(t, dt):
+    '''
+    Converts a given time to an integer time step. This function slightly shifts
+    the time before dividing it by ``dt`` to make sure that multiples of ``dt``
+    do not end up in the preceding time step due to floating point issues. This
+    function is used in the refractoriness calculation.
+
+    .. versionadded:: 2.1.3
+
+    Parameters
+    ----------
+    t : np.ndarray or Quantity
+        The time to convert.
+    dt : float or Quantity
+        The length of a simulation time step.
+
+    Returns
+    -------
+    ts : int
+        The time step corresponding to the given time.
+
+    Notes
+    -----
+    This function can handle infinity values, it will return a value equal to
+    half of the maximal integer value. This assures that an expression such as
+    ``timestep(t) - timestep(lastspike)`` will result in a reasonable value even
+    if ``lastspike`` is ``-inf``. If ``timestep(lastspike)`` were equal to the
+    minimal representable integer value, this expression would overflow.
+    '''
     elapsed_steps = (t + 1e-3*dt)/dt
     if np.isscalar(elapsed_steps) or elapsed_steps.shape == ():
         if np.isinf(elapsed_steps):

--- a/brian2/core/functions.py
+++ b/brian2/core/functions.py
@@ -554,14 +554,14 @@ def timestep(t, dt):
 
     Parameters
     ----------
-    t : np.ndarray or Quantity
+    t : np.ndarray, float, Quantity
         The time to convert.
     dt : float or Quantity
         The length of a simulation time step.
 
     Returns
     -------
-    ts : int
+    ts : np.ndarray, int
         The time step corresponding to the given time.
 
     Notes

--- a/brian2/core/functions.py
+++ b/brian2/core/functions.py
@@ -541,24 +541,23 @@ class log10(sympy_Function):
         return sympy.functions.elementary.exponential.log(args, 10)
 
 
-_iinfo = np.iinfo(int)
+_infinity_int = np.iinfo(int).max//2
 
 def timestep(t, dt):
-    elapsed_steps = (t + 1e-3 * dt) / dt
+    elapsed_steps = (t + 1e-3*dt)/dt
     if np.isscalar(elapsed_steps) or elapsed_steps.shape == ():
         if np.isinf(elapsed_steps):
             if elapsed_steps > 0:
-                return _iinfo.max
+                return _infinity_int
             else:
-                return _iinfo.min
+                return -_infinity_int
         else:
             return np.int_(elapsed_steps)
     else:
-        are_inf = np.isinf(elapsed_steps)
         int_steps = np.asarray(elapsed_steps, dtype=int)
-        if any(are_inf):
-            int_steps[are_inf & (elapsed_steps < 0)] = _iinfo.min
-            int_steps[are_inf & (elapsed_steps > 0)] = _iinfo.max
+        are_inf, = np.nonzero(np.isinf(elapsed_steps))
+        int_steps[are_inf] = np.where(elapsed_steps[are_inf] > 0,
+                                      _infinity_int, -_infinity_int)
         return int_steps
 
 

--- a/brian2/devices/cpp_standalone/templates/common_group.cpp
+++ b/brian2/devices/cpp_standalone/templates/common_group.cpp
@@ -6,6 +6,7 @@
 #include<ctime>
 #include<iostream>
 #include<fstream>
+#include<climits>
 {% block extra_headers %}
 {% endblock %}
 {% for name in user_headers | sort %}

--- a/brian2/groups/neurongroup.py
+++ b/brian2/groups/neurongroup.py
@@ -117,7 +117,7 @@ class StateUpdater(CodeRunner):
                                                       'of seconds but got '
                                                       '{value}'),
                                         value=ref)
-            if prefs.core.legacy_refractory_timing:
+            if prefs.legacy.refractory_timing:
                 abstract_code = 'not_refractory = (t - lastspike) > %f\n' % ref
             else:
                 abstract_code = 'not_refractory = timestep(t - lastspike, dt) >= timestep(%f, dt)\n' % ref
@@ -128,7 +128,7 @@ class StateUpdater(CodeRunner):
                                                user_identifiers=identifiers)
             dims = parse_expression_dimensions(str(ref), variables)
             if dims is second.dim:
-                if prefs.core.legacy_refractory_timing:
+                if prefs.legacy.refractory_timing:
                     abstract_code = '(t - lastspike) > %s\n' % ref
                 else:
                     abstract_code = 'not_refractory = timestep(t - lastspike, dt) >= timestep(%s, dt)\n' % ref

--- a/brian2/groups/neurongroup.py
+++ b/brian2/groups/neurongroup.py
@@ -117,7 +117,7 @@ class StateUpdater(CodeRunner):
                                                       '{value}'),
                                         value=ref)
 
-            abstract_code = 'not_refractory = (t - lastspike) > %f\n' % ref
+            abstract_code = 'not_refractory = timestep(t - lastspike, dt) >= timestep(%f, dt)\n' % ref
         else:
             identifiers = get_identifiers(ref)
             variables = self.group.resolve_all(identifiers,
@@ -125,7 +125,7 @@ class StateUpdater(CodeRunner):
                                                user_identifiers=identifiers)
             dims = parse_expression_dimensions(str(ref), variables)
             if dims is second.dim:
-                abstract_code = 'not_refractory = (t - lastspike) > %s\n' % ref
+                abstract_code = 'not_refractory = timestep(t - lastspike, dt) >= timestep(%s, dt)\n' % ref
             elif dims is DIMENSIONLESS:
                 if not is_boolean_expression(str(ref), variables):
                     raise TypeError(('Refractory expression is dimensionless '

--- a/brian2/groups/neurongroup.py
+++ b/brian2/groups/neurongroup.py
@@ -8,6 +8,7 @@ import sympy
 from pyparsing import Word
 
 from brian2.codegen.translation import analyse_identifiers
+from brian2.core.preferences import prefs
 from brian2.core.spikesource import SpikeSource
 from brian2.core.variables import (Variables, LinkedVariable,
                                    DynamicArrayVariable, Subexpression)
@@ -116,8 +117,10 @@ class StateUpdater(CodeRunner):
                                                       'of seconds but got '
                                                       '{value}'),
                                         value=ref)
-
-            abstract_code = 'not_refractory = timestep(t - lastspike, dt) >= timestep(%f, dt)\n' % ref
+            if prefs.core.legacy_refractory_timing:
+                abstract_code = 'not_refractory = (t - lastspike) > %f\n' % ref
+            else:
+                abstract_code = 'not_refractory = timestep(t - lastspike, dt) >= timestep(%f, dt)\n' % ref
         else:
             identifiers = get_identifiers(ref)
             variables = self.group.resolve_all(identifiers,
@@ -125,7 +128,10 @@ class StateUpdater(CodeRunner):
                                                user_identifiers=identifiers)
             dims = parse_expression_dimensions(str(ref), variables)
             if dims is second.dim:
-                abstract_code = 'not_refractory = timestep(t - lastspike, dt) >= timestep(%s, dt)\n' % ref
+                if prefs.core.legacy_refractory_timing:
+                    abstract_code = '(t - lastspike) > %s\n' % ref
+                else:
+                    abstract_code = 'not_refractory = timestep(t - lastspike, dt) >= timestep(%s, dt)\n' % ref
             elif dims is DIMENSIONLESS:
                 if not is_boolean_expression(str(ref), variables):
                     raise TypeError(('Refractory expression is dimensionless '

--- a/brian2/tests/test_GSL.py
+++ b/brian2/tests/test_GSL.py
@@ -358,7 +358,7 @@ def test_GSL_non_autonomous():
 @with_setup(teardown=reinit_devices)
 @skip_if_not_implemented
 def test_GSL_refractory():
-    eqs = '''dv/dt = 100*Hz : 1 (unless refractory)'''
+    eqs = '''dv/dt = 99.99*Hz : 1 (unless refractory)'''
     neuron = NeuronGroup(1, eqs, method='gsl', threshold='v>1', reset='v=0', refractory=3*ms)
     neuron2 = NeuronGroup(1, eqs, method='euler', threshold='v>1', reset='v=0', refractory=3*ms)
     mon = SpikeMonitor(neuron, 'v')

--- a/brian2/tests/test_cpp_standalone.py
+++ b/brian2/tests/test_cpp_standalone.py
@@ -40,7 +40,6 @@ def test_cpp_standalone():
     assert len(M.i)>=17000 and len(M.i)<=18000
     assert len(M.t) == len(M.i)
     assert M.t[0] == 0.
-    assert M.t[-1] == 100*ms - defaultclock.dt
     reset_device()
 
 @attr('cpp_standalone', 'standalone-only')

--- a/brian2/tests/test_functions.py
+++ b/brian2/tests/test_functions.py
@@ -3,6 +3,7 @@ from nose.plugins.attrib import attr
 from numpy.testing import assert_equal, assert_raises, assert_allclose
 
 from brian2 import *
+from brian2.core.functions import timestep
 from brian2.parsing.sympytools import str_to_sympy, sympy_to_str
 from brian2.utils.logger import catch_logs
 from brian2.devices.device import reinit_devices
@@ -134,6 +135,23 @@ def test_bool_to_int():
     run(defaultclock.dt)
     assert_equal(s_mon.intexpr1.flatten(), [1, 0])
     assert_equal(s_mon.intexpr2.flatten(), [1, 0])
+
+@attr('codegen-independent')
+def test_timestep_function():
+    dt = defaultclock.dt_
+    # Check that multiples of dt end up in the correct time step
+    t = np.arange(100000)*dt
+    assert_equal(timestep(t, dt), np.arange(100000))
+    # Check that inf is handled correctly
+    t = np.array([-np.inf, np.inf])
+    ts = timestep(t, dt)
+    assert ts[0] < -1e9
+    assert ts[1] > 1e9
+
+    # Scalar values should stay scalar
+    ts = timestep(0.0005, 0.0001)
+    assert np.isscalar(ts) and ts == 5
+
 
 @attr('standalone-compatible')
 @with_setup(teardown=reinit_devices)
@@ -640,6 +658,7 @@ if __name__ == '__main__':
             test_math_functions,
             test_clip,
             test_bool_to_int,
+            test_timestep_function,
             test_user_defined_function,
             test_user_defined_function_units,
             test_simple_user_defined_function,

--- a/brian2/tests/test_refractory.py
+++ b/brian2/tests/test_refractory.py
@@ -1,3 +1,4 @@
+from brian2.core.functions import timestep
 from brian2.utils.logger import catch_logs
 from nose import with_setup
 from nose.plugins.attrib import attr
@@ -36,8 +37,8 @@ def test_missing_refractory_warning():
 @with_setup(teardown=reinit_devices)
 def test_refractoriness_basic():
     G = NeuronGroup(1, '''
-                       dv/dt = 100*Hz : 1 (unless refractory)
-                       dw/dt = 100*Hz : 1
+                       dv/dt = 99.999*Hz : 1 (unless refractory)
+                       dw/dt = 99.999*Hz : 1
                        ''',
                     threshold='v>1', reset='v=0;w=0',
                     refractory=5*ms)
@@ -46,15 +47,17 @@ def test_refractoriness_basic():
     mon = StateMonitor(G, ['v', 'w'], record=True, when='end')
     run(20*ms)
     # No difference before the spike
-    assert_equal(mon[0].v[mon.t < 10*ms], mon[0].w[mon.t < 10*ms])
+    assert_equal(mon[0].v[:timestep(10*ms, defaultclock.dt)],
+                 mon[0].w[:timestep(10*ms, defaultclock.dt)])
     # v is not updated during refractoriness
-    in_refractoriness = mon[0].v[(mon.t >= 10*ms) & (mon.t <15*ms)]
+    in_refractoriness = mon[0].v[timestep(10*ms, defaultclock.dt):timestep(15*ms, defaultclock.dt)]
     assert_equal(in_refractoriness, np.zeros_like(in_refractoriness))
     # w should evolve as before
-    assert_equal(mon[0].w[mon.t < 5*ms], mon[0].w[(mon.t >= 10*ms) & (mon.t <15*ms)])
-    assert np.all(mon[0].w[(mon.t >= 10*ms) & (mon.t <15*ms)] > 0)
+    assert_equal(mon[0].w[:timestep(5*ms, defaultclock.dt)],
+                 mon[0].w[timestep(10*ms, defaultclock.dt)+1:timestep(15*ms, defaultclock.dt)+1])
+    assert np.all(mon[0].w[timestep(10*ms, defaultclock.dt)+1:timestep(15*ms, defaultclock.dt)+1] > 0)
     # After refractoriness, v should increase again
-    assert np.all(mon[0].v[(mon.t >= 15*ms) & (mon.t <20*ms)] > 0)
+    assert np.all(mon[0].v[timestep(15*ms, defaultclock.dt):timestep(20*ms, defaultclock.dt)] > 0)
 
 
 @attr('standalone-compatible')
@@ -62,17 +65,17 @@ def test_refractoriness_basic():
 def test_refractoriness_variables():
     # Try a string evaluating to a quantity an an explicit boolean
     # condition -- all should do the same thing
-    for ref_time in ['5*ms', '(t-lastspike) <= 5*ms',
-                     'time_since_spike <= 5*ms', 'ref_subexpression',
+    for ref_time in ['5*ms', '(t-lastspike) < 5*ms',
+                     'time_since_spike < 5*ms', 'ref_subexpression',
                      '(t-lastspike) <= ref', 'ref', 'ref_no_unit*ms']:
         reinit_devices()
         G = NeuronGroup(1, '''
-                        dv/dt = 100*Hz : 1 (unless refractory)
-                        dw/dt = 100*Hz : 1
+                        dv/dt = 99.999*Hz : 1 (unless refractory)
+                        dw/dt = 99.999*Hz : 1
                         ref : second
                         ref_no_unit : 1
                         time_since_spike = t - lastspike : second
-                        ref_subexpression = (t - lastspike) <= ref : boolean
+                        ref_subexpression = (t - lastspike) < ref : boolean
                         ''',
                         threshold='v>1', reset='v=0;w=0',
                         refractory=ref_time)
@@ -84,30 +87,33 @@ def test_refractoriness_variables():
         run(20*ms)
         try:
             # No difference before the spike
-            assert_equal(mon[0].v[mon.t < 10*ms], mon[0].w[mon.t < 10*ms])
+            assert_equal(mon[0].v[:timestep(10*ms, defaultclock.dt)],
+                         mon[0].w[:timestep(10*ms, defaultclock.dt)])
             # v is not updated during refractoriness
-            in_refractoriness = mon[0].v[(mon.t >= 10*ms) & (mon.t <15*ms)]
+            in_refractoriness = mon[0].v[timestep(10*ms, defaultclock.dt):timestep(15*ms, defaultclock.dt)]
             assert_equal(in_refractoriness, np.zeros_like(in_refractoriness))
             # w should evolve as before
-            assert_equal(mon[0].w[mon.t < 5*ms], mon[0].w[(mon.t >= 10*ms) & (mon.t <15*ms)])
-            assert np.all(mon[0].w[(mon.t >= 10*ms) & (mon.t <15*ms)] > 0)
+            assert_equal(mon[0].w[:timestep(5*ms, defaultclock.dt)],
+                         mon[0].w[timestep(10*ms, defaultclock.dt)+1:timestep(15*ms, defaultclock.dt)+1])
+            assert np.all(mon[0].w[timestep(10*ms, defaultclock.dt)+1:timestep(15*ms, defaultclock.dt)+1] > 0)
             # After refractoriness, v should increase again
-            assert np.all(mon[0].v[(mon.t >= 15*ms) & (mon.t <20*ms)] > 0)
+            assert np.all(mon[0].v[timestep(15*ms, defaultclock.dt):timestep(20*ms, defaultclock.dt)])
         except AssertionError as ex:
-            raise AssertionError('Assertion failed when using %r as refractory argument:\n%s' % (ref_time, ex))
+            raise
+            # raise AssertionError('Assertion failed when using %r as refractory argument:\n%s' % (ref_time, ex))
 
 @attr('standalone-compatible')
 @with_setup(teardown=reinit_devices)
 def test_refractoriness_threshold_basic():
     G = NeuronGroup(1, '''
-    dv/dt = 200*Hz : 1
+    dv/dt = 199.99*Hz : 1
     ''', threshold='v > 1', reset='v=0', refractory=10*ms)
     # The neuron should spike after 5ms but then not spike for the next
     # 10ms. The state variable should continue to integrate so there should
     # be a spike after 15ms
     spike_mon = SpikeMonitor(G)
     run(16*ms)
-    assert_allclose(spike_mon.t, [4.9, 15] * ms)
+    assert_allclose(spike_mon.t, [5, 15] * ms)
 
 
 @attr('standalone-compatible')
@@ -119,7 +125,7 @@ def test_refractoriness_threshold():
                      '(t-lastspike) <= ref', 'ref', 'ref_no_unit*ms']:
         reinit_devices()
         G = NeuronGroup(1, '''
-                        dv/dt = 200*Hz : 1
+                        dv/dt = 199.99*Hz : 1
                         ref : second
                         ref_no_unit : 1
                         ''', threshold='v > 1',
@@ -131,7 +137,7 @@ def test_refractoriness_threshold():
         # be a spike after 15ms
         spike_mon = SpikeMonitor(G)
         run(16*ms)
-        assert_allclose(spike_mon.t, [4.9, 15] * ms)
+        assert_allclose(spike_mon.t, [5, 15] * ms)
 
 
 @attr('codegen-independent')
@@ -214,8 +220,10 @@ def test_conditional_write_automatic_and_manual():
 if __name__ == '__main__':
     test_add_refractoriness()
     test_missing_refractory_warning()
+    test_refractoriness_basic()
     test_refractoriness_variables()
     test_refractoriness_threshold()
+    test_refractoriness_threshold_basic()
     test_refractoriness_types()
     test_conditional_write_set()
     test_conditional_write_behaviour()

--- a/docs_sphinx/introduction/known_issues.rst
+++ b/docs_sphinx/introduction/known_issues.rst
@@ -77,3 +77,8 @@ stimulations which changes the way the library is linked so that it does not
 suffer from this problem. If this environment variable leads to unwanted
 behaviour on your machine, change the
 `prefs.devices.cpp_standalone.run_environment_variables` preference.
+
+Cython fails with compilation error on OS X: ``error: use of undeclared identifier 'isinf'``
+-------------------------------------------------------------------------------------------
+
+Try setting the environment variable ``MACOSX_DEPLOYMENT_TARGET=10.9``.

--- a/docs_sphinx/user/refractoriness.rst
+++ b/docs_sphinx/user/refractoriness.rst
@@ -84,7 +84,7 @@ converting a time into a time step in a safe way.
 .. versionadded:: 2.1.3
     The `timestep` function is now used to avoid floating point issues in the
     refractoriness calculation. To restore the previous behaviour, set the
-    `core.legacy_refractory_timing` preference to ``True``.
+    `legacy.refractory_timing` preference to ``True``.
 
 Defining model behaviour during refractoriness
 ----------------------------------------------

--- a/docs_sphinx/user/refractoriness.rst
+++ b/docs_sphinx/user/refractoriness.rst
@@ -69,8 +69,22 @@ The ``refractory`` keyword should be read as "stay refractory as long as the
 condition remains true". In fact, specifying a time span for the refractoriness
 will be automatically transformed into a logical expression using the current
 time ``t`` and the time of the last spike ``lastspike``. Specifying
-``refractory=2*ms`` is equivalent to specifying
-``refractory='(t - lastspike) <= 2*ms'``.
+``refractory=2*ms`` is basically equivalent to specifying
+``refractory='(t - lastspike) <= 2*ms'``. However, this expression can give
+inconsistent results for the common case that the refractory period is a
+multiple of the simulation timestep. Due to floating point impreciseness, the
+actual value of ``t - lastspike`` can be slightly above or below a multiple of
+the simulation time step; comparing it directly to the refractory period can
+therefore lead to an end of the refractory one time step sooner or later. To
+avoid this issue, the actual code used for the above example is equivalent to
+``refractory='timestep(t - lastspike, dt) <= timestep(2*ms, dt)'``. The
+`~brian2.core.functions.timestep` function is provided by Brian and takes care of
+converting a time into a time step in a safe way.
+
+.. versionadded:: 2.1.3
+    The `timestep` function is now used to avoid floating point issues in the
+    refractoriness calculation. To restore the previous behaviour, set the
+    `core.legacy_refractory_timing` preference to ``True``.
 
 Defining model behaviour during refractoriness
 ----------------------------------------------


### PR DESCRIPTION
This introduces a new `timestep` function and uses it for the implementation of refractoriness, as discussed in #949. It's basically done except for a bit of documentation.

A few things to discuss before merging:
* I used a shift of 1e-3dt to be consistent what we are doing in `SpikeGeneratorGroup`, not sure whether a smaller shift would be better...
* the implementation of the `timestep` function is slightly complicated by the fact that the time of the last spike is `-inf` before the first timestep. My handling of all this in the numpy implementation is probably not optimal, I'm seeing something like a 2% slowdown for the COBAHH example.
* I added a preference to switch back to the old behaviour -- not sure it's well explained and named, though (`core.legacy_refractory_timing`). Maybe we should have a preference category for this kind of thing?
* GSL integration was a bit tricky to get to work again, the way we use `timestep(t, dt)` in the refractoriness condition means that `dt` is used in the scalar and in the vector code, we never had this before.
