### PR TITLE
Update documentation by removing broken links and obsolete locations

### DIFF
--- a/docs_sphinx/developer/GSL.rst
+++ b/docs_sphinx/developer/GSL.rst
@@ -4,7 +4,7 @@ Solving differential equations with the GNU Scientific Library
 Conventionally, Brian generates its own code performing :doc:`../user/numerical_integration`
 according to the chosen algorithm (see the section on :doc:`codegen`).
 Another option is to let the differential equation solvers defined in the
-`GNU Scientific Library (GSL) <https://www.gnu.org/software/gsl/manual/html_node/Ordinary-Differential-Equations.html>`_
+`GNU Scientific Library (GSL) <https://www.gnu.org/software/gsl/doc/html/ode-initval.html>`_
 solve the given equations. In addition to offering a few extra integration methods,
 the GSL integrator comes with the option of having an adaptable timestep. The
 latter functionality can have benefits for the speed with which large simulations

--- a/docs_sphinx/developer/equations_namespaces.rst
+++ b/docs_sphinx/developer/equations_namespaces.rst
@@ -6,7 +6,7 @@ Equation parsing
 Parsing is done via `pyparsing`_, for now find the grammar at the top of the
 `brian2.equations.equations` file.
 
-.. _pyparsing: http://pyparsing.wikispaces.com/
+.. _pyparsing: https://pythonhosted.org/pyparsing/pyparsing-module.html
 
 Variables
 ----------

--- a/docs_sphinx/developer/guidelines/documentation.rst
+++ b/docs_sphinx/developer/guidelines/documentation.rst
@@ -4,9 +4,7 @@ Documentation
 It is very important to maintain documentation. We use the
 `Sphinx documentation generator <http://www.sphinx-doc.org/en/stable/>`__
 tools. The documentation is all hand written. Sphinx source files are stored in the
-``docs_sphinx`` folder (currently: ``docs_sphinx``). The HTML files
-can be generated via the script ``dev/tools/docs/build_html_brian2.py`` and end
-up in the ``docs`` folder (currently: ``dev/brian2/docs``).  #not sure about the location
+``docs_sphinx`` folder.                                                      
 
 Most of the documentation is stored directly in the Sphinx
 source text files, but reference documentation for important Brian classes and
@@ -47,7 +45,7 @@ is obvious what it does. For example, there is normally no need to document
 ``__str__`` with "Return a string representation.".
 
 For the docstring format, we use the our own sphinx extension (in
-`brian2.utils.sphinxext`) based on                     #equivalent file ..
+`brian2/sphinxext`) based on                 
 `numpydoc <https://pypi.python.org/pypi/numpydoc/>`__, allowing to write
 docstrings that are well readable both in sourcecode as well as in the
 rendered HTML. We generally follow the `format used by numpy

--- a/docs_sphinx/developer/guidelines/documentation.rst
+++ b/docs_sphinx/developer/guidelines/documentation.rst
@@ -6,7 +6,7 @@ It is very important to maintain documentation. We use the
 tools. The documentation is all hand written. Sphinx source files are stored in the
 ``docs_sphinx`` folder. The HTML files can be generated via the script
 ``dev/tools/docs/build_html_brian2.py`` and end
-up in the ``docs`` folder (currently: ``dev/tools/docs``).
+up in the ``docs`` folder.
 
 Most of the documentation is stored directly in the Sphinx
 source text files, but reference documentation for important Brian classes and

--- a/docs_sphinx/developer/guidelines/documentation.rst
+++ b/docs_sphinx/developer/guidelines/documentation.rst
@@ -4,9 +4,9 @@ Documentation
 It is very important to maintain documentation. We use the
 `Sphinx documentation generator <http://www.sphinx-doc.org/en/stable/>`__
 tools. The documentation is all hand written. Sphinx source files are stored in the
-``docs_sphinx`` folder (currently: ``dev/brian2/docs_sphinx``). The HTML files
+``docs_sphinx`` folder (currently: ``docs_sphinx``). The HTML files
 can be generated via the script ``dev/tools/docs/build_html_brian2.py`` and end
-up in the ``docs`` folder (currently: ``dev/brian2/docs``).
+up in the ``docs`` folder (currently: ``dev/brian2/docs``).  #not sure about the location
 
 Most of the documentation is stored directly in the Sphinx
 source text files, but reference documentation for important Brian classes and
