### PR TITLE
[MRG] `timestep` function: implement the "overflow-safe" infinity value for C++/Cython

### DIFF
--- a/brian2/codegen/generators/cpp_generator.py
+++ b/brian2/codegen/generators/cpp_generator.py
@@ -463,17 +463,18 @@ namespace std {
 #endif
 #endif
 #endif
-        static inline int _timestep(double t, double dt)
-        {
-            if (std::isinf(t))
-            {
-                if (t < 0)
-                    return INT_MIN;
-                else
-                    return INT_MAX;
-            }
-            return (int)((t + 1e-3*dt)/dt); 
-        }
+static inline int _timestep(double t, double dt)
+{
+    const int _infinity_int = 1073741823;  // maximum 32bit integer divided by 2
+    if (std::isinf(t))
+    {
+        if (t < 0)
+            return -_infinity_int;
+        else
+            return _infinity_int;
+    }
+    return (int)((t + 1e-3*dt)/dt); 
+}
         '''
 DEFAULT_FUNCTIONS['timestep'].implementations.add_implementation(CPPCodeGenerator,
                                                                  code=timestep_code,

--- a/brian2/codegen/generators/cython_generator.py
+++ b/brian2/codegen/generators/cython_generator.py
@@ -392,7 +392,7 @@ cdef int _timestep(double t, double dt):
     cdef int _infinity_int = 1073741823  # maximum 32bit integer divided by 2
     if npy_isinf(t):
         if t < 0:
-            return _infinity_int
+            return -_infinity_int
         else:
             return  _infinity_int
     return <int>((t + 1e-3*dt)/dt)

--- a/brian2/codegen/generators/cython_generator.py
+++ b/brian2/codegen/generators/cython_generator.py
@@ -389,11 +389,12 @@ DEFAULT_FUNCTIONS['clip'].implementations.add_implementation(CythonCodeGenerator
 
 timestep_code = '''
 cdef int _timestep(double t, double dt):
+    cdef int _infinity_int = 1073741823  # maximum 32bit integer divided by 2
     if npy_isinf(t):
         if t < 0:
-            return INT_MIN
+            return _infinity_int
         else:
-            return INT_MAX
+            return  _infinity_int
     return <int>((t + 1e-3*dt)/dt)
 '''
 DEFAULT_FUNCTIONS['timestep'].implementations.add_implementation(CythonCodeGenerator,

--- a/brian2/core/functions.py
+++ b/brian2/core/functions.py
@@ -541,7 +541,7 @@ class log10(sympy_Function):
         return sympy.functions.elementary.exponential.log(args, 10)
 
 
-_infinity_int = np.iinfo(int).max//2
+_infinity_int = 1073741823  # maximum 32bit integer divided by 2
 
 def timestep(t, dt):
     '''

--- a/brian2/tests/test_functions.py
+++ b/brian2/tests/test_functions.py
@@ -157,6 +157,19 @@ def test_timestep_function():
 
 @attr('standalone-compatible')
 @with_setup(teardown=reinit_devices)
+def test_timestep_function_during_run():
+    group = NeuronGroup(3, '''ref_t : second
+                              ts = timestep(ref_t, dt) + timestep(t, dt) : integer''')
+    group.ref_t = [-np.inf*second, 5*defaultclock.dt, np.inf*second]
+    mon = StateMonitor(group, 'ts', record=True)
+    run(5*defaultclock.dt)
+    assert all(mon.ts[0] < -1e9)
+    assert_equal(mon.ts[1], [5, 6, 7, 8, 9])
+    assert all(mon.ts[2] > 1e9)
+
+
+@attr('standalone-compatible')
+@with_setup(teardown=reinit_devices)
 def test_user_defined_function():
     @implementation('cpp',"""
                 inline double usersin(double x)
@@ -661,6 +674,7 @@ if __name__ == '__main__':
             test_clip,
             test_bool_to_int,
             test_timestep_function,
+            test_timestep_function_during_run,
             test_user_defined_function,
             test_user_defined_function_units,
             test_simple_user_defined_function,


### PR DESCRIPTION
I noticed two bugs in our recently introduced `timestep` function and fix them in this PR:

1. In the documentation we state: 
> This function can handle infinity values, it will return a value equal to half of the maximal integer value. This assures that an expression such as `timestep(t) - timestep(lastspike)` will result in a reasonable value even if `lastspike` is `-inf`.

This was actually only true for the numpy implementation, C++ and Cython still returned the minimum/maximum possible integer, leading to potential overflow issues.

2. If you declare a variables as `: integer` in equations, it will by default use a 32bit integer. Now, such a variable might be a natural way to store a timestep calculated with the `timestep` value. Unfortunately,  the "maximum integer" that we divide by 2 and use as the "infinity value" in numpy asks for the maximum value of a *Python* integer, which corresponds to a `long` in C and therefore to a 64bit integer on Linux/OS X... I know simply hardcoded the maximum 32bit integer / 2 everywhere...

Both issues would have been detected by the test I just added.