### PR TITLE
[MRG] Restore random state

### DIFF
--- a/brian2/core/magic.py
+++ b/brian2/core/magic.py
@@ -239,12 +239,14 @@ class MagicNetwork(Network):
         super(MagicNetwork, self).store(name=name, filename=filename)
         self.objects.clear()
 
-    def restore(self, name='default', filename=None, level=0):
+    def restore(self, name='default', filename=None, restore_random_state=False,
+                level=0):
         '''
-        See `Network.store`.
+        See `Network.restore`.
         '''
         self._update_magic_objects(level=level+1)
-        super(MagicNetwork, self).restore(name=name, filename=filename)
+        super(MagicNetwork, self).restore(name=name, filename=filename,
+                                          restore_random_state=restore_random_state)
         self.objects.clear()
 
     def get_states(self, units=True, format='dict', subexpressions=False,
@@ -392,7 +394,7 @@ def store(name='default', filename=None):
     magic_network.store(name=name, filename=filename, level=1)
 
 
-def restore(name='default', filename=None):
+def restore(name='default', filename=None, restore_random_state=False):
     '''
     Restore the state of the network and all included objects.
 
@@ -406,12 +408,22 @@ def restore(name='default', filename=None):
         not specified, it is expected that the state exist in memory
         (i.e. `Network.store` was previously called without the ``filename``
         argument).
-
+    restore_random_state : bool, optional
+        Whether to restore the state of the random number generator. If set
+        to ``True``, going back to an earlier state of the simulation will
+        continue exactly where it left off, even if the simulation is
+        stochastic. If set to ``False`` (the default), random numbers are
+        independent between runs (except for explicitly set random seeds),
+        regardless of whether `store`/`restore` has been used or not. Note
+        that this also restores numpy's random number generator (since it is
+        used internally by Brian), but it does *not* restore Python's
+        builtin random number generator in the ``random`` module.
     See Also
     --------
     Network.restore
     '''
-    magic_network.restore(name=name, filename=filename, level=1)
+    magic_network.restore(name=name, filename=filename,
+                          restore_random_state=restore_random_state, level=1)
 
 
 def stop():

--- a/brian2/core/network.py
+++ b/brian2/core/network.py
@@ -23,7 +23,7 @@ from brian2.utils.logger import get_logger
 from brian2.core.names import Nameable
 from brian2.core.base import BrianObject, brian_object_exception
 from brian2.core.clocks import Clock, defaultclock
-from brian2.devices.device import get_device, all_devices
+from brian2.devices.device import get_device, all_devices, RuntimeDevice
 from brian2.groups.group import Group
 from brian2.units.fundamentalunits import check_units, Quantity
 from brian2.units.allunits import second, msecond
@@ -411,7 +411,7 @@ class Network(Nameable):
     @property
     def profiling_info(self):
         '''
-        The time spent in executing the various `CodeObject`\ s.
+        The time spent in executing the various `CodeObject` s.
 
         A list of ``(name, time)`` tuples, containing the name of the
         `CodeObject` and the total execution time for simulations of this object
@@ -571,6 +571,10 @@ class Network(Nameable):
             clock._set_t_update_dt(target_t=self.t)
 
         state = self._full_state()
+        # Store the state of the random number generator
+        dev = get_device()
+        state['_random_generator_state'] = dev.get_random_state()
+
         if filename is None:
             self._stored_state[name] = state
         else:
@@ -587,9 +591,10 @@ class Network(Nameable):
                 pickle.dump(store_state, f, protocol=pickle.HIGHEST_PROTOCOL)
 
     @device_override('network_restore')
-    def restore(self, name='default', filename=None):
+    def restore(self, name='default', filename=None,
+                restore_random_state=False):
         '''
-        restore(name='default', filename=None)
+        restore(name='default', filename=None, restore_random_state=False)
 
         Retore the state of the network and all included objects.
 
@@ -603,6 +608,16 @@ class Network(Nameable):
             not specified, it is expected that the state exist in memory
             (i.e. `Network.store` was previously called without the ``filename``
             argument).
+        restore_random_state : bool, optional
+            Whether to restore the state of the random number generator. If set
+            to ``True``, going back to an earlier state of the simulation will
+            continue exactly where it left off, even if the simulation is
+            stochastic. If set to ``False`` (the default), random numbers are
+            independent between runs (except for explicitly set random seeds),
+            regardless of whether `store`/`restore` has been used or not. Note
+            that this also restores numpy's random number generator (since it is
+            used internally by Brian), but it does *not* restore Python's
+            builtin random number generator in the ``random`` module.
         '''
         all_objects = _get_all_objects(self.objects)
         if filename is None:
@@ -611,6 +626,9 @@ class Network(Nameable):
             with open(filename, 'rb') as f:
                 state = pickle.load(f)[name]
         self.t_ = state['0_t']
+        if restore_random_state:
+            dev = get_device()
+            dev.set_random_state(state['_random_generator_state'])
         clocks = {obj.clock for obj in all_objects}
         restored_objects = set()
         for obj in all_objects:
@@ -626,7 +644,8 @@ class Network(Nameable):
             clock._restore_from_full_state(state[clock.name])
         clock_names = {c.name for c in clocks}
 
-        unnused = set(state.keys()) - restored_objects - clock_names - {'0_t'}
+        unnused = (set(state.keys()) - restored_objects - clock_names -
+                   {'0_t', '_random_generator_state'})
         if len(unnused):
             raise KeyError('The stored state contains the state of the '
                            'following objects which were not present in the '

--- a/brian2/devices/device.py
+++ b/brian2/devices/device.py
@@ -75,6 +75,7 @@ def auto_target():
 
     return _auto_target
 
+
 class Device(object):
     '''
     Base Device object.
