### PR TITLE
[MRG] Revisit use of vectorisation_idx in function + add poisson function

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -594,6 +594,45 @@ POSSIBILITY OF SUCH DAMAGE.
 
 -------------------------------------------------------------------------------
 
+The implementations for binomial (brian2.input.binomial) and Poisson
+distributed random numbers (in brian2.codegen.generators.cython_generator and
+brian2.codegen.generators.cpp_generator) are based on the respective
+implementations in the numpy library (https://github.com/numpy/numpy),
+available under the BSD license:
+
+Copyright (c) 2005-2019, NumPy Developers.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+    * Redistributions of source code must retain the above copyright
+       notice, this list of conditions and the following disclaimer.
+
+    * Redistributions in binary form must reproduce the above
+       copyright notice, this list of conditions and the following
+       disclaimer in the documentation and/or other materials provided
+       with the distribution.
+
+    * Neither the name of the NumPy Developers nor the names of any
+       contributors may be used to endorse or promote products derived
+       from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+-------------------------------------------------------------------------------
+
 The spelling corrector code in brian2.utils.stringtools is based on the spelling
 corrector by Peter Norvig, available at: http://norvig.com/spell.py
 It is published under the MIT license:

--- a/brian2/codegen/generators/base.py
+++ b/brian2/codegen/generators/base.py
@@ -55,6 +55,15 @@ class CodeGenerator(object):
         self.allows_scalar_write = allows_scalar_write
         self.name = name
         self.template_name = template_name
+        # Gather the names of functions that should get an additional
+        # "_vectorisation_idx" argument in the generated code. Take care
+        # of storing their translated name (e.g. "_rand" instead of "rand")
+        # if necessary
+        self.auto_vectorise = {self.func_name_replacements.get(name, name)
+                               for name in self.variables
+                               if getattr(self.variables[name],
+                                          'auto_vectorise', False)}
+
 
     @staticmethod
     def get_array_name(var, access_data=True):

--- a/brian2/codegen/generators/cpp_generator.py
+++ b/brian2/codegen/generators/cpp_generator.py
@@ -181,7 +181,7 @@ class CPPCodeGenerator(CodeGenerator):
 
     def translate_expression(self, expr):
         expr = word_substitute(expr, self.func_name_replacements)
-        return CPPNodeRenderer().render_expr(expr).strip()
+        return CPPNodeRenderer(auto_vectorise=self.auto_vectorise).render_expr(expr).strip()
 
     def translate_statement(self, statement):
         var, op, expr, comment = (statement.var, statement.op,

--- a/brian2/codegen/generators/cpp_generator.py
+++ b/brian2/codegen/generators/cpp_generator.py
@@ -516,3 +516,95 @@ static inline int64_t _timestep(double t, double dt)
 DEFAULT_FUNCTIONS['timestep'].implementations.add_implementation(CPPCodeGenerator,
                                                                  code=timestep_code,
                                                                  name='_timestep')
+
+poisson_code = '''
+double _loggam(double x) {
+  double x0, x2, xp, gl, gl0;
+  int32_t k, n;
+
+  static double a[10] = {8.333333333333333e-02, -2.777777777777778e-03,
+                         7.936507936507937e-04, -5.952380952380952e-04,
+                         8.417508417508418e-04, -1.917526917526918e-03,
+                         6.410256410256410e-03, -2.955065359477124e-02,
+                         1.796443723688307e-01, -1.39243221690590e+00};
+  x0 = x;
+  n = 0;
+  if ((x == 1.0) || (x == 2.0))
+    return 0.0;
+  else if (x <= 7.0) {
+    n = (int32_t)(7 - x);
+    x0 = x + n;
+  }
+  x2 = 1.0 / (x0 * x0);
+  xp = 2 * M_PI;
+  gl0 = a[9];
+  for (k=8; k>=0; k--) {
+    gl0 *= x2;
+    gl0 += a[k];
+  }
+  gl = gl0 / x0 + 0.5 * log(xp) + (x0 - 0.5) * log(x0) - x0;
+  if (x <= 7.0) {
+    for (k=1; k<=n; k++) {
+      gl -= log(x0 - 1.0);
+      x0 -= 1.0;
+    }
+  }
+  return gl;
+}
+
+int32_t _poisson_mult(double lam, int _vectorisation_idx) {
+  int32_t X;
+  double prod, U, enlam;
+
+  enlam = exp(-lam);
+  X = 0;
+  prod = 1.0;
+  while (1) {
+    U = _rand(_vectorisation_idx);
+    prod *= U;
+    if (prod > enlam)
+      X += 1;
+    else
+      return X;
+  }
+}
+
+int32_t _poisson_ptrs(double lam, int _vectorisation_idx) {
+  int32_t k;
+  double U, V, slam, loglam, a, b, invalpha, vr, us;
+
+  slam = sqrt(lam);
+  loglam = log(lam);
+  b = 0.931 + 2.53 * slam;
+  a = -0.059 + 0.02483 * b;
+  invalpha = 1.1239 + 1.1328 / (b - 3.4);
+  vr = 0.9277 - 3.6224 / (b - 2);
+
+  while (1) {
+    U = _rand(_vectorisation_idx) - 0.5;
+    V = _rand(_vectorisation_idx);
+    us = 0.5 - abs(U);
+    k = (int32_t)floor((2 * a / us + b) * U + lam + 0.43);
+    if ((us >= 0.07) && (V <= vr))
+      return k;
+    if ((k < 0) || ((us < 0.013) && (V > us)))
+      continue;
+    if ((log(V) + log(invalpha) - log(a / (us * us) + b)) <=
+        (-lam + k * loglam - _loggam(k + 1)))
+      return k;
+  }
+}
+int32_t _poisson(double lam, int32_t _idx) {
+  if (lam >= 10)
+    return _poisson_ptrs(lam, _idx);
+  else if (lam == 0)
+    return 0;
+  else
+    return _poisson_mult(lam, _idx);
+}
+'''
+
+DEFAULT_FUNCTIONS['poisson'].implementations.add_implementation(CPPCodeGenerator,
+                                                                code=poisson_code,
+                                                                name='_poisson',
+                                                                dependencies={'_rand': DEFAULT_FUNCTIONS['rand']})

--- a/brian2/codegen/generators/cython_generator.py
+++ b/brian2/codegen/generators/cython_generator.py
@@ -254,6 +254,15 @@ class CythonCodeGenerator(CodeGenerator):
                                         numpy_dtype=get_numpy_dtype(
                                             ns_value.dtype),
                                         var_name=ns_key))
