### PR TITLE
[MRG] Add less names to the namespace when using wildcard imports

### DIFF
--- a/brian2/__init__.py
+++ b/brian2/__init__.py
@@ -178,13 +178,16 @@ def clear_cache(target):
     shutil.rmtree(cache_dir)
 
 
-from brian2.codegen.runtime.weave_rt.weave_rt import get_weave_cache_dir as _get_weave_cache_dir
-from brian2.codegen.runtime.cython_rt.extension_manager import get_cython_cache_dir as _get_cython_cache_dir
-from brian2.codegen.runtime.weave_rt.weave_rt import get_weave_extensions as _get_weave_extensions
-from brian2.codegen.runtime.cython_rt.extension_manager import get_cython_extensions as _get_cython_extensions
+def _check_caches():
+    from brian2.codegen.runtime.weave_rt.weave_rt import get_weave_cache_dir
+    from brian2.codegen.runtime.cython_rt.extension_manager import get_cython_cache_dir
+    from brian2.codegen.runtime.weave_rt.weave_rt import get_weave_extensions
+    from brian2.codegen.runtime.cython_rt.extension_manager import get_cython_extensions
 
-for _target, (_dir, _extensions) in [('weave', (_get_weave_cache_dir(), _get_weave_extensions())),
-                                     ('cython', (_get_cython_cache_dir(), _get_cython_extensions()))]:
-    _cache_dirs_and_extensions[_target] = (_dir, _extensions)
-    if prefs.codegen.max_cache_dir_size > 0:
-        check_cache(_target)
+    for target, (dirname, extensions) in [('weave', (get_weave_cache_dir(), get_weave_extensions())),
+                                         ('cython', (get_cython_cache_dir(), get_cython_extensions()))]:
+        _cache_dirs_and_extensions[target] = (dirname, extensions)
+        if prefs.codegen.max_cache_dir_size > 0:
+            check_cache(target)
+
+_check_caches()

--- a/brian2/__init__.py
+++ b/brian2/__init__.py
@@ -93,10 +93,14 @@ def _check_dependency_version(name, version):
 
             logger.warn(message, 'outdated_dependency')
 
-for _name, _version in [('numpy',  '1.10'),
-                        ('sympy',  '0.7.6'),
-                        ('jinja2', '2.7')]:
-    _check_dependency_version(_name, _version)
+
+def _check_dependency_versions():
+    for name, version in [('numpy',  '1.10'),
+                            ('sympy',  '0.7.6'),
+                            ('jinja2', '2.7')]:
+        _check_dependency_version(name, version)
+
+_check_dependency_versions()
 
 # Initialize the logging system
 BrianLogger.initialize()

--- a/brian2/__init__.py
+++ b/brian2/__init__.py
@@ -1,46 +1,45 @@
 '''
 Brian 2
 '''
-import os
-import shutil
-
 # Import setuptools to do some monkey patching of distutils, necessary for
 # working weave/Cython on Windows with the Python for C++ compiler
 import setuptools as _setuptools
 
-# Check basic dependencies
-import sys
-from distutils.version import LooseVersion
-missing = []
-try:
-    import numpy
-except ImportError as ex:
-    sys.stderr.write('Importing numpy failed: %s\n' % ex)
-    missing.append('numpy')
-try:
-    import sympy
-except ImportError as ex:
-    sys.stderr.write('Importing sympy failed: %s\n' % ex)
-    missing.append('sympy')
-try:
-    import pyparsing
-except ImportError as ex:
-    sys.stderr.write('Importing pyparsing failed: %s\n' % ex)
-    missing.append('pyparsing')
-try:
-    import jinja2
-except ImportError as ex:
-    sys.stderr.write('Importing Jinja2 failed: %s\n' % ex)
-    missing.append('jinja2')
+def _check_dependencies():
+    '''Check basic dependencies'''
+    import sys
+    missing = []
+    try:
+        import numpy
+    except ImportError as ex:
+        sys.stderr.write('Importing numpy failed: %s\n' % ex)
+        missing.append('numpy')
+    try:
+        import sympy
+    except ImportError as ex:
+        sys.stderr.write('Importing sympy failed: %s\n' % ex)
+        missing.append('sympy')
+    try:
+        import pyparsing
+    except ImportError as ex:
+        sys.stderr.write('Importing pyparsing failed: %s\n' % ex)
+        missing.append('pyparsing')
+    try:
+        import jinja2
+    except ImportError as ex:
+        sys.stderr.write('Importing Jinja2 failed: %s\n' % ex)
+        missing.append('jinja2')
 
