### PR TITLE
[MRG] Make the exponential_euler state updater handle constant RHS equations

### DIFF
--- a/brian2/stateupdaters/exponential_euler.py
+++ b/brian2/stateupdaters/exponential_euler.py
@@ -49,16 +49,20 @@ def get_conditionally_linear_system(eqs, variables=None):
     for name, expr in diff_eqs:
         var = sp.Symbol(name, real=True)
     
-        # Factor out the variable
-        s_expr = sp.collect(str_to_sympy(expr.code, variables).expand(),
-                            var, evaluate=False)
-        
-        if len(s_expr) > 2 or var not in s_expr:
-            raise ValueError(('The expression "%s", defining the variable %s, '
-                             'could not be separated into linear components') %
-                             (expr, name))
-        coefficients[name] = (s_expr[var], s_expr.get(1, 0))
-    
+        s_expr = str_to_sympy(expr.code, variables).expand()
+        if s_expr.has(var):
+            # Factor out the variable
+            s_expr = sp.collect(s_expr,
+                                var, evaluate=False)
+
+            if len(s_expr) > 2 or var not in s_expr:
+                raise ValueError(('The expression "%s", defining the variable %s, '
+                                 'could not be separated into linear components') %
+                                 (expr, name))
+            coefficients[name] = (s_expr[var], s_expr.get(1, 0))
+        else:
+            coefficients[name] = (0, s_expr)
+
     return coefficients
 
 
@@ -114,4 +118,5 @@ class ExponentialEulerStateUpdater(StateUpdateMethod):
     # Copy doc from parent class
     __call__.__doc__ = StateUpdateMethod.__call__.__doc__
 
-exponential_euler = ExponentialEulerStateUpdater() 
+exponential_euler = ExponentialEulerStateUpdater()
+


### PR DESCRIPTION
In principle the exact state updater should of course also be able to handle such equations, but I have to think a bit more about how to implement this. For now, this solves the original problem of the OP from #1010  who wanted to use `exponential_euler` (in the context of a multicompartment model).

Fixes #1010 