@@ -47,11 +47,11 @@ is obvious what it does. For example, there is normally no need to document
 ``__str__`` with "Return a string representation.".
 
 For the docstring format, we use the our own sphinx extension (in
-`brian2.utils.sphinxext`) based on
+`brian2.utils.sphinxext`) based on                     #equivalent file ..
 `numpydoc <https://pypi.python.org/pypi/numpydoc/>`__, allowing to write
 docstrings that are well readable both in sourcecode as well as in the
 rendered HTML. We generally follow the `format used by numpy
-<https://github.com/numpy/numpy/blob/master/doc/HOWTO_DOCUMENT.rst.txt>`__
+<https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard>`__
 
 When the docstring uses variable, class or function names, these should be
 enclosed in single backticks. Class and function/method names will be

--- a/docs_sphinx/developer/guidelines/documentation.rst
+++ b/docs_sphinx/developer/guidelines/documentation.rst
@@ -4,7 +4,9 @@ Documentation
 It is very important to maintain documentation. We use the
 `Sphinx documentation generator <http://www.sphinx-doc.org/en/stable/>`__
 tools. The documentation is all hand written. Sphinx source files are stored in the
-``docs_sphinx`` folder.                                                      
+``docs_sphinx`` folder. The HTML files can be generated via the script
+``dev/tools/docs/build_html_brian2.py`` and end
+up in the ``docs`` folder (currently: ``dev/tools/docs``).
 
 Most of the documentation is stored directly in the Sphinx
 source text files, but reference documentation for important Brian classes and
@@ -45,7 +47,7 @@ is obvious what it does. For example, there is normally no need to document
 ``__str__`` with "Return a string representation.".
 
 For the docstring format, we use the our own sphinx extension (in
-`brian2/sphinxext`) based on                 
+`brian2/sphinxext`) based on
 `numpydoc <https://pypi.python.org/pypi/numpydoc/>`__, allowing to write
 docstrings that are well readable both in sourcecode as well as in the
 rendered HTML. We generally follow the `format used by numpy

--- a/docs_sphinx/introduction/install.rst
+++ b/docs_sphinx/introduction/install.rst
@@ -33,8 +33,8 @@ the Anaconda distribution. You should have access to the ``conda`` command in
 a terminal and running ``python`` (e.g. from your IDE) should show a header like
 this, indicating that you are using Anaconda's Python interpreter::
 
-    Python 3.7.3 (default, Mar 27 2019, 22:11:17) 
-    [GCC 7.3.0] :: Anaconda, Inc. on linux
+    Python 2.7.10 |Anaconda 2.3.0 (64-bit)| (default, May 28 2015, 17:02:03)
+    [GCC 4.4.7 20120313 (Red Hat 4.4.7-1)] on linux2
     Type "help", "copyright", "credits" or "license" for more information.
 
 Here's some documentation on how to set up some popular IDEs for Anaconda:
@@ -80,7 +80,7 @@ them from anaconda, simply do::
 
 You should also have a look at the brian2tools_ package, which contains several
 useful functions to visualize Brian 2 simulations and recordings. You can
-install it with pip or anaconda, similar to Brian 2 itself (but as of now, it is   # is it available now??
+install it with pip or anaconda, similar to Brian 2 itself (but as of now, it is
 not included in the ``conda-forge`` channel, you therefore have to install it
 from our own ``brian-team`` channel), e.g. with::
 
@@ -174,7 +174,7 @@ or put them in a batch file::
 **Python 3.5 and 3.6**
 
 * Install the `Microsoft Build Tools for Visual Studio 2017 <https://www.visualstudio.com/downloads/#build-tools-for-visual-studio-2017>`_.