-try:
-    import cpuinfo
-except Exception as ex:
-    sys.stderr.write('Importing cpuinfo failed: %s\n' % ex)
-    # we don't append it to "missing", Brian runs fine without it
+    try:
+        import cpuinfo
+    except Exception as ex:
+        sys.stderr.write('Importing cpuinfo failed: %s\n' % ex)
+        # we don't append it to "missing", Brian runs fine without it
 
-if len(missing):
-    raise ImportError('Some required dependencies are missing:\n' + ', '.join(missing))
+    if len(missing):
+        raise ImportError('Some required dependencies are missing:\n' + ', '.join(missing))
+
+_check_dependencies()
 
 try:
     from pylab import *
@@ -76,6 +75,7 @@ from brian2.only import *
 
 # Check for outdated dependency versions
 def _check_dependency_version(name, version):
+    from distutils.version import LooseVersion
     from core.preferences import prefs
     from utils.logger import get_logger
     logger = get_logger(__name__)
@@ -93,10 +93,10 @@ def _check_dependency_version(name, version):
 
             logger.warn(message, 'outdated_dependency')
 
-for name, version in [('numpy',  '1.10'),
-                      ('sympy',  '0.7.6'),
-                      ('jinja2', '2.7')]:
-    _check_dependency_version(name, version)
+for _name, _version in [('numpy',  '1.10'),
+                        ('sympy',  '0.7.6'),
+                        ('jinja2', '2.7')]:
+    _check_dependency_version(_name, _version)
 
 # Initialize the logging system
 BrianLogger.initialize()
@@ -104,6 +104,7 @@ logger = get_logger(__name__)
 
 # Check the caches
 def _get_size_recursively(dirname):
+    import os
     total_size = 0
     for dirpath, _, filenames in os.walk(dirname):
         for fname in filenames:
