### PR TITLE
[MRG] Allow compiler keywords in function implementations

### DIFF
--- a/brian2/codegen/codeobject.py
+++ b/brian2/codegen/codeobject.py
@@ -128,22 +128,57 @@ def _error_msg(code, name):
     return error_msg
 
 
+def check_compiler_kwds(compiler_kwds, accepted_kwds, target):
+    '''
+    Internal function to check the provided compiler keywords against the list
+    of understood keywords.
+
+    Parameters
+    ----------
+    compiler_kwds : dict
+        Dictionary of compiler keywords and respective list of values.
+    accepted_kwds : list of str
+        The compiler keywords understood by the code generation target
+    target : str
+        The name of the code generation target (used for the error message).
+
+    Raises
+    ------
+    ValueError
+        If a compiler keyword is not understood
+    '''
+    for key, value in compiler_kwds.iteritems():
+        if key not in accepted_kwds:
+            formatted_kwds = ', '.join("'{}'".format(kw)
+                                       for kw in accepted_kwds)
+            raise ValueError("The keyword argument '{}' is not understood by "
+                             "the code generation target '{}'. The valid "
+                             "arguments are: {}.".format(key, target,
+                                                         formatted_kwds))
+
+
 def _merge_compiler_kwds(list_of_kwds):
     '''
+    Merges a list of keyword dictionaries. Values in these dictionaries are
+    lists of values, the merged dictionaries will contain the concatenations
+    of lists specified for the same key.
 
     Parameters
     ----------
     list_of_kwds : list of dict
-        TODO
+        A list of compiler keyword dictionaries that should be merged.
 
     Returns
     -------
     merged_kwds : dict
-        TODO
+        The merged dictionary
     '''
     merged_kwds = collections.defaultdict(list)
     for kwds in list_of_kwds:
         for key, values in kwds.iteritems():
+            if not isinstance(values, list):
+                raise TypeError("Compiler keyword argument '{}' requires a "
+                                "list of values.".format(key))
             merged_kwds[key].extend(values)
     return merged_kwds
 

--- a/brian2/codegen/runtime/cython_rt/cython_rt.py
+++ b/brian2/codegen/runtime/cython_rt/cython_rt.py
@@ -75,7 +75,8 @@ class CythonCodeObject(NumpyCodeObject):
                  name='cython_code_object*'):
         check_compiler_kwds(compiler_kwds, ['libraries', 'include_dirs',
                                             'library_dirs',
-                                            'runtime_library_dirs'],
+                                            'runtime_library_dirs',
+                                            'sources'],
                             'Cython')
         super(CythonCodeObject, self).__init__(owner, code, variables,
                                                variable_indices,
@@ -107,6 +108,7 @@ class CythonCodeObject(NumpyCodeObject):
 
         self.libraries = (list(prefs['codegen.cpp.libraries']) +
                           compiler_kwds.get('libraries', []))
+        self.sources = compiler_kwds.get('sources', [])
 
     @classmethod
     def is_available(cls):
@@ -131,7 +133,6 @@ class CythonCodeObject(NumpyCodeObject):
                         'failed_compile_test')
             return False
 
-
     def compile(self):
         self.compiled_code = cython_extension_manager.create_extension(
             self.code,
@@ -143,6 +144,7 @@ class CythonCodeObject(NumpyCodeObject):
             library_dirs=self.library_dirs,
             compiler=self.compiler,
             owner_name=self.owner.name+'_'+self.template_name,
+            sources=self.sources
             )
         
     def run(self):

--- a/brian2/codegen/runtime/cython_rt/cython_rt.py
+++ b/brian2/codegen/runtime/cython_rt/cython_rt.py
@@ -10,7 +10,7 @@ from brian2.core.preferences import prefs, BrianPreference
 from brian2.utils.logger import get_logger
 from brian2.utils.stringtools import get_identifiers
 
