### PR TITLE
[MRG[ Documentation updates

### DIFF
--- a/dev/tools/docs/build_tutorials.py
+++ b/dev/tools/docs/build_tutorials.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 import os
 import shutil
 import glob
@@ -27,7 +29,7 @@ for fname in sorted(glob.glob1(src_dir, '*.ipynb')):
     output_ipynb_fname = os.path.join(target_dir, fname)
     output_rst_fname = os.path.join(target_dir, basename + '.rst')
 
-    print 'Running', fname
+    print('Running', fname)
     with open(os.path.join(src_dir, fname), 'r') as f:
         notebook = reads(f.read())
 
@@ -41,7 +43,7 @@ for fname in sorted(glob.glob1(src_dir, '*.ipynb')):
     notebook, _ = preprocessor.preprocess(notebook,
                                           {'metadata': {'path': src_dir}})
 
-    print 'Saving notebook and converting to RST'
+    print('Saving notebook and converting to RST')
     exporter = NotebookExporter()
     output, _ = exporter.from_notebook_node(notebook)
     with codecs.open(output_ipynb_fname, 'w', encoding='utf-8') as f:
@@ -74,11 +76,11 @@ for fname in sorted(glob.glob1(src_dir, '*.ipynb')):
     with codecs.open(output_rst_fname, 'w', encoding='utf-8') as f:
         f.write(output)
 
-    for image_name, image_data in resources['outputs'].iteritems():
+    for image_name, image_data in resources['outputs'].items():
         with open(os.path.join(target_dir, image_name), 'wb') as f:
             f.write(image_data)
 
-print 'Generating index.rst'
+print('Generating index.rst')
 
 text = '''
 ..

--- a/docs_sphinx/conf.py
+++ b/docs_sphinx/conf.py
@@ -98,7 +98,8 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'Brian 2'
-copyright = u'2012, Brian authors'
+import datetime
+copyright = u'2012–{}, Brian authors'.format(datetime.datetime.today().year)
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/docs_sphinx/introduction/index.rst
+++ b/docs_sphinx/introduction/index.rst
@@ -5,6 +5,7 @@ Introduction
    :maxdepth: 1
 
    install
+   scripts
    release_notes
    changes
    known_issues

--- a/docs_sphinx/introduction/install.rst
+++ b/docs_sphinx/introduction/install.rst
@@ -101,23 +101,6 @@ You might want to add the ``--user`` flag, to install Brian 2 for the local user
 only, which means that you don't need administrator privileges for the
 installation.
 
-If you have an older version of pip, first update pip itself::
-
-    # On Linux/MacOsX:
-    pip install -U pip
-
-    # On Windows
-    python -m pip install -U pip
-
-If you don't have ``pip`` but you have the ``easy_install`` utility, you can use
-it to install ``pip``::
-
-    easy_install pip
-
-If you have neither ``pip`` nor ``easy_install``, use the approach described
-here to install ``pip``: https://pip.pypa.io/en/latest/installing/
-
-
 .. _installation_cpp:
 
 Requirements for C++ code generation

--- a/docs_sphinx/introduction/install.rst
+++ b/docs_sphinx/introduction/install.rst
@@ -76,7 +76,7 @@ Brian. These include: matplotlib_ (for plotting), nose_ (for running the test
 suite), ipython_ and jupyter_-notebook (for an interactive console). To install
 them from anaconda, simply do::
 
-    conda install matplotlib nose ipython jupyter
+    conda install matplotlib nose ipython notebook
 
 You should also have a look at the brian2tools_ package, which contains several
 useful functions to visualize Brian 2 simulations and recordings. You can
@@ -132,9 +132,11 @@ using ``pip install cython`` or ``pip install weave``.
 
 Linux and OS X
 ~~~~~~~~~~~~~~
-On Linux and Mac OS X, you will most likely already have a working C++ compiler
-installed (try calling ``g++ --version`` in a terminal). If not, use your
-distribution's package manager to install a ``g++`` package.
+On Linux and Mac OS X, the conda package will automatically install a C++ compiler.
+But even if you install Brian from source, you will most likely already have a
+working C++ compiler installed on your system (try calling ``g++ --version``
+in a terminal). If not, use your distribution's package manager to install a
+``g++`` package.
 
 .. _compiler_setup_windows:
 
@@ -144,33 +146,13 @@ On Windows, the necessary steps to get :ref:`runtime` (i.e. Cython/weave) to wor
 depend on the Python version you are using (also see the
 `notes in the Python wiki <https://wiki.python.org/moin/WindowsCompilers#Compilers_Installation_and_configuration>`_):
 
-**Python 2.7**
+* **Python >= 3.5**
+    * Install the `Microsoft Build Tools for Visual Studio 2017 <https://www.visualstudio.com/downloads/#build-tools-for-visual-studio-2017>`_.
+    * Make sure that your ``setuptools`` package has at least version 34.4.0 (use ``conda update setuptools`` when using Anaconda, or
+        ``pip install --upgrade setuptools`` when using pip).
 
-* Download and install the `Microsoft Visual C++ Compiler for Python 2.7  <http://www.microsoft.com/en-us/download/details.aspx?id=44266>`_
-
-This should be all you need.
-
-**Python 3.4**
-
-* Follow the `instructions to install Microsoft Visual C++ 10.0 <https://wiki.python.org/moin/WindowsCompilers#Microsoft_Visual_C.2B-.2B-_10.0_standalone:_Windows_SDK_7.1_.28x86.2C_x64.2C_ia64.29>`_
-  in the Python wiki.
-
-For 64 Bit Windows with Python 3.4, you have to additionally set up your
-environment correctly every time you run your Brian script (this is why we
-recommend against using this combination on Windows). To do this, run the
-following commands (assuming the default installation path) at the CMD prompt,
-or put them in a batch file::
-
-    setlocal EnableDelayedExpansion
-    CALL "C:\Program Files\Microsoft SDKs\Windows\v7.1\Bin\SetEnv.cmd" /x64 /release
-    set DISTUTILS_USE_SDK=1
-
-**Python 3.5 and 3.6**
-
-* Install the `Microsoft Build Tools for Visual Studio 2017 <https://www.visualstudio.com/downloads/#build-tools-for-visual-studio-2017>`_.
-* Make sure that your ``setuptools`` package has at least version 34.4.0 (use ``conda update setuptools`` when using Anaconda, or
-  ``pip install --upgrade setuptools`` when using pip).
-
+* **Python 2.7**
+    * Download and install the `Microsoft Visual C++ Compiler for Python 2.7  <http://www.microsoft.com/en-us/download/details.aspx?id=44266>`_
 
 For :ref:`cpp_standalone`, you can either use the compiler installed above or any other version of Visual Studio -- in this
 case, the Python version does not matter.

--- a/docs_sphinx/introduction/install.rst
+++ b/docs_sphinx/introduction/install.rst
@@ -101,6 +101,11 @@ You might want to add the ``--user`` flag, to install Brian 2 for the local user
 only, which means that you don't need administrator privileges for the
 installation.
 
+Note that when installing ``brian2`` from source with pip, support for using
+:ref:`numerical integration with the GSL <gsl_integration>` requires a working
+installation of the GSL development libraries (e.g. the package ``libgsl-dev``
+on Debian/Ubuntu Linux).
+
 .. _installation_cpp:
 
 Requirements for C++ code generation

--- a/docs_sphinx/introduction/install.rst
+++ b/docs_sphinx/introduction/install.rst
@@ -117,12 +117,6 @@ it to install ``pip``::
 If you have neither ``pip`` nor ``easy_install``, use the approach described
 here to install ``pip``: https://pip.pypa.io/en/latest/installing/
 
-Alternatively, you can download the source package directly and uncompress it.
-You can then either run ``python setup.py install`` or
-``python setup.py develop`` to install it, or simply add
-the source directory to your ``PYTHONPATH`` (this will only work for Python
-2.x).
-
 
 .. _installation_cpp:
 
@@ -187,34 +181,13 @@ installation to make sure everything is working as expected.
 Development version
 -------------------
 
-To run the latest development code, you can install from brian-team's "dev"
-channel with Anaconda. Note that if you previously added the ``brian-team``
-channel to your list of channels, you have to first remove it::
+To run the latest development code, you can directly clone the git repository at github
+(https://github.com/brian-team/brian2) and then run ``pip install -e .``, to install
+Brian in "development mode". With this installation, updating the git repository is in
+general enough to keep up with changes in the code, i.e. it is not necessary to install
+it again.
 
-    conda config --remove channels brian-team -f
-
-Also uninstall any version of Brian 2 that you might have previously installed::
-
-    conda remove brian2
-
-Finally, install the ``brian2`` package from the development channel::
-
-    conda install -c brian-team/channel/dev brian2
-
-If this fails with an error message about the ``py-cpuinfo`` package (a
-dependency that we provide in the main brian-team channel), install it
-from the main channel::
-
-    conda install -c brian-team py-cpuinfo
-
-Then repeat the command to install Brian 2 from the development channel.
-
-You can also directly clone the git repository at github
-(https://github.com/brian-team/brian2) and then run ``python setup.py install``
-or ``python setup.py develop`` or simply add the source directory to your
-``PYTHONPATH`` (this will only work for Python 2.x).
-
-Finally, another option is to use ``pip`` to directly install from github::
+Another option is to use ``pip`` to directly install from github::
 
     pip install https://github.com/brian-team/brian2/archive/master.zip
 

--- a/docs_sphinx/introduction/scripts.rst
+++ b/docs_sphinx/introduction/scripts.rst
@@ -1,0 +1,97 @@
+Running Brian scripts
+=====================
+
+Brian scripts are standard Python scripts, and can therefore be run in the same way.
+For interactive, explorative work, you might want to run code in a
+jupyter notebook or in an ipython shell; for running finished code, you might want
+to execute scripts through the standard Python interpreter; finally, for working on
+big projects spanning multiple files, a dedicated integrated development environment
+for Python could be a good choice. We will briefly describe all these approaches and
+how they relate to Brian's examples and tutorial that are part of this documentation.
+Note that none of these approaches are specific to Brian, so you can also search for
+more information in any of the resources listed on the
+`Python website <https://www.python.org/about/gettingstarted/>`_.
+
+.. contents::
+    :local:
+    :depth: 1
+
+Jupyter notebook
+----------------
+    The Jupyter Notebook is an open-source web application that allows you to create
+    and share documents that contain live code, equations, visualizations and narrative text.
+
+    (from `jupyter.org <https://jupyter.org>`_)
+
+Jupyter notebooks are a great tool to run Brian code interactively, and include
+the results of the simulations, as well as additional explanatory text in a common
+document. Such documents have the file ending ``.ipynb``, and in Brian we use this
+format to store the :doc:`../resources/tutorials/index`. These files can be displayed by
+github (see e.g. `the first Brian tutorial <https://github.com/brian-team/brian2/blob/master/tutorials/1-intro-to-brian-neurons.ipynb>`_),
+but in this case you can only see them as a static website, not edit or execute any
+of the code.
+
+To make the full use of such notebooks, you have to run them using the
+jupyter infrastructure. The easiest option is to use the free
+`mybinder.org <https://mybinder.org>`_ web service, which allows you to try out
+Brian without installing it on your own machine. Links to run the tutorials on this
+infrastructure are provided as *"launch binder"* buttons on the
+:doc:`../resources/tutorials/index` page, and also for each of the
+:doc:`../examples/index` at the top of the respective page (e.g.
+:doc:`../examples/COBAHH`). To run notebooks on your own machine, you need
+an installation of the jupyter notebook software on your own machine, as well as
+Brian itself (see the :doc:`install` instructions for details). To open an existing
+notebook, you have to download it to your machine. For the Brian tutorials, you find
+the necessary links on the :doc:`../resources/tutorials/index` page. When you have
+downloaded/installed everything necessary, you can start the jupyter notebook from
+the command line (using Terminal on OS X/Linux, Command Prompt on Windows)::
+
+    jupyter notebook
+
+this will open the "Notebook Dashboard" in your default browser, from which you can
+either open an existing notebook or create a new one. In the notebook, you can then
+execute individual "code cells" by pressing ``SHIFT+ENTER`` on your keyboard, or
+by pressing the play button in the toolbar.
+
+For more information, see the
+`jupyter notebook documentation <https://jupyter-notebook.readthedocs.io>`_.
+
+
+IPython shell
+-------------
+An alternative to using the jupyter notebook is to use the interactive Python shell
+`IPython <https://ipython.readthedocs.io/>`_, which runs in the
+Terminal/Command Prompt. You can use it to directly type Python code interactively
+(each line will be executed as soon as you press ``ENTER``), or to run Python code
+stored in a file. Such files typically have the file ending ``.py``. You can
+either create it yourself in a text editor of your choice (e.g. by copying&pasting
+code from one of the :doc:`../examples/index`), or by downloading such files from
+places such as github (e.g. the `Brian examples <https://github.com/brian-team/brian2/tree/master/examples>`_),
+or `ModelDB <https://senselab.med.yale.edu/modeldb/>`_. You can then run them from
+within IPython via::
+
+    %run filename.py
+
+
+Python interpreter
+------------------
+The most basic way to run Python code is to run it through the standard Python
+interpreter. While you can also use this interpreter interactively, it is much less
+convenient to use than the IPython shell or the jupyter notebook described above.
+However, if all you want to do is to run an existing Python script (e.g. one of
+the Brian :doc:`../examples/index`), then you can do this by calling::
+
+    python filename.py
+
+in a Terminal/Command Prompt.
+
+Integrated development environment (IDE)
+----------------------------------------
+Python is a widely used programming language, and is therefore support by a wide
+range of integrated development environments (IDE). Such IDEs provide features
+that are very convenient for developing complex projects, e.g. they integrate
+text editor and interactive Python console, graphical debugging tools, etc.
+Popular environments include `Spyder <https://www.spyder-ide.org/>`_,
+`PyCharm <https://www.jetbrains.com/pycharm/>`_, and
+`Visual Studio Code <https://code.visualstudio.com/>`_, for an extensive list
+see the `Python wiki <https://wiki.python.org/moin/IntegratedDevelopmentEnvironments>`_.

--- a/docs_sphinx/user/models.rst
+++ b/docs_sphinx/user/models.rst
@@ -153,6 +153,8 @@ You can also set the value only if a condition holds, for example:
     >>> G.v
     <neurongroup.v: array([-70., -70., -70., -70., -70., -60., -60., -60., -60., -60.]) * mvolt>
 
+.. _subgroups:
+
 Subgroups
 ---------
 It is often useful to refer to a subset of neurons, this can be achieved using

--- a/docs_sphinx/user/numerical_integration.rst
+++ b/docs_sphinx/user/numerical_integration.rst
@@ -83,6 +83,8 @@ objects will use ``'exact'``, ``'exponential_euler'``, ``'rk2'`` or ``'heun'``.
 You can also define your own numerical integrators, see
 :doc:`../advanced/state_update` for details.
 
+.. _gsl_integration:
+
 GSL stateupdaters
 -----------------
 The stateupdaters preceded with the gsl tag use ODE solvers defined in the GNU


### PR DESCRIPTION
This PR updates/improves several parts of the documentation. The most important changes:
* the installation instructions have been shortened to no longer mention the conda development packages (which we haven't been building for a while), the complicated instructions for running code generation on Windows with Python3.4 (which is officially no longer supported), or the various ways to install/update `pip` (it is pre-installed by default now)
* new documentation for Python beginners, briefly explaining the various ways to run Brian code (jupyter notebook, etc.)
* new sections in the monitor/synapses documentation, detailing how to do common tasks (e.g. freeing up memory during a simulation, using synaptic matrices, ...)