### PR TITLE
[MRG] Fix inefficiencies in the Quantity/Unit implementation

### DIFF
--- a/brian2/tests/test_units.py
+++ b/brian2/tests/test_units.py
@@ -1021,6 +1021,22 @@ def test_get_unit():
 
 
 @attr('codegen-independent')
+def test_get_best_unit():
+    # get_best_unit should not check all values for long arrays, since it is
+    # a function used for display purposes only. Instead, only the first and
+    # last few values should matter (see github issue #966)
+    long_ar = np.ones(10000)*siemens
+    long_ar[:10] = 1*nS
+    long_ar[-10:] = 2*nS
+    values = [(np.arange(10)*mV, mV),
+              ([0.001, 0.002, 0.003]*second, ms),
+              (long_ar, nS)]
+    for ar, expected_unit in values:
+        assert ar.get_best_unit() is expected_unit
+        assert str(expected_unit) in ar.in_best_unit()
+
+
+@attr('codegen-independent')
 def test_switching_off_unit_checks():
     '''
     Check switching off unit checks (used for external functions).
@@ -1181,6 +1197,7 @@ if __name__ == '__main__':
     test_list()
     test_check_units()
     test_get_unit()
+    test_get_best_unit()
     test_switching_off_unit_checks()
     test_fail_for_dimension_mismatch()
     test_deepcopy()

--- a/brian2/units/fundamentalunits.py
+++ b/brian2/units/fundamentalunits.py
@@ -2148,9 +2148,24 @@ class UnitRegistry(object):
         if len(matching) == 0:
             raise KeyError("Unit not found in registry.")
 
-        # determine how well this unit represents the value
         matching_values = np.array(matching.keys(), copy=False)
-        x_flat = np.array(x, copy=False).flatten()
+        print_opts = np.get_printoptions()
+        edgeitems, threshold = print_opts['edgeitems'], print_opts['threshold']
+        if x.size > threshold:
+            # Only care about optimizing the units for the values that will
+            # actually be shown later
+            # The code looks a bit complex, but should return the same numbers
+            # that are shown by numpy's string conversion
+            slices = []
+            for shape in x.shape:
+                if shape > 2*edgeitems:
+                    slices.append((slice(0, edgeitems), slice(-edgeitems, None)))
+                else:
+                    slices.append((slice(None), ))
+            x_flat = np.hstack([x[use_slices].flatten() for use_slices in
+                                itertools.product(*slices)])
+        else:
+            x_flat = np.array(x, copy=False).flatten()
         floatreps = np.tile(np.abs(x_flat), (len(matching), 1)).T / matching_values
         # ignore zeros, they are well represented in any unit
         floatreps[floatreps == 0] = np.nan

--- a/brian2/units/fundamentalunits.py
+++ b/brian2/units/fundamentalunits.py
@@ -2036,7 +2036,7 @@ class Unit(Quantity):
             return other.__div__(self)
         else:
             try:
-                if other == 1:
+                if is_dimensionless(other) and other == 1:
                     return self**-1
             except (ValueError, TypeError, DimensionMismatchError):
                 pass


### PR DESCRIPTION
See problem description in #966. In addition to that issue, this PR also fixes an inefficiency when dividing large quantities by a unit (most commonly used to remove units, e.g. `mon.t/second`)