+                # Rename references to any dependencies if necessary
+                for dep_name, dep in impl.dependencies.items():
+                    dep_impl = dep.implementations[self.codeobj_class]
+                    dep_impl_name = dep_impl.name
+                    if dep_impl_name is None:
+                        dep_impl_name = dep.pyfunc.__name__
+                    if dep_name != dep_impl_name:
+                        func_code = word_substitute(func_code,
+                                                    {dep_name: dep_impl_name})
                 support_code.append(deindent(func_code))
             elif callable(func_code):
                 self.variables[varname] = func_code

--- a/brian2/codegen/generators/cython_generator.py
+++ b/brian2/codegen/generators/cython_generator.py
@@ -66,7 +66,7 @@ class CythonCodeGenerator(CodeGenerator):
 
     def translate_expression(self, expr):
         expr = word_substitute(expr, self.func_name_replacements)
-        return CythonNodeRenderer().render_expr(expr, self.variables).strip()
+        return CythonNodeRenderer(auto_vectorise=self.auto_vectorise).render_expr(expr, self.variables).strip()
 
     def translate_statement(self, statement):
         var, op, expr, comment = (statement.var, statement.op,

--- a/brian2/codegen/generators/cython_generator.py
+++ b/brian2/codegen/generators/cython_generator.py
@@ -404,6 +404,86 @@ cdef double _rand(int _idx):
 
 randn_code = rand_code.replace('rand', 'randn').replace('randnom', 'random')
 
+poisson_code = '''
+cdef double _loggam(double x):
+  cdef double x0, x2, xp, gl, gl0
+  cdef int32_t k, n
+
+  cdef double a[10]
+  a[:] = [8.333333333333333e-02, -2.777777777777778e-03,
+          7.936507936507937e-04, -5.952380952380952e-04,
+          8.417508417508418e-04, -1.917526917526918e-03,
+          6.410256410256410e-03, -2.955065359477124e-02,
+          1.796443723688307e-01, -1.39243221690590e+00]
+  x0 = x
+  n = 0
+  if (x == 1.0) or (x == 2.0):
+    return 0.0
+  elif x <= 7.0:
+    n = <int32_t>(7 - x)
+    x0 = x + n
+  x2 = 1.0 / (x0 * x0)
+  xp = 2 * M_PI
+  gl0 = a[9]
+  for k in range(8, -1, -1):
+    gl0 *= x2
+    gl0 += a[k]
+  gl = gl0 / x0 + 0.5 * log(xp) + (x0 - 0.5) * log(x0) - x0
+  if x <= 7.0:
+    for k in range(1, n+1):
+      gl -= log(x0 - 1.0)
+      x0 -= 1.0
+  return gl
+
+
+cdef int32_t _poisson_mult(double lam, int _vectorisation_idx):
+  cdef int32_t X
+  cdef double prod, U, enlam
+
+  enlam = exp(-lam)
+  X = 0
+  prod = 1.0
+  while True:
+    U = _rand(_vectorisation_idx)
+    prod *= U
+    if (prod > enlam):
+      X += 1
+    else:
+      return X
+
+cdef int32_t _poisson_ptrs(double lam, int _vectorisation_idx):
+  cdef int32_t k
+  cdef double U, V, slam, loglam, a, b, invalpha, vr, us
+
+  slam = sqrt(lam)
+  loglam = log(lam)
+  b = 0.931 + 2.53 * slam
+  a = -0.059 + 0.02483 * b
+  invalpha = 1.1239 + 1.1328 / (b - 3.4)
+  vr = 0.9277 - 3.6224 / (b - 2)
+
+  while True:
+    U = _rand(_vectorisation_idx) - 0.5
+    V = _rand(_vectorisation_idx)
+    us = 0.5 - abs(U)
+    k = <int32_t>floor((2 * a / us + b) * U + lam + 0.43)
+    if (us >= 0.07) and (V <= vr):
+      return k
+    if ((k < 0) or ((us < 0.013) and (V > us))):
+      continue
+    if ((log(V) + log(invalpha) - log(a / (us * us) + b)) <=
+        (-lam + k * loglam - _loggam(k + 1))):
+      return k
+
+cdef int32_t _poisson(double lam, int32_t _idx):
+  if lam >= 10:
+    return _poisson_ptrs(lam, _idx)
+  elif lam == 0:
+    return 0
+  else:
+    return _poisson_mult(lam, _idx)
+'''
+
 device = all_devices['runtime']
 DEFAULT_FUNCTIONS['rand'].implementations.add_implementation(CythonCodeGenerator,
                                                              code=rand_code,
@@ -417,6 +497,10 @@ DEFAULT_FUNCTIONS['randn'].implementations.add_implementation(CythonCodeGenerato
                                                               namespace={
                                                                   '_randn_buffer': device.randn_buffer,
                                                                   '_randn_buffer_index': device.randn_buffer_index})
+DEFAULT_FUNCTIONS['poisson'].implementations.add_implementation(CythonCodeGenerator,
+                                                                code=poisson_code,
+                                                                name='_poisson',
+                                                                dependencies={'_rand': DEFAULT_FUNCTIONS['rand']})
 
 sign_code = '''
 ctypedef fused _to_sign:

--- a/brian2/codegen/generators/numpy_generator.py
+++ b/brian2/codegen/generators/numpy_generator.py
@@ -317,11 +317,20 @@ def rand_func(vectorisation_idx):
         # scalar value
         return np.random.rand()
 
+def poisson_func(lam, vectorisation_idx):
+    try:
+        N = len(vectorisation_idx)
+        return np.random.poisson(lam, size=N)
+    except TypeError:
+        # scalar value
+        return np.random.poisson(lam)
 
 DEFAULT_FUNCTIONS['randn'].implementations.add_implementation(NumpyCodeGenerator,
                                                               code=randn_func)
 DEFAULT_FUNCTIONS['rand'].implementations.add_implementation(NumpyCodeGenerator,
                                                              code=rand_func)
+DEFAULT_FUNCTIONS['poisson'].implementations.add_implementation(NumpyCodeGenerator,
+                                                                code=poisson_func)
 clip_func = lambda array, a_min, a_max: np.clip(array, a_min, a_max)
 DEFAULT_FUNCTIONS['clip'].implementations.add_implementation(NumpyCodeGenerator,
                                                              code=clip_func)

--- a/brian2/codegen/generators/numpy_generator.py
+++ b/brian2/codegen/generators/numpy_generator.py
@@ -34,7 +34,7 @@ class NumpyCodeGenerator(CodeGenerator):
 
     def translate_expression(self, expr):
         expr = word_substitute(expr, self.func_name_replacements)
-        return NumpyNodeRenderer().render_expr(expr, self.variables).strip()
+        return NumpyNodeRenderer(auto_vectorise=self.auto_vectorise).render_expr(expr, self.variables).strip()
 
     def translate_statement(self, statement):
         # TODO: optimisation, translate arithmetic to a sequence of inplace
@@ -79,8 +79,7 @@ class NumpyCodeGenerator(CodeGenerator):
         used_variables.update(used)
         if statement.var in used_variables:
             raise VectorisationError()
-
-        expr = NumpyNodeRenderer().render_expr(statement.expr)
+        expr = NumpyNodeRenderer(auto_vectorise=self.auto_vectorise).render_expr(statement.expr)
 
         if statement.op == ':=' or indices[statement.var] == '_idx' or not statement.inplace:
             if statement.op == ':=':

--- a/brian2/codegen/optimisation.py
+++ b/brian2/codegen/optimisation.py
@@ -317,7 +317,7 @@ class Simplifier(BrianASTRenderer):
         self.loop_invariants = OrderedDict()
         self.loop_invariant_dtypes = {}
         self.n = 0
-        self.node_renderer = NodeRenderer(use_vectorisation_idx=False)
+        self.node_renderer = NodeRenderer()
         self.arithmetic_simplifier = ArithmeticSimplifier(variables)
         self.scalar_statements = scalar_statements
         if extra_lio_prefix is None:
@@ -416,7 +416,7 @@ def cancel_identical_terms(primary, inverted):
     inverted : list of AST nodes
         Inverted nodes after cancellation
     '''
-    nr = NodeRenderer(use_vectorisation_idx=False)
+    nr = NodeRenderer()
     expressions = dict((node, nr.render_node(node)) for node in primary)
     expressions.update(dict((node, nr.render_node(node)) for node in inverted))
     new_primary = []

--- a/brian2/core/functions.py
+++ b/brian2/core/functions.py
@@ -250,6 +250,8 @@ class FunctionImplementation(object):
         if compiler_kwds is None:
             compiler_kwds = {}
         self.name = name
+        if dependencies is None:
+            dependencies = {}
         self.dependencies = dependencies
         self._code = code
         self._namespace = namespace
@@ -455,7 +457,7 @@ class FunctionImplementationContainer(Mapping):
 
 
 def implementation(target, code=None, namespace=None, dependencies=None,
-                   discard_units=None, **compiler_kwds):
+                   discard_units=None, name=None, **compiler_kwds):
     '''
     A simple decorator to extend user-written Python functions to work with code
     generation in other languages.
@@ -491,6 +493,9 @@ def implementation(target, code=None, namespace=None, dependencies=None,
         units indirectly (e.g. uses ``brian2.ms`` instead of ``ms``). If no
         value is given, defaults to the preference setting
         `codegen.runtime.numpy.discard_units`.
+    name : str, optional
+        The name of the function in the target language. Should only be
+        specified if the function has to be renamed for the target language.
     compiler_kwds : dict, optional
         Additional keyword arguments will be transferred to the code generation
         stage, e.g. for C++-based targets, the code can make use of additional
@@ -541,6 +546,7 @@ def implementation(target, code=None, namespace=None, dependencies=None,
             function.implementations.add_implementation(target, code=code,
                                                         dependencies=dependencies,
                                                         namespace=namespace,
+                                                        name=name,
                                                         compiler_kwds=compiler_kwds)
         # # copy any annotation attributes
         # if hasattr(func, '_annotation_attributes'):

--- a/brian2/core/functions.py
+++ b/brian2/core/functions.py
@@ -648,6 +648,8 @@ DEFAULT_FUNCTIONS = {
     # functions that need special treatment
     'rand': Function(pyfunc=rand, arg_units=[], return_unit=1, stateless=False, auto_vectorise=True),
     'randn': Function(pyfunc=randn, arg_units=[], return_unit=1, stateless=False, auto_vectorise=True),
+    'poisson': Function(pyfunc=np.random.poisson, arg_units=[1], return_unit=1, return_type='integer',
+                        stateless=False, auto_vectorise=True),
     'clip': Function(pyfunc=np.clip, arg_units=[None, None, None],
                      return_type='highest',
                      return_unit=lambda u1, u2, u3: u1,),

--- a/brian2/core/functions.py
+++ b/brian2/core/functions.py
@@ -110,6 +110,15 @@ class Function(object):
         always returns the same output when called with the same arguments.
         This is true for mathematical functions but not true for ``rand()``, for
         example. Defaults to ``True``.
+    auto_vectorise : bool, optional
+        Whether the implementations of this function should get an additional
+        argument (not specified in abstract code) that can be used to determine
+        the number of values that should be returned (for the numpy target), or
+        an index potentially useful for generating deterministic values
+        independent of the order of vectorisation (for all other targets). The
+        main use case are random number functions, e.g. equations refer to
+        ``rand()``, but the generate code will actually call
+        ``rand(_vectorisation_idx)``. Defaults to ``False``.
 
     Notes
     -----
@@ -121,7 +130,7 @@ class Function(object):
     def __init__(self, pyfunc, sympy_func=None,
                  arg_units=None, return_unit=None,
                  arg_types=None, return_type=None,
-                 stateless=True):
+                 stateless=True, auto_vectorise=False):
         self.pyfunc = pyfunc
         self.sympy_func = sympy_func
         self._arg_units = arg_units
@@ -133,6 +142,7 @@ class Function(object):
         self._arg_types = arg_types
         self._return_type = return_type
         self.stateless = stateless
+        self.auto_vectorise = auto_vectorise
         if self._arg_units is None:
             if not hasattr(pyfunc, '_arg_units'):
                 raise ValueError(('The Python function "%s" does not specify '
@@ -636,8 +646,8 @@ DEFAULT_FUNCTIONS = {
     'sign': Function(pyfunc=np.sign, sympy_func=sympy.sign, return_type='highest',
                      arg_units=[None], return_unit=1),
     # functions that need special treatment
-    'rand': Function(pyfunc=rand, arg_units=[], return_unit=1, stateless=False),
-    'randn': Function(pyfunc=randn, arg_units=[], return_unit=1, stateless=False),
+    'rand': Function(pyfunc=rand, arg_units=[], return_unit=1, stateless=False, auto_vectorise=True),
+    'randn': Function(pyfunc=randn, arg_units=[], return_unit=1, stateless=False, auto_vectorise=True),
     'clip': Function(pyfunc=np.clip, arg_units=[None, None, None],
                      return_type='highest',
                      return_unit=lambda u1, u2, u3: u1,),

--- a/brian2/core/functions.py
+++ b/brian2/core/functions.py
@@ -370,12 +370,16 @@ class FunctionImplementationContainer(Mapping):
                                                                     compiler_kwds=None)
         else:
             def wrapper_function(*args):
-                if not len(args) == len(self._function._arg_units):
+                arg_units = list(self._function._arg_units)
+
+                if self._function.auto_vectorise:
+                    arg_units += [DIMENSIONLESS]
+                if not len(args) == len(arg_units):
                     raise ValueError(('Function %s got %d arguments, '
                                       'expected %d') % (self._function.pyfunc.__name__, len(args),
-                                                        len(self._function._arg_units)))
+                                                        len(arg_units)))
                 new_args = []
-                for arg, arg_unit in zip(args, self._function._arg_units):
+                for arg, arg_unit in zip(args, arg_units):
                     if arg_unit == bool:
                         new_args.append(arg)
                     else:

--- a/brian2/core/network.py
+++ b/brian2/core/network.py
@@ -865,10 +865,7 @@ class Network(Nameable):
 
         for obj in all_objects:
             if obj.active:
-                try:
-                    obj.before_run(run_namespace)
-                except Exception as ex:
-                    raise brian_object_exception("An error occurred when preparing an object.", obj, ex)
+                obj.before_run(run_namespace)
 
         # Check that no object has been run as part of another network before
         for obj in all_objects:

--- a/brian2/core/network.py
+++ b/brian2/core/network.py
@@ -865,7 +865,10 @@ class Network(Nameable):
 
         for obj in all_objects:
             if obj.active:
-                obj.before_run(run_namespace)
+                try:
+                    obj.before_run(run_namespace)
+                except Exception as ex:
+                    raise brian_object_exception("An error occurred when preparing an object.", obj, ex)
 
         # Check that no object has been run as part of another network before
         for obj in all_objects:

--- a/brian2/core/variables.py
+++ b/brian2/core/variables.py
@@ -634,22 +634,6 @@ class Subexpression(Variable):
         #: The expression defining the subexpression
         self.expr = expr.strip()
 
-        if scalar:
-            from brian2.parsing.sympytools import str_to_sympy
-            # We check here if the corresponding sympy expression contains a
-            # reference to _vectorisation_idx which indicates that an implicitly
-            # vectorized function (e.g. rand() ) has been used. We do not allow
-            # this since it would lead to incorrect results when substituted into
-            # vector equations
-            sympy_expr = str_to_sympy(self.expr)
-            if sympy.Symbol('_vectorisation_idx') in sympy_expr.atoms():
-                raise SyntaxError(('The scalar subexpression %s refers to an '
-                                   'implicitly vectorized function -- this is '
-                                   'not allowed since it leads to different '
-                                   'interpretations of this subexpression '
-                                   'depending on whether it is used in a '
-                                   'scalar or vector context.') % name)
-
         #: The identifiers used in the expression
         self.identifiers = get_identifiers(expr)
 

--- a/brian2/input/binomial.py
+++ b/brian2/input/binomial.py
@@ -183,7 +183,8 @@ class BinomialFunction(Function, Nameable):
                 return np.random.binomial(n, p, size=N)
 
         Function.__init__(self, pyfunc=lambda: sample_function(1),
-                          arg_units=[], return_unit=1, stateless=False)
+                          arg_units=[], return_unit=1, stateless=False,
+                          auto_vectorise=True)
 
         self.implementations.add_implementation('numpy', sample_function)
 

--- a/brian2/parsing/bast.py
+++ b/brian2/parsing/bast.py
@@ -184,7 +184,8 @@ class BrianASTRenderer(object):
             funcvar = self.variables[node.func.id]
             # sometimes this attribute doesn't exist, if so assume it's not stateless
             node.stateless = getattr(funcvar, 'stateless', False)
-            if node.stateless:
+            node.auto_vectorise = getattr(funcvar, 'auto_vectorise', False)
+            if node.stateless and not node.auto_vectorise:
                 node.scalar = logical_all(subnode.scalar for subnode in node.args)
             # check that argument types are valid
             node_arg_types = [subnode.dtype for subnode in node.args]

--- a/brian2/parsing/sympytools.py
+++ b/brian2/parsing/sympytools.py
@@ -154,8 +154,8 @@ def sympy_to_str(sympy_expr):
                              name, c in DEFAULT_CONSTANTS.items()
                              if str(c.sympy_obj) != name))
 
-    # Replace _vectorisation_idx by an empty symbol
-    replacements[sympy.Symbol('_vectorisation_idx')] = sympy.Symbol('')
+    # Replace the placeholder argument by an empty symbol
+    replacements[sympy.Symbol('_placeholder_arg')] = sympy.Symbol('')
     atoms = (sympy_expr.atoms() |
              {f.func for f in sympy_expr.atoms(sympy.Function)})
     for old, new in replacements.items():

--- a/brian2/synapses/parse_synaptic_generator_syntax.py
+++ b/brian2/synapses/parse_synaptic_generator_syntax.py
@@ -108,7 +108,7 @@ def parse_synapse_generator(expr):
         Dictionary of key/value pairs representing the keywords. See
         `handle_range` and `handle_sample`.
     '''
-    nr = NodeRenderer(use_vectorisation_idx=False)
+    nr = NodeRenderer()
     parse_error = ("Error parsing expression '%s'. Expression must have "
                    "generator syntax, for example 'k for k in range(i-10, "
                    "i+10)'." % expr)

--- a/brian2/tests/test_functions.py
+++ b/brian2/tests/test_functions.py
@@ -896,6 +896,27 @@ def test_binomial():
     assert np.var(mon[0].y) > 0
 
 
+@attr('standalone-compatible')
+@with_setup(teardown=reinit_devices)
+def test_poisson():
+    # Just check that it does not raise an error and that it produces some
+    # values
+    G = NeuronGroup(5, '''l : 1
+                          x : integer
+                          y : integer
+                          z : integer
+                          ''')
+    G.l = [0, 1, 5, 15, 25]
+    G.run_regularly('''x = poisson(l)
+                       y = poisson(5)
+                       z = poisson(0)''')
+    mon = StateMonitor(G, ['x', 'y', 'z'], record=True)
+    run(100*defaultclock.dt)
+    assert_equal(mon.x[0], 0)
+    assert all(np.var(mon.x[1:], axis=1) > 0)
+    assert all(np.var(mon.y, axis=1) > 0)
+    assert_equal(mon.z, 0)
+
 def test_declare_types():
     if prefs.codegen.target != 'numpy':
         raise SkipTest('numpy-only test')
@@ -1003,6 +1024,7 @@ if __name__ == '__main__':
             test_function_dependencies_cython,
             test_repeated_function_dependencies,
             test_binomial,
+            test_poisson,
             test_declare_types,
             test_multiple_stateless_function_calls,
             ]:

--- a/brian2/tests/test_functions.py
+++ b/brian2/tests/test_functions.py
@@ -798,6 +798,39 @@ def test_function_dependencies_weave():
     assert_allclose(G.v_[:], 84*0.001)
 
 
+def test_function_dependencies_weave_rename():
+    if prefs.codegen.target != 'weave':
+        raise SkipTest('weave-only test')
+
+    @implementation('cpp', '''
+    float _foo(float x)
+    {
+        return 42*0.001;
+    }''', name='_foo')
+    @check_units(x=volt, result=volt)
+    def foo(x):
+        return 42*mV
+
+    # Second function with an independent implementation for numpy and an
+    # implementation for C++ that makes use of the previous function.
+
+    @implementation('cpp', '''
+    float bar(float x)
+    {
+        return 2*my_foo(x);
+    }''', dependencies={'my_foo': foo})
+    @check_units(x=volt, result=volt)
+    def bar(x):
+        return 84*mV
+
+    G = NeuronGroup(5, 'v : volt')
+    G.run_regularly('v = bar(v)')
+    net = Network(G)
+    net.run(defaultclock.dt)
+
+    assert_allclose(G.v_[:], 84*0.001)
+
+
 def test_function_dependencies_cython():
     if prefs.codegen.target != 'cython':
         raise SkipTest('cython-only test')
