### PR TITLE
[MRG] Correctly store/restore internal `SpikeGeneratorGroup` state

### DIFF
--- a/brian2/input/spikegeneratorgroup.py
+++ b/brian2/input/spikegeneratorgroup.py
@@ -145,6 +145,20 @@ class SpikeGeneratorGroup(Group, CodeRunner, SpikeSource):
 
         self.variables['period'].set_value(period)
 
+    def _full_state(self):
+        state = super(SpikeGeneratorGroup, self)._full_state()
+        # Store the internal information we use to decide whether to rebuild
+        # the time bins
+        state['_previous_dt'] = self._previous_dt
+        state['_spikes_changed'] = self._spikes_changed
+        return state
+
+    def _restore_from_full_state(self, state):
+        state = state.copy()  # copy to avoid errors for multiple restores
+        self._previous_dt = state.pop('_previous_dt')
+        self._spikes_changed = state.pop('_spikes_changed')
+        super(SpikeGeneratorGroup, self)._restore_from_full_state(state)
+
     def before_run(self, run_namespace):
         # Do some checks on the period vs. dt
         dt = self.dt_[:]  # make a copy

--- a/brian2/tests/test_spikegenerator.py
+++ b/brian2/tests/test_spikegenerator.py
@@ -8,7 +8,7 @@ import tempfile
 
 from nose import with_setup
 from nose.plugins.attrib import attr
-from numpy.testing.utils import assert_raises, assert_equal
+from numpy.testing.utils import assert_raises, assert_equal, assert_array_equal
 
 from brian2 import *
 from brian2.core.network import schedule_propagation_offset
@@ -370,6 +370,21 @@ def test_spikegenerator_multiple_runs():
     assert spike_mon.num_spikes == 5
 
 
+def test_spikegenerator_restore():
+    # Check whether SpikeGeneratorGroup works with store/restore
+    # See github issue #1084
+    gen = SpikeGeneratorGroup(1, [0, 0, 0], [0, 1, 2]*ms)
+    mon = SpikeMonitor(gen)
+    store()
+    run(3*ms)
+    assert_array_equal(mon.i, [0, 0, 0])
+    assert_allclose(mon.t, [0, 1, 2] * ms)
+    restore()
+    run(3 * ms)
+    assert_array_equal(mon.i, [0, 0, 0])
+    assert_allclose(mon.t, [0, 1, 2]*ms)
+
+
 if __name__ == '__main__':
     import time
     start = time.time()
@@ -391,4 +406,5 @@ if __name__ == '__main__':
     test_spikegenerator_rounding_period()
     test_spikegenerator_multiple_spikes_per_bin()
     test_spikegenerator_multiple_runs()
+    test_spikegenerator_restore()
     print('Tests took', time.time()-start)


### PR DESCRIPTION
In `SpikeGeneratorGroup`, we use variables directly stored in the object (i.e. not as `Variables`) to decide whether we need to rebuild the integer timestep representation of spike times (e.g. when `dt` has changed between runs). In principle, we *could* store them as "proper" variables, but that would also be somewhat inconvenient: e.g. we currently set `_previous_dt = None` to note that the simulation has not been run yet; if it were a variable using our full machinery, then it would necessarily have to store a value in seconds,  so we'd need some workaround like `_previous_dt = 0*second` to denote "not run yet".

With this PR I opted for the straightforward solution to fix #1084: we now manually store/restore the two internal variable values.

Using proper variables might have been a cleaner option, but it would also have been a more fundamental change and potentially introduce new problems (e.g. for C++ standalone or Brian2GeNN).