-from ...codeobject import constant_or_scalar
+from ...codeobject import constant_or_scalar, check_compiler_kwds
 from ..numpy_rt import NumpyCodeObject
 from ...templates import Templater
 from ...generators.cython_generator import (CythonCodeGenerator, get_cpp_dtype,
@@ -73,10 +73,14 @@ class CythonCodeObject(NumpyCodeObject):
     def __init__(self, owner, code, variables, variable_indices,
                  template_name, template_source, compiler_kwds,
                  name='cython_code_object*'):
+        check_compiler_kwds(compiler_kwds, ['libraries', 'include_dirs',
+                                            'library_dirs',
+                                            'runtime_library_dirs'],
+                            'Cython')
         super(CythonCodeObject, self).__init__(owner, code, variables,
                                                variable_indices,
                                                template_name, template_source,
-                                               compiler_kwds=compiler_kwds,
+                                               compiler_kwds={}, # do not pass the actual args
                                                name=name)
         self.compiler, self.extra_compile_args = get_compiler_and_args()
         self.define_macros = list(prefs['codegen.cpp.define_macros'])

--- a/brian2/codegen/runtime/cython_rt/cython_rt.py
+++ b/brian2/codegen/runtime/cython_rt/cython_rt.py
@@ -71,27 +71,38 @@ class CythonCodeObject(NumpyCodeObject):
     class_name = 'cython'
 
     def __init__(self, owner, code, variables, variable_indices,
-                 template_name, template_source, name='cython_code_object*'):
+                 template_name, template_source, compiler_kwds,
+                 name='cython_code_object*'):
         super(CythonCodeObject, self).__init__(owner, code, variables,
                                                variable_indices,
                                                template_name, template_source,
+                                               compiler_kwds=compiler_kwds,
                                                name=name)
         self.compiler, self.extra_compile_args = get_compiler_and_args()
         self.define_macros = list(prefs['codegen.cpp.define_macros'])
         self.extra_link_args = list(prefs['codegen.cpp.extra_link_args'])
         self.headers = []  # not actually used
+
+        self.include_dirs = (list(prefs['codegen.cpp.include_dirs']) +
+                             compiler_kwds.get('include_dirs', []))
         self.include_dirs = list(prefs['codegen.cpp.include_dirs'])
         if sys.platform == 'win32':
             self.include_dirs += [os.path.join(sys.prefix, 'Library', 'include')]
         else:
             self.include_dirs += [os.path.join(sys.prefix, 'include')]
-        self.library_dirs = list(prefs['codegen.cpp.library_dirs'])
+
+        self.library_dirs = (list(prefs['codegen.cpp.library_dirs']) +
+                             compiler_kwds.get('library_dirs', []))
         if sys.platform == 'win32':
             self.library_dirs += [os.path.join(sys.prefix, 'Library', 'lib')]
         else:
             self.library_dirs += [os.path.join(sys.prefix, 'lib')]
-        self.runtime_library_dirs = list(prefs['codegen.cpp.runtime_library_dirs'])
-        self.libraries = list(prefs['codegen.cpp.libraries'])
+
+        self.runtime_library_dirs = (list(prefs['codegen.cpp.runtime_library_dirs']),
+                                     compiler_kwds.get('runtime_library_dirs', []))
+
+        self.libraries = (list(prefs['codegen.cpp.libraries']) +
+                          compiler_kwds.get('libraries', []))
 
     @classmethod
     def is_available(cls):

--- a/brian2/codegen/runtime/cython_rt/extension_manager.py
+++ b/brian2/codegen/runtime/cython_rt/extension_manager.py
@@ -52,8 +52,8 @@ def get_cython_cache_dir():
 
 
 def get_cython_extensions():
-    return {'.pyx', '.pyd', '.cpp', '.so', '.o', '.o.d', '.lock', '.dll',
-            '.obj', '.exp', '.lib'}
+    return {'.pyx', '.pxd', '.pyd', '.cpp', '.c', '.so', '.o', '.o.d', '.lock',
+            '.dll', '.obj', '.exp', '.lib'}
 
 
 class CythonExtensionManager(object):

--- a/brian2/codegen/runtime/cython_rt/extension_manager.py
+++ b/brian2/codegen/runtime/cython_rt/extension_manager.py
@@ -267,13 +267,12 @@ class CythonExtensionManager(object):
             build_extension = self._get_build_extension(compiler=compiler)
             try:
                 opts = dict(
-                    quiet=False,
+                    quiet=True,
                     annotate=False,
                     force=True,
-                    verbose=True
                     )
                 # suppresses the output on stdout
-                with std_silent(True):
+                with std_silent():
                     build_extension.extensions = Cython_Build.cythonize([extension] + final_sources, **opts)
 
                     build_extension.build_temp = os.path.dirname(pyx_file)

