### PR TITLE
[WIP] Compile Cython in parallel

### DIFF
--- a/brian2/codegen/generators/cython_generator.py
+++ b/brian2/codegen/generators/cython_generator.py
@@ -236,12 +236,15 @@ class CythonCodeGenerator(CodeGenerator):
                             "global _namespace_num{var_name}",
                             "cdef _numpy.ndarray[{cpp_dtype}, ndim=1, mode='c'] _buf_{var_name} = _namespace['{var_name}']",
                             "_namespace{var_name} = <{cpp_dtype} *> _buf_{var_name}.data",
-                            "_namespace_num{var_name} = len(_namespace['{var_name}'])"
+                            "_namespace_num{var_name} = _buf_{var_name}.shape[0]"
                         ]
-                        support_code.append(
+                        support_code.extend([
                             "cdef {cpp_dtype} *_namespace{var_name}".format(
                                 cpp_dtype=get_cpp_dtype(ns_value.dtype),
-                                var_name=ns_key))
+                                var_name=ns_key),
+                            "cdef int _namespace_num{var_name}".format(
+                                var_name=ns_key)
+                        ])
 
                     else:  # e.g. a function
                         newlines = [
@@ -326,7 +329,7 @@ class CythonCodeGenerator(CodeGenerator):
                                 "cdef {cpp_dtype} * {array_name} = <{cpp_dtype} *> _buf_{array_name}.data"]
 
                 if not var.scalar:
-                    newlines += ["cdef int _num{array_name} = len(_namespace['{array_name}'])"]
+                    newlines += ["cdef int _num{array_name} = _buf_{array_name}.shape[0]"]
 
                 if var.scalar and var.constant:
                     newlines += ['cdef {cpp_dtype} {varname} = _namespace["{varname}"]']

--- a/brian2/codegen/runtime/cython_rt/templates/common.pyx
+++ b/brian2/codegen/runtime/cython_rt/templates/common.pyx
@@ -2,6 +2,7 @@
 #cython: boundscheck=False
 #cython: wraparound=False
 #cython: cdivision=False
+#cython: initializedcheck=False
 #cython: infer_types=True
 from __future__ import division
 

--- a/brian2/codegen/runtime/cython_rt/templates/synapses.pyx
+++ b/brian2/codegen/runtime/cython_rt/templates/synapses.pyx
@@ -10,7 +10,7 @@
 
     cdef int _spiking_synapse_idx
 
-    for _spiking_synapse_idx in range(len(_spiking_synapses)):
+    for _spiking_synapse_idx in range(_spiking_synapses.shape[0]):
         # vector code
         _idx = _spiking_synapses[_spiking_synapse_idx]
         _vectorisation_idx = _idx

--- a/brian2/codegen/runtime/cython_rt/templates/synapses_create_generator.pyx
+++ b/brian2/codegen/runtime/cython_rt/templates/synapses_create_generator.pyx
@@ -11,13 +11,13 @@ USES_VARIABLES { _synaptic_pre, _synaptic_post, rand, N,
 
 {% block template_support_code %}
 cdef int _buffer_size = 1024
-cdef int[:] _prebuf = _numpy.zeros(_buffer_size, dtype=_numpy.int32)
-cdef int[:] _postbuf = _numpy.zeros(_buffer_size, dtype=_numpy.int32)
+cdef int _prebuf[1024]
+cdef int _postbuf[1024]
 cdef int _curbuf = 0
 cdef int _raw_pre_idx
 cdef int _raw_post_idx
 
-cdef void _flush_buffer(buf, dynarr, int buf_len):
+cdef void _flush_buffer(int[:] buf, dynarr, int buf_len):
     _curlen = dynarr.shape[0]
     _newlen = _curlen+buf_len
     # Resize the array
@@ -76,7 +76,7 @@ cdef void _flush_buffer(buf, dynarr, int buf_len):
         while {{iteration_variable}}+1<_iter_high:
             {{iteration_variable}} += 1
             if _jump_algo:
-                _jump = int(floor(log(_rand(_vectorisation_idx))*_pconst))*_iter_step
+                _jump = <int>(floor(log(_rand(_vectorisation_idx))*_pconst))*_iter_step
                 {{iteration_variable}} += _jump
                 if {{iteration_variable}}>=_iter_high:
                     break


### PR DESCRIPTION
As mentioned in #1073, Cython takes a long time to compile, starting a simple example like CUBA from scratch (i.e. with an empty cache) takes about 13s on my machine. Fairly complex templates like the one for synapse generation take ~1s to get turned into C++ code, and a further ~3s to compile. There is not that much we can do about, maybe compiling regularly used "support functions" (e.g. `rand`) only once into a library that then gets linked and referred to from the Cython code would help a bit, but this would be a major change and come with all kind of new potential bugs.

There is one pretty straight forward thing, though, that I've been thinking about for a while but never got around implementing: at a start of a run, we call `compile()` on all `CodeObject`s, before they get used during the run. This is done sequentially, but could also be done in parallel. This is what this PR does: `compile()` calls `create_extension`, but if the Cython module is not yet available in the disk or memory cache it does not compile it and wait for completion. Instead, it fires of a `Process` and returns the `Process` object. Later, when the module is actually needed (i.e. in `CodeObject.run`), we join this process to make sure that it has finished. We then get the module and carry on.

This slightly complicates the logic for file locking (which now becomes necessary even when we don't run multiple Cython scripts in parallel), but it is not too bad either. I'd say we remove/deprecate the preference that allows the user to switch off lock file usage (don't think any user ever did this anyway), this simplifies things a bit.

I implemented these changes in this PR, apart from some documentation and additional testing it seems to work on my machine, the Cython test suite (which runs tests in parallel and is therefore quite suited for finding problems with file locking) runs fine.

Oh, and I forgot: for the CUBA example, it brings down the compilation time from ~13s to ~7s, this is quite significant! Did I overlook something (potentially the test suite will tell...)?