### PR TITLE
Make translation of abstract code codeobject-dependent in `CodeGenerator`

### DIFF
--- a/brian2/codegen/generators/base.py
+++ b/brian2/codegen/generators/base.py
@@ -100,10 +100,12 @@ class CodeGenerator(object):
         '''
         raise NotImplementedError
 
-    def translate_one_statement_sequence(self, statements, scalar=False):
+    def translate_one_statement_sequence(self, statements, scalar=False,
+                                         **additional_kwds):
         raise NotImplementedError
 
-    def translate_statement_sequence(self, scalar_statements, vector_statements):
+    def translate_statement_sequence(self, scalar_statements, vector_statements,
+                                     additional_kwds):
         '''
         Translate a sequence of `Statement` into the target language, taking
         care to declare variables, etc. if necessary.
@@ -117,9 +119,13 @@ class CodeGenerator(object):
         scalar_code = {}
         vector_code = {}
         for name, block in scalar_statements.iteritems():
-            scalar_code[name] = self.translate_one_statement_sequence(block, scalar=True)
+            scalar_code[name] = self.translate_one_statement_sequence(block,
+                                                                      scalar=True,
+                                                                      **additional_kwds)
         for name, block in vector_statements.iteritems():
-            vector_code[name] = self.translate_one_statement_sequence(block, scalar=False)
+            vector_code[name] = self.translate_one_statement_sequence(block,
+                                                                      scalar=False,
+                                                                      **additional_kwds)
 
         kwds = self.determine_keywords()
 
@@ -215,9 +221,12 @@ class CodeGenerator(object):
                          if index not in ('_idx', '0'))
         return not all_unique
 
-    def translate(self, code, dtype):
+    def translate(self, code, dtype, additional_kwds):
         '''
         Translates an abstract code block into the target language.
+
+        In additional_kwds, codeobject dependent parameters can be passed (for
+        devices that inherit from the CodeObject class).
         '''
         scalar_statements = {}
         vector_statements = {}
@@ -250,6 +259,7 @@ class CodeGenerator(object):
                              'matter. ' + error_msg))
 
         translated = self.translate_statement_sequence(scalar_statements,
-                                                       vector_statements)
+                                                       vector_statements,
+                                                       additional_kwds)
 
         return translated

--- a/brian2/devices/cpp_standalone/device.py
+++ b/brian2/devices/cpp_standalone/device.py
@@ -538,11 +538,15 @@ class CPPStandaloneDevice(Device):
 
     def code_object(self, owner, name, abstract_code, variables, template_name,
                     variable_indices, codeobj_class=None, template_kwds=None,
-                    override_conditional_write=None):
+                    override_conditional_write=None, translate_kwds=None):
         if template_kwds is None:
             template_kwds = dict()
         else:
             template_kwds = dict(template_kwds)
+        if translate_kwds is None:
+            translate_kwds = dict()
+        else:
+            translate_kwds = dict(translate_kwds)
         template_kwds['user_headers'] = self.headers + prefs['codegen.cpp.headers']
         template_kwds['profiled'] = self.enable_profiling
         codeobj = super(CPPStandaloneDevice, self).code_object(owner, name, abstract_code, variables,
@@ -550,6 +554,7 @@ class CPPStandaloneDevice(Device):
                                                                codeobj_class=codeobj_class,
                                                                template_kwds=template_kwds,
                                                                override_conditional_write=override_conditional_write,
+                                                               translate_kwds=translate_kwds
                                                                )
         self.code_objects[codeobj.name] = codeobj
         if self.enable_profiling:

--- a/brian2/devices/device.py
+++ b/brian2/devices/device.py
@@ -309,7 +309,7 @@ class Device(object):
 
         scalar_code, vector_code, kwds = generator.translate(abstract_code,
                                                              dtype=prefs['core.default_float_dtype'],
-                                                             translate_kwds)
+                                                             additional_kwds=translate_kwds)
         # Add the array names as keywords as well
         for varname, var in variables.iteritems():
             if isinstance(var, ArrayVariable):

--- a/brian2/devices/device.py
+++ b/brian2/devices/device.py
@@ -269,7 +269,8 @@ class Device(object):
 
     def code_object(self, owner, name, abstract_code, variables, template_name,
                     variable_indices, codeobj_class=None,
-                    template_kwds=None, override_conditional_write=None):
+                    template_kwds=None, override_conditional_write=None,
+                    translate_kwds=None):
         name = find_name(name)
         codeobj_class = self.code_object_class(codeobj_class)
         template = getattr(codeobj_class.templater, template_name)
@@ -288,6 +289,9 @@ class Device(object):
         else:
             template_kwds = template_kwds.copy()
 
+        if translate_kwds is None:
+            translate_kwds = dict()
+
         # Check that all functions are available
         for varname, value in variables.iteritems():
             if isinstance(value, Function):
@@ -304,7 +308,8 @@ class Device(object):
         logger.diagnostic('%s abstract code:\n%s' % (name, indent(code_representation(abstract_code))))
 
         scalar_code, vector_code, kwds = generator.translate(abstract_code,
-                                                             dtype=prefs['core.default_float_dtype'])
+                                                             dtype=prefs['core.default_float_dtype'],
+                                                             translate_kwds)
         # Add the array names as keywords as well
         for varname, var in variables.iteritems():
             if isinstance(var, ArrayVariable):


### PR DESCRIPTION
The `CodeGenerator` class translates all abstract code blocks in the same way for all codeobjects. For brian2cuda I need this to be template dependent, since some templates execute host code and others device code, for which I sometimes want to use `atomicAdd` in the created vector code.

I have simply added an optional keyword argument dictionary to the `Device.code_object()`, which gets passed down through `CodeObject.translate()` until `CodeObject.translate_one_statement_sequence()`, which gets overwritten in the `CUDACodeObject(CodeObject)` class.

What do you think? Is there another way to achieve what I want or are there concerns about this?