### PR TITLE
[MRG] Add new ways to create subgroups (e.g. with single numbers or arrays)

### DIFF
--- a/brian2/tests/test_spatialneuron.py
+++ b/brian2/tests/test_spatialneuron.py
@@ -662,6 +662,13 @@ def test_spatialneuron_indexing():
     assert len(neuron.sec1.sec12.main.v[:]) == 8
     assert len(neuron.sec2.main.v[:]) == 16
     assert len(neuron.sec2.sec21.main.v[:]) == 32
+    # Accessing subgroups
+    assert len(neuron[0].indices[:]) == 1
+    assert len(neuron[0*um:50*um].indices[:]) == 1
+    assert len(neuron[0:1].indices[:]) == 1
+    assert len(neuron[sec.sec2.indices[:]]) == 16
+    assert len(neuron[sec.sec2]) == 16
+
 
 @attr('codegen-independent')
 def test_tree_index_consistency():
@@ -808,6 +815,7 @@ def test_spatialneuron_capacitive_currents():
     device.build(direct_call=False, **device.build_options)
     assert_allclose((mon.Im-mon.Ic).sum(axis=0)/(mA/cm**2), np.zeros(230),
                     atol=1e6)
+
 
 if __name__ == '__main__':
     test_custom_events()

--- a/brian2/tests/test_subgroup.py
+++ b/brian2/tests/test_subgroup.py
@@ -650,13 +650,28 @@ def test_spike_monitor():
 @attr('codegen-independent')
 def test_wrong_indexing():
     G = NeuronGroup(10, 'v:1')
-    assert_raises(TypeError, lambda: G[0])
-    assert_raises(TypeError, lambda: G[[0, 1]])
     assert_raises(TypeError, lambda: G['string'])
 
+    assert_raises(IndexError, lambda: G[10])
     assert_raises(IndexError, lambda: G[10:])
     assert_raises(IndexError, lambda: G[::2])
     assert_raises(IndexError, lambda: G[3:2])
+    assert_raises(IndexError, lambda: G[[5, 4, 3]])
+    assert_raises(IndexError, lambda: G[[2, 4, 6]])
+    assert_raises(IndexError, lambda: G[[-1, 0, 1]])
+    assert_raises(IndexError, lambda: G[[9, 10, 11]])
+    assert_raises(IndexError, lambda: G[[9, 10]])
+    assert_raises(IndexError, lambda: G[[10, 11]])
+    assert_raises(TypeError, lambda: G[[2.5, 3.5, 4.5]])
+
+
+@attr('codegen-independent')
+def test_alternative_indexing():
+    G = NeuronGroup(10, 'v : integer')
+    G.v = 'i'
+    assert_equal(G[-3:].v, np.array([7, 8, 9]))
+    assert_equal(G[3].v, np.array([3]))
+    assert_equal(G[[3, 4, 5]].v, np.array([3, 4, 5]))
 
 
 def test_no_reference_1():

--- a/docs_sphinx/user/models.rst
+++ b/docs_sphinx/user/models.rst
@@ -173,6 +173,14 @@ Python's slicing syntax::
 Here ``G1`` refers to the first 5 neurons in G, and ``G2`` to the second 5
 neurons. In general ``G[i:j]`` refers to the neurons with indices from ``i``
 to ``j-1``, as in general in Python.
+
+For convenience, you can also use a single index, i.e. ``G[i]`` is equivalent
+to ``G[i:i+1]``. In some situations, it can be easier to provide a list of
+indices instead of a slice, Brian therefore also allows for this syntax. Note
+that this is restricted to cases that are strictly equivalent with slicing
+syntax, e.g. you can write ``G[[3, 4, 5]]`` instead of ``G[3:6]``, but you
+*cannot* write ``G[[3, 5, 7]]`` or ``G[[5, 4, 3]]``.
+
 Subgroups can be used in most places where regular groups are used, e.g. their
 state variables or spiking activity can be recorded using monitors, they can be
 connected via `Synapses`, etc. In such situations, indices (e.g. the indices of

--- a/docs_sphinx/user/multicompartmental.rst
+++ b/docs_sphinx/user/multicompartmental.rst
@@ -309,6 +309,29 @@ A part of a section can be accessed as follows::
 
     initial_segment = neuron.axon[10*um:50*um]
 
+Finally, similar to the way that you can refer to a subset of neurons of a
+`NeuronGroup`, you can also index the `SpatialNeuron` object itself, e.g. to
+get a group representing only the first compartment of a cell (typically the
+soma), you can use::
+
+    soma = neuron[0]
+
+In the same way as for sections, you can also use slices, either with the
+indices of compartments, or with the distance from the root::
+
+    first_compartments = neurons[:3]
+    first_compartments = neurons[0*um:30*um]
+
+However, note that this is restricted to contiguous indices which most of the
+time means that all compartments indexed in this way have to be part of the
+same section. Such indices can be acquired directly from the morphology::
+
+    axon = neurons[morpho.axon.indices[:]]
+
+or, more concisely::
+
+    axon = neurons[morpho.axon]
+
 Synaptic inputs
 ~~~~~~~~~~~~~~~
 There are two methods to have synapses on `SpatialNeuron`.
@@ -386,3 +409,8 @@ Again the location of the threshold can be specified with spatial position::
                            threshold_location=morpho.axon[30*um],
                            refractory='m > 0.4')
 
+Subgroups
+~~~~~~~~~
+
+In the same way that you can refer to a subset of neurons in a `NeuronGroup`,
+you can also refer to a subset of compartments in a `SpatialNeuron`


### PR DESCRIPTION
Sometimes, especially in the context of `SpatialNeuron`, you might want to refer to only a single element as a subgroup. For this, you'd previously have to use an awkward slice such as `group[2:3]`. With the changes here, you can use `group[2]` instead. You can also use arrays, e.g. `group[[3, 4, 5]]` instead of `group[3:6]`, which again is something that is useful for `SpatialNeuron`, where you can get such indices from the `Morphology` object (e.g. `morpho.dend.indices[:]` will get the indices of the `dend` section).

It's not a big feature, but it adds a bit of consistency/flexibility, I think. Under the hood, it doesn't change anything, subgroups still have to be contiguous.