### PR TITLE
[MRG] Measure/store preparation and "after run time" for C++ standalone

### DIFF
--- a/brian2/devices/cpp_standalone/templates/main.cpp
+++ b/brian2/devices/cpp_standalone/templates/main.cpp
@@ -22,6 +22,13 @@
 
 int main(int argc, char **argv)
 {
+    {% if openmp_pragma('with_openmp') %}
+    double _clock_start;
+    _clock_start = omp_get_wtime();
+    {% else %}
+    std::clock_t _clock_start;
+    _clock_start = std::clock();
+    {% endif %}
 
 	brian_start();
 
@@ -34,5 +41,24 @@ int main(int argc, char **argv)
 
 	brian_end();
 
+	{% if openmp_pragma('with_openmp') %}
+    Network::_after_run_time = omp_get_wtime() - _clock_start;
+    {% else %}
+    Network::_after_run_time = ((double)(std::clock() - _clock_start) / CLOCKS_PER_SEC);
+    {% endif %}
+    // Write last run info to disk
+	ofstream outfile_last_run_info;
+	outfile_last_run_info.open("results/last_run_info.txt", ios::out);
+	if(outfile_last_run_info.is_open())
+	{
+		outfile_last_run_info << (Network::_before_run_time) << " ";
+		outfile_last_run_info << (Network::_last_run_time) << " ";
+		outfile_last_run_info << (Network::_after_run_time) << " ";
+		outfile_last_run_info << (Network::_last_run_completed_fraction) << std::endl;
+		outfile_last_run_info.close();
+	} else
+	{
+	    std::cout << "Error writing last run info to file." << std::endl;
+	}
 	return 0;
 }

--- a/brian2/devices/cpp_standalone/templates/network.cpp
+++ b/brian2/devices/cpp_standalone/templates/network.cpp
@@ -11,6 +11,8 @@
 
 double Network::_last_run_time = 0.0;
 double Network::_last_run_completed_fraction = 0.0;
+double Network::_before_run_time = 0.0;
+double Network::_after_run_time = 0.0;
 
 Network::Network()
 {
@@ -114,7 +116,7 @@ void Network::run(const double duration, void (*report_func)(const double, const
 
     if(!did_break_early) t = t_end;
 
-    _last_run_time = elapsed_realtime;
+    _last_run_time += elapsed_realtime;
     if(duration>0)
     {
         _last_run_completed_fraction = (t-t_start)/duration;
@@ -188,6 +190,8 @@ public:
     double t;
     static double _last_run_time;
     static double _last_run_completed_fraction;
+    static double _before_run_time;
+    static double _after_run_time;
 
     Network();
     void clear();

--- a/brian2/devices/cpp_standalone/templates/objects.cpp
+++ b/brian2/devices/cpp_standalone/templates/objects.cpp
@@ -201,17 +201,6 @@ void _write_arrays()
 	    std::cout << "Error writing profiling info to file." << std::endl;
 	}
     {% endif %}
-	// Write last run info to disk
-	ofstream outfile_last_run_info;
-	outfile_last_run_info.open("results/last_run_info.txt", ios::out);
-	if(outfile_last_run_info.is_open())
-	{
-		outfile_last_run_info << (Network::_last_run_time) << " " << (Network::_last_run_completed_fraction) << std::endl;
-		outfile_last_run_info.close();
-	} else
-	{
-	    std::cout << "Error writing last run info to file." << std::endl;
-	}
 }
 
 void _dealloc_arrays()


### PR DESCRIPTION
This measures the time spent within a standalone simulation but before the first run (i.e., synapse creation, initialization), and after the last run (i.e., writing results to disk). The implementation is not that great and for consistency we should probably do the same thing for runtime, but this should be good enough for benchmarking right now (also, we don't advertise this as a mechanism that users should use).