### PR TITLE
[MRG] Fix an issue with indexing in `PopulationRateMonitor`

### DIFF
--- a/brian2/codegen/runtime/cython_rt/templates/ratemonitor.pyx
+++ b/brian2/codegen/runtime/cython_rt/templates/ratemonitor.pyx
@@ -1,7 +1,7 @@
 {% extends 'common.pyx' %}
 
 {% block maincode %}
-    {# USES_VARIABLES { t, rate, _clock_t, _clock_dt, _spikespace,
+    {# USES_VARIABLES { N, t, rate, _clock_t, _clock_dt, _spikespace,
                         _num_source_neurons, _source_start, _source_stop } #}
 
     cdef int _num_spikes = {{_spikespace}}[_num{{_spikespace}}-1]
@@ -32,6 +32,7 @@
 
     # Resize the arrays
     _owner.resize(_new_len)
+    {{N}} = _new_len
 
     # Set the new values
     {{_dynamic_t}}.data[_new_len-1] = {{_clock_t}}

--- a/brian2/codegen/runtime/numpy_rt/templates/ratemonitor.py_
+++ b/brian2/codegen/runtime/numpy_rt/templates/ratemonitor.py_
@@ -7,5 +7,6 @@ _spikes = {{_spikespace}}[:{{_spikespace}}[-1]]
 _spikes = _spikes[(_spikes >= _source_start) & (_spikes < _source_stop)]
 _new_len = {{N}} + 1
 _owner.resize(_new_len)
+{{N}} = _new_len
 {{_dynamic_t}}[-1] = {{_clock_t}}
 {{_dynamic_rate}}[-1] = 1.0 * len(_spikes) / {{_clock_dt}} / _num_source_neurons

--- a/brian2/codegen/runtime/weave_rt/templates/ratemonitor.cpp
+++ b/brian2/codegen/runtime/weave_rt/templates/ratemonitor.cpp
@@ -1,7 +1,7 @@
 {% import 'common_macros.cpp' as common with context %}
 {% macro main() %}
     {{ common.insert_group_preamble() }}
-    {# USES_VARIABLES { t, rate, _clock_t, _clock_dt, _spikespace,
+    {# USES_VARIABLES { N, t, rate, _clock_t, _clock_dt, _spikespace,
                         _num_source_neurons, _source_start, _source_stop } #}
 	int _num_spikes = {{_spikespace}}[_num_spikespace-1];
     // For subgroups, we do not want to record all spikes
@@ -42,7 +42,7 @@
     //Set the new values
     t_data[_new_len - 1] = {{_clock_t}};
     rate_data[_new_len - 1] = 1.0 * _num_spikes / {{_clock_dt}} / _num_source_neurons;
-
+    {{N}} = _new_len;
 {% endmacro %}
 
 {% macro support_code() %}

--- a/brian2/devices/cpp_standalone/templates/ratemonitor.cpp
+++ b/brian2/devices/cpp_standalone/templates/ratemonitor.cpp
@@ -1,9 +1,9 @@
 {% extends 'common_group.cpp' %}
 
 {% block maincode %}
-	{# USES_VARIABLES { rate, t, _spikespace, _clock_t, _clock_dt,
+	{# USES_VARIABLES { N, rate, t, _spikespace, _clock_t, _clock_dt,
 	                    _num_source_neurons, _source_start, _source_stop } #}
-
+    {# WRITES_TO_READ_ONLY_VARIABLES { N } #}
 	int _num_spikes = {{_spikespace}}[_num_spikespace-1];
 	// For subgroups, we do not want to record all spikes
     // We assume that spikes are ordered
@@ -32,5 +32,6 @@
     _num_spikes = _end_idx - _start_idx;
     {{_dynamic_rate}}.push_back(1.0*_num_spikes/{{_clock_dt}}/_num_source_neurons);
     {{_dynamic_t}}.push_back({{_clock_t}});
+    {{N}}++;
 {% endblock %}
 

--- a/brian2/monitors/ratemonitor.py
+++ b/brian2/monitors/ratemonitor.py
@@ -74,7 +74,9 @@ class PopulationRateMonitor(Group, CodeRunner):
         self._enable_group_attributes()
 
     def resize(self, new_size):
-        self.variables['N'].set_value(new_size)
+        # Note that this does not set N, this has to be done in the template
+        # since we use a restricted pointer to access it (which promises that
+        # we only change the value through this pointer)
         self.variables['rate'].resize(new_size)
         self.variables['t'].resize(new_size)
 

--- a/brian2/tests/test_monitor.py
+++ b/brian2/tests/test_monitor.py
@@ -57,6 +57,10 @@ def test_spike_monitor():
     assert_raises(KeyError, lambda: spike_trains[-1])
     assert_raises(KeyError, lambda: spike_trains['string'])
 
+    # Check that indexing into the VariableView works (this fails if we do not
+    # update the N variable correctly)
+    assert_allclose(mon.t[:5], [0.9, 1.9, 2.9, 3.9, 4.9]*ms)
+
 
 def test_spike_monitor_indexing():
     generator = SpikeGeneratorGroup(3, [0, 0, 0, 1], [0, 1, 2, 1]*ms)
@@ -433,8 +437,12 @@ def test_rate_monitor_1():
 
     assert_allclose(rate_mon.t, np.arange(10) * defaultclock.dt)
     assert_allclose(rate_mon.t_, np.arange(10) * defaultclock.dt_)
+    assert_allclose(rate_mon.t, np.arange(10) * defaultclock.dt)
     assert_allclose(rate_mon.rate, np.ones(10) / defaultclock.dt)
     assert_allclose(rate_mon.rate_, np.asarray(np.ones(10) / defaultclock.dt_))
+    # Check that indexing into the VariableView works (this fails if we do not
+    # update the N variable correctly)
+    assert_allclose(rate_mon.t[:5], np.arange(5) * defaultclock.dt)
 
 @attr('standalone-compatible')
 @with_setup(teardown=reinit_and_delete)


### PR DESCRIPTION
In C++-based targets, the stored length of the recorded timepoints/rates were not correctly updated. Indexing with slices would then return empty arrays. The fix is the same as we did a while ago for `SpikeMonitor`: update "N" (the total number of time points/rates stored) from within
the template code.

The issue is only triggered in standalone mode, although for consistency the change has to be made everywhere. It can be reproduced with something like this:
```pycon
>>> from brian2 import *
>>> set_device('cpp_standalone')
>>> group = PoissonGroup(10, rates=100*Hz)
>>> mon = PopulationRateMonitor(group)
>>> run(1*ms)
>>> mon.t
<ratemonitor.t: array([0. , 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9]) * msecond>
>>> mon.t[:5]
array([], dtype=float64) * second
```
There are easy workarounds (e.g. `mon.t[:][:5]` would work), but of course this should work correctly in the first place.