--- a/brian2/codegen/runtime/cython_rt/extension_manager.py
+++ b/brian2/codegen/runtime/cython_rt/extension_manager.py
@@ -7,6 +7,7 @@ https://github.com/ipython/ipython/blob/master/IPython/extensions/cythonmagic.py
 import glob
 import imp
 import os
+import shutil
 import sys
 import time
 
@@ -68,9 +69,11 @@ class CythonExtensionManager(object):
                          extra_link_args=None,
                          libraries=None,
                          compiler=None,
+                         sources=None,
                          owner_name='',
                          ):
-
+        if sources is None:
+            sources = []
         self._simplify_paths()
 
         if Cython is None:
@@ -120,18 +123,19 @@ class CythonExtensionManager(object):
                 else:
                     fcntl.flock(f, fcntl.LOCK_EX)
                 module = self._load_module(module_path,
-                                         define_macros=define_macros,
-                                         include_dirs=include_dirs,
-                                         library_dirs=library_dirs,
-                                         extra_compile_args=extra_compile_args,
-                                         extra_link_args=extra_link_args,
-                                         libraries=libraries,
-                                         code=code,
-                                         lib_dir=lib_dir,
-                                         module_name=module_name,
-                                         runtime_library_dirs=runtime_library_dirs,
-                                         compiler=compiler,
-                                         key=key)
+                                           define_macros=define_macros,
+                                           include_dirs=include_dirs,
+                                           library_dirs=library_dirs,
+                                           extra_compile_args=extra_compile_args,
+                                           extra_link_args=extra_link_args,
+                                           libraries=libraries,
+                                           code=code,
+                                           lib_dir=lib_dir,
+                                           module_name=module_name,
+                                           runtime_library_dirs=runtime_library_dirs,
+                                           compiler=compiler,
+                                           key=key,
+                                           sources=sources)
                 # Unlock
                 if msvcrt:
                     msvcrt.locking(f.fileno(), msvcrt.LK_UNLCK,
@@ -152,7 +156,8 @@ class CythonExtensionManager(object):
                                      module_name=module_name,
                                      runtime_library_dirs=runtime_library_dirs,
                                      compiler=compiler,
-                                     key=key)
+                                     key=key,
+                                     sources=sources)
 
     @property
     def so_ext(self):
@@ -195,7 +200,7 @@ class CythonExtensionManager(object):
     def _load_module(self, module_path, define_macros, include_dirs, library_dirs,
                      extra_compile_args, extra_link_args, libraries, code,
                      lib_dir, module_name, runtime_library_dirs, compiler,
-                     key):
+                     key, sources):
         have_module = os.path.isfile(module_path)
 
         if not have_module:
@@ -234,7 +239,20 @@ class CythonExtensionManager(object):
             update_for_cross_compilation(library_dirs,
                                          extra_compile_args,
                                          extra_link_args, logger=logger)
-
+            for source in sources:
+                if not source.lower().endswith('.pyx'):
+                    raise ValueError('Additional Cython source files need to '
+                                     'have an .pyx ending')
+                # Copy source and header file (if present) to library directory
+                shutil.copyfile(source, os.path.join(lib_dir,
+                                                     os.path.basename(source)))
+                name_without_ext = os.path.splitext(os.path.basename(source))[0]
+                header_name = name_without_ext + '.pxd'
+                if os.path.exists(os.path.join(os.path.dirname(source), header_name)):
+                    shutil.copyfile(os.path.join(os.path.dirname(source), header_name),
+                                    os.path.join(lib_dir, header_name))
+            final_sources = [os.path.join(lib_dir, os.path.basename(source))
+                             for source in sources]
             extension = Extension(
                 name=module_name,
                 sources=[pyx_file],
@@ -245,18 +263,18 @@ class CythonExtensionManager(object):
                 extra_compile_args=extra_compile_args,
                 extra_link_args=extra_link_args,
                 libraries=libraries,
-                language='c++',
-                )
+                language='c++')
             build_extension = self._get_build_extension(compiler=compiler)
             try:
                 opts = dict(
-                    quiet=True,
+                    quiet=False,
                     annotate=False,
                     force=True,
+                    verbose=True
                     )
                 # suppresses the output on stdout
-                with std_silent():
-                    build_extension.extensions = Cython_Build.cythonize([extension], **opts)
+                with std_silent(True):
+                    build_extension.extensions = Cython_Build.cythonize([extension] + final_sources, **opts)
 
                     build_extension.build_temp = os.path.dirname(pyx_file)
                     build_extension.build_lib = lib_dir
