### PR TITLE
[MRG] Remove lastupdate variable, except for event-driven

### DIFF
--- a/brian2/groups/group.py
+++ b/brian2/groups/group.py
@@ -803,8 +803,21 @@ class Group(VariableOwner, BrianObject):
             if internal_variable is not None:
                 return None
             else:
-                raise KeyError(('The identifier "%s" could not be resolved.') %
-                               (identifier))
+                # Give a more detailed explanation for the lastupdate variable
+                # that was removed with #988
+                if identifier == 'lastupdate':
+                    error_msg = ('The identifier "lastupdate" could not be '
+                                 'resolved. Note that this variable is only '
+                                 'automatically defined for models with '
+                                 'event-driven synapses. You can define it '
+                                 'manually by adding "lastupdate : second" to '
+                                 'the equations and setting "lastupdate = t" '
+                                 'at the end of your on_pre and/or on_post '
+                                 'statements.')
+                else:
+                    error_msg = ('The identifier "%s" could not be resolved.' %
+                                 identifier)
+                raise KeyError(error_msg)
 
         elif len(matches) > 1:
             # Possibly, all matches refer to the same object

--- a/brian2/groups/group.py
+++ b/brian2/groups/group.py
@@ -804,7 +804,7 @@ class Group(VariableOwner, BrianObject):
                 return None
             else:
                 # Give a more detailed explanation for the lastupdate variable
-                # that was removed with #988
+                # that was removed with PR #1003
                 if identifier == 'lastupdate':
                     error_msg = ('The identifier "lastupdate" could not be '
                                  'resolved. Note that this variable is only '

--- a/brian2/tests/test_synapses.py
+++ b/brian2/tests/test_synapses.py
@@ -1450,13 +1450,16 @@ def test_event_driven():
     S2 = Synapses(pre, post,
                   '''w : 1
                      Apre : 1
-                     Apost : 1''',
+                     Apost : 1
+                     lastupdate : second''',
                   on_pre='''Apre=Apre*exp((lastupdate-t)/taupre)+dApre
                          Apost=Apost*exp((lastupdate-t)/taupost)
-                         w = clip(w+Apost, 0, gmax)''',
+                         w = clip(w+Apost, 0, gmax)
+                         lastupdate = t''',
                   on_post='''Apre=Apre*exp((lastupdate-t)/taupre)
                           Apost=Apost*exp((lastupdate-t)/taupost) +dApost
-                          w = clip(w+Apre, 0, gmax)''')
+                          w = clip(w+Apre, 0, gmax)
+                          lastupdate = t''')
     S2.connect(j='i')
     S1.w = 0.5*gmax
     S2.w = 0.5*gmax
@@ -1517,7 +1520,7 @@ def test_pre_post_variables():
     for var in ['v_pre', 'v', 'v_post', 'w', 'w_post', 'x',
                 'N_pre', 'N_post', 'N_incoming', 'N_outgoing',
                 'i', 'j',
-                't', 'lastupdate', 'dt']:
+                't', 'dt']:
         assert var in S.variables
     # Check that postsynaptic variables without suffix refer to the correct
     # variable

--- a/docs_sphinx/user/equations.rst
+++ b/docs_sphinx/user/equations.rst
@@ -185,7 +185,7 @@ lastspike
     Last time that the neuron spiked (for refractoriness)
 lastupdate
     Time of the last update of synaptic variables in event-driven
-    equations.
+    equations (only defined when event-driven equations are used).
 N
     Number of neurons (`NeuronGroup`) or synapses (`Synapses`). Use
     ``N_pre`` or ``N_post`` for the number of presynaptic or

--- a/docs_sphinx/user/synapses.rst
+++ b/docs_sphinx/user/synapses.rst
@@ -83,7 +83,8 @@ used in equations, ``on_pre`` and ``on_post`` statements, as well as when
 ``lastupdate``
     The last time this synapse has applied an ``on_pre`` or ``on_post``
     statement. There is normally no need to refer to this variable explicitly,
-    it is used to implement :ref:`event_driven_updates` (see below).
+    it is used to implement :ref:`event_driven_updates` (see below). It is only
+    defined when event-driven equations are used.
 
 .. _event_driven_updates:
 
@@ -453,20 +454,22 @@ Explicit event-driven updates
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 As mentioned above, it is possible to write event-driven update code for the synaptic variables.
-For this, two special variables are provided: ``t`` is the current time when the code is executed,
-and ``lastupdate`` is the last time when the synapse was updated (either through ``on_pre`` or ``on_post``
-code). An example is short-term plasticity (in fact this could be done automatically with the use
-of the ``(event-driven)`` keyword mentioned above)::
+This can also be done manually, by defining the variable ``lastupdate`` and
+referring to the predefined variable ``t`` (current time).
+Here's an example for short-term plasticity -- but note that using the automatic
+``event-driven`` approach from above is usually preferable::
 
 	S=Synapses(input,neuron,
 	           model='''x : 1
 	                    u : 1
-	                    w : 1''',
+	                    w : 1
+	                    lastupdate : second''',
 	           on_pre='''u=U+(u-U)*exp(-(t-lastupdate)/tauf)
 	                  x=1+(x-1)*exp(-(t-lastupdate)/taud)
 	                  i+=w*u*x
 	                  x*=(1-u)
-	                  u+=U*(1-u)''')
+	                  u+=U*(1-u)
+	                  lastupdate = t''')
 
 By default, the ``pre`` pathway is executed before the ``post`` pathway (both
 are executed in the ``'synapses'`` scheduling slot, but the ``pre`` pathway has


### PR DESCRIPTION
Following the discussion in #979 (and as an alternative solution), this PR:
* Only creates a `lastupdate` variable if it is used by Brian automatically, i.e. for `event-driven` synapses.
* Tells the user that they have to add the variable manually, if they try to access it.

This breaks backwards-compatibility for users that manually used `lastupdate`, but I think with the error message, this should be ok. There's rarely a use case for doing this manually instead of using the `event-driven` mechanism.
The check whether a user tries to access `lastupdate` is a bit ugly, directly in `groups.py`, but I think it is worth it, given that we do not want to silently break backwards-compatibility. 