@@ -828,6 +861,36 @@ def test_function_dependencies_cython():
 
     assert_allclose(G.v_[:], 84*0.001)
 
+
+def test_function_dependencies_cython_rename():
+    if prefs.codegen.target != 'cython':
+        raise SkipTest('cython-only test')
+
+    @implementation('cython', '''
+    cdef float _foo(float x):
+        return 42*0.001
+    ''', name='_foo')
+    @check_units(x=volt, result=volt)
+    def foo(x):
+        return 42*mV
+
+    # Second function with an independent implementation for numpy and an
+    # implementation for C++ that makes use of the previous function.
+
+    @implementation('cython', '''
+    cdef float bar(float x):
+        return 2*my_foo(x)
+    ''', dependencies={'my_foo': foo})
+    @check_units(x=volt, result=volt)
+    def bar(x):
+        return 84*mV
+
+    G = NeuronGroup(5, 'v : volt')
+    G.run_regularly('v = bar(v)')
+    net = Network(G)
+    net.run(defaultclock.dt)
+
+    assert_allclose(G.v_[:], 84*0.001)
 
 def test_function_dependencies_numpy():
     if prefs.codegen.target != 'numpy':
@@ -1021,7 +1084,9 @@ if __name__ == '__main__':
             test_function_implementation_container,
             test_function_dependencies_numpy,
             test_function_dependencies_weave,
