### PR TITLE
[MRG] Copy over public attributes in DerivedBrianObjectException

### DIFF
--- a/brian2/core/base.py
+++ b/brian2/core/base.py
@@ -342,4 +342,10 @@ def brian_object_exception(message, brianobj, original_exception):
     DerivedBrianObjectException = type('BrianObjectException',
                                        (BrianObjectException, original_exception.__class__),
                                        {})
-    return DerivedBrianObjectException(message, brianobj, original_exception)
+    new_exception = DerivedBrianObjectException(message, brianobj, original_exception)
+    # Copy over all exception attributes
+    for attribute in dir(original_exception):
+        if attribute.startswith('_'):
+            continue
+        setattr(new_exception, attribute, getattr(original_exception, attribute))
+    return new_exception


### PR DESCRIPTION
Leads to a more useful display of syntax errors in ipython notebooks
Fixes #964 

This seems to be the right thing to do. Error message in a jupyter notebook for a `SyntaxError` (see #964) before this change:
```
  File "<string>", line unknown
BrianObjectException
```
After this change:
```
  File "<unknown>", line 1
    `False
         ^
BrianObjectException: unexpected EOF while parsing
```
It does not seem to affect other error messages or error messages outside of notebooks/ipython.