-* Make sure that your ``setuptools`` package has at least version 34.4.0 (use ``conda update setuptools`` when using Anaconda, or #should update version number?
+* Make sure that your ``setuptools`` package has at least version 34.4.0 (use ``conda update setuptools`` when using Anaconda, or 
   ``pip install --upgrade setuptools`` when using pip).
 
 

--- a/docs_sphinx/introduction/install.rst
+++ b/docs_sphinx/introduction/install.rst
@@ -48,7 +48,7 @@ Installing Brian 2
     :ref:`installation_from_source` instead.
 
 You can either install Brian 2 in the Anaconda root environment, or create a
-new environment for Brian 2 (https://docs.anaconda.com/anaconda/navigator/tutorials/manage-environments/).
+new environment for Brian 2 (https://conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html).
 The latter has the advantage that you can update (or not update) the dependencies
 of Brian 2 independently from the rest of your system.
 

--- a/docs_sphinx/introduction/install.rst
+++ b/docs_sphinx/introduction/install.rst
@@ -174,7 +174,7 @@ or put them in a batch file::
 **Python 3.5 and 3.6**
 
 * Install the `Microsoft Build Tools for Visual Studio 2017 <https://www.visualstudio.com/downloads/#build-tools-for-visual-studio-2017>`_.
-* Make sure that your ``setuptools`` package has at least version 34.4.0 (use ``conda update setuptools`` when using Anaconda, or 
+* Make sure that your ``setuptools`` package has at least version 34.4.0 (use ``conda update setuptools`` when using Anaconda, or
   ``pip install --upgrade setuptools`` when using pip).
 
 

--- a/docs_sphinx/introduction/install.rst
+++ b/docs_sphinx/introduction/install.rst
@@ -5,7 +5,7 @@ Installation
     :local:
     :depth: 1
 
-We recommend users to use the `Anaconda distribution <https://www.continuum.io/downloads>`_
+We recommend users to use the `Anaconda distribution <https://www.anaconda.com/distribution/#download-section>`_
 by Continuum Analytics. Its use will make the installation of Brian 2 and its
 dependencies simpler, since packages are provided in binary form, meaning that
 they don't have to be build from the source code at your machine. Furthermore,
@@ -15,7 +15,7 @@ configuration.
 
 However, Brian 2 can also be installed independent of Anaconda, either with
 other Python distributions (`Enthought Canopy <https://www.enthought.com/products/canopy/>`_,
-`Python(x,y) for Windows <https://code.google.com/p/pythonxy/>`_, ...) or simply
+`Python(x,y) for Windows <http://python-xy.github.io>`_, ...) or simply
 based on Python and ``pip`` (see :ref:`installation_from_source` below).
 
 Installation with Anaconda
@@ -23,7 +23,7 @@ Installation with Anaconda
 
 Installing Anaconda
 ~~~~~~~~~~~~~~~~~~~
-`Download the Anaconda distribution <https://continuum.io/downloads>`_
+`Download the Anaconda distribution <https://www.anaconda.com/distribution/#download-section>`_
 for your Operating System. Note that the choice between Python 2.7 and Python
 3.x is not very important at this stage, Anaconda allows you to create a Python
 3 environment from Python 2 Anaconda and vice versa.
@@ -33,14 +33,12 @@ the Anaconda distribution. You should have access to the ``conda`` command in
 a terminal and running ``python`` (e.g. from your IDE) should show a header like
 this, indicating that you are using Anaconda's Python interpreter::
 
-    Python 2.7.10 |Anaconda 2.3.0 (64-bit)| (default, May 28 2015, 17:02:03)
-    [GCC 4.4.7 20120313 (Red Hat 4.4.7-1)] on linux2
+    Python 3.7.3 (default, Mar 27 2019, 22:11:17) 
+    [GCC 7.3.0] :: Anaconda, Inc. on linux
     Type "help", "copyright", "credits" or "license" for more information.
-    Anaconda is brought to you by Continuum Analytics.
-    Please check out: http://continuum.io/thanks and https://binstar.org
 
 Here's some documentation on how to set up some popular IDEs for Anaconda:
-https://docs.continuum.io/anaconda/ide_integration
+https://docs.anaconda.com/anaconda/user-guide/tasks/integration
 
 Installing Brian 2
 ~~~~~~~~~~~~~~~~~~
@@ -50,8 +48,8 @@ Installing Brian 2
     :ref:`installation_from_source` instead.
 
 You can either install Brian 2 in the Anaconda root environment, or create a
-new environment for Brian 2 (http://conda.pydata.org/docs/using/envs.html). The
-latter has the advantage that you can update (or not update) the dependencies
+new environment for Brian 2 (https://docs.anaconda.com/anaconda/navigator/tutorials/manage-environments/).
+The latter has the advantage that you can update (or not update) the dependencies
 of Brian 2 independently from the rest of your system.
 
 Brian 2 is not part of the main Anaconda distribution, but built using the
@@ -82,7 +80,7 @@ them from anaconda, simply do::
 
 You should also have a look at the brian2tools_ package, which contains several
 useful functions to visualize Brian 2 simulations and recordings. You can
-install it with pip or anaconda, similar to Brian 2 itself (but as of now, it is
+install it with pip or anaconda, similar to Brian 2 itself (but as of now, it is   # is it available now??
 not included in the ``conda-forge`` channel, you therefore have to install it
 from our own ``brian-team`` channel), e.g. with::
 
@@ -176,7 +174,7 @@ or put them in a batch file::
 **Python 3.5 and 3.6**
 
 * Install the `Microsoft Build Tools for Visual Studio 2017 <https://www.visualstudio.com/downloads/#build-tools-for-visual-studio-2017>`_.
-* Make sure that your ``setuptools`` package has at least version 34.4.0 (use ``conda update setuptools`` when using Anaconda, or
+* Make sure that your ``setuptools`` package has at least version 34.4.0 (use ``conda update setuptools`` when using Anaconda, or #should update version number?
   ``pip install --upgrade setuptools`` when using pip).
 
 


### PR DESCRIPTION
Checked the documentation and updated out-of-date items, however I felt everything is updated on sections other than `Introduction` and `Developer's Guide` as other sections are mostly docstring generated. 
Kindly correct me if anything is incorrect. Please mention any particular sections which I would have possibly missed out and likely to need update. 