@@ -148,6 +149,8 @@ def clear_cache(target):
         If the cache directory contains unexpected files, suggesting that
         deleting it would also delete files unrelated to the cache.
     '''
+    import os
+    import shutil
     cache_dir, extensions = _cache_dirs_and_extensions.get(target, (None, None))
     if cache_dir is None:
         raise ValueError('No cache directory registered for target '
@@ -176,8 +179,8 @@ from brian2.codegen.runtime.cython_rt.extension_manager import get_cython_cache_
 from brian2.codegen.runtime.weave_rt.weave_rt import get_weave_extensions as _get_weave_extensions
 from brian2.codegen.runtime.cython_rt.extension_manager import get_cython_extensions as _get_cython_extensions
 
-for target, (dir, extensions) in [('weave', (_get_weave_cache_dir(), _get_weave_extensions())),
-                                  ('cython', (_get_cython_cache_dir(), _get_cython_extensions()))]:
-    _cache_dirs_and_extensions[target] = (dir, extensions)
+for _target, (_dir, _extensions) in [('weave', (_get_weave_cache_dir(), _get_weave_extensions())),
+                                     ('cython', (_get_cython_cache_dir(), _get_cython_extensions()))]:
+    _cache_dirs_and_extensions[_target] = (_dir, _extensions)
     if prefs.codegen.max_cache_dir_size > 0:
-        check_cache(target)
+        check_cache(_target)

--- a/brian2/__init__.py
+++ b/brian2/__init__.py
@@ -78,6 +78,7 @@ def _check_dependency_version(name, version):
     from distutils.version import LooseVersion
     from core.preferences import prefs
     from utils.logger import get_logger
+    import sys
     logger = get_logger(__name__)
 
     module = sys.modules[name]
@@ -96,8 +97,8 @@ def _check_dependency_version(name, version):
 
 def _check_dependency_versions():
     for name, version in [('numpy',  '1.10'),
-                            ('sympy',  '0.7.6'),
-                            ('jinja2', '2.7')]:
+                          ('sympy',  '0.7.6'),
+                          ('jinja2', '2.7')]:
         _check_dependency_version(name, version)
 
 _check_dependency_versions()

--- a/brian2/codegen/__init__.py
+++ b/brian2/codegen/__init__.py
@@ -1,10 +1,9 @@
 '''
 Package providing the code generation framework.
 '''
-
-from .generators import *
-from .statements import *
-from .translation import *
+# Import the runtime packages so that they can register their preferences
 from .runtime import *
-from ._prefs import *
+import _prefs
 import cpp_prefs as _cpp_prefs
+
+__all__ = ['NumpyCodeObject', 'WeaveCodeObject', 'CythonCodeObject']

--- a/brian2/codegen/translation.py
+++ b/brian2/codegen/translation.py
@@ -34,8 +34,7 @@ from brian2.parsing.sympytools import str_to_sympy, sympy_to_str
 from .statements import Statement
 from .optimisation import optimise_statements
 
-__all__ = ['make_statements', 'analyse_identifiers',
-           'get_identifiers_recursively']
+__all__ = ['analyse_identifiers', 'get_identifiers_recursively']
 
 
 class LineInfo(object):

--- a/brian2/core/base.py
+++ b/brian2/core/base.py
@@ -12,9 +12,7 @@ from brian2.units.allunits import second
 from brian2.units.fundamentalunits import check_units
 
 __all__ = ['BrianObject',
-           'weakproxy_with_fallback',
            'BrianObjectException',
-           'brian_object_exception',
            ]
 
 logger = get_logger(__name__)

--- a/brian2/core/core_preferences.py
+++ b/brian2/core/core_preferences.py
@@ -6,12 +6,16 @@ from numpy import float64, int32
 
 from brian2.core.preferences import BrianPreference, prefs
 
+__all__ = []
+
 
 def dtype_repr(dtype):
     return dtype.__name__
 
+
 def default_float_dtype_validator(dtype):
     return dtype is float64
+
 
 prefs.register_preferences('core', 'Core Brian preferences',
     default_float_dtype=BrianPreference(

--- a/brian2/groups/__init__.py
+++ b/brian2/groups/__init__.py
@@ -5,3 +5,5 @@ Package providing groups such as `NeuronGroup` or `PoissonGroup`.
 from .group import *
 from .neurongroup import *
 from .subgroup import *
+
+__all__ = ['CodeRunner', 'Group', 'VariableOwner', 'NeuronGroup']

--- a/brian2/input/__init__.py
+++ b/brian2/input/__init__.py
@@ -7,3 +7,6 @@ from .poissongroup import *
 from .poissoninput import *
 from .spikegeneratorgroup import *
 from .timedarray import *
+
+__all__ = ['BinomialFunction', 'PoissonGroup', 'PoissonInput',
+           'SpikeGeneratorGroup', 'TimedArray']

--- a/brian2/monitors/__init__.py
+++ b/brian2/monitors/__init__.py
@@ -1,3 +1,10 @@
+'''
+Base package for all monitors, i.e. objects to record activity during a
+simulation run.
+'''
 from spikemonitor import *
 from statemonitor import *
 from ratemonitor import *
+
+__all__ = ['SpikeMonitor', 'EventMonitor', 'StateMonitor',
+           'PopulationRateMonitor']

--- a/brian2/only.py
+++ b/brian2/only.py
@@ -5,7 +5,6 @@ the pylab (numpy + matplotlib) namespace.
 Usage: ``from brian2.only import *``
 
 '''
-import gc
 # To minimize the problems with imports, import the packages in a sensible
 # order
 
@@ -35,6 +34,7 @@ from brian2.stateupdaters import *
 from brian2.codegen import *
 from brian2.core.namespace import *
 from brian2.groups import *
+from brian2.groups.subgroup import *
 from brian2.synapses import *
 from brian2.monitors import *
 from brian2.importexport import *
@@ -44,7 +44,7 @@ from brian2.devices import set_device, get_device, device, all_devices, seed
 import brian2.devices.cpp_standalone as _cpp_standalone
 
 # preferences
-from brian2.core.core_preferences import *
+import brian2.core.core_preferences as _core_preferences
 prefs.load_preferences()
 prefs.do_validation()
 
