### PR TITLE
[MRG] Standalone code slots

### DIFF
--- a/brian2/devices/cpp_standalone/device.py
+++ b/brian2/devices/cpp_standalone/device.py
@@ -170,7 +170,15 @@ class CPPStandaloneDevice(Device):
         self.static_array_specs =[]
         self.report_func = ''
         self.synapses = []
-        
+
+        #: Code lines that have been manually added with `device.insert_code`
+        #: Dictionary mapping slot names to lists of lines.
+        #: Note that the main slot is handled separately as part of `main_queue`
+        self.code_lines = {'before_start': [],
+                           'after_start': [],
+                           'before_end': [],
+                           'after_end': []}
+
         self.clocks = set([])
 
         self.extra_compile_args = []
@@ -241,8 +249,10 @@ class CPPStandaloneDevice(Device):
         '''
         Insert code directly into main.cpp
         '''
-        if slot=='main':
+        if slot == 'main':
             self.main_queue.append(('insert_code', code))
+        elif slot in self.code_lines:
+            self.code_lines[slot].append(code)
         else:
             logger.warn("Ignoring device code, unknown slot: %s, code: %s" % (slot, code))
             
@@ -698,6 +708,7 @@ class CPPStandaloneDevice(Device):
         # smarter about that.
         main_tmp = self.code_object_class().templater.main(None, None,
                                                            main_lines=main_lines,
+                                                           code_lines=self.code_lines,
                                                            code_objects=self.code_objects.values(),
                                                            report_func=self.report_func,
                                                            dt=float(self.defaultclock.dt),

--- a/brian2/devices/cpp_standalone/device.py
+++ b/brian2/devices/cpp_standalone/device.py
@@ -703,16 +703,14 @@ class CPPStandaloneDevice(Device):
             if hasattr(codeobj.code, 'main_finalise'):
                 main_lines.append(codeobj.code.main_finalise)
 
-        # The code_objects are passed in the right order to run them because they were
-        # sorted by the Network object. To support multiple clocks we'll need to be
-        # smarter about that.
+        user_headers = self.headers + prefs['codegen.cpp.headers']
         main_tmp = self.code_object_class().templater.main(None, None,
                                                            main_lines=main_lines,
                                                            code_lines=self.code_lines,
                                                            code_objects=self.code_objects.values(),
                                                            report_func=self.report_func,
                                                            dt=float(self.defaultclock.dt),
-                                                           user_headers=self.headers
+                                                           user_headers=user_headers
                                                            )
         writer.write('main.cpp', main_tmp)
 

--- a/brian2/devices/cpp_standalone/templates/main.cpp
+++ b/brian2/devices/cpp_standalone/templates/main.cpp
@@ -22,17 +22,17 @@
 
 int main(int argc, char **argv)
 {
-
+    {{'\n'.join(code_lines['before_start'])|autoindent}}
 	brian_start();
-
+    {{'\n'.join(code_lines['after_start'])|autoindent}}
 	{
 		using namespace brian;
 
 		{{ openmp_pragma('set_num_threads') }}
         {{main_lines|autoindent}}
 	}
-
+    {{'\n'.join(code_lines['before_end'])|autoindent}}
 	brian_end();
-
+    {{'\n'.join(code_lines['after_end'])|autoindent}}
 	return 0;
 }


### PR DESCRIPTION
This adds four new code slots that can be used with `device.insert_code`: `before_start`, `after_start`, `before_end`, `after_end`. With this we can add code before/after things like loading static arrays from disk or writing the results to disk.

This offers as an alternative for benchmarking and replaces #1002.