### PR TITLE
[MRG] Fix compatibility with Python 3.8

### DIFF
--- a/brian2/codegen/optimisation.py
+++ b/brian2/codegen/optimisation.py
@@ -44,6 +44,15 @@ def expression_complexity(expr, variables):
     return brian_ast(expr, variables).complexity
 
 
+def get_value(node):
+    '''Helper function to mask differences between Python versions'''
+    value = getattr(node, 'n', getattr(node, 'value', None))
+    if value is None:
+        raise AttributeError('Node {} has neither "n" nor "value" '
+                             'attribute'.format(node))
+    return value
+
+
 def optimise_statements(scalar_statements, vector_statements, variables, blockname=''):
     '''
     Optimise a sequence of scalar and vector statements
@@ -151,9 +160,9 @@ def _replace_with_zero(zero_node, node):
     # e.g. handle 0/float->0.0 and 0.0/int->0.0
     zero_node.dtype = node.dtype
     if node.dtype == 'integer':
-        zero_node.n = 0
+        zero_node.value = 0
     else:
-        zero_node.n = prefs.core.default_float_dtype(0.0)
+        zero_node.value = prefs.core.default_float_dtype(0.0)
     return zero_node
 
 
@@ -190,7 +199,8 @@ class ArithmeticSimplifier(BrianASTRenderer):
         if not node.scalar:
             return node
         # No evaluation necessary for simple names or numbers
-        if node.__class__.__name__ in ['Name', 'NameConstant', 'Num']:
+        if node.__class__.__name__ in ['Name', 'NameConstant', 'Num',
+                                       'Constant']:
             return node
         # Don't evaluate stateful nodes (e.g. those containing a rand() call)
         if not node.stateless:
@@ -201,7 +211,9 @@ class ArithmeticSimplifier(BrianASTRenderer):
         if evaluated:
             if node.dtype == 'boolean':
                 val = bool(val)
-                if hasattr(ast, 'NameConstant'):
+                if hasattr(ast, 'Constant'):
+                    newnode = ast.Constant(val)
+                elif hasattr(ast, 'NameConstant'):
                     newnode = ast.NameConstant(val)
                 else:
                     # None is the expression context, we don't use it so we just set to None
@@ -211,7 +223,10 @@ class ArithmeticSimplifier(BrianASTRenderer):
             else:
                 val = prefs.core.default_float_dtype(val)
             if node.dtype != 'boolean':
-                newnode = ast.Num(val)
+                if hasattr(ast, 'Constant'):
+                    newnode = ast.Constant(val)
+                else:
+                    newnode = ast.Num(val)
             newnode.dtype = node.dtype
             newnode.scalar = True
             newnode.stateless = node.stateless
@@ -233,27 +248,28 @@ class ArithmeticSimplifier(BrianASTRenderer):
         if op.__class__.__name__ == 'Mult':
             for operand, other in [(left, right),
                                    (right, left)]:
-                if operand.__class__.__name__ == 'Num':
-                    if operand.n == 0:
+                if operand.__class__.__name__ in ['Num', 'Constant']:
+                    op_value = get_value(operand)
+                    if op_value == 0:
                         # Do not remove stateful functions
                         if node.stateless:
                             return _replace_with_zero(operand, node)
-                    if operand.n==1:
+                    if op_value == 1:
                         # only simplify this if the type wouldn't be cast by the operation
                         if dtype_hierarchy[operand.dtype] <= dtype_hierarchy[other.dtype]:
                             return other
         # Handle division by 1, or 0/x
         elif op.__class__.__name__ == 'Div':
-            if left.__class__.__name__ == 'Num' and left.n == 0:  # 0/x
+            if left.__class__.__name__ in ['Num', 'Constant'] and get_value(left) == 0:  # 0/x
                 if node.stateless:
                     # Do not remove stateful functions
                     return _replace_with_zero(left, node)
-            if right.__class__.__name__ == 'Num' and right.n == 1:  # x/1
+            if right.__class__.__name__ in ['Num', 'Constant'] and get_value(right) == 1:  # x/1
                 # only simplify this if the type wouldn't be cast by the operation
                 if dtype_hierarchy[right.dtype] <= dtype_hierarchy[left.dtype]:
                     return left
         elif op.__class__.__name__ == 'FloorDiv':
-            if left.__class__.__name__ == 'Num' and left.n == 0:  # 0//x
+            if left.__class__.__name__ in ['Num', 'Constant'] and get_value(left) == 0:  # 0//x
                 if node.stateless:
                     # Do not remove stateful functions
                     return _replace_with_zero(left, node)
@@ -261,19 +277,19 @@ class ArithmeticSimplifier(BrianASTRenderer):
             # for floating point values, floor division by 1 changes the value,
             # and division by 1.0 can change the type for an integer value
             if (left.dtype == right.dtype == 'integer' and
-                    right.__class__.__name__ == 'Num' and right.n == 1):  # x//1
+                    right.__class__.__name__ in ['Num', 'Constant'] and get_value(right) == 1):  # x//1
                     return left
         # Handle addition of 0
         elif op.__class__.__name__ == 'Add':
             for operand, other in [(left, right),
                                    (right, left)]:
-                if operand.__class__.__name__ == 'Num' and operand.n == 0:
+                if operand.__class__.__name__ in ['Num', 'Constant'] and get_value(operand) == 0:
                     # only simplify this if the type wouldn't be cast by the operation
                     if dtype_hierarchy[operand.dtype]<=dtype_hierarchy[other.dtype]:
                         return other
         # Handle subtraction of 0
         elif op.__class__.__name__ == 'Sub':
-            if right.__class__.__name__ == 'Num' and right.n == 0:
+            if right.__class__.__name__ in ['Num', 'Constant'] and get_value(right) == 0:
                 # only simplify this if the type wouldn't be cast by the operation
                 if dtype_hierarchy[right.dtype]<=dtype_hierarchy[left.dtype]:
                     return left
@@ -282,9 +298,11 @@ class ArithmeticSimplifier(BrianASTRenderer):
         # but might be useful for some codegen targets
         if node.dtype=='float' and op.__class__.__name__ in ['Mult', 'Add', 'Sub', 'Div']:
             for subnode in [node.left, node.right]:
-                if subnode.__class__.__name__ == 'Num':
+                if (subnode.__class__.__name__ in ['Num', 'Constant'] and
+                        not (get_value(subnode) is True or
+                             get_value(subnode) is False)):
                     subnode.dtype = 'float'
-                    subnode.n = prefs.core.default_float_dtype(subnode.n)
+                    subnode.value = prefs.core.default_float_dtype(get_value(subnode))
         return node
 
 
@@ -316,7 +334,7 @@ class Simplifier(BrianASTRenderer):
         BrianASTRenderer.__init__(self, variables, copy_variables=False)
         self.loop_invariants = OrderedDict()
         self.loop_invariant_dtypes = {}
-        self.n = 0
+        self.value = 0
         self.node_renderer = NodeRenderer()
         self.arithmetic_simplifier = ArithmeticSimplifier(variables)
         self.scalar_statements = scalar_statements
@@ -342,8 +360,8 @@ class Simplifier(BrianASTRenderer):
             if expr in self.loop_invariants:
                 name = self.loop_invariants[expr]
             else:
-                self.n += 1
-                name = '_lio_'+self.extra_lio_prefix+str(self.n)
+                self.value += 1
+                name = '_lio_'+self.extra_lio_prefix+str(self.value)
                 self.loop_invariants[expr] = name
                 self.loop_invariant_dtypes[name] = node.dtype
                 numpy_dtype = {'boolean': bool,
@@ -379,12 +397,12 @@ def reduced_node(terms, op):
     Examples
     --------
     >>> import ast
-    >>> nodes = [ast.Name(id='x'), ast.Num(n=3), ast.Name(id='y')]
+    >>> nodes = [ast.Name(id='x'), ast.Name(id='y'), ast.Name(id='z')]
     >>> ast.dump(reduced_node(nodes, ast.Mult), annotate_fields=False)
-    "BinOp(BinOp(Name('x'), Mult(), Num(3)), Mult(), Name('y'))"
-    >>> nodes = [ast.Num(n=17.0)]
+    "BinOp(BinOp(Name('x'), Mult(), Name('y')), Mult(), Name('z'))"
+    >>> nodes = [ast.Name(id='x')]
     >>> ast.dump(reduced_node(nodes, ast.Add), annotate_fields=False)
-    'Num(17.0)'
+    "Name('x')"
     '''
     # Remove None terms
     terms = [term for term in terms if term is not None]
