### PR TITLE
[MRG] Use an epsilon independent of dt when comparing times

### DIFF
--- a/brian2/core/clocks.py
+++ b/brian2/core/clocks.py
@@ -36,8 +36,7 @@ def check_dt(new_dt, old_dt, target_t):
     ------
     ValueError
         If using the new dt value would lead to a difference in the target
-        time of more than `Clock.epsilon_dt` times ``new_dt`` (by default,
-        0.01% of the new dt).
+        time of more than `Clock.epsilon_dt` (by default, 10ns).
 
     Examples
     --------
@@ -52,7 +51,7 @@ def check_dt(new_dt, old_dt, target_t):
     old_t = np.int64(np.round(target_t / old_dt)) * old_dt
     new_t = np.int64(np.round(target_t / new_dt)) * new_dt
     error_t = target_t
-    if abs(new_t - old_t)/new_dt > Clock.epsilon_dt:
+    if abs(new_t - old_t) > Clock.epsilon_dt:
         raise ValueError(('Cannot set dt from {old} to {new}, the '
                           'time {t} is not a multiple of '
                           '{new}').format(old=str(old_dt * second),
@@ -74,10 +73,8 @@ class Clock(VariableOwner):
     Notes
     -----
     Clocks are run in the same `Network.run` iteration if `~Clock.t` is the
-    same. The condition for two
-    clocks to be considered as having the same time is
-    ``abs(t1-t2)<epsilon*abs(t1)``, a standard test for equality of floating
-    point values. The value of ``epsilon`` is ``1e-14``.
+    same. The condition for two clocks to be considered as having the same time
+    is ``abs(t1-t2)<10*ns``.
     '''
 
     def __init__(self, dt, name='clock*'):
@@ -121,7 +118,7 @@ class Clock(VariableOwner):
     def _calc_timestep(self, target_t):
         '''
         Calculate the integer time step for the target time. If it cannot be
-        exactly represented (up to 0.01% of dt), round up.
+        exactly represented (up to 10ns), round up.
 
         Parameters
         ----------
@@ -136,7 +133,7 @@ class Clock(VariableOwner):
         new_i = np.int64(np.round(target_t / self.dt_))
         new_t = new_i * self.dt_
         if (new_t == target_t or
-                        np.abs(new_t - target_t)/self.dt_ <= Clock.epsilon_dt):
+                        np.abs(new_t - target_t) <= Clock.epsilon_dt):
             new_timestep = new_i
         else:
             new_timestep = np.int64(np.ceil(target_t / self.dt_))
@@ -189,9 +186,9 @@ class Clock(VariableOwner):
                                      self._i_end),
                         'many_timesteps')
 
-    #: The relative difference for times (in terms of dt) so that they are
+    #: The absolute difference for times (in seconds) so that clocks are
     #: considered identical.
-    epsilon_dt = 1e-4
+    epsilon_dt = 1e-8
 
 
 class DefaultClockProxy(object):

--- a/brian2/core/network.py
+++ b/brian2/core/network.py
@@ -877,7 +877,7 @@ class Network(Nameable):
         minclock, min_time, minclock_dt = min(clocks_times_dt, key=lambda k: k[1])
         curclocks = set(clock for clock, time, dt in clocks_times_dt if
                         (time == min_time or
-                         abs(time - min_time)/min(minclock_dt, dt) < Clock.epsilon_dt))
+                         abs(time - min_time) < Clock.epsilon_dt))
         return minclock, curclocks
 
     @device_override('network_run')


### PR DESCRIPTION
I'm not super happy with this fix, but I did not see any other obvious solution.

As a bit of context: in Brian, we are making our life hard by being very flexible on everything related to clocks. Users can use multiple clocks with varying dt's (which do not have to be multiples of each other), dt's can change between runs, and runs do not need to express times in multiples of dt (e.g. with the default dt of 0.1ms, you can run a network twice for 0.05ms and it will work fine, running everything for a single time step). Since this entails comparing floating point time values (instead of just integer time steps), we have to deal with floating point inaccuracies and cannot simply do exact comparisons to figure out whether two clocks with differing dt's should be executed within the same time step, etc.

Our previous solution was to consider two times as being equal iff they differ by less than 0.01% of dt. The problem is, that 0.01% of dt can be a meaningful amount of time if dt is very long. In #1054, a `run_regularly` operation had a very long dt, and a run had a runtime of less than 0.01% of this dt before doing a long run. From the point of view of the `run_regular` operation, the start and end time of the short run were identical, leading to weird behaviour (which differed between standalone and runtime...).

The fix I went for is to simply use an *absolute* difference when comparing times, i.e. 10ns (which is 0.01% of the default dt). This has the advantage of being easy to explain and should avoid issues when having big differences in dt. It is still far away from reasonably chosen dt's, and if someone wants to simulate stuff in the nanosecond range for some reason, they could always change `Clock.epsilon_dt` manually.

Fixes #1054 (@Felix11H, I tested with the code you provided, but please give it a go with your actual code as well)