@@ -275,8 +293,12 @@ class CythonExtensionManager(object):
 
             except Cython_Compiler.Errors.CompileError:
                 return
-
+        # Temporarily insert the Cython directory to the Python path so that
+        # code importing from an external module that was declared via
+        # sources works
+        sys.path.insert(0, lib_dir)
         module = imp.load_dynamic(module_name, module_path)
+        sys.path.pop(0)
         self._code_cache[key] = module
         return module
         #self._import_all(module)

--- a/brian2/codegen/runtime/numpy_rt/numpy_rt.py
+++ b/brian2/codegen/runtime/numpy_rt/numpy_rt.py
@@ -12,7 +12,7 @@ from brian2.core.variables import (DynamicArrayVariable, ArrayVariable,
                                    AuxiliaryVariable, Subexpression)
 from brian2.core.functions import Function
 
-from ...codeobject import CodeObject, constant_or_scalar
+from ...codeobject import CodeObject, constant_or_scalar, check_compiler_kwds
 
 from ...templates import Templater
 from ...generators.numpy_generator import NumpyCodeGenerator
@@ -158,6 +158,8 @@ class NumpyCodeObject(CodeObject):
     def __init__(self, owner, code, variables, variable_indices,
                  template_name, template_source, compiler_kwds,
                  name='numpy_code_object*'):
+        check_compiler_kwds(compiler_kwds, [],
+                            'numpy')
         from brian2.devices.device import get_device
         self.device = get_device()
         self.namespace = {'_owner': owner,

--- a/brian2/codegen/runtime/numpy_rt/numpy_rt.py
+++ b/brian2/codegen/runtime/numpy_rt/numpy_rt.py
@@ -156,14 +156,16 @@ class NumpyCodeObject(CodeObject):
     class_name = 'numpy'
 
     def __init__(self, owner, code, variables, variable_indices,
-                 template_name, template_source, name='numpy_code_object*'):
+                 template_name, template_source, compiler_kwds,
+                 name='numpy_code_object*'):
         from brian2.devices.device import get_device
         self.device = get_device()
         self.namespace = {'_owner': owner,
                           # TODO: This should maybe go somewhere else
                           'logical_not': np.logical_not}
         CodeObject.__init__(self, owner, code, variables, variable_indices,
-                            template_name, template_source, name=name)
+                            template_name, template_source,
+                            compiler_kwds=compiler_kwds, name=name)
         self.variables_to_namespace()
 
     @classmethod

--- a/brian2/codegen/runtime/weave_rt/weave_rt.py
+++ b/brian2/codegen/runtime/weave_rt/weave_rt.py
@@ -149,6 +149,7 @@ class WeaveCodeObject(CodeObject):
                          '"stdint_compat.h"'] +
                         prefs['codegen.cpp.headers'] +
                         compiler_kwds.get('headers', []))
+        self.additional_sources = compiler_kwds.get('sources', [])
         self.numpy_version = '.'.join(numpy.__version__.split('.')[:2])  # Only use major.minor version
         self.annotated_code = self.code.main+'''
 /*
@@ -313,6 +314,7 @@ numpy version: {self.numpy_version}
                 extra_link_args=self.extra_link_args,
                 include_dirs=self.include_dirs,
                 library_dirs=self.library_dirs,
+                sources=self.additional_sources,
                 verbose=0)
             with std_silent():
                 ret_val = weave.inline(*self._inline_args, **self._inline_kwds)

--- a/brian2/codegen/runtime/weave_rt/weave_rt.py
+++ b/brian2/codegen/runtime/weave_rt/weave_rt.py
@@ -5,6 +5,8 @@ import os
 import sys
 import numpy
 
+from brian2.codegen.codeobject import check_compiler_kwds
+
 try:
     from scipy import weave
     from scipy.weave.c_spec import num_to_c_types
@@ -76,6 +78,7 @@ class WeaveCodeGenerator(CPPCodeGenerator):
         super(WeaveCodeGenerator, self).__init__(*args, **kwds)
         self.c_data_type = weave_data_type
 
+
 class WeaveCodeObject(CodeObject):
     '''
     Weave code object