@@ -498,19 +516,26 @@ def collect(node):
     remaining_terms_primary = []
     remaining_terms_inverted = []
     for term in terms_primary:
-        if term.__class__.__name__=='Num':
+        if term.__class__.__name__ == 'Num':
             x = op_py_primary(x, term.n)
+        elif term.__class__.__name__ == 'Constant':
+            x = op_py_primary(x, term.value)
         else:
             remaining_terms_primary.append(term)
     for term in terms_inverted:
-        if term.__class__.__name__=='Num':
+        if term.__class__.__name__ == 'Num':
             x = op_py_inverted(x, term.n)
+        elif term.__class__.__name__ == 'Constant':
+            x = op_py_inverted(x, term.value)
         else:
             remaining_terms_inverted.append(term)
     # if the fully evaluated node is just the identity/null element then we
     # don't have to make it into an explicit term
     if x != op_null:
-        num_node = ast.Num(x)
+        if hasattr(ast, 'Constant'):
+            num_node = ast.Constant(x)
+        else:
+            num_node = ast.Num(x)
     else:
         num_node = None
     terms_primary = remaining_terms_primary
@@ -530,11 +555,17 @@ def collect(node):
         node = reduced_node([node, prod_primary], op_primary)
         if prod_inverted is not None:
             if node is None:
