### PR TITLE
[MRG] Improve Visual Studio support on Windows

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,6 +8,13 @@ environment:
     CMD_IN_ENV: "cmd /E:ON /V:ON /C .\\dev\\continuous-integration\\appveyor\\run_with_env.cmd"
 
   matrix:
+    - PYTHON: "C:\\Miniconda37-x64"
+      PYTHON_VERSION: "3.7"
+      PYTHON_ARCH: "64"
+      platform: x64
+      STANDALONE: "TRUE"
+      FLOAT_DTYPE_32: "TRUE"
+
     - PYTHON: "C:\\Miniconda37"
       PYTHON_VERSION: "3.7"
       PYTHON_ARCH: "32"
@@ -90,13 +97,6 @@ environment:
       PYTHON_ARCH: "64"
       platform: x64
       STANDALONE: "TRUE"
-
-    - PYTHON: "C:\\Miniconda37-x64"
-      PYTHON_VERSION: "3.7"
-      PYTHON_ARCH: "64"
-      platform: x64
-      STANDALONE: "TRUE"
-      FLOAT_DTYPE_32: "TRUE"
 
 install:
   # Add the paths

--- a/brian2/codegen/generators/GSL_generator.py
+++ b/brian2/codegen/generators/GSL_generator.py
@@ -395,7 +395,7 @@ class GSLCodeGenerator(object):
                 restrict = self.generator.restrict
             except AttributeError:
                 restrict = ''
-            if var_obj.scalar:
+            if var_obj.scalar or var_obj.size == 1:
                 restrict = ''
             return '%s* %s %s{end_statement}'%(dtype, restrict, pointer_name)
         else:

--- a/brian2/codegen/generators/cpp_generator.py
+++ b/brian2/codegen/generators/cpp_generator.py
@@ -439,7 +439,7 @@ class CPPCodeGenerator(CodeGenerator):
                     continue  # multidimensional (dynamic) arrays have to be treated differently
                 restrict = self.restrict
                 # turn off restricted pointers for scalars for safety
