### PR TITLE
[MRG] Fix _vectorisation_idx definition in numpy fallback loop for synapses

### DIFF
--- a/brian2/codegen/generators/numpy_generator.py
+++ b/brian2/codegen/generators/numpy_generator.py
@@ -161,7 +161,9 @@ class NumpyCodeGenerator(CodeGenerator):
                             once=True)
             lines = []
             lines.extend(['_full_idx = _idx',
-                          'for _idx in _full_idx:'])
+                          'for _idx in _full_idx:',
+                          '    _vectorisation_idx = _idx'
+                          ])
             read, write, indices, conditional_write_vars = self.arrays_helper(statements)
             lines.extend(indent(code) for code in
                          self.read_arrays(read, write, indices,


### PR DESCRIPTION
See #1024, trivial fix (finding the actual issue took way more time ;) ).