-                node = ast.Num(op_null_with_dtype)
+                if hasattr(ast, 'Constant'):
+                    node = ast.Constant(op_null_with_dtype)
+                else:
+                    node = ast.Num(op_null_with_dtype)
             node = ast.BinOp(node, op_inverted(), prod_inverted)
 
     if node is None:  # everything cancelled
-        node = ast.Num(op_null_with_dtype)
+        if hasattr(ast, 'Constant'):
+            node = ast.Constant(op_null_with_dtype)
+        else:
+            node = ast.Num(op_null_with_dtype)
     if hasattr(node, 'dtype') and dtype_hierarchy[node.dtype]<dtype_hierarchy[orignode_dtype]:
         node = ast.BinOp(ast.Num(op_null_with_dtype), op_primary(), node)
     node.collected = True

--- a/brian2/devices/cpp_standalone/device.py
+++ b/brian2/devices/cpp_standalone/device.py
@@ -9,7 +9,7 @@ import subprocess
 import sys
 import inspect
 import struct
-from collections import defaultdict, Counter, Mapping
+from collections import defaultdict, Counter
 import itertools
 import numbers
 import tempfile

--- a/brian2/equations/codestrings.py
+++ b/brian2/equations/codestrings.py
@@ -4,7 +4,10 @@ information about its namespace. Only serves as a parent class, its subclasses
 `Expression` and `Statements` are the ones that are actually used.
 '''
 from __future__ import absolute_import
-import collections
+try:
+    from collections.abc import Hashable
+except ImportError:
+    from collections import Hashable
 
 import sympy
 
@@ -17,7 +20,7 @@ __all__ = ['Expression', 'Statements']
 logger = get_logger(__name__)
 
 
-class CodeString(collections.Hashable):
+class CodeString(Hashable):
     '''
     A class for representing "code strings", i.e. a single Python expression
     or a sequence of Python statements.

--- a/brian2/equations/equations.py
+++ b/brian2/equations/equations.py
@@ -2,11 +2,10 @@ from __future__ import absolute_import
 '''
 Differential equations for Brian models.
 '''
-import collections
 try:
-    from collections.abc import Mapping
+    from collections.abc import Mapping, Hashable
 except ImportError:  # Python 2
-    from collections import Mapping
+    from collections import Mapping, Hashable
 import keyword
 import re
 import string
@@ -387,7 +386,7 @@ def parse_string_equations(eqns):
     return equations
 
 