-                if var.scalar:
+                if var.scalar or var.size == 1:
                     restrict = ' '
                 line = '{0}* {1} {2} = {3};'.format(self.c_data_type(var.dtype),
                                                     restrict,

--- a/brian2/conftest.py
+++ b/brian2/conftest.py
@@ -9,7 +9,7 @@ import pytest
 from brian2.units import ms
 from brian2.core.clocks import defaultclock
 from brian2.core.functions import Function, DEFAULT_FUNCTIONS
-from brian2.devices.device import reinit_and_delete
+from brian2.devices.device import reinit_and_delete, set_device
 
 
 def pytest_ignore_collect(path, config):
@@ -50,7 +50,8 @@ def setup_and_teardown(request):
     # Set preferences before each test
     import brian2
     if hasattr(request.config, 'slaveinput'):
-        for key, value in request.config.slaveinput['brian_prefs'].items():
+        config = request.config.slaveinput
+        for key, value in config['brian_prefs'].items():
             if isinstance(value, tuple) and value[0] == 'TYPE':
                 matches = re.match(r"<(type|class) 'numpy\.(.+)'>", value[1])
                 if matches is None or len(matches.groups()) != 2:
@@ -67,9 +68,11 @@ def setup_and_teardown(request):
                     value = np.int32
 
             brian2.prefs[key] = value
+        set_device(config['device'], **config['device_options'])
     else:
         for k, v in request.config.brian_prefs.items():
             brian2.prefs[k] = v
+        set_device(request.config.device, **request.config.device_options)
     brian2.prefs._backup()
     # Print output changed in numpy 1.14, stick with the old format to
     # avoid doctest failures

--- a/brian2/devices/cpp_standalone/device.py
+++ b/brian2/devices/cpp_standalone/device.py
@@ -947,10 +947,13 @@ class CPPStandaloneDevice(Device):
                     msvc_env = CPPStandaloneDevice.msvc_env
                     if msvc_env is None:
                         try:
+                            # Note that the following seems to fail on Python 2 (at least
+                            # under some configurations), we catch the AttributeError that
+                            # gets raised below
                             msvc_env = msvc.msvc14_get_vc_env(arch_name)
                             # Cache the result
                             CPPStandaloneDevice.msvc_env = msvc_env
-                        except distutils.errors.DistutilsPlatformError:
+                        except (AttributeError, distutils.errors.DistutilsPlatformError):
                             # Use the old way of searching for MSVC
                             # FIXME: Remove this when we remove Python 2 support
                             #        and require Visual Studio 2015?

--- a/brian2/devices/cpp_standalone/device.py
+++ b/brian2/devices/cpp_standalone/device.py
@@ -950,11 +950,20 @@ class CPPStandaloneDevice(Device):
                             msvc_env = msvc.msvc14_get_vc_env(arch_name)
                             # Cache the result
                             CPPStandaloneDevice.msvc_env = msvc_env
-                        except distutils.errors.DistutilsPlatformError as ex:
-                            raise IOError("Cannot find Microsoft Visual Studio, You "
-                                          "can try to set the path to vcvarsall.bat "
-                                          "via the codegen.cpp.msvc_vars_location "
-                                          "preference explicitly.")
+                        except distutils.errors.DistutilsPlatformError:
+                            # Use the old way of searching for MSVC
+                            # FIXME: Remove this when we remove Python 2 support
+                            #        and require Visual Studio 2015?
+                            for version in range(16, 8, -1):
+                                fname = msvc.msvc9_find_vcvarsall(version)
+                                if fname:
+                                    vcvars_loc = fname
+                                    break
+                            if vcvars_loc == '':
+                                raise IOError("Cannot find Microsoft Visual Studio, You "
+                                              "can try to set the path to vcvarsall.bat "
+                                              "via the codegen.cpp.msvc_vars_location "
+                                              "preference explicitly.")
                 if vcvars_loc:
                     vcvars_cmd = '"{vcvars_loc}" {arch_name}'.format(
                             vcvars_loc=vcvars_loc, arch_name=arch_name)

--- a/brian2/devices/cpp_standalone/device.py
+++ b/brian2/devices/cpp_standalone/device.py
@@ -123,6 +123,8 @@ class CPPStandaloneDevice(Device):
     '''
     The `Device` used for C++ standalone simulations.
     '''
+    msvc_env = None  #: cached environment variables for MSVC
+
     def __init__(self):
         super(CPPStandaloneDevice, self).__init__()
         #: Dictionary mapping `ArrayVariable` objects to their globally
@@ -942,13 +944,17 @@ class CPPStandaloneDevice(Device):
                         arch_name = 'x86'
                 vcvars_loc = prefs['codegen.cpp.msvc_vars_location']
                 if vcvars_loc == '':
-                    try:
-                        msvc_env = msvc.msvc14_get_vc_env(arch_name)
-                    except distutils.errors.DistutilsPlatformError as ex:
-                        raise IOError("Cannot find Microsoft Visual Studio, You "
-                                      "can try to set the path to vcvarsall.bat "
-                                      "via the codegen.cpp.msvc_vars_location "
-                                      "preference explicitly.")
+                    msvc_env = CPPStandaloneDevice.msvc_env
+                    if msvc_env is None:
+                        try:
+                            msvc_env = msvc.msvc14_get_vc_env(arch_name)
+                            # Cache the result
+                            CPPStandaloneDevice.msvc_env = msvc_env
+                        except distutils.errors.DistutilsPlatformError as ex:
+                            raise IOError("Cannot find Microsoft Visual Studio, You "
+                                          "can try to set the path to vcvarsall.bat "
+                                          "via the codegen.cpp.msvc_vars_location "
+                                          "preference explicitly.")
                 if vcvars_loc:
                     vcvars_cmd = '"{vcvars_loc}" {arch_name}'.format(
                             vcvars_loc=vcvars_loc, arch_name=arch_name)

--- a/brian2/devices/cpp_standalone/templates/win_makefile
+++ b/brian2/devices/cpp_standalone/templates/win_makefile
@@ -12,4 +12,4 @@ clean:
 {% endfor %}
 
 main.exe: {% for base in source_bases | sort%}{{base}}.obj {% endfor %} win_makefile sourcefiles.txt
-    link @sourcefiles.txt {{linker_flags}} /OUT:main.exe {{linker_debug_flags}}
+    link @sourcefiles.txt {{linker_flags}} /LIBPATH:. /OUT:main.exe {{linker_debug_flags}}

--- a/brian2/tests/__init__.py
+++ b/brian2/tests/__init__.py
@@ -117,8 +117,7 @@ def make_argv(dirnames, markers=None, doctests=False):
             '-c', os.path.join(os.path.dirname(__file__), 'pytest.ini'),
             '--quiet',
             '-m', '{}'.format(markers),
-            '--confcutdir', os.path.abspath(os.path.join(os.path.dirname(__file__), '..')),
-            '-x'
+            '--confcutdir', os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
             ]
     return argv
 
