### PR TITLE
[MRG] Expose integer timestep

### DIFF
--- a/brian2/codegen/runtime/cython_rt/templates/spikegenerator.pyx
+++ b/brian2/codegen/runtime/cython_rt/templates/spikegenerator.pyx
@@ -1,10 +1,10 @@
 {% extends 'common.pyx' %}
 
 {% block maincode %}
-    {# USES_VARIABLES { _spikespace, t, dt, neuron_index, _timebins, _period_bins, _lastindex, timestep, N } #}
+    {# USES_VARIABLES { _spikespace, neuron_index, _timebins, _period_bins, _lastindex, t_in_timesteps, N } #}
 
     cdef int32_t _the_period    = {{_period_bins}}
-    cdef int32_t _timebin       = _timestep({{t}}, {{dt}})
+    cdef int32_t _timebin       = {{t_in_timesteps}}
     cdef int32_t _cpp_numspikes = 0;
 
     if _the_period > 0:

--- a/brian2/codegen/runtime/numpy_rt/templates/spikegenerator.py_
+++ b/brian2/codegen/runtime/numpy_rt/templates/spikegenerator.py_
@@ -1,9 +1,9 @@
-{# USES_VARIABLES { _spikespace, t, dt, neuron_index, _timebins, _period_bins, _lastindex, timestep } #}
+{# USES_VARIABLES { _spikespace, neuron_index, _timebins, _period_bins, _lastindex, t_in_timesteps } #}
 from __future__ import division
 import numpy as _numpy
 
 _the_period    = {{_period_bins}}
-_timebin       = timestep({{t}}, {{dt}})
+_timebin       = {{t_in_timesteps}}
 _n_spikes      = 0
 
 _lastindex_before = {{_lastindex}}

--- a/brian2/codegen/runtime/weave_rt/templates/spikegenerator.cpp
+++ b/brian2/codegen/runtime/weave_rt/templates/spikegenerator.cpp
@@ -1,10 +1,10 @@
 {% extends 'common_group.cpp' %}
 {% block maincode %}
-    {# USES_VARIABLES { _spikespace, t, dt, neuron_index, _timebins, _period_bins, _lastindex, timestep, N } #}
+    {# USES_VARIABLES { _spikespace, neuron_index, _timebins, _period_bins, _lastindex, t_in_timesteps, N } #}
 
-    const int32_t _the_period    = {{_period_bins}};
-    int32_t _timebin             = _timestep({{t}}, {{dt}});
-    const int32_t _n_spikes      = 0;
+    const int32_t _the_period = {{_period_bins}};
+    int32_t _timebin          = {{t_in_timesteps}};
+    const int32_t _n_spikes   = 0;
 
     if (_the_period > 0) {
         _timebin %= _the_period;

--- a/brian2/core/variables.py
+++ b/brian2/core/variables.py
@@ -1862,5 +1862,6 @@ class Variables(collections.Mapping):
             not confuse the dynamic array of recorded times with the current
             time in the recorded group.
         '''
-        for name in ['t', 'dt']:
-            self.add_reference(prefix+name, clock, name)
+        self.add_reference(prefix + 't', clock, 't')
+        self.add_reference(prefix + 'dt', clock, 'dt')
+        self.add_reference(prefix + 't_in_timesteps', clock, 'timestep')

--- a/brian2/devices/cpp_standalone/templates/spikegenerator.cpp
+++ b/brian2/devices/cpp_standalone/templates/spikegenerator.cpp
@@ -1,10 +1,10 @@
 {% extends 'common_group.cpp' %}
 {% block maincode %}
-    {# USES_VARIABLES { _spikespace, t, dt, neuron_index, _timebins, _period_bins, _lastindex, timestep, N } #}
+    {# USES_VARIABLES { _spikespace, neuron_index, _timebins, _period_bins, _lastindex, t_in_timesteps, N } #}
 
-    const int32_t _the_period    = {{_period_bins}};
-    int32_t _timebin             = _timestep({{t}}, {{dt}});
-    const int32_t _n_spikes      = 0;
+    const int32_t _the_period = {{_period_bins}};
+    int32_t _timebin          = {{t_in_timesteps}};
+    const int32_t _n_spikes   = 0;
 
     if (_the_period > 0) {
         _timebin %= _the_period;

--- a/brian2/input/spikegeneratorgroup.py
+++ b/brian2/input/spikegeneratorgroup.py
@@ -134,7 +134,6 @@ class SpikeGeneratorGroup(Group, CodeRunner, SpikeSource):
         CodeRunner.__init__(self, self,
                             code='',
                             template='spikegenerator',
-                            needed_variables=['timestep'],
                             clock=self._clock,
                             when=when,
                             order=order,

--- a/brian2/tests/test_network.py
+++ b/brian2/tests/test_network.py
@@ -1235,7 +1235,9 @@ def test_get_set_states():
     states2 = magic_network.get_states()
     states3 = net.get_states(read_only_variables=False)
     assert set(states1.keys()) == set(states2.keys()) == set(states3.keys()) == {'a_neurongroup'}
-    assert set(states1['a_neurongroup'].keys()) == set(states2['a_neurongroup'].keys()) == {'i', 'dt', 'N', 't', 'v'}
+    assert (set(states1['a_neurongroup'].keys()) ==
+            set(states2['a_neurongroup'].keys()) ==
+            {'i', 'dt', 'N', 't', 'v', 't_in_timesteps'})
     assert set(states3['a_neurongroup']) == {'v'}
 
     # Try re-setting the state

--- a/brian2/tests/test_neurongroup.py
+++ b/brian2/tests/test_neurongroup.py
@@ -78,7 +78,7 @@ def test_variables():
     Test the correct creation of the variables dictionary.
     '''
     G = NeuronGroup(1, 'dv/dt = -v/(10*ms) : 1')
-    assert 'v' in G.variables and 't' in G.variables and 'dt' in G.variables
+    assert all((x in G.variables) for x in ['v', 't', 'dt', 't_in_timesteps'])
     assert 'not_refractory' not in G.variables and 'lastspike' not in G.variables
 
     G = NeuronGroup(1, 'dv/dt = -v/tau + xi*tau**-0.5: 1')
@@ -1349,10 +1349,11 @@ def test_get_states():
     assert_allclose(states['subexpr2'], 11*np.arange(10))
 
     all_states = G.get_states(units=True)
-    assert set(all_states.keys()) == {'v', 'x', 'N', 't', 'dt', 'i'}
+    assert set(all_states.keys()) == {'v', 'x', 'N', 't', 'dt', 'i',
+                                      't_in_timesteps'}
     all_states = G.get_states(units=True, subexpressions=True)
     assert set(all_states.keys()) == {'v', 'x', 'N', 't', 'dt', 'i',
-                                      'subexpr', 'subexpr2'}
+                                      't_in_timesteps', 'subexpr', 'subexpr2'}
 
 
 @attr('codegen-independent')
@@ -1398,10 +1399,11 @@ def test_get_states_pandas():
     assert_allclose(states['subexpr2'].values, 11*np.arange(10))
 
     all_states = G.get_states(units=False, format='pandas')
-    assert set(all_states.columns) == {'v', 'x', 'N', 't', 'dt', 'i'}
+    assert set(all_states.columns) == {'v', 'x', 'N', 't', 'dt', 'i',
+                                       't_in_timesteps'}
     all_states = G.get_states(units=False, subexpressions=True, format='pandas')
     assert set(all_states.columns) == {'v', 'x', 'N', 't', 'dt', 'i',
-                                       'subexpr', 'subexpr2'}
+                                       't_in_timesteps', 'subexpr', 'subexpr2'}
 
 
 @attr('codegen-independent')


### PR DESCRIPTION
This should fix #1043. The PR speeds up things, but it seems that the current integer-based code is still slower than the previous float-based code. I don't see any obvious reason for this. Well, it is probably not worth spending much time on this, given that performance is never great with the `numpy` codegen target.