-class SingleEquation(collections.Hashable, CacheKey):
+class SingleEquation(Hashable, CacheKey):
     '''
     Class for internal use, encapsulates a single equation or parameter.
 
@@ -528,7 +527,7 @@ class SingleEquation(collections.Hashable, CacheKey):
         return '$' + sympy.latex(self) + '$'
 
 
-class Equations(collections.Hashable, Mapping):
+class Equations(Hashable, Mapping):
     """
     Container that stores equations from which models can be created.
     

--- a/brian2/parsing/bast.py
+++ b/brian2/parsing/bast.py
@@ -11,7 +11,7 @@ import weakref
 import numpy
 from builtins import all as logical_all  # defensive programming against numpy import
 
-from brian2.parsing.rendering import NodeRenderer
+from brian2.parsing.rendering import NodeRenderer, get_node_value
 from brian2.utils.logger import get_logger
 
 __all__ = ['brian_ast', 'BrianASTRenderer', 'dtype_hierarchy']
@@ -81,15 +81,6 @@ def brian_dtype_from_dtype(dtype):
     elif is_boolean_dtype(dtype):
         return 'boolean'
     raise TypeError("Unknown dtype: "+str(dtype))
-
-
-def get_value(node):
-    '''Helper function to mask differences between Python versions'''
-    value = getattr(node, 'n', getattr(node, 'value', None))
-    if value is None:
-        raise AttributeError('Node {} has neither "n" nor "value" '
-                             'attribute'.format(node))
-    return value
 
 
 def brian_ast(expr, variables):
@@ -169,7 +160,7 @@ class BrianASTRenderer(object):
 
     def render_Num(self, node):
         node.complexity = 0
-        node.dtype = brian_dtype_from_value(get_value(node))
+        node.dtype = brian_dtype_from_value(get_node_value(node))
         node.scalar = True
         node.stateless = True
         return node

--- a/brian2/parsing/rendering.py
+++ b/brian2/parsing/rendering.py
@@ -8,11 +8,12 @@ from brian2.core.functions import DEFAULT_FUNCTIONS, DEFAULT_CONSTANTS
 __all__ = ['NodeRenderer',
            'NumpyNodeRenderer',
            'CPPNodeRenderer',
-           'SympyNodeRenderer'
+           'SympyNodeRenderer',
+           'get_node_value'
            ]
 
 
-def get_value(node):
+def get_node_value(node):
     '''Helper function to mask differences between Python versions'''
     value = getattr(node, 'n', getattr(node, 'value', None))
     if value is None:
@@ -89,7 +90,7 @@ class NodeRenderer(object):
         return node.id
     
     def render_Num(self, node):
-        return repr(get_value(node))
+        return repr(get_node_value(node))
 
     def render_Constant(self, node):  # For literals in Python 3.8
         if node.value is True or node.value is False or node.value is None:
@@ -121,7 +122,7 @@ class NodeRenderer(object):
         '''
         if node.__class__.__name__ in ['Name', 'NameConstant']:
             return self.render_node(node)
-        elif node.__class__.__name__ in ['Num', 'Constant'] and get_value(node) >= 0:
+        elif node.__class__.__name__ in ['Num', 'Constant'] and get_node_value(node) >= 0:
             return self.render_node(node)
         elif node.__class__.__name__ == 'Call':
             return self.render_node(node)

--- a/brian2/parsing/rendering.py
+++ b/brian2/parsing/rendering.py
@@ -12,6 +12,15 @@ __all__ = ['NodeRenderer',
            ]
 
 
+def get_value(node):
+    '''Helper function to mask differences between Python versions'''
+    value = getattr(node, 'n', getattr(node, 'value', None))
+    if value is None:
+        raise AttributeError('Node {} has neither "n" nor "value" '
+                             'attribute'.format(node))
+    return value
+
+
 class NodeRenderer(object):
     expression_ops = {
       # BinOp
@@ -80,7 +89,13 @@ class NodeRenderer(object):
         return node.id
     
     def render_Num(self, node):
-        return repr(node.n)
+        return repr(get_value(node))
+
+    def render_Constant(self, node):  # For literals in Python 3.8
+        if node.value is True or node.value is False or node.value is None:
+            return self.render_NameConstant(node)
+        else:
+            return self.render_Num(node)
 
     def render_Call(self, node):
         if len(node.keywords):
@@ -106,7 +121,7 @@ class NodeRenderer(object):
         '''
         if node.__class__.__name__ in ['Name', 'NameConstant']:
             return self.render_node(node)
-        elif node.__class__.__name__ == 'Num' and node.n >= 0:
+        elif node.__class__.__name__ in ['Num', 'Constant'] and get_value(node) >= 0:
             return self.render_node(node)
         elif node.__class__.__name__ == 'Call':
             return self.render_node(node)


### PR DESCRIPTION
This is a bit of a quick-and-dirty fix for #1130, but it makes the test suite run with Python 3.8 on my machine (after merging #1127, I'll make the automatic test suite run tests on Python 3.8 as well). This is quite urgent, since you'll now get Python 3.8 if you install it from www.python.org or create a new environment with `conda`.

The problem is that with Python 3.8, number literals like `17.4` or `42`, as well as other constants such as `True` or `None` are represented as `Constant` objects in the AST, whereas previously numbers where `Num`, and the others were `NameConstant`.

We could certainly simplify all this a bit, but this will also be easier when we no longer have to worry about supporting Python 2.