### PR TITLE
[MRG] Single precision everywhere

### DIFF
--- a/brian2/devices/cpp_standalone/device.py
+++ b/brian2/devices/cpp_standalone/device.py
@@ -227,6 +227,9 @@ class CPPStandaloneDevice(Device):
                 # Use a renderer to correctly transform constants such as True or inf
                 renderer = CPPNodeRenderer()
                 string_value = renderer.render_expr(repr(v))
+                if (prefs.core.default_float_dtype == np.float32 and
+                        isinstance(v, (float, np.float32, np.float64))):
+                    string_value += 'f'
                 if v < 0:
                     string_value = '(%s)' % string_value
                 code = word_substitute(code, {k: string_value})

--- a/brian2/parsing/bast.py
+++ b/brian2/parsing/bast.py
@@ -37,7 +37,7 @@ def is_integer(value):
 
 
 def is_float(value):
-    return isinstance(value, (float, numpy.float))
+    return isinstance(value, (float, numpy.float32, numpy.float64))
 
 
 def brian_dtype_from_value(value):

--- a/brian2/tests/test_GSL.py
+++ b/brian2/tests/test_GSL.py
@@ -333,7 +333,8 @@ def test_GSL_non_autonomous():
     mon2 = StateMonitor(neuron2, 'v', record=True)
     run(20*ms)
     abs_err = np.abs(mon.v.T - mon2.v.T)
-    assert np.max(abs_err) < 1e-12
+    max_allowed = 1000*np.finfo(prefs.core.default_float_dtype).eps
+    assert np.max(abs_err) < max_allowed
 
 
 @attr('standalone-compatible')
@@ -350,7 +351,8 @@ def test_GSL_non_autonomous():
     mon2 = StateMonitor(neuron2, 'v', record=True)
     run(20*ms)
     abs_err = np.abs(mon.v.T - mon2.v.T)
-    assert np.max(abs_err) < 1e-12
+    max_allowed = 1000 * np.finfo(prefs.core.default_float_dtype).eps
+    assert np.max(abs_err) < max_allowed
 
 @attr('standalone-compatible')
 @with_setup(teardown=reinit_devices)

--- a/brian2/tests/test_poissongroup.py
+++ b/brian2/tests/test_poissongroup.py
@@ -58,7 +58,7 @@ def test_time_dependent_rate():
     timed_array = TimedArray(np.array([[0, 0],
                                        [1./defaultclock.dt, 0]])*Hz, dt=1*ms)
     group_1 = PoissonGroup(2, rates='timed_array(t, i)')
-    group_2 = PoissonGroup(2, rates='int(i==0)*int(t>=1*ms)*(1/dt)')
+    group_2 = PoissonGroup(2, rates='int(i==0)*int(t>1*ms-dt/2)*(1/dt)')
     spikes_1 = SpikeMonitor(group_1)
     spikes_2 = SpikeMonitor(group_2)
     run(2*ms)

--- a/brian2/tests/test_refractory.py
+++ b/brian2/tests/test_refractory.py
@@ -67,17 +67,17 @@ def test_refractoriness_basic():
 def test_refractoriness_variables():
     # Try a string evaluating to a quantity an an explicit boolean
     # condition -- all should do the same thing
-    for ref_time in ['5*ms', '(t-lastspike) < 5*ms',
-                     'time_since_spike < 5*ms', 'ref_subexpression',
-                     '(t-lastspike) <= ref', 'ref', 'ref_no_unit*ms']:
+    for ref_time in ['5*ms', '(t-lastspike + 1e-3*dt) < 5*ms',
+                     'time_since_spike + 1e-3*dt < 5*ms', 'ref_subexpression',
+                     '(t-lastspike + 1e-3*dt) <= ref', 'ref', 'ref_no_unit*ms']:
         reinit_devices()
         G = NeuronGroup(1, '''
                         dv/dt = 99.999*Hz : 1 (unless refractory)
                         dw/dt = 99.999*Hz : 1
                         ref : second
                         ref_no_unit : 1
-                        time_since_spike = t - lastspike : second
-                        ref_subexpression = (t - lastspike) < ref : boolean
+                        time_since_spike = (t - lastspike) +1e-3*dt : second
+                        ref_subexpression = (t - lastspike + 1e-3*dt) < ref : boolean
                         ''',
                         threshold='v>1', reset='v=0;w=0',
                         refractory=ref_time,
@@ -103,7 +103,6 @@ def test_refractoriness_variables():
                          mon[0].w[timestep(10*ms, defaultclock.dt)+1:timestep(15*ms, defaultclock.dt)+1])
             assert np.all(mon[0].w[timestep(10*ms, defaultclock.dt)+1:timestep(15*ms, defaultclock.dt)+1] > 0)
             # After refractoriness, v should increase again
-            print mon[0].v[timestep(15*ms, defaultclock.dt):timestep(20*ms, defaultclock.dt)]
             assert np.all(mon[0].v[timestep(15*ms, defaultclock.dt):timestep(20*ms, defaultclock.dt)] > 0)
         except AssertionError as ex:
             raise
@@ -257,15 +256,17 @@ def test_conditional_write_automatic_and_manual():
 
 
 if __name__ == '__main__':
-    test_add_refractoriness()
-    test_missing_refractory_warning()
-    test_refractoriness_basic()
+    prefs.core.default_float_dtype = np.float32
+    prefs.codegen.target = 'cython'
+    # test_add_refractoriness()
+    # test_missing_refractory_warning()
+    # test_refractoriness_basic()
     test_refractoriness_variables()
-    test_refractoriness_threshold()
-    test_refractoriness_threshold_basic()
-    test_refractoriness_repeated()
-    test_refractoriness_repeated_legacy()
-    test_refractoriness_types()
-    test_conditional_write_set()
-    test_conditional_write_behaviour()
-    test_conditional_write_automatic_and_manual()
+    # test_refractoriness_threshold()
+    # test_refractoriness_threshold_basic()
+    # test_refractoriness_repeated()
+    # test_refractoriness_repeated_legacy()
+    # test_refractoriness_types()
+    # test_conditional_write_set()
+    # test_conditional_write_behaviour()
+    # test_conditional_write_automatic_and_manual()

--- a/brian2/tests/test_synapses.py
+++ b/brian2/tests/test_synapses.py
@@ -651,8 +651,8 @@ def test_state_variable_indexing():
     assert_equal(S.w[0:3, :], S.w['i<3'])
     assert_equal(S.w[:, 0:3], S.w['j<3'])
     assert_equal(S.w[:, :, 0], S.w['k == 0'])
-    assert_equal(S.w[0:3, :], S.w['v_pre < 3*mV'])
-    assert_equal(S.w[:, 0:3], S.w['v_post < 13*mV'])
+    assert_equal(S.w[0:3, :], S.w['v_pre < 2.5*mV'])
+    assert_equal(S.w[:, 0:3], S.w['v_post < 12.5*mV'])
 
     #invalid indices
     assert_raises(IndexError, lambda: S.w.__getitem__((1, 2, 3, 4)))


### PR DESCRIPTION
This avoids generating many intermediate values in double precision, even when the `core.default_float_dtype` preference is set to `float32`. Does not seem to have much impact on speed, though (using script from #1001).