### PR TITLE
[MRG] Warn when SpikeGeneratorGroup sets spike times < current time 

### DIFF
--- a/brian2/devices/cpp_standalone/device.py
+++ b/brian2/devices/cpp_standalone/device.py
@@ -568,18 +568,17 @@ class CPPStandaloneDevice(Device):
         if self.enable_profiling:
             self.profiled_codeobjects.append(codeobj.name)
 
-        # Mark all the non-read-only or non-constant variables used in this code
-        # object as "dirty". This is almost certainly too much, most of these
+        # Mark all the non-read-only used in this code object as "dirty". This
+        # is almost certainly too much, most of these
         # variables will only be read. However, the templates for synapse
-        # creation will write to read-only variables.. This is noted in the
+        # creation will write to read-only variables. This is noted in the
         # WRITES_TO_READ_ONLY_VARIABLES comment in the template.
         template = getattr(codeobj.templater, template_name)
         written_readonly_vars = {codeobj.variables[varname]
                                  for varname in template.writes_read_only}
         for var in codeobj.variables.itervalues():
             if (isinstance(var, ArrayVariable) and
-                    (not var.read_only or not var.constant or
-                             var in written_readonly_vars)):
+                    (not var.read_only or var in written_readonly_vars)):
                 self.array_cache[var] = None
 
         return codeobj

--- a/brian2/devices/cpp_standalone/templates/spikemonitor.cpp
+++ b/brian2/devices/cpp_standalone/templates/spikemonitor.cpp
@@ -4,6 +4,7 @@
 	//// MAIN CODE ////////////
     {# USES_VARIABLES { N, _clock_t, count,
                         _source_start, _source_stop} #}
