### PR TITLE
[MRG] The `timestep` function should not use `Quantity` objects during a simulation

### DIFF
--- a/brian2/codegen/generators/numpy_generator.py
+++ b/brian2/codegen/generators/numpy_generator.py
@@ -4,7 +4,7 @@ import numpy as np
 
 from brian2.parsing.bast import brian_dtype_from_dtype
 from brian2.parsing.rendering import NumpyNodeRenderer
-from brian2.core.functions import DEFAULT_FUNCTIONS, Function
+from brian2.core.functions import DEFAULT_FUNCTIONS, timestep
 from brian2.core.variables import ArrayVariable
 from brian2.utils.stringtools import get_identifiers, word_substitute, indent
 from brian2.utils.logger import get_logger
@@ -328,7 +328,14 @@ DEFAULT_FUNCTIONS['int'].implementations.add_implementation(NumpyCodeGenerator,
                                                             code=int_func)
 ceil_func = lambda value: np.int32(np.ceil(value))
 DEFAULT_FUNCTIONS['ceil'].implementations.add_implementation(NumpyCodeGenerator,
-                                                            code=ceil_func)
+                                                             code=ceil_func)
 floor_func = lambda value: np.int32(np.floor(value))
 DEFAULT_FUNCTIONS['floor'].implementations.add_implementation(NumpyCodeGenerator,
-                                                            code=floor_func)
+                                                              code=floor_func)
+
+# We need to explicitly add an implementation for the timestep function,
+# otherwise Brian would *add* units during simulation, thinking that the
+# timestep function would not work correctly otherwise. This would slow the
+# function down significantly.
+DEFAULT_FUNCTIONS['timestep'].implementations.add_implementation(NumpyCodeGenerator,
+                                                                 code=timestep)


### PR DESCRIPTION
While I only saw a minor slow down for the numpy target with the COBAHH example due to the introduction of the `timestep`, I just realized that simpler examples are much more affected. One of them is part of our benchmarking: https://brian-team.github.io/brian2_benchmarks/#benchmarks.FullExamples.time_reliability_example

I found that due to the way that I added the `timestep` function, Brian thought that the function *requires* quantities instead of simple floats/arrays and was therefore helpfully converting the floats/arrays that we are using during simulation to quantities and back. Not only the conversion itself itself is somewhat costly, but arithmetic operation on quantities are also significantly slower due to the additional checks and unit conversions.

