### PR TITLE
List default functions and constants in namespace documentation

### DIFF
--- a/docs_sphinx/advanced/namespaces.rst
+++ b/docs_sphinx/advanced/namespaces.rst
@@ -5,7 +5,7 @@ Namespaces
 external parameters or functions. During the initialisation of a `NeuronGroup`
 or a `Synapses` object, this *namespace* can be provided as an argument. This
 is a group-specific namespace that will only be used for names in the context
-of the respective group. Note that units and a set of standard functions are
+of the respective group. Note that units and a set of standard functions (listed below) are
 always provided and should not be given explicitly.
 This namespace does not necessarily need to be exhaustive at the time of the
 creation of the `NeuronGroup`/`Synapses`, entries can be added (or modified)
@@ -53,3 +53,37 @@ variable values, all having the same effect in this case::
 
 External variables are free to change between runs (but not during one run),
 the value at the time of the `run` call is used in the simulation. 
+
+Default functions and constants
+-------------------------------
+
+        # numpy functions that behave the same name in numpy and math.h
+        cos
+        sin
+        tan
+        cosh
+        sinh
+        tanh
+        exp
+        log
+        log10
+        sqrt
+        ceil
+        floor
+        arccos
+        arcsin
+        arctan
+        abs
+        sign
+
+        # other
+        rand
+        randn
+        clip
+        int
+        timestep
+
+        # constants
+        pi
+        e
+        inf


### PR DESCRIPTION
This PR adds a list of the default namespace functions and constants in the documentation for namespaces (units are well documented in other places). It took me some time (not long but long enough to be annoying) to track down the default functions that are imported into any namespace and I thought I might save the next person some time. 

I don't have any experience with sphinx nor do I have it set up so I can't really check the formatting. It would be good if somebody else could. 
 
##### Additional comment:

Quite frankly, the standard doc-string for `namespace` needs some more love. It has taken me a long time and reading through pretty much all of brians documentation and then some experimentation to realize it's expressiveness. I think it would be good to have a discussion about what could and should be included in a new doc-string for `namespace`. I am not confident enough in my understanding of all the things that can be done with `namespace` to write a new doc-string by myself.  