@@ -96,6 +99,11 @@ class WeaveCodeObject(CodeObject):
                  name='weave_code_object*'):
         from brian2.devices.device import get_device
         self.device = get_device()
+        check_compiler_kwds(compiler_kwds, ['headers', 'sources',
+                                            'define_macros', 'libraries',
+                                            'include_dirs', 'library_dirs',
+                                            'runtime_library_dirs'],
+                            'weave')
         self._done_first_run = False
         self.namespace = {'_owner': owner}
         super(WeaveCodeObject, self).__init__(owner, code, variables,

--- a/brian2/codegen/runtime/weave_rt/weave_rt.py
+++ b/brian2/codegen/runtime/weave_rt/weave_rt.py
@@ -92,7 +92,8 @@ class WeaveCodeObject(CodeObject):
     class_name = 'weave'
 
     def __init__(self, owner, code, variables, variable_indices,
-                 template_name, template_source, name='weave_code_object*'):
+                 template_name, template_source, compiler_kwds,
+                 name='weave_code_object*'):
         from brian2.devices.device import get_device
         self.device = get_device()
         self._done_first_run = False
@@ -100,9 +101,11 @@ class WeaveCodeObject(CodeObject):
         super(WeaveCodeObject, self).__init__(owner, code, variables,
                                               variable_indices,
                                               template_name, template_source,
+                                              compiler_kwds=compiler_kwds,
                                               name=name)
         self.compiler, self.extra_compile_args = get_compiler_and_args()
-        self.define_macros = list(prefs['codegen.cpp.define_macros'])
+        self.define_macros = (list(prefs['codegen.cpp.define_macros']) +
+                              compiler_kwds.get('define_macros', []))
         if self.compiler == 'msvc':
             self.define_macros.extend([
                 ('INFINITY', '(std::numeric_limits<double>::infinity())'),
@@ -110,7 +113,8 @@ class WeaveCodeObject(CodeObject):
                 ('M_PI', '3.14159265358979323846')
             ])
         self.extra_link_args = list(prefs['codegen.cpp.extra_link_args'])
-        self.include_dirs = list(prefs['codegen.cpp.include_dirs'])
+        self.include_dirs = (list(prefs['codegen.cpp.include_dirs']) +
+                             compiler_kwds.get('include_dirs', []))
         if sys.platform == 'win32':
             self.include_dirs += [os.path.join(sys.prefix, 'Library', 'include')]
         else:
@@ -120,7 +124,8 @@ class WeaveCodeObject(CodeObject):
         import brian2.synapses as synapses
         synapses_dir = os.path.dirname(synapses.__file__)
         self.include_dirs.append(synapses_dir)
-        self.library_dirs = list(prefs['codegen.cpp.library_dirs'])
+        self.library_dirs = (list(prefs['codegen.cpp.library_dirs']) +
+                             compiler_kwds.get('library_dirs', []))
         if sys.platform == 'win32':
             self.library_dirs += [os.path.join(sys.prefix, 'Library', 'lib')]
         else:
@@ -128,9 +133,14 @@ class WeaveCodeObject(CodeObject):
         update_for_cross_compilation(self.library_dirs,
                                      self.extra_compile_args,
                                      self.extra_link_args, logger=logger)
