### PR TITLE
[MRG] Optimization for refractoriness calculation

### DIFF
--- a/brian2/codegen/generators/GSL_generator.py
+++ b/brian2/codegen/generators/GSL_generator.py
@@ -905,7 +905,9 @@ class GSLCodeGenerator(object):
         GSL_main_code = self.unpack_namespace(variables_in_vector, variables_in_scalar, ['t'])
 
         # rewrite actual calculations described by vector_code and put them in _GSL_func
-        GSL_support_code += self.make_function_code(self.translate_vector_code(vector_code[None],
+        func_code = self.translate_one_statement_sequence(vector_statements[None],
+                                                          scalar=False)
+        GSL_support_code += self.make_function_code(self.translate_vector_code(func_code,
                                                                                to_replace))
 
         # rewrite scalar code, keep variables that are needed in scalar code normal

--- a/brian2/codegen/generators/GSL_generator.py
+++ b/brian2/codegen/generators/GSL_generator.py
@@ -909,10 +909,11 @@ class GSLCodeGenerator(object):
                                                           scalar=False)
         GSL_support_code += self.make_function_code(self.translate_vector_code(func_code,
                                                                                to_replace))
-
+        scalar_func_code = self.translate_one_statement_sequence(scalar_statements[None],
+                                                                 scalar=True)
         # rewrite scalar code, keep variables that are needed in scalar code normal
         # and add variables to _dataholder for vector_code
-        GSL_main_code += '\n' + self.translate_scalar_code(scalar_code[None],
+        GSL_main_code += '\n' + self.translate_scalar_code(scalar_func_code,
                                                     variables_in_scalar,
                                                     variables_in_vector)
         if len(self.variables_to_be_processed) > 0:

--- a/brian2/codegen/generators/cython_generator.py
+++ b/brian2/codegen/generators/cython_generator.py
@@ -389,13 +389,7 @@ DEFAULT_FUNCTIONS['clip'].implementations.add_implementation(CythonCodeGenerator
 
 timestep_code = '''
 cdef int _timestep(double t, double dt):
-    cdef int _infinity_int = 1073741823  # maximum 32bit integer divided by 2
-    if npy_isinf(t):
-        if t < 0:
-            return -_infinity_int
-        else:
-            return  _infinity_int
-    return <int>((t + 1e-3*dt)/dt)
+    return <int64_t>((t + 1e-3*dt)/dt)
 '''
 DEFAULT_FUNCTIONS['timestep'].implementations.add_implementation(CythonCodeGenerator,
                                                                  code=timestep_code,

--- a/brian2/core/functions.py
+++ b/brian2/core/functions.py
@@ -561,32 +561,19 @@ def timestep(t, dt):
 
     Returns
     -------
-    ts : np.ndarray, int
+    ts : np.ndarray, np.int64
         The time step corresponding to the given time.
 
     Notes
     -----
-    This function can handle infinity values, it will return a value equal to
-    half of the maximal integer value. This assures that an expression such as
-    ``timestep(t) - timestep(lastspike)`` will result in a reasonable value even
-    if ``lastspike`` is ``-inf``. If ``timestep(lastspike)`` were equal to the
-    minimal representable integer value, this expression would overflow.
+    This function cannot handle infinity values, use big values instead (e.g.
+    a `NeuronGroup` will use ``-1e4*second`` as the value of the ``lastspike``
+    variable for neurons that never spiked).
     '''
-    elapsed_steps = (t + 1e-3*dt)/dt
-    if np.isscalar(elapsed_steps) or elapsed_steps.shape == ():
-        if np.isinf(elapsed_steps):
-            if elapsed_steps > 0:
-                return _infinity_int
-            else:
-                return -_infinity_int
-        else:
-            return np.int_(elapsed_steps)
-    else:
-        int_steps = np.asarray(elapsed_steps, dtype=int)
-        are_inf, = np.nonzero(np.isinf(elapsed_steps))
-        int_steps[are_inf] = np.where(elapsed_steps[are_inf] > 0,
-                                      _infinity_int, -_infinity_int)
-        return int_steps
+    elapsed_steps = np.array((t + 1e-3*dt)/dt, dtype=np.int64)
+    if elapsed_steps.shape == ():
+        elapsed_steps = elapsed_steps.item()
+    return elapsed_steps
 
 
 DEFAULT_FUNCTIONS = {

--- a/brian2/groups/neurongroup.py
+++ b/brian2/groups/neurongroup.py
@@ -522,7 +522,7 @@ class NeuronGroup(Group, SpikeSource):
 
         if refractory is not False:
             # Set the refractoriness information
-            self.variables['lastspike'].set_value(-np.inf*second)
+            self.variables['lastspike'].set_value(-1e4*second)
             self.variables['not_refractory'].set_value(True)
 
         # Activate name attribute access

--- a/brian2/tests/test_functions.py
+++ b/brian2/tests/test_functions.py
@@ -144,28 +144,26 @@ def test_timestep_function():
     # Check that multiples of dt end up in the correct time step
     t = np.arange(100000)*dt
     assert_equal(timestep(t, dt), np.arange(100000))
-    # Check that inf is handled correctly
-    t = np.array([-np.inf, np.inf])
-    ts = timestep(t, dt)
-    assert ts[0] < -1e9
-    assert ts[1] > 1e9
 
     # Scalar values should stay scalar
     ts = timestep(0.0005, 0.0001)
     assert np.isscalar(ts) and ts == 5
 
+    # Length-1 arrays should stay arrays
+    ts = timestep(np.array([0.0005]), 0.0001)
+    assert ts.shape == (1,) and ts == 5
+
 
 @attr('standalone-compatible')
 @with_setup(teardown=reinit_devices)
 def test_timestep_function_during_run():
-    group = NeuronGroup(3, '''ref_t : second
+    group = NeuronGroup(2, '''ref_t : second
                               ts = timestep(ref_t, dt) + timestep(t, dt) : integer''')
-    group.ref_t = [-np.inf*second, 5*defaultclock.dt, np.inf*second]
+    group.ref_t = [-1e4*second, 5*defaultclock.dt]
     mon = StateMonitor(group, 'ts', record=True)
     run(5*defaultclock.dt)
-    assert all(mon.ts[0] < -1e9)
+    assert all(mon.ts[0] <= -1e4)
     assert_equal(mon.ts[1], [5, 6, 7, 8, 9])
-    assert all(mon.ts[2] > 1e9)
 
 
 @attr('standalone-compatible')


### PR DESCRIPTION
See discussion in #991 . The changes in this PR are:
* `timestep` function is no longer safe to use with infinity values
* `timestep` function uses `int64` to avoid overflow
* Instead of setting `lastspike` to `-inf*second` for neurons that never spiked, we now set this value to `-10000*second`
* C++ and Cython code generation has been refactored so that scalar variables are read in the scalar code block (i.e. outside of the loop), regardless of whether they are used in the scalar or vector code. This is particularly relevant for `dt` and `t`.

The last change speeds up things considerably, even though the use of `int64` slows down things again. Nevertheless, if we are looking at the time the stateupdater takes in the context of a real simulation (CUBA example), this all now looks pretty reasonable (rough "best of 3" times, do not take them too seriously):

| *target/branch*        | master+legacy        | master | This PR  |
| ------------- | ------------------:| -----------------------:| ---------------:|
| **weave**       | 126ms | 203ms | 132ms | 
| **Cython**      | 196ms | 910ms | 209ms |
| **numpy**     | 970ms | 1610ms | 1250ms |
| **C++ standalone** | 104ms | 203ms | 109ms |

"master+legacy" means activating the preference that switches off the use of the `timestep` function.
