### PR TITLE
Don't create `lastupdate` variables if they are not needed

### DIFF
--- a/brian2/synapses/synapses.py
+++ b/brian2/synapses/synapses.py
@@ -732,8 +732,11 @@ class Synapses(Group):
                 raise SyntaxError('"%s" is a reserved name that cannot be '
                                   'used as a variable name.' % name)
 
-        # Add the lastupdate variable, needed for event-driven updates
-        model = model + Equations('lastupdate : second')
+        # Check if a `lastupdate` variable is needed
+        need_lastupdate = self._check_lastupdate(model, on_pre, on_post)
+        if need_lastupdate:
+            model = model + Equations('lastupdate : second')
+
         # Add the "multisynaptic index", if desired
         self.multisynaptic_index = multisynaptic_index
         if multisynaptic_index is not None:
@@ -922,6 +925,28 @@ class Synapses(Group):
     def __getitem__(self, item):
         indices = self.indices[item]
         return SynapticSubgroup(self, indices)
+
+    def _check_lastupdate(self, model, on_pre, on_post):
+        # check if `lastupdate` is used as identifier in synapse model equations
+        if 'lastupdate' in model.identifiers:
+            return True
+        # check if we have `event-driven` dynamics
+        for eq in model.itervalues():
+            if 'event-driven' in eq.flags:
+                return True
+        # get all pathway event update codes
+        pathway_codes = []
+        for argument in [on_pre, on_post]:
+            if isinstance(argument, basestring):
+                pathway_codes.append(argument)
+            elif isinstance(argument, collections.Mapping):
+                for value in argument.intervalues():
+                    pathway_codes.append(value)
+        # check if lastupdate is needed for event update code
+        for code in pathway_codes:
+            # TODO: this also catches e.g. 'mylastupdate', use some brian parser!
+                return True
+        return False
 
     def _set_delay(self, delay, with_unit):
         if 'pre' not in self._synaptic_updaters:

--- a/brian2/synapses/synapses.py
+++ b/brian2/synapses/synapses.py
@@ -940,11 +940,12 @@ class Synapses(Group):
             if isinstance(argument, basestring):
                 pathway_codes.append(argument)
             elif isinstance(argument, collections.Mapping):
-                for value in argument.intervalues():
+                for value in argument.itervalues():
                     pathway_codes.append(value)
         # check if lastupdate is needed for event update code
         for code in pathway_codes:
             # TODO: this also catches e.g. 'mylastupdate', use some brian parser!
+            if 'lastupdate' in code:
                 return True
         return False
 

--- a/brian2/synapses/synapses.py
+++ b/brian2/synapses/synapses.py
@@ -281,7 +281,8 @@ class SynapticPathway(CodeRunner, Group):
             self.abstract_code = ''
 
         self.abstract_code += self.code + '\n'
-        self.abstract_code += 'lastupdate = t\n'
+        if self.synapses.need_lastupdate:
+            self.abstract_code += 'lastupdate = t\n'
 
     @device_override('synaptic_pathway_before_run')
     def before_run(self, run_namespace):
@@ -733,8 +734,8 @@ class Synapses(Group):
                                   'used as a variable name.' % name)
 
         # Check if a `lastupdate` variable is needed
-        need_lastupdate = self._check_lastupdate(model, on_pre, on_post)
-        if need_lastupdate:
+        self.need_lastupdate = self._check_lastupdate(model, on_pre, on_post)
+        if self.need_lastupdate:
             model = model + Equations('lastupdate : second')
 
         # Add the "multisynaptic index", if desired

--- a/brian2/tests/test_synapses.py
+++ b/brian2/tests/test_synapses.py
@@ -1513,6 +1513,14 @@ def test_lastupdate_variable():
     for syn in [S1_, S2_, S3_]:
         assert not 'lastupdate' in syn.variables
 
+@attr('codegen-independent')
+def test_lastupdate_in_run_regularly():
+    G = NeuronGroup(10, 'v : 1')
+    S = Synapses(G, G, 'x : 1')
+    S.run_regularly('x += lastupdate')
+
+    assert 'lastupdate' in S.variables
+
 
 @attr('codegen-independent')
 def test_variables_by_owner():
@@ -2455,6 +2463,7 @@ if __name__ == '__main__':
     test_pre_before_post()
     test_pre_post_simple()
     test_lastupdate_variable()
+    test_lastupdate_in_run_regularly()
     test_transmission_simple()
     test_transmission_custom_event()
     test_invalid_custom_event()

--- a/brian2/tests/test_synapses.py
+++ b/brian2/tests/test_synapses.py
@@ -1480,7 +1480,7 @@ def test_pre_post_variables():
     for var in ['v_pre', 'v', 'v_post', 'w', 'w_post', 'x',
                 'N_pre', 'N_post', 'N_incoming', 'N_outgoing',
                 'i', 'j',
-                't', 'lastupdate', 'dt']:
+                't', 'dt']:
         assert var in S.variables
     # Check that postsynaptic variables without suffix refer to the correct
     # variable
@@ -1491,6 +1491,27 @@ def test_pre_post_variables():
     assert '_spikespace_pre' not in S.variables
     assert '_spikespace' not in S.variables
     assert '_spikespace_post' not in S.variables
+
+
+@attr('codegen-independent')
+def test_lastupdate_variable():
+    G = NeuronGroup(10, 'v : 1', threshold='False')
+    S1 = Synapses(G, G, 'x = lastupdate : second')
+    S2 = Synapses(G, G, 'x : 1', on_pre='x += lastupdate')
+    S3 = Synapses(G, G, 'x : 1', on_post='x += lastupdate')
+    on_pre = {'path1': 'x+=1',
+              'path2': 'x += lastupdate'}
+    S3 = Synapses(G, G, 'x : 1', on_pre=on_pre)
+
+    for syn in [S1, S2, S3]:
+        assert 'lastupdate' in syn.variables
+
+    S1_ = Synapses(G, G, 'x : 1')
+    S2_ = Synapses(G, G, 'x : 1', on_pre='x += 1')
+    S3_ = Synapses(G, G, 'x : 1', on_post='x += 1')
+
+    for syn in [S1_, S2_, S3_]:
+        assert not 'lastupdate' in syn.variables
 
 
 @attr('codegen-independent')
@@ -2433,6 +2454,7 @@ if __name__ == '__main__':
     test_delays_pathways_subgroups()
     test_pre_before_post()
     test_pre_post_simple()
+    test_lastupdate_variable()
     test_transmission_simple()
     test_transmission_custom_event()
     test_invalid_custom_event()


### PR DESCRIPTION
For `Synapses` without model equations, the `lastupdate` variable makes up around `~1/3` of the memory demand of a `Synapses` object if I'm not mistaken (`lastupdate`: 8 byte, `preID/postID`: 4 byte each, `delay`: 8 byte). But the `lastupdate` variable is only needed for `event-driven` dynamics or if it is used as identifier in the `Synapses` model equations of the `SynapticPathways` update code.

In this PR I tried to get rid of the `lastupdate`, when its not needed. I'm not sure if I caught all cases (guess the tests wills show). Because of GPU memory limits, this PR would be quite useful for us. But I guess generally also for brian2? Would appreciate some comments.

And in this version I'm checking naively for `lastupdate` being in any of `SynapticPathway` codes. This should be done in a safe way (right now it would also catch `wronglastupdate`). Before I start searching brian for the correct parser function, I was hoping you could just point me to it :)