+            test_function_dependencies_weave_rename,
             test_function_dependencies_cython,
+            test_function_dependencies_cython_rename,
             test_repeated_function_dependencies,
             test_binomial,
             test_poisson,

--- a/brian2/tests/test_neurongroup.py
+++ b/brian2/tests/test_neurongroup.py
@@ -1147,7 +1147,11 @@ def test_scalar_subexpression():
                                                           sub = freq + array*Hz : Hz (shared)'''))
 
     # A scalar subexpresion cannot refer to implicitly vectorized functions
-    assert_raises(SyntaxError, lambda: NeuronGroup(10, 'sub = rand() : 1 (shared)'))
+    group = NeuronGroup(10, '''x : 1
+                               sub = rand() : 1 (shared)''')
+    group.run_regularly('x = sub')
+    net = Network(group)
+    assert_raises(SyntaxError, net.run, 0*ms)
 
 @attr('standalone-compatible')
 @with_setup(teardown=reinit_devices)

--- a/brian2/tests/test_stateupdaters.py
+++ b/brian2/tests/test_stateupdaters.py
@@ -128,22 +128,20 @@ def restore_randn():
     DEFAULT_FUNCTIONS['randn'] = old_randn
 
 # The "random" values are always 0.5
-@implementation('cpp',
-                '''
-                double randn(int vectorisation_idx)
-                {
-                    return 0.5;
-                }
-                ''')
-@implementation('cython',
-                '''
-                cdef double randn(int vectorisation_idx):
-                    return 0.5
-                ''')
-@check_units(N=Unit(1), result=Unit(1))
-def fake_randn(N):
-    return 0.5*np.ones_like(N)
-fake_randn.auto_vectorise = True
+def fake_randn(vectorisation_idx):
+    return 0.5*np.ones_like(vectorisation_idx)
+fake_randn = Function(fake_randn, arg_units=[], return_unit=1, auto_vectorise=True,
+                      stateless=False)
+fake_randn.implementations.add_implementation('cpp', '''
+                                              double randn(int vectorisation_idx)
+                                              {
+                                                  return 0.5;
+                                              }
+                                              ''')
+fake_randn.implementations.add_implementation('cython','''
+                                    cdef double randn(int vectorisation_idx):
+                                        return 0.5
+                                    ''')
 
 @with_setup(setup=store_randn, teardown=restore_randn)
 def test_multiple_noise_variables_deterministic_noise():

--- a/brian2/tests/test_stateupdaters.py
+++ b/brian2/tests/test_stateupdaters.py
@@ -142,7 +142,8 @@ def restore_randn():
                 ''')
 @check_units(N=Unit(1), result=Unit(1))
 def fake_randn(N):