@@ -390,6 +391,36 @@ class Device(object):
         '''
         pass
 
+    def get_random_state(self):
+        '''
+        Return a (pickable) representation of the current random number
+        generator state. Providing the returned object (e.g. a dict) to
+        `.Device.set_random_state` should restore the random number generator
+        state.
+
+        Returns
+        -------
+        state
+            The state of the random number generator in a representation
+            that can be passed as an argument to `.Device.set_random_state`.
+        '''
+        raise NotImplementedError('Device does not support getting the state '
+                                  'of the random number generator.')
+
+    def set_random_state(self, state):
+        '''
+        Reset the random number generator state to a previously stored state
+        (see `.Device.get_random_state`).
+
+        Parameters
+        ----------
+        state
+            A random number generator state as provided by
+            `Device.get_random_state`.
+        '''
+        raise NotImplementedError('Device does not support setting the state '
+                                  'of the random number generator.')
+
 
 class RuntimeDevice(Device):
     '''
@@ -487,6 +518,21 @@ class RuntimeDevice(Device):
         np.random.seed(seed)
         self.rand_buffer_index[:] = 0
         self.randn_buffer_index[:] = 0
+
+    def get_random_state(self):
+        return {'numpy_state': np.random.get_state(),
+                'rand_buffer_index': np.array(self.rand_buffer_index),
+                'rand_buffer': np.array(self.rand_buffer),
+                'randn_buffer_index': np.array(self.randn_buffer_index),
+                'randn_buffer': np.array(self.randn_buffer)
+                }
+
+    def set_random_state(self, state):
+        np.random.set_state(state['numpy_state'])
+        self.rand_buffer_index[:] = state['rand_buffer_index']
+        self.rand_buffer[:] = state['rand_buffer']
+        self.randn_buffer_index[:] = state['randn_buffer_index']
+        self.randn_buffer[:] = state['randn_buffer']
 
 
 class Dummy(object):


### PR DESCRIPTION
[Note that this is currently built on top of the pytest branch, so don't merge it as it is]

During the discussion in #1124 I realized that our store/restore mechanism could be even more powerful with a little added feature. Currently, it restores the full network state but not the state of the random number generator. This is often what you want, e.g. to run a stochastic sampling of the same simulation. However, there are also situations (like the one by the user in #1124), where you *do* want to restore the state so that a simulation can be reproduced exactly starting at a snapshot point. This feature isn't difficult to add, so I made two changes:
* The  `store()` call always stores the random number generator state (including the buffer, that's on the order of a couple of KB, so negligible space-/memory-wise)
* The `restore()` call has an optional argument `restore_random_state` that is `False` by default (to keep backwards compatibility), but if set to `True`, restores the full state of the random number generator, including its buffer.