@@ -352,8 +351,7 @@ def run(codegen_targets=None, long_tests=False, test_codegen_independent=True,
         pref_plugin.device = test_standalone
         if test_standalone:
             from brian2.devices.device import get_device, set_device
-            pref_plugin.device_options = {'directory': None, 'with_output': True,
-                                          'debug': True}
+            pref_plugin.device_options = {'directory': None, 'with_output': False}
             pref_plugin.device_options.update(build_options)
             print('Testing standalone device "%s"' % test_standalone)
             print('Running standalone-compatible standard tests (single run statement)')

--- a/brian2/tests/__init__.py
+++ b/brian2/tests/__init__.py
@@ -284,7 +284,7 @@ def run(codegen_targets=None, long_tests=False, test_codegen_independent=True,
 
     # Switch off code optimization to get faster compilation times
     prefs['codegen.cpp.extra_compile_args_gcc'].extend(['-w', '-O0'])
-    prefs['codegen.cpp.extra_compile_args_msvc'].extend(['-w', '-O0'])
+    prefs['codegen.cpp.extra_compile_args_msvc'].extend(['/Od'])
 
     pref_plugin = PreferencePlugin(prefs, fail_for_not_implemented)
     try:

--- a/brian2/tests/__init__.py
+++ b/brian2/tests/__init__.py
@@ -45,31 +45,35 @@ except ImportError:
 
 class PreferencePlugin(object):
     def __init__(self, prefs, fail_for_not_implemented=True):
-        self._prefs = prefs
+        self.prefs = prefs
+        self.device = 'runtime'
+        self.device_options = {}
         self.fail_for_not_implemented = fail_for_not_implemented
 
     def pytest_configure(self, config):
-        config.brian_prefs = dict(self._prefs)
+        config.brian_prefs = dict(self.prefs)
         config.fail_for_not_implemented = self.fail_for_not_implemented
+        config.device = self.device
+        config.device_options = self.device_options
         if config.pluginmanager.hasplugin("xdist"):
-            xdist_plugin = XDistPreferencePlugin(self._prefs,
-                                                 self.fail_for_not_implemented)
+            xdist_plugin = XDistPreferencePlugin(self)
             config.pluginmanager.register(xdist_plugin)
 
 
 class XDistPreferencePlugin(object):
-    def __init__(self, prefs, fail_for_not_implemented=True):
-        self._prefs = prefs
-        self.fail_for_not_implemented = fail_for_not_implemented
+    def __init__(self, pref_plugin):
+        self._pref_plugin = pref_plugin
 
     def pytest_configure_node(self, node):
         """xdist hook"""
-        prefs = dict(self._prefs)
+        prefs = dict(self._pref_plugin.prefs)
         for k, v in prefs.items():
             if isinstance(v, type):
                 prefs[k] = ('TYPE', repr(v))
         node.slaveinput['brian_prefs'] = prefs
-        node.slaveinput['fail_for_not_implemented'] = self.fail_for_not_implemented
+        node.slaveinput['fail_for_not_implemented'] = self._pref_plugin.fail_for_not_implemented
+        node.slaveinput['device'] = self._pref_plugin.device
+        node.slaveinput['device_options'] = self._pref_plugin.device_options
 
 
 def clear_caches():
@@ -281,11 +285,11 @@ def run(codegen_targets=None, long_tests=False, test_codegen_independent=True,
     prefs['codegen.cpp.extra_compile_args_gcc'].extend(['-w', '-O0'])
     prefs['codegen.cpp.extra_compile_args_msvc'].extend(['-w', '-O0'])
 
-    from brian2.devices import set_device
-    set_device('runtime')
     pref_plugin = PreferencePlugin(prefs, fail_for_not_implemented)
     try:
         success = []
+        pref_plugin.device = 'runtime'
+        pref_plugin.device_options = {}
         if test_codegen_independent:
             print('Running doctests')
             # Some doctests do actually use code generation, use numpy for that
@@ -344,10 +348,11 @@ def run(codegen_targets=None, long_tests=False, test_codegen_independent=True,
                                        plugins=[pref_plugin]) == 0)
             clear_caches()
 
+        pref_plugin.device = test_standalone
         if test_standalone:
             from brian2.devices.device import get_device, set_device
-            set_device(test_standalone, directory=None,  # use temp directory
-                       with_output=False, **build_options)
+            pref_plugin.device_options = {'directory': None, 'with_output': False}
+            pref_plugin.device_options.update(build_options)
             print('Testing standalone device "%s"' % test_standalone)
             print('Running standalone-compatible standard tests (single run statement)')
             markers = 'and not long' if not long_tests else ''
@@ -362,8 +367,10 @@ def run(codegen_targets=None, long_tests=False, test_codegen_independent=True,
             reset_device()
 
             print('Running standalone-compatible standard tests (multiple run statements)')
-            set_device(test_standalone, directory=None,  # use temp directory
-                       with_output=False, build_on_run=False, **build_options)
+            pref_plugin.device_options = {'directory': None,
+                                          'with_output': False,
+                                          'build_on_run': False}
+            pref_plugin.device_options.update(build_options)
             markers = ' and not long' if not long_tests else ''
             markers += ' and multiple_runs'
             argv = make_argv(dirnames, 'standalone_compatible'+markers)
@@ -376,8 +383,9 @@ def run(codegen_targets=None, long_tests=False, test_codegen_independent=True,
 
             if test_openmp and test_standalone == 'cpp_standalone':
                 # Run all the standalone compatible tests again with 4 threads
-                set_device(test_standalone, directory=None, # use temp directory
-                           with_output=False, **build_options)
+                pref_plugin.device_options = {'directory': None,
+                                              'with_output': False}
+                pref_plugin.device_options.update(build_options)
                 prefs['devices.cpp_standalone.openmp_threads'] = 4
                 print('Running standalone-compatible standard tests with OpenMP (single run statements)')
                 markers = ' and not long' if not long_tests else ''
@@ -389,8 +397,10 @@ def run(codegen_targets=None, long_tests=False, test_codegen_independent=True,
                 clear_caches()
                 reset_device()
 
-                set_device(test_standalone, directory=None, # use temp directory
-                           with_output=False, build_on_run=False, **build_options)
+                pref_plugin.device_options = {'directory': None,
+                                              'with_output': False,
+                                              'build_on_run': False}
+                pref_plugin.device_options.update(build_options)
                 print('Running standalone-compatible standard tests with OpenMP (multiple run statements)')
                 markers = ' and not long' if not long_tests else ''
                 markers += ' and multiple_runs'

--- a/brian2/tests/__init__.py
+++ b/brian2/tests/__init__.py
@@ -117,7 +117,8 @@ def make_argv(dirnames, markers=None, doctests=False):
             '-c', os.path.join(os.path.dirname(__file__), 'pytest.ini'),
             '--quiet',
             '-m', '{}'.format(markers),
-            '--confcutdir', os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+            '--confcutdir', os.path.abspath(os.path.join(os.path.dirname(__file__), '..')),
+            '-x'
             ]
     return argv
 
@@ -351,7 +352,8 @@ def run(codegen_targets=None, long_tests=False, test_codegen_independent=True,
         pref_plugin.device = test_standalone
         if test_standalone:
             from brian2.devices.device import get_device, set_device
-            pref_plugin.device_options = {'directory': None, 'with_output': False}
+            pref_plugin.device_options = {'directory': None, 'with_output': True,
+                                          'debug': True}
             pref_plugin.device_options.update(build_options)
             print('Testing standalone device "%s"' % test_standalone)
             print('Running standalone-compatible standard tests (single run statement)')

--- a/brian2/tests/test_cpp_standalone.py
+++ b/brian2/tests/test_cpp_standalone.py
@@ -120,7 +120,7 @@ def test_openmp_consistency():
     dApre     *=  0.1*gmax
 
     connectivity = numpy.random.randn(n_cells, n_cells)
-    sources      = numpy.random.random_integers(0, n_cells-1, 10*n_cells)
+    sources      = numpy.random.randint(0, n_cells-1, 10*n_cells)
     # Only use one spike per time step (to rule out that a single source neuron
     # has more than one spike in a time step)
     times        = numpy.random.choice(numpy.arange(10*n_cells), 10*n_cells,

--- a/dev/conda-recipe/meta.yaml
+++ b/dev/conda-recipe/meta.yaml
@@ -12,7 +12,7 @@ requirements:
   host:
     - python
     - cython >=0.29
-    - setuptools >=21
+    - setuptools >=24
     # we build against the oldest supported numpy version
     - numpy 1.10  # [py < 36]
     - numpy 1.11  # [py >= 36]
@@ -30,7 +30,7 @@ requirements:
     - gsl >1.15
     - cython >=0.29
     - jinja2 >=2.7
-    - setuptools >=21
+    - setuptools >=24
     - py-cpuinfo  # [win]
     - future
 

--- a/setup.py
+++ b/setup.py
@@ -175,11 +175,11 @@ setup(name='Brian2',
                         'pyparsing',
                         'jinja2>=2.7',
                         'py-cpuinfo;platform_system=="Windows"',
-                        'setuptools>=21',
+                        'setuptools>=24',
                         'future'
                        ],
       setup_requires=['numpy>=1.10',
-                      'setuptools>=21'
+                      'setuptools>=24'
                       ],
       cmdclass={'build_ext': optional_build_ext},
       provides=['brian2'],


### PR DESCRIPTION
While debugging an error that only occurred under Windows (more on this later) I noticed that our technique for finding `vcvarsall.bat`(via `msvc9compiler.find_vcvarsall`)  does not work for Visual Studio 2019. There is a new function in setuptools that is meant to be used for more recent Visual Studio versions (from 2015 on, I think). This function works a bit differently, it does not return the `vcvarsall.bat` filename but instead directly a dictionary with all environment variables. With this PR, we support this way of configuring the compiler environment as well. The code is currently a bit long and messy, but we could potentially simplify it when we drop Python 2.7 support and no longer need to support Visual Studio 2008. 

There are a few other minor standalone-related changes:
* We no longer delete the standalone directory for failed tests (to make debugging easier)
* I fixed wrong parameters to switch off code optimization on msvc (not sure this was always wrong, maybe I introduced this problem during the test refactoring)

All this work is basically a side project of an endless debugging session in my Windows VM, where I tried to figure out why [a test](https://ci.appveyor.com/project/brianteam/brian2/builds/28973532/job/qb1bw798ogdsceae) crashed with an "Access violation reading violation" with Visual Studio 2015 and single precision floats... I did not manage to get to the bottom of it – I could reproduce it in the VM, but it disappeared when I added print statements in certain places, and when I switched off optimization to get debugging information :roll_eyes: I suspected it had something to do with the `__restrict` definition (that's why I switched them off for arrays of length 1 – since such arrays are equivalent to a single primitive pointer, it is a bit unclear whether you are allowed to annotate them), but I did not manage to fix it. The error now no longer occurrs on the test server because this PR switches off the optimization, so I'll give up for now. If you happen to be motivated to investigate this further, the failing test was `test_linked_variables_scalar` in `test_neurongroup` (with the standalone device and Visual Studio 2015, and `default_float_dtype=float32`)...