+    {# WRITES_TO_READ_ONLY_VARIABLES { N, count } #}
     {#  Get the name of the array that stores these events (e.g. the spikespace array) #}
     {% set _eventspace = get_array_name(eventspace_variable) %}
 

--- a/brian2/devices/cpp_standalone/templates/statemonitor.cpp
+++ b/brian2/devices/cpp_standalone/templates/statemonitor.cpp
@@ -2,7 +2,7 @@
 
 {% block maincode %}
     {# USES_VARIABLES { t, _clock_t, _indices, N } #}
-
+    {# WRITES_TO_READ_ONLY_VARIABLES { t, N } #}
     {{_dynamic_t}}.push_back({{_clock_t}});
 
     const int _new_size = {{_dynamic_t}}.size();

--- a/brian2/input/spikegeneratorgroup.py
+++ b/brian2/input/spikegeneratorgroup.py
@@ -2,8 +2,9 @@
 Module defining `SpikeGeneratorGroup`.
 '''
 import numpy as np
-from brian2.core.functions import timestep
 
+from brian2.core.functions import timestep
+from brian2.utils.logger import get_logger
 from brian2.core.spikesource import SpikeSource
 from brian2.units.fundamentalunits import check_units, Unit, Quantity
 from brian2.units.allunits import second
@@ -11,6 +12,9 @@ from brian2.core.variables import Variables
 from brian2.groups.group import CodeRunner, Group
 
 __all__ = ['SpikeGeneratorGroup']
+
+
+logger = get_logger(__name__)
 
 
 class SpikeGeneratorGroup(Group, CodeRunner, SpikeSource):
@@ -162,6 +166,11 @@ class SpikeGeneratorGroup(Group, CodeRunner, SpikeSource):
             current_step = timestep(current_t, dt)
             in_the_past = np.nonzero(timesteps < current_step)[0]
             if len(in_the_past):
+                logger.warn('The SpikeGeneratorGroup contains spike times '
+                            'earlier than the start time of the current run '
+                            '(t = {}), these spikes will be '
+                            'ignored.'.format(str(current_t*second)),
+                            name_suffix='ignored_spikes')
                 self.variables['_lastindex'].set_value(in_the_past[-1] + 1)
             else:
                 self.variables['_lastindex'].set_value(0)

--- a/brian2/input/spikegeneratorgroup.py
+++ b/brian2/input/spikegeneratorgroup.py
@@ -2,6 +2,7 @@
 Module defining `SpikeGeneratorGroup`.
 '''
 import numpy as np
+from brian2.core.functions import timestep
 
 from brian2.core.spikesource import SpikeSource
 from brian2.units.fundamentalunits import check_units, Unit, Quantity
@@ -92,11 +93,11 @@ class SpikeGeneratorGroup(Group, CodeRunner, SpikeSource):
         self.start = 0
         self.stop = N
 
+        self.variables = Variables(self)
+        self.variables.create_clock_variables(self._clock)
+
         indices, times = self._check_args(indices, times, period, N, sorted)
 
-        self.variables = Variables(self)
-
-        # standard variables
         self.variables.add_constant('N', value=N)
         self.variables.add_array('period', dimensions=second.dim, size=1,
                                  constant=True, read_only=True, scalar=True,
@@ -119,7 +120,6 @@ class SpikeGeneratorGroup(Group, CodeRunner, SpikeSource):
         self.variables.add_array('_spikespace', size=N+1, dtype=np.int32)
         self.variables.add_array('_lastindex', size=1, values=0, dtype=np.int32,
                                  read_only=True, scalar=True)
-        self.variables.create_clock_variables(self._clock)
 
         #: Remember the dt we used the last time when we checked the spike bins
         #: to not repeat the work for multiple runs with the same dt
@@ -155,6 +155,16 @@ class SpikeGeneratorGroup(Group, CodeRunner, SpikeSource):
                                           'of %s.' % (self.name,
                                                       self.period,
                                                       dt))
+
+        if self._spikes_changed:
+            current_t = self.variables['t'].get_value().item()
+            timesteps = timestep(self._spike_time, dt)
+            current_step = timestep(current_t, dt)
+            in_the_past = np.nonzero(timesteps < current_step)[0]
+            if len(in_the_past):
+                self.variables['_lastindex'].set_value(in_the_past[-1] + 1)
+            else:
+                self.variables['_lastindex'].set_value(0)
 
         # Check that we don't have more than one spike per neuron in a time bin
         if self._previous_dt is None or dt != self._previous_dt or self._spikes_changed:
@@ -216,7 +226,7 @@ class SpikeGeneratorGroup(Group, CodeRunner, SpikeSource):
         self.variables['spike_number'].set_value(np.arange(len(indices)))
         self.variables['neuron_index'].set_value(indices)
         self.variables['spike_time'].set_value(times)
-        self.variables['_lastindex'].set_value(0)
+        # _lastindex will be set as part of before_run
 
     def _check_args(self, indices, times, period, N, sorted):
         times = Quantity(times)

--- a/brian2/monitors/spikemonitor.py
+++ b/brian2/monitors/spikemonitor.py
@@ -157,8 +157,9 @@ class EventMonitor(Group, CodeRunner):
 
         self.variables.create_clock_variables(self._clock,
                                               prefix='_clock_')
-
         self.add_dependency(source)
+        self.written_readonly_vars = {self.variables[varname]
+                                      for varname in self.record_variables}
         self._enable_group_attributes()
 
     def resize(self, new_size):

--- a/brian2/monitors/statemonitor.py
+++ b/brian2/monitors/statemonitor.py
@@ -271,6 +271,8 @@ class StateMonitor(Group, CodeRunner):
 
         self.needed_variables = recorded_names
         self.template_kwds = {'_recorded_variables': self.recorded_variables}
+        self.written_readonly_vars = {self.variables[varname]
+                                      for varname in self.record_variables}
         self._enable_group_attributes()
 
     def resize(self, new_size):


### PR DESCRIPTION
As discussed in #1017 , spikes that fall before the current time (set between runs with `set_spikes`) are now ignored and a warning is issued. To make this work with standalone, I had to make some minor adjustments to the way read-only variables are marked as "dirty" by code writing to them.

Fixes #1017