### PR TITLE
[MRG] Raise an error for event-driven equations that are non-linear and not independent

### DIFF
--- a/brian2/synapses/synapses.py
+++ b/brian2/synapses/synapses.py
@@ -267,6 +267,7 @@ class SynapticPathway(CodeRunner, Group):
     def update_abstract_code(self, run_namespace=None, level=0):
         if self.synapses.event_driven is not None:
             event_driven_eqs = self.synapses.event_driven
+            clock_driven_eqs = self.synapses.equations
             try:
                 event_driven_update = linear(event_driven_eqs,
                                              self.group.variables)
@@ -276,11 +277,12 @@ class SynapticPathway(CodeRunner, Group):
                     for identifier in expr.identifiers:
                         if identifier == var:
                             continue
-                        if identifier in event_driven_eqs.diff_eq_names:
+                        if (identifier in event_driven_eqs.diff_eq_names or
+                                identifier in clock_driven_eqs):
                             err = ("Cannot solve the differential equation for "
                                    "'{}' as event-driven, it depends on "
-                                   "another event-driven variable '{}'. Use "
-                                   "(clock-driven) instead.".format(var,
+                                   "another variable '{}'. Use (clock-driven) "
+                                   "instead.".format(var,
                                                                     identifier))
                             raise UnsupportedEquationsException(err)
                 # All equations are independent, go ahead

--- a/brian2/synapses/synapses.py
+++ b/brian2/synapses/synapses.py
@@ -266,10 +266,24 @@ class SynapticPathway(CodeRunner, Group):
     @device_override('synaptic_pathway_update_abstract_code')
     def update_abstract_code(self, run_namespace=None, level=0):
         if self.synapses.event_driven is not None:
+            event_driven_eqs = self.synapses.event_driven
             try:
-                event_driven_update = linear(self.synapses.event_driven,
+                event_driven_update = linear(event_driven_eqs,
                                              self.group.variables)
             except UnsupportedEquationsException:
+                # Check whether equations are independent
+                for var, expr in event_driven_eqs.diff_eq_expressions:
+                    for identifier in expr.identifiers:
+                        if identifier == var:
+                            continue
+                        if identifier in event_driven_eqs.diff_eq_names:
+                            err = ("Cannot solve the differential equation for "
+                                   "'{}' as event-driven, it depends on "
+                                   "another event-driven variable '{}'. Use "
+                                   "(clock-driven) instead.".format(var,
+                                                                    identifier))
+                            raise UnsupportedEquationsException(err)
+                # All equations are independent, go ahead
                 event_driven_update = independent(self.synapses.event_driven,
                                                   self.group.variables)
             # TODO: Any way to do this more elegantly?

--- a/brian2/tests/test_synapses.py
+++ b/brian2/tests/test_synapses.py
@@ -13,6 +13,7 @@ from brian2.codegen.generators import NumpyCodeGenerator
 from brian2.core.network import schedule_propagation_offset
 from brian2.core.variables import variables_by_owner, ArrayVariable, Constant
 from brian2.core.functions import DEFAULT_FUNCTIONS
+from brian2.stateupdaters.base import UnsupportedEquationsException
 from brian2.utils.logger import catch_logs
 from brian2.utils.stringtools import get_identifiers, word_substitute, indent, deindent
 from brian2.devices.device import reinit_devices, all_devices, get_device
@@ -1464,6 +1465,20 @@ def test_event_driven():
 
 
 @attr('codegen-independent')
+def test_event_driven_dependency_error():
+    stim = SpikeGeneratorGroup(1, [0], [0]*ms, period=5*ms)
+    tau = 5*ms
+    syn = Synapses(stim, stim, '''
+                   da/dt = -a / tau : 1 (event-driven)
+                   db/dt = -b / tau : 1 (event-driven)
+                   dc/dt = a*b / tau : 1 (event-driven)''',
+                   on_pre='a+=1')
+    syn.connect()
+    net = Network(collect())
+    assert_raises(UnsupportedEquationsException, lambda: net.run(0*ms))
+
+
+@attr('codegen-independent')
 def test_repr():
     G = NeuronGroup(1, 'v: volt', threshold='False')
     S = Synapses(G, G,
@@ -2497,6 +2512,7 @@ if __name__ == '__main__':
     test_sim_with_constant_subexpression()
     test_external_variables()
     test_event_driven()
+    test_event_driven_dependency_error()
     test_repr()
     test_pre_post_variables()
     test_variables_by_owner()

--- a/brian2/tests/test_synapses.py
+++ b/brian2/tests/test_synapses.py
@@ -1467,16 +1467,28 @@ def test_event_driven():
 @attr('codegen-independent')
 def test_event_driven_dependency_error():
     stim = SpikeGeneratorGroup(1, [0], [0]*ms, period=5*ms)
-    tau = 5*ms
     syn = Synapses(stim, stim, '''
-                   da/dt = -a / tau : 1 (event-driven)
-                   db/dt = -b / tau : 1 (event-driven)
-                   dc/dt = a*b / tau : 1 (event-driven)''',
+                   da/dt = -a / (5*ms) : 1 (event-driven)
+                   db/dt = -b / (5*ms) : 1 (event-driven)
+                   dc/dt = a*b / (5*ms) : 1 (event-driven)''',
                    on_pre='a+=1')
     syn.connect()
     net = Network(collect())
     assert_raises(UnsupportedEquationsException, lambda: net.run(0*ms))
 
+
+@attr('codegen-independent')
+def test_event_driven_dependency_error2():
+    stim = SpikeGeneratorGroup(1, [0], [0]*ms, period=5*ms)
+    tau = 5*ms
+    syn = Synapses(stim, stim, '''
+                   da/dt = -a / (5*ms) : 1 (clock-driven)
+                   db/dt = -b / (5*ms) : 1 (clock-driven)
+                   dc/dt = a*b / (5*ms) : 1 (event-driven)''',
+                   on_pre='a+=1')
+    syn.connect()
+    net = Network(collect())
+    assert_raises(UnsupportedEquationsException, lambda: net.run(0*ms))
 
 @attr('codegen-independent')
 def test_repr():
@@ -2513,6 +2525,7 @@ if __name__ == '__main__':
     test_external_variables()
     test_event_driven()
     test_event_driven_dependency_error()
+    test_event_driven_dependency_error2()
     test_repr()
     test_pre_post_variables()
     test_variables_by_owner()


### PR DESCRIPTION
[Sorry for the spam, here's the new PR]
If you use non-linear synaptic equations like the ones in PR #995, currently Brian will allow you to mark them as (event-driven), but since it cannot solve them exactly, it will solve all equations independently. This gives wrong results, because it does not take the development of the other variables during the time between updates into account.

This PR does nothing fancy to handle such equations, it just raises an error if the situation occurs.