### PR TITLE
Remove import print_function for compatibility with binder setup

### DIFF
--- a/examples/frompapers/Destexhe_et_al_1998.py
+++ b/examples/frompapers/Destexhe_et_al_1998.py
@@ -30,7 +30,6 @@ Notes
 * Other small discrepancies with the paper -- values from the NEURON code were
   used whenever different from the values stated in the paper
 '''
-from __future__ import print_function
 from brian2 import *
 from brian2.units.constants import (zero_celsius, faraday_constant as F,
                                     gas_constant as R)


### PR DESCRIPTION
The line "from __future__ import print_function" occurring after the magic "%matplotlib notebook" (added as part of the brian2-binder preparation) and before "from brian2 import *" results in this bug: https://github.com/ipython/ipython/issues/11366

Since Python 2 is soon to be retired, it is probably simplest just to remove the offending line.