### PR TITLE
Fix #1065

### DIFF
--- a/brian2/core/operations.py
+++ b/brian2/core/operations.py
@@ -34,8 +34,8 @@ class NetworkOperation(BrianObject):
     network_operation, Network, BrianObject
     """
     add_to_magic_network = True
-    def __init__(self, function, dt=None, clock=None, when='start', order=0):
-        BrianObject.__init__(self, dt=dt, clock=clock, when=when, order=order, name='networkoperation*')
+    def __init__(self, function, dt=None, clock=None, when='start', order=0, name='networkoperation*'):
+        BrianObject.__init__(self, dt=dt, clock=clock, when=when, order=order, name=name)
 
         #: The function to be called each time step
         self.function = function

--- a/brian2/tests/test_network.py
+++ b/brian2/tests/test_network.py
@@ -475,6 +475,33 @@ def test_incorrect_network_operations():
 
 @attr('codegen-independent')
 @with_setup(teardown=restore_initial_state)
+def test_network_operations_name():
+    # test NetworkOperation name input
+    seq = []
+    def f1():
+        seq.append('a')
+
+    def f2():
+        seq.append('b')
+
+    op = NetworkOperation(lambda: x)
+    assert_equal(op.name, 'networkoperation')
+
+    op0 = NetworkOperation(lambda: x, name='named_network')
+    assert_equal(op0.name, 'named_network')
+
+    op1 = NetworkOperation(f1, name='networkoperation_1')
+    op2 = NetworkOperation(f1, name='networkoperation_3')
+    op3 = NetworkOperation(f2, name='networkoperation_2')
+
+    net = Network(op1, op2, op3)
+    net.run(1*ms)
+
+    assert_equal(''.join(seq), 'aba'*10)
+
+
+@attr('codegen-independent')
+@with_setup(teardown=restore_initial_state)
 def test_network_active_flag():
     # test that the BrianObject.active flag is recognised by Network.run
     x = Counter()
@@ -1432,6 +1459,7 @@ if __name__ == '__main__':
             test_network_stop,
             test_network_operations,
             test_incorrect_network_operations,
+            test_network_operations_name,
             test_network_active_flag,
             test_network_t,
             test_incorrect_dt_defaultclock,


### PR DESCRIPTION
NetworkOperation allow for setting a name when init