-        self.runtime_library_dirs = list(prefs['codegen.cpp.runtime_library_dirs'])
-        self.libraries = list(prefs['codegen.cpp.libraries'])
-        self.headers = ['<math.h>','<algorithm>', '<limits>', '"stdint_compat.h"'] + prefs['codegen.cpp.headers']
+        self.runtime_library_dirs = (list(prefs['codegen.cpp.runtime_library_dirs']),
+                                     compiler_kwds.get('runtime_library_dirs', []))
+        self.libraries = (list(prefs['codegen.cpp.libraries']) +
+                          compiler_kwds.get('libraries', []))
+        self.headers = (['<math.h>','<algorithm>', '<limits>',
+                         '"stdint_compat.h"'] +
+                        prefs['codegen.cpp.headers'] +
+                        compiler_kwds.get('headers', []))
         self.numpy_version = '.'.join(numpy.__version__.split('.')[:2])  # Only use major.minor version
         self.annotated_code = self.code.main+'''
 /*

--- a/brian2/devices/cpp_standalone/device.py
+++ b/brian2/devices/cpp_standalone/device.py
@@ -16,7 +16,7 @@ from distutils import ccompiler
 import numpy as np
 
 import brian2
-
+from brian2.codegen.codeobject import check_compiler_kwds
 from brian2.codegen.cpp_prefs import get_compiler_and_args
 from brian2.core.network import Network
 from brian2.devices.device import Device, all_devices, set_device, reset_device
@@ -552,14 +552,18 @@ class CPPStandaloneDevice(Device):
     def code_object(self, owner, name, abstract_code, variables, template_name,
                     variable_indices, codeobj_class=None, template_kwds=None,
                     override_conditional_write=None, compiler_kwds=None):
+        check_compiler_kwds(compiler_kwds, ['headers', 'sources',
+                                            'define_macros', 'libraries',
+                                            'include_dirs', 'library_dirs',
+                                            'runtime_library_dirs'],
+                            'C++ standalone')
         if template_kwds is None:
             template_kwds = dict()
         else:
             template_kwds = dict(template_kwds)
         # In standalone mode, the only place where we use additional header
-        # files is by inserting them into the template, we do not need this
-        # information later
-        codeobj_headers = compiler_kwds.pop('headers', [])
+        # files is by inserting them into the template
+        codeobj_headers = compiler_kwds.get('headers', [])
         template_kwds['user_headers'] = (self.headers +
                                          prefs['codegen.cpp.headers'] +
                                          codeobj_headers)

--- a/brian2/devices/cpp_standalone/device.py
+++ b/brian2/devices/cpp_standalone/device.py
@@ -551,18 +551,25 @@ class CPPStandaloneDevice(Device):
 
     def code_object(self, owner, name, abstract_code, variables, template_name,
                     variable_indices, codeobj_class=None, template_kwds=None,
-                    override_conditional_write=None):
+                    override_conditional_write=None, compiler_kwds=None):
         if template_kwds is None:
             template_kwds = dict()
         else:
             template_kwds = dict(template_kwds)
-        template_kwds['user_headers'] = self.headers + prefs['codegen.cpp.headers']
+        # In standalone mode, the only place where we use additional header
+        # files is by inserting them into the template, we do not need this
+        # information later
+        codeobj_headers = compiler_kwds.pop('headers', [])
+        template_kwds['user_headers'] = (self.headers +
+                                         prefs['codegen.cpp.headers'] +
+                                         codeobj_headers)
         template_kwds['profiled'] = self.enable_profiling
         codeobj = super(CPPStandaloneDevice, self).code_object(owner, name, abstract_code, variables,
                                                                template_name, variable_indices,
                                                                codeobj_class=codeobj_class,
                                                                template_kwds=template_kwds,
                                                                override_conditional_write=override_conditional_write,
+                                                               compiler_kwds=compiler_kwds
                                                                )
         self.code_objects[codeobj.name] = codeobj
         if self.enable_profiling:
@@ -1116,11 +1123,46 @@ class CPPStandaloneDevice(Device):
         compiler, default_extra_compile_args = get_compiler_and_args()
         extra_compile_args = self.extra_compile_args + default_extra_compile_args
         extra_link_args = self.extra_link_args + prefs['codegen.cpp.extra_link_args']
-        define_macros = self.define_macros + prefs['codegen.cpp.define_macros']
-        include_dirs = self.include_dirs + prefs['codegen.cpp.include_dirs']
-        library_dirs = self.library_dirs + prefs['codegen.cpp.library_dirs']
-        runtime_library_dirs = self.runtime_library_dirs + prefs['codegen.cpp.runtime_library_dirs']
-        libraries = self.libraries + prefs['codegen.cpp.libraries']
+
+        codeobj_define_macros = [macro for codeobj in
+                                 self.code_objects.itervalues()
+                                 for macro in
+                                 codeobj.compiler_kwds.get('define_macros', [])]
+        define_macros = (self.define_macros +
+                         prefs['codegen.cpp.define_macros'] +
+                         codeobj_define_macros)
+
+        codeobj_include_dirs = [include_dir for codeobj in
+                                self.code_objects.itervalues()
+                                for include_dir in
+                                codeobj.compiler_kwds.get('include_dirs', [])]
+        include_dirs = (self.include_dirs +
+                        prefs['codegen.cpp.include_dirs'] +
+                        codeobj_include_dirs)
+
+        codeobj_library_dirs = [library_dir for codeobj in
+                                self.code_objects.itervalues()
+                                for library_dir in
+                                codeobj.compiler_kwds.get('library_dirs', [])]
+        library_dirs = (self.library_dirs +
+                        prefs['codegen.cpp.library_dirs'] +
+                        codeobj_library_dirs)
+
+        codeobj_runtime_dirs = [runtime_dir for codeobj in
+                                self.code_objects.itervalues()
+                                for runtime_dir in
+                                codeobj.compiler_kwds.get('runtime_dirs', [])]
+        runtime_library_dirs = (self.runtime_library_dirs +
+                                prefs['codegen.cpp.runtime_library_dirs'] +
+                                codeobj_runtime_dirs)
+
+        codeobj_libraries = [library for codeobj in
+                             self.code_objects.itervalues()
+                             for library in
+                             codeobj.compiler_kwds.get('libraries', [])]
+        libraries = (self.libraries +
+                     prefs['codegen.cpp.libraries'] +
+                     codeobj_libraries)
 
         compiler_obj = ccompiler.new_compiler(compiler=compiler)
         compiler_flags = (ccompiler.gen_preprocess_options(define_macros,
@@ -1132,7 +1174,12 @@ class CPPStandaloneDevice(Device):
                                                   libraries=libraries) +
                         extra_link_args)
 
-        additional_source_files.append('brianlib/randomkit/randomkit.c')
+        codeobj_source_files = [source_file for codeobj in
+                                self.code_objects.itervalues()
+                                for source_file in
+                                codeobj.compiler_kwds.get('sources', [])]
+        additional_source_files += (codeobj_source_files +
+                                    ['brianlib/randomkit/randomkit.c'])
 
         for d in ['code_objects', 'results', 'static_arrays']:
             ensure_directory(os.path.join(directory, d))

--- a/brian2/devices/cpp_standalone/device.py
+++ b/brian2/devices/cpp_standalone/device.py
@@ -1155,7 +1155,7 @@ class CPPStandaloneDevice(Device):
         codeobj_runtime_dirs = [runtime_dir for codeobj in
                                 self.code_objects.itervalues()
                                 for runtime_dir in
-                                codeobj.compiler_kwds.get('runtime_dirs', [])]
+                                codeobj.compiler_kwds.get('runtime_library_dirs', [])]
         runtime_library_dirs = (self.runtime_library_dirs +
                                 prefs['codegen.cpp.runtime_library_dirs'] +
                                 codeobj_runtime_dirs)

--- a/brian2/devices/device.py
+++ b/brian2/devices/device.py
@@ -269,7 +269,10 @@ class Device(object):
 
     def code_object(self, owner, name, abstract_code, variables, template_name,
                     variable_indices, codeobj_class=None,
-                    template_kwds=None, override_conditional_write=None):
+                    template_kwds=None, override_conditional_write=None,
+                    compiler_kwds=None):
+        if compiler_kwds is None:
+            compiler_kwds = {}
         name = find_name(name)
         codeobj_class = self.code_object_class(codeobj_class)
         template = getattr(codeobj_class.templater, template_name)
@@ -332,7 +335,7 @@ class Device(object):
         codeobj = codeobj_class(owner, code, variables, variable_indices,
                                 template_name=template_name,
                                 template_source=template.template_source,
-                                name=name)
+                                name=name, compiler_kwds=compiler_kwds)
         codeobj.compile()
         return codeobj
     

--- a/brian2/devices/device.py
+++ b/brian2/devices/device.py
@@ -291,19 +291,6 @@ class Device(object):
         else:
             template_kwds = template_kwds.copy()
 
-        # Check that all functions are available
-        for varname, value in variables.iteritems():
-            if isinstance(value, Function):
-                try:
-                    value.implementations[codeobj_class]
-                except KeyError as ex:
-                    # if we are dealing with numpy, add the default implementation
-                    if codeobj_class is NumpyCodeObject:
-                        value.implementations.add_numpy_implementation(value.pyfunc)
-                    else:
-                        raise NotImplementedError(('Cannot use function '
-                                                   '%s: %s') % (varname, ex))
-
         logger.diagnostic('%s abstract code:\n%s' % (name, indent(code_representation(abstract_code))))
 
         scalar_code, vector_code, kwds = generator.translate(abstract_code,

--- a/brian2/tests/func_def_cpp.cpp
+++ b/brian2/tests/func_def_cpp.cpp
@@ -1,0 +1,4 @@
+double foo(const double x, const double y)
+{
+    return x + y + 3;
+}

--- a/brian2/tests/func_def_cpp.h
+++ b/brian2/tests/func_def_cpp.h
@@ -1,0 +1,1 @@
+double foo(const double, const double);

--- a/brian2/tests/func_def_cython.pxd
+++ b/brian2/tests/func_def_cython.pxd
@@ -1,0 +1,1 @@
+cdef double foo(double, const double)

--- a/brian2/tests/func_def_cython.pyx
+++ b/brian2/tests/func_def_cython.pyx
@@ -1,0 +1,2 @@
+cdef double foo(double x, const double y):
+    return x + y + 3

--- a/examples/advanced/opencv_movie.py
+++ b/examples/advanced/opencv_movie.py
@@ -33,20 +33,6 @@ width, height, frame_count = (int(video.get(cv2.CAP_PROP_FRAME_WIDTH)),
 fps = 24
 time_between_frames = 1*second/fps
 
-# Links the necessary libraries
-prefs.codegen.cpp.libraries += ['opencv_core',
-                                'opencv_highgui',
-                                'opencv_videoio']
-
-# Includes the header files in all generated files
-prefs.codegen.cpp.headers += ['<opencv2/core/core.hpp>',
-                              '<opencv2/highgui/highgui.hpp>']
-
-# Pass in values as macros
-# Note that in general we could also pass in the filename this way, but to get
-# the string quoting right is unfortunately quite difficult
-prefs.codegen.cpp.define_macros += [('VIDEO_WIDTH', width),
-                                    ('VIDEO_HEIGHT', height)]
 @implementation('cpp', '''
 double* get_frame(bool new_frame)
 {
@@ -81,7 +67,14 @@ double video_input(const int x, const int y)
     double *frame = get_frame(x==0 && y==0);
     return frame[y*VIDEO_WIDTH + x];
 }