@@ -60,6 +60,7 @@ def restore_initial_state():
     `BrianGlobalPreferences._restore` preferences, and set
     `BrianObject._scope_current_key` back to 0.
     '''
+    import gc
     prefs._restore()
     BrianObject._scope_current_key = 0
     defaultclock.dt = 0.1*ms
@@ -67,3 +68,46 @@ def restore_initial_state():
 
 # make the test suite available via brian2.test()
 from brian2.tests import run as test
+
+from brian2.units import __all__ as _all_units
+
+__all__ = [
+    'get_logger', 'BrianLogger', 'std_silent',
+    'Trackable',
+    'Nameable',
+    'SpikeSource',
+    'linked_var',
+    'DEFAULT_FUNCTIONS', 'Function', 'implementation', 'declare_types',
+    'PreferenceError', 'BrianPreference', 'prefs', 'brian_prefs',
+    'Clock', 'defaultclock',
+    'Equations', 'Expression', 'Statements',
+    'BrianObject',
+    'BrianObjectException',
+    'Network', 'profiling_summary', 'scheduling_summary',
+    'MagicNetwork', 'magic_network',
+    'MagicError',
+    'run', 'stop', 'collect', 'store', 'restore',
+    'start_scope',
+    'NetworkOperation', 'network_operation',
+    'StateUpdateMethod',
+    'linear', 'exact', 'independent',
+    'milstein', 'heun', 'euler', 'rk2', 'rk4', 'ExplicitStateUpdater',
+    'exponential_euler',
+    'gsl_rk2', 'gsl_rk4', 'gsl_rkf45', 'gsl_rkck', 'gsl_rk8pd',
+    'NumpyCodeObject', 'WeaveCodeObject', 'CythonCodeObject',
+    'get_local_namespace', 'DEFAULT_FUNCTIONS', 'DEFAULT_UNITS',
+    'DEFAULT_CONSTANTS',
+    'CodeRunner', 'Group', 'VariableOwner', 'NeuronGroup',
+    'Subgroup',
+    'Synapses',
+    'SpikeMonitor', 'EventMonitor', 'StateMonitor',
+    'PopulationRateMonitor',
+    'ImportExport',
+    'BinomialFunction', 'PoissonGroup', 'PoissonInput',
+    'SpikeGeneratorGroup', 'TimedArray',
+    'Morphology', 'Soma', 'Cylinder', 'Section', 'SpatialNeuron',
+    'set_device', 'get_device', 'device', 'all_devices', 'seed',
+    'test',
+    'restore_initial_state'
+]
+__all__.extend(_all_units)

--- a/brian2/spatialneuron/__init__.py
+++ b/brian2/spatialneuron/__init__.py
@@ -1,2 +1,4 @@
-from morphology import *
-from spatialneuron import *
+from .morphology import *
+from .spatialneuron import *
+
+__all__ = ['Morphology', 'Soma', 'Cylinder', 'Section', 'SpatialNeuron']

--- a/brian2/stateupdaters/__init__.py
+++ b/brian2/stateupdaters/__init__.py
@@ -25,3 +25,8 @@ StateUpdateMethod.register('gsl_rk8pd', gsl_rk8pd)
 # as we consider rkf45 the default we also register it under 'gsl'
 StateUpdateMethod.register('gsl', gsl_rkf45)
 
+__all__ = ['StateUpdateMethod',
+           'linear', 'exact', 'independent',
+           'milstein', 'heun', 'euler', 'rk2', 'rk4', 'ExplicitStateUpdater',
+           'exponential_euler',
+           'gsl_rk2', 'gsl_rk4', 'gsl_rkf45', 'gsl_rkck', 'gsl_rk8pd']

--- a/brian2/synapses/__init__.py
+++ b/brian2/synapses/__init__.py
@@ -3,3 +3,5 @@ Package providing synapse support.
 '''
 
 from .synapses import *
+
+__all__ = ['Synapses']

--- a/brian2/tests/test_functions.py
+++ b/brian2/tests/test_functions.py
@@ -7,6 +7,8 @@ from brian2.core.functions import timestep
 from brian2.parsing.sympytools import str_to_sympy, sympy_to_str
 from brian2.utils.logger import catch_logs
 from brian2.devices.device import reinit_devices
+from brian2.codegen.generators import CodeGenerator
+from brian2.codegen.codeobject import CodeObject
 
 @attr('codegen-independent')
 def test_constants_sympy():

--- a/brian2/tests/test_synapses.py
+++ b/brian2/tests/test_synapses.py
@@ -8,6 +8,7 @@ from numpy.testing.utils import (assert_equal, assert_allclose, assert_raises,
 
 from brian2 import *
 from brian2.codegen.translation import make_statements
+from brian2.codegen.generators import NumpyCodeGenerator
 from brian2.core.network import schedule_propagation_offset
 from brian2.core.variables import variables_by_owner, ArrayVariable, Constant
 from brian2.core.functions import DEFAULT_FUNCTIONS

--- a/brian2/tests/test_synapses.py
+++ b/brian2/tests/test_synapses.py
@@ -5,6 +5,7 @@ from nose import with_setup, SkipTest
 from nose.plugins.attrib import attr
 from numpy.testing.utils import (assert_equal, assert_allclose, assert_raises,
                                  assert_raises_regex, assert_array_equal)
+import sympy
 
 from brian2 import *
 from brian2.codegen.translation import make_statements

--- a/brian2/units/fundamentalunits.py
+++ b/brian2/units/fundamentalunits.py
@@ -30,7 +30,7 @@ __all__ = [
     'DimensionMismatchError', 'get_or_create_dimension',
     'get_dimensions', 'is_dimensionless', 'have_same_dimensions',
     'in_unit', 'in_best_unit', 'Quantity', 'Unit', 'register_new_unit',
-    'check_units', 'is_scalar_type', 'get_unit', 'unit_checking'
+    'check_units', 'is_scalar_type', 'get_unit',
     ]
 
 

--- a/brian2/utils/__init__.py
+++ b/brian2/utils/__init__.py
@@ -3,3 +3,5 @@ Utility functions for Brian.
 '''
 
 from .logger import *
+
+__all__ = ['get_logger', 'BrianLogger', 'std_silent']


### PR DESCRIPTION
This PR reduces the number of names that get imported with a `from brian2 import *`, by adding `__all__` definitions and a few code rearrangements in `brian2.__init__`.

We still import many names that users will most likely never need (e.g. `NumpyCodeObject`), but I was rather conservative in removing names to avoid breaking existing code.

The following **functions** are no longer added to the namespace:
```
analyse_identifiers, brian_object_exception, c_data_type, default_float_dtype_validator, 
dtype_repr, get_identifiers_recursively, make_statements, weakproxy_with_fallback
```
There's actually one new function: `binomial` now refers to numpy's `binomial` function, it was previously shadowed by our module of the same name (see below).

The following **modules** (some are Brian modules, some are third-party modules that we use) are no longer added to the namespace:
```
base, binomial, codeobject, cpp_generator, cpp_prefs, cpuinfo, cython_rt, environment, explicit, 
extension_manager, gc, generators, group, jinja2, morphology, numpy_generator, numpy_rt,
optimisation, os, parse_synaptic_generator_syntax, permutation_analysis, poissongroup,
poissoninput, pyparsing, ratemonitor, runtime, shutil, spikegeneratorgroup, spikemonitor,
statements, statemonitor, stringtools, subgroup, targets, templates, timedarray, translation,
weave_rt
```

The following **classes** are no longer added to the namespace:
```
CPPCodeGenerator, CodeGenerator, CodeObject, GSLCodeGenerator, GSLCythonCodeGenerator,
GSLCythonCodeObject, GSLWeaveCodeGenerator, GSLWeaveCodeObject, IntegrationError,
NumpyCodeGenerator, Statement, WeaveCodeGenerator, LooseVersion
```

The following **other objects** (mostly variables that were used in `brian2.__init__`) are no longer added to the namespace:
```
dir, extensions, missing, name, target, unit_checking, version
```
Of these, `dir` is particularly annoying because it shadows the builtin of the same name, but `version` also led to confusion because you could think it is Brian's version (even more confusing when accessing it as `brian2.version`!), while it was simply the version of the last dependency that was checked (Jinja2).