### PR TITLE
[MRG] Explicitly set language_level in Cython files

### DIFF
--- a/brian2/codegen/runtime/cython_rt/templates/common.pyx
+++ b/brian2/codegen/runtime/cython_rt/templates/common.pyx
@@ -1,3 +1,4 @@
+#cython: language_level=3
 #cython: boundscheck=False
 #cython: wraparound=False
 #cython: cdivision=False

--- a/brian2/codegen/runtime/cython_rt/templates/synapses_initialise_queue.pyx
+++ b/brian2/codegen/runtime/cython_rt/templates/synapses_initialise_queue.pyx
@@ -1,2 +1,4 @@
+#cython: language_level = 3
+
 def main(ns):
     ns['_owner'].initialise_queue()

--- a/brian2/codegen/runtime/cython_rt/templates/synapses_push_spikes.pyx
+++ b/brian2/codegen/runtime/cython_rt/templates/synapses_push_spikes.pyx
@@ -1,2 +1,4 @@
+#cython: language_level = 3
+
 def main(ns):
     ns['_owner'].push_spikes()

--- a/brian2/synapses/cythonspikequeue.pyx
+++ b/brian2/synapses/cythonspikequeue.pyx
@@ -1,3 +1,4 @@
+# cython: language_level = 3
 # distutils: language = c++
 # distutils: sources = brian2/synapses/cspikequeue.cpp
 


### PR DESCRIPTION
Newer Cython versions will raise a `FutureWarning` otherwise (which makes tests that care about warnings fail). I've set `language_level` to 3 everywhere, we do use Python 3 semantics for division already, and everything else (imports, prints, unicode, ...) is not relevant to our code.