-    return 0.5*ones(N)
+    return 0.5*np.ones_like(N)
+fake_randn.auto_vectorise = True
 
 @with_setup(setup=store_randn, teardown=restore_randn)
 def test_multiple_noise_variables_deterministic_noise():

--- a/docs_sphinx/advanced/functions.rst
+++ b/docs_sphinx/advanced/functions.rst
@@ -25,7 +25,7 @@ ready for use:
 * Random numbers: ``rand`` (random numbers drawn from a uniform distribution
   between 0 and 1), ``randn`` (random numbers drawn from the standard normal
   distribution, i.e. with mean 0 and standard deviation 1),
-  and ``poisson` (discrete random numbers from a Poisson distribution with rate
+  and ``poisson`` (discrete random numbers from a Poisson distribution with rate
   parameter :math:`\lambda`)
 * Elementary functions: ``sqrt``, ``exp``, ``log``, ``log10``, ``abs``, ``sign``
 * Trigonometric functions: ``sin``, ``cos``, ``tan``, ``sinh``, ``cosh``,
@@ -33,7 +33,7 @@ ready for use:
 * General utility functions: ``clip``, ``floor``, ``ceil``
 
 Brian also provides a special purpose function ``int``, which can be used to
-convert a an expression or variable into an integer value. This is especially
+convert an expression or variable into an integer value. This is especially
 useful for boolean values (which will be converted into 0 or 1), for example to
 have a conditional evaluation as part of an equation or statement which
 sometimes allows to circumvent the lack of an ``if`` statement. For


### PR DESCRIPTION
This will need a bit of explanation...

When the user includes a call to `rand()` or `randn()` in the code, the generated code will be actually `rand(vectorisation_idx)`. This is necessary for the numpy target, because we have to know how many random numbers the function call should return. `vectorisation_idx` will be an array of all neuron indices e.g. in the state updater, but only a subset of the indices when used as part of e.g. the reset. In C-based code generation targets, `vectorisation_idx` will always be a single (e.g. neuron) index, which could be potentially useful to generate the same random numbers independent of execution order in OpenMP. This is not implemented yet, though, so C-based targets simply ignore this argument.

Note that an alternative solution to this issue would have been to require calls such as `rand(i)` (where `i` refers to the neuron index) instead of `rand()`, but this would have been ugly, confusing and prone to errors, and also not straightforward to do in synaptic contexts (there is no global "synapse index").

So what we did was instead to translate all calls to function without arguments, to one with the `vectorisation_idx` argument. This worked ok, but was also constraining: it was impossible to have functions that return arrays of values (in numpy), without at the same time having at least one argument that was a vector. For most functions that wouldn't be an issue, because only scalar arguments would also mean that the return value (vector or not) would be identical for all neurons. However, there is a very relevant category of functions where it *is* a problem, i.e. random number generators that take an additional argument. For binomial functions, we somewhat worked around it by having the user create a function object outside of the code with fixed distribution parameters, this special `my_binomial` function could then be called without parameters in the code. This of course only works if the parameters can be fixed in advance (as we require for `PoissonInput`).

In this PR, I implemented a slightly more general but generally backwards-compatible system (Brian2GeNN needs a small fix, though): `Function` objects have an additional attribute `auto_vectorize`, which states that `vectorisation_idx` should be added as an additional argument. This can be used for argumentless functions like `rand`, but also for functions that take an argument.

As part of this PR, I also added a `poisson` (cf. #1107) function which makes use of this system. The user writes `poisson(lambda_value)`, but the generated code will be `poisson(lambda_value, vectorisation_idx)`. The implementation for numpy uses numpy's function, and the C-based target basically use a copy&pasted version of numpy's underlying C code. I briefly considered using the GSL instead, but I did not quite see how to integrate it with our system for setting seeds. Maybe let's discuss about this aspect and which other random distributions we should support in #1107?