-'''.replace('VIDEO_FILENAME', filename))
+'''.replace('VIDEO_FILENAME', filename),
+                libraries=['opencv_core',
+                           'opencv_highgui',
+                           'opencv_videoio'],
+                headers=['<opencv2/core/core.hpp>',
+                         '<opencv2/highgui/highgui.hpp>'],
+                define_macros=[('VIDEO_WIDTH', width),
+                               ('VIDEO_HEIGHT', height)])
 @check_units(x=1, y=1, result=1)
 def video_input(x, y):
     # we assume this will only be called in the custom operation (and not for

--- a/setup.py
+++ b/setup.py
@@ -152,9 +152,13 @@ setup(name='Brian2',
                     # include test template files
                     'brian2.tests.test_templates.fake_package_1': ['templates/*.txt'],
                     'brian2.tests.test_templates.fake_package_2': ['templates/*.txt'],
-                    # Include RALLPACK test data
+                    # Include RALLPACK test data and external code
                     'brian2.tests': ['rallpack_data/README',
-                                     'rallpack_data/ref_*'],
+                                     'rallpack_data/ref_*',
+                                     'func_def_cpp.cpp',
+                                     'func_def_cpp.h',
+                                     'func_def_cython.pyx',
+                                     'func_def_cython.pxd'],
                     # include C++/Cython version of spike queue
                     'brian2.synapses': ['cspikequeue.cpp',
                                         'cythonspikequeue.pyx',


### PR DESCRIPTION
When writing functions with target-specific native, non-trivial code (e.g. as in the [OpenCV example](https://brian2.readthedocs.io/en/stable/examples/advanced.opencv_movie.html)), you might have to use additional header files and libraries. We already support this via preferences which is motivated by standalone where you compile everything at once. For runtime targets like weave or Cython, we do not need to compile every code object file with these additional arguments, but only those where the function is used (potentially this could speed up compilation, but not sure it makes a practical difference).
Finally, we currently do not support to put the code in a completely separate file and compile it with the Brian-generated files. With this PR, this is possible by providing the separate source file(s) as an argument to a `sources` keyword in the `@implementation` decorator.

I modified the OpenCV example a bit to use the new keyword arguments, it does not use the separate source file thing, though.

This is basically ready to be merged from my side, the only major thing missing is support for external source files in Cython. Then, I still need to write a bit of documentation and I wanted to have a look whether (or rather how...) this breaks Brian2GeNN and Brian2CUDA.

Closes #672