### PR TITLE
[MRG] Unsigned data type index

### DIFF
--- a/brian2/codegen/generators/cython_generator.py
+++ b/brian2/codegen/generators/cython_generator.py
@@ -336,7 +336,7 @@ class CythonCodeGenerator(CodeGenerator):
                                 "cdef {cpp_dtype} * {array_name} = <{cpp_dtype} *> _buf_{array_name}.data"]
 
                 if not var.scalar:
-                    newlines += ["cdef int _num{array_name} = len(_namespace['{array_name}'])"]
+                    newlines += ["cdef size_t _num{array_name} = len(_namespace['{array_name}'])"]
 
                 if var.scalar and var.constant:
                     newlines += ['cdef {cpp_dtype} {varname} = _namespace["{varname}"]']
@@ -348,7 +348,7 @@ class CythonCodeGenerator(CodeGenerator):
                                        numpy_dtype=get_numpy_dtype(var.dtype),
                                        pointer_name=pointer_name,
                                        array_name=array_name,
-                                       varname=varname,
+                                       varname=varname
                                        )
                     load_namespace.append(line)
                 handled_pointers.add(pointer_name)
@@ -516,6 +516,7 @@ ctypedef fused _to_sign:
     char
     short
     int
+    long
     float
     double
 
@@ -531,6 +532,7 @@ ctypedef fused _to_clip:
     char
     short
     int
+    long
     float
     double
 
@@ -546,7 +548,7 @@ DEFAULT_FUNCTIONS['clip'].implementations.add_implementation(CythonCodeGenerator
                                                              name='_clip')
 
 timestep_code = '''
-cdef int _timestep(double t, double dt):
+cdef int64_t _timestep(double t, double dt):
     return <int64_t>((t + 1e-3*dt)/dt)
 '''
 DEFAULT_FUNCTIONS['timestep'].implementations.add_implementation(CythonCodeGenerator,

--- a/brian2/codegen/runtime/cython_rt/templates/common.pyx
+++ b/brian2/codegen/runtime/cython_rt/templates/common.pyx
@@ -49,8 +49,8 @@ cdef extern from "stdint_compat.h":
 {% endblock %}
 
 def main(_namespace):
-    cdef int _idx
-    cdef int _vectorisation_idx
+    cdef size_t _idx
+    cdef size_t _vectorisation_idx
     {{ load_namespace | autoindent }}
     if '_owner' in _namespace:
         _owner = _namespace['_owner']

--- a/brian2/codegen/runtime/cython_rt/templates/group_get_indices.pyx
+++ b/brian2/codegen/runtime/cython_rt/templates/group_get_indices.pyx
@@ -6,7 +6,7 @@
 
     _vectorisation_idx = 1
 
-    cdef int _num_elements = 0
+    cdef size_t _num_elements = 0
     cdef _numpy.ndarray[int, ndim=1, mode='c'] _elements = _numpy.zeros(N, dtype=_numpy.int32)
     cdef int[:] _elements_view = _elements
     

--- a/brian2/codegen/runtime/cython_rt/templates/group_variable_get.pyx
+++ b/brian2/codegen/runtime/cython_rt/templates/group_variable_get.pyx
@@ -13,7 +13,7 @@
 
     _vectorisation_idx = 1
     
-    cdef int _num_elements = 0
+    cdef size_t _num_elements = 0
     cdef _numpy.ndarray[{{c_type}}, ndim=1, mode='c'] _elements = _numpy.zeros(_num{{_group_idx}}, dtype=_numpy.{{np_type}})
     cdef {{c_type}}[:] _elements_view = _elements
     

--- a/brian2/codegen/runtime/cython_rt/templates/group_variable_get_conditional.pyx
+++ b/brian2/codegen/runtime/cython_rt/templates/group_variable_get_conditional.pyx
@@ -10,8 +10,8 @@
 
     _vectorisation_idx = 1
 
-    cdef int _N = {{constant_or_scalar('N', variables['N'])}}
-    cdef int _num_elements = 0
+    cdef size_t _N = {{constant_or_scalar('N', variables['N'])}}
+    cdef size_t _num_elements = 0
     cdef _numpy.ndarray[{{c_type}}, ndim=1, mode='c'] _elements = _numpy.zeros(_N, dtype=_numpy.{{np_type}})
     cdef {{c_type}}[:] _elements_view = _elements
 

--- a/brian2/codegen/runtime/cython_rt/templates/group_variable_set.pyx
+++ b/brian2/codegen/runtime/cython_rt/templates/group_variable_set.pyx
@@ -5,7 +5,7 @@
 
 {% block maincode %}
 
-    cdef int _target_idx
+    cdef size_t _target_idx
     
     _vectorisation_idx = 1
     

--- a/brian2/codegen/runtime/cython_rt/templates/group_variable_set_conditional.pyx
+++ b/brian2/codegen/runtime/cython_rt/templates/group_variable_set_conditional.pyx
@@ -4,7 +4,7 @@
 {# ALLOWS_SCALAR_WRITE #}
 
 {% block maincode %}
-    cdef int _N = {{constant_or_scalar('N', variables['N'])}}
+    cdef size_t _N = {{constant_or_scalar('N', variables['N'])}}
     _vectorisation_idx = 1
     
     {{scalar_code['condition']|autoindent}}

--- a/brian2/codegen/runtime/cython_rt/templates/ratemonitor.pyx
+++ b/brian2/codegen/runtime/cython_rt/templates/ratemonitor.pyx
@@ -4,13 +4,13 @@
     {# USES_VARIABLES { N, t, rate, _clock_t, _clock_dt, _spikespace,
                         _num_source_neurons, _source_start, _source_stop } #}
 
-    cdef int _num_spikes = {{_spikespace}}[_num{{_spikespace}}-1]
+    cdef size_t _num_spikes = {{_spikespace}}[_num{{_spikespace}}-1]
     
     # For subgroups, we do not want to record all spikes
     # We assume that spikes are ordered
     cdef int _start_idx = -1
     cdef int _end_idx = -1
-    cdef int _j
+    cdef size_t _j
     for _j in range(_num_spikes):
         _idx = {{_spikespace}}[_j]
         if _idx >= _source_start:
@@ -28,7 +28,7 @@
     _num_spikes = _end_idx - _start_idx
     
     # Calculate the new length for the arrays
-    cdef int _new_len = {{_dynamic_t}}.shape[0] + 1
+    cdef size_t _new_len = {{_dynamic_t}}.shape[0] + 1
 
     # Resize the arrays
     _owner.resize(_new_len)

--- a/brian2/codegen/runtime/cython_rt/templates/reset.pyx
+++ b/brian2/codegen/runtime/cython_rt/templates/reset.pyx
@@ -7,7 +7,7 @@
     {#  Get the name of the array that stores these events (e.g. the spikespace array) #}
     {% set _eventspace = get_array_name(eventspace_variable) %}
 
-    cdef int _num_events = {{_eventspace}}[_num{{_eventspace}}-1]
+    cdef size_t _num_events = {{_eventspace}}[_num{{_eventspace}}-1]
     for _index_events in range(_num_events):
         # vector code
         _idx = {{_eventspace}}[_index_events]

--- a/brian2/codegen/runtime/cython_rt/templates/spikemonitor.pyx
+++ b/brian2/codegen/runtime/cython_rt/templates/spikemonitor.pyx
@@ -7,8 +7,8 @@
     {#  Get the name of the array that stores these events (e.g. the spikespace array) #}
     {% set _eventspace = get_array_name(eventspace_variable) %}
 
-    cdef int _num_events = {{_eventspace}}[_num{{_eventspace}}-1]
-    cdef int _start_idx, _end_idx, _curlen, _newlen, _j
+    cdef size_t _num_events = {{_eventspace}}[_num{{_eventspace}}-1]
+    cdef size_t _start_idx, _end_idx, _curlen, _newlen, _j
     {% for varname, var in record_variables | dictsort %}
     cdef {{cpp_dtype(var.dtype)}}[:] _{{varname}}_view
     {% endfor %}

--- a/brian2/codegen/runtime/cython_rt/templates/statemonitor.pyx
+++ b/brian2/codegen/runtime/cython_rt/templates/statemonitor.pyx
@@ -4,7 +4,7 @@
 
 {% block maincode %}
 
-    cdef int _new_len = {{N}} + 1
+    cdef size_t _new_len = {{N}} + 1
 
     # Resize the recorded times
     _var_t.resize(_new_len)
@@ -14,7 +14,7 @@
     _vectorisation_idx = 1
     {{ scalar_code|autoindent }}
 
-    cdef int _i
+    cdef size_t _i
 
     {% for varname, var in _recorded_variables | dictsort %}
     {% set c_type = cpp_dtype(variables[varname].dtype) %}

--- a/brian2/codegen/runtime/cython_rt/templates/synapses.pyx
+++ b/brian2/codegen/runtime/cython_rt/templates/synapses.pyx
@@ -8,7 +8,7 @@
     _vectorisation_idx = 1
     {{ scalar_code | autoindent }}
 
-    cdef int _spiking_synapse_idx
+    cdef size_t _spiking_synapse_idx
 
     for _spiking_synapse_idx in range(len(_spiking_synapses)):
         # vector code

--- a/brian2/codegen/runtime/cython_rt/templates/synapses_create_array.pyx
+++ b/brian2/codegen/runtime/cython_rt/templates/synapses_create_array.pyx
@@ -7,8 +7,8 @@
     #}
     {# WRITES_TO_READ_ONLY_VARIABLES { _synaptic_pre, _synaptic_post, N}
     #}
-    cdef int _old_num_synapses = {{N}}
-    cdef int _new_num_synapses = _old_num_synapses + _num{{sources}}
+    cdef size_t _old_num_synapses = {{N}}
+    cdef size_t _new_num_synapses = _old_num_synapses + _num{{sources}}
 
     {{_dynamic__synaptic_pre}}.resize(_new_num_synapses)
     {{_dynamic__synaptic_post}}.resize(_new_num_synapses)

--- a/brian2/codegen/runtime/cython_rt/templates/synapses_create_generator.pyx
+++ b/brian2/codegen/runtime/cython_rt/templates/synapses_create_generator.pyx
@@ -18,8 +18,8 @@ cdef int _raw_pre_idx
 cdef int _raw_post_idx
 
 cdef void _flush_buffer(buf, dynarr, int buf_len):
-    _curlen = dynarr.shape[0]
-    _newlen = _curlen+buf_len
+    cdef size_t _curlen = dynarr.shape[0]
+    cdef size_t _newlen = _curlen+buf_len
     # Resize the array
     dynarr.resize(_newlen)
     # Get the potentially newly created underlying data arrays
@@ -37,13 +37,13 @@ cdef void _flush_buffer(buf, dynarr, int buf_len):
 
     global _curbuf
 
-    cdef int oldsize = len({{_dynamic__synaptic_pre}})
-    cdef int newsize
+    cdef size_t oldsize = len({{_dynamic__synaptic_pre}})
+    cdef size_t newsize
 
     # The following variables are only used for probabilistic connections
     cdef bool _jump_algo
     cdef double _log1p, _pconst
-    cdef int _jump
+    cdef size_t _jump
 
     # scalar code
     _vectorisation_idx = 1

--- a/brian2/codegen/runtime/cython_rt/templates/threshold.pyx
+++ b/brian2/codegen/runtime/cython_rt/templates/threshold.pyx
@@ -10,7 +10,7 @@
     _vectorisation_idx = 1
     {{ scalar_code | autoindent }}
 
-    cdef long _cpp_numevents = 0
+    cdef size_t _cpp_numevents = 0
 
     {#  Get the name of the array that stores these events (e.g. the spikespace array) #}
     {% set _eventspace = get_array_name(eventspace_variable) %}

--- a/brian2/codegen/runtime/weave_rt/templates/group_get_indices.cpp
+++ b/brian2/codegen/runtime/weave_rt/templates/group_get_indices.cpp
@@ -4,23 +4,23 @@
     //// MAIN CODE ////////////
     // This allows everything to work correctly for synapses where N is not a
     // constant
-    const int _N = {{constant_or_scalar('N', variables['N'])}};
+    const size_t _N = {{constant_or_scalar('N', variables['N'])}};
 
     {%set c_type = c_data_type(variables['_indices'].dtype) %}
     {%set numpy_dtype = dtype(variables['_indices'].dtype).char %}
     {%set numpy_type_int = dtype(variables['_indices'].dtype).num %}
     // {{c_type}} {{numpy_dtype}} {{numpy_type_int}}
-    int _cpp_numelements = 0;
+    size_t _cpp_numelements = 0;
     // Container for all the potential values
     {{c_type}}* _elements = ({{c_type}}*)malloc(sizeof({{c_type}}) * _N);
 
     // scalar code
-    const int _vectorisation_idx = 1;
+    const size_t _vectorisation_idx = 1;
     {{scalar_code|autoindent}}
-    for(int _idx=0; _idx<_N; _idx++)
+    for(size_t _idx=0; _idx<_N; _idx++)
     {
         // vector code
-        const int _vectorisation_idx = _idx;
+        const size_t _vectorisation_idx = _idx;
         {{super()}}
         if(_cond) {
             // _variable is set in the abstract code, see Group._get_with_code

--- a/brian2/codegen/runtime/weave_rt/templates/group_variable_get.cpp
+++ b/brian2/codegen/runtime/weave_rt/templates/group_variable_get.cpp
@@ -10,18 +10,18 @@
     {%set numpy_dtype = dtype(variables['_variable'].dtype).char %}
     {%set numpy_type_int = dtype(variables['_variable'].dtype).num %}
     // {{c_type}} {{numpy_dtype}} {{numpy_type_int}}
-    int _cpp_numelements = 0;
+    size_t _cpp_numelements = 0;
     // Container for the return values
     {{c_type}}* _elements = ({{c_type}}*)malloc(sizeof({{c_type}}) * _num_group_idx);
 
     // scalar code
-    const int _vectorisation_idx = 1;
+    const size_t _vectorisation_idx = 1;
     {{scalar_code|autoindent}}
-    for(int _idx_group_idx=0; _idx_group_idx<_num_group_idx; _idx_group_idx++)
+    for(size_t _idx_group_idx=0; _idx_group_idx<_num_group_idx; _idx_group_idx++)
     {
         // vector code
-        const int _idx = {{_group_idx}}[_idx_group_idx];
-        const int _vectorisation_idx = _idx;
+        const size_t _idx = {{_group_idx}}[_idx_group_idx];
+        const size_t _vectorisation_idx = _idx;
         {{ super() }}
         _elements[_idx_group_idx] = _variable;
     }

--- a/brian2/codegen/runtime/weave_rt/templates/group_variable_get_conditional.cpp
+++ b/brian2/codegen/runtime/weave_rt/templates/group_variable_get_conditional.cpp
@@ -5,24 +5,24 @@
     //// MAIN CODE ////////////
     // This allows everything to work correctly for synapses where N is not a
     // constant
-    const int _N = {{constant_or_scalar('N', variables['N'])}};
+    const size_t _N = {{constant_or_scalar('N', variables['N'])}};
 
     {%set c_type = c_data_type(variables['_variable'].dtype) %}
     {%set numpy_dtype = dtype(variables['_variable'].dtype).char %}
     {%set numpy_type_int = dtype(variables['_variable'].dtype).num %}
     // {{c_type}} {{numpy_dtype}} {{numpy_type_int}}
-    int _cpp_numelements = 0;
+    size_t _cpp_numelements = 0;
     // Container for all the potential values
     {{c_type}}* _elements = ({{c_type}}*)malloc(sizeof({{c_type}}) * _N);
 
     // scalar code
-	const int _vectorisation_idx = 1;
-	{{scalar_code|autoindent}}
+    const size_t _vectorisation_idx = 1;
+    {{scalar_code|autoindent}}
 
-    for(int _idx=0; _idx<_N; _idx++)
+    for(size_t _idx=0; _idx<_N; _idx++)
     {
         // vector code
-        const int _vectorisation_idx = _idx;
+        const size_t _vectorisation_idx = _idx;
         {{ super() }}
         if(_cond) {
             // _variable is set in the abstract code, see Group._get_with_code

--- a/brian2/codegen/runtime/weave_rt/templates/group_variable_set.cpp
+++ b/brian2/codegen/runtime/weave_rt/templates/group_variable_set.cpp
@@ -1,19 +1,19 @@
 {% extends 'common_group.cpp' %}
 
 {% block maincode %}
-	{# USES_VARIABLES { _group_idx } #}
-	//// MAIN CODE ////////////
+    {# USES_VARIABLES { _group_idx } #}
+    //// MAIN CODE ////////////
 
-	// scalar code
-	const int _vectorisation_idx = 1;
-	{{scalar_code|autoindent}}
+    // scalar code
+    const size_t _vectorisation_idx = 1;
+    {{scalar_code|autoindent}}
 
-	for(int _idx_group_idx=0; _idx_group_idx<_num_group_idx; _idx_group_idx++)
-	{
-	    // vector code
-		const int _idx = {{_group_idx}}[_idx_group_idx];
-		const int _vectorisation_idx = _idx;
-		const int _target_idx = _idx;
-		{{ super() }}
-	}
+    for(size_t _idx_group_idx=0; _idx_group_idx<_num_group_idx; _idx_group_idx++)
+    {
+        // vector code
+        const size_t _idx = {{_group_idx}}[_idx_group_idx];
+        const size_t _vectorisation_idx = _idx;
+        const size_t _target_idx = _idx;
+        {{ super() }}
+    }
 {% endblock %}

--- a/brian2/codegen/runtime/weave_rt/templates/group_variable_set_conditional.cpp
+++ b/brian2/codegen/runtime/weave_rt/templates/group_variable_set_conditional.cpp
@@ -3,33 +3,33 @@
 {# ALLOWS_SCALAR_WRITE #}
 
 {% macro main() %}
-	{{ common.insert_lines_commented('SUPPORT CODE', support_code_lines) }}
-	{{ common.insert_lines('HANDLE DENORMALS', denormals_code_lines) }}
-	{{ common.insert_lines('HASH DEFINES', hashdefine_lines) }}
-	{{ common.insert_lines('POINTERS', pointers_lines) }}
-	//// MAIN CODE ////////////
+    {{ common.insert_lines_commented('SUPPORT CODE', support_code_lines) }}
+    {{ common.insert_lines('HANDLE DENORMALS', denormals_code_lines) }}
+    {{ common.insert_lines('HASH DEFINES', hashdefine_lines) }}
+    {{ common.insert_lines('POINTERS', pointers_lines) }}
+    //// MAIN CODE ////////////
     // This allows everything to work correctly for synapses where N is not a
     // constant
-    const int _N = {{constant_or_scalar('N', variables['N'])}};
-	// scalar code
-	const int _vectorisation_idx = 1;
-	{# Note that the scalar_code['statement'] will not write to any scalar
-	   variables (except if the condition is simply 'True' and no vector code
-	   is present), it will only read in scalar variables that are used by the
-	   vector code. #}
-	{{scalar_code['condition']|autoindent}}
-	{{scalar_code['statement']|autoindent}}
+    const size_t _N = {{constant_or_scalar('N', variables['N'])}};
+    // scalar code
+    const size_t _vectorisation_idx = 1;
+    {# Note that the scalar_code['statement'] will not write to any scalar
+       variables (except if the condition is simply 'True' and no vector code
+       is present), it will only read in scalar variables that are used by the
+       vector code. #}
+    {{scalar_code['condition']|autoindent}}
+    {{scalar_code['statement']|autoindent}}
 
-	for(int _idx=0; _idx<_N; _idx++)
-	{
-	    const int _vectorisation_idx = _idx;
-	    {{ common.insert_lines('CONDITION', vector_code['condition']) }}
-		if(_cond) {
-			{{ common.insert_lines('STATEMENT', vector_code['statement']) }}
-		}
-	}
+    for(size_t _idx=0; _idx<_N; _idx++)
+    {
+        const size_t _vectorisation_idx = _idx;
+        {{ common.insert_lines('CONDITION', vector_code['condition']) }}
+        if(_cond) {
+            {{ common.insert_lines('STATEMENT', vector_code['statement']) }}
+        }
+    }
 {% endmacro %}
 
 {% macro support_code() %}
-	{{ common.insert_lines('SUPPORT CODE', support_code_lines) }}
+    {{ common.insert_lines('SUPPORT CODE', support_code_lines) }}
 {% endmacro %}

--- a/brian2/codegen/runtime/weave_rt/templates/ratemonitor.cpp
+++ b/brian2/codegen/runtime/weave_rt/templates/ratemonitor.cpp
@@ -3,14 +3,14 @@
     {{ common.insert_group_preamble() }}
     {# USES_VARIABLES { N, t, rate, _clock_t, _clock_dt, _spikespace,
                         _num_source_neurons, _source_start, _source_stop } #}
-	int _num_spikes = {{_spikespace}}[_num_spikespace-1];
+    size_t _num_spikes = {{_spikespace}}[_num_spikespace-1];
     // For subgroups, we do not want to record all spikes
     // We assume that spikes are ordered
     int _start_idx = -1;
     int _end_idx = - 1;
-    for(int _j=0; _j<_num_spikes; _j++)
+    for(size_t _j=0; _j<_num_spikes; _j++)
     {
-        const int _idx = {{_spikespace}}[_j];
+        const size_t _idx = {{_spikespace}}[_j];
         if (_idx >= _source_start) {
             _start_idx = _j;
             break;
@@ -18,9 +18,9 @@
     }
     if (_start_idx == -1)
         _start_idx = _num_spikes;
-    for(int _j=_start_idx; _j<_num_spikes; _j++)
+    for(size_t _j=_start_idx; _j<_num_spikes; _j++)
     {
-        const int _idx = {{_spikespace}}[_j];
+        const size_t _idx = {{_spikespace}}[_j];
         if (_idx >= _source_stop) {
             _end_idx = _j;
             break;

--- a/brian2/codegen/runtime/weave_rt/templates/reset.cpp
+++ b/brian2/codegen/runtime/weave_rt/templates/reset.cpp
@@ -3,17 +3,17 @@
 {% block maincode %}
     //// MAIN CODE ////////////
     // scalar code
-    const int _vectorisation_idx = 1;
+    const size_t _vectorisation_idx = 1;
     {{scalar_code|autoindent}}
 
     {#  Get the name of the array that stores these events (e.g. the spikespace array) #}
     {% set _eventspace = get_array_name(eventspace_variable) %}
-    const int _num_events = {{_eventspace}}[_num{{eventspace_variable.name}}-1];
-    for(int _index_events=0; _index_events<_num_events; _index_events++)
+    const size_t _num_events = {{_eventspace}}[_num{{eventspace_variable.name}}-1];
+    for(size_t _index_events=0; _index_events<_num_events; _index_events++)
     {
         // vector code
-        const int _idx = {{_eventspace}}[_index_events];
-        const int _vectorisation_idx = _idx;
+        const size_t _idx = {{_eventspace}}[_index_events];
+        const size_t _vectorisation_idx = _idx;
         {{ super() }}
     }
 {% endblock %}

--- a/brian2/codegen/runtime/weave_rt/templates/spikemonitor.cpp
+++ b/brian2/codegen/runtime/weave_rt/templates/spikemonitor.cpp
@@ -7,24 +7,24 @@
     {#  Get the name of the array that stores these events (e.g. the spikespace array) #}
     {% set _eventspace = get_array_name(eventspace_variable) %}
 
-    int _num_events = {{_eventspace}}[_num{{eventspace_variable.name}}-1];
+    size_t _num_events = {{_eventspace}}[_num{{eventspace_variable.name}}-1];
     if (_num_events > 0)
     {
         // For subgroups, we do not want to record all spikes
         // We assume that spikes are ordered
-        int _start_idx = _num_events;
-        int _end_idx = _num_events;
-        for(int _j=0; _j<_num_events; _j++)
+        size_t _start_idx = _num_events;
+        size_t _end_idx = _num_events;
+        for(size_t _j=0; _j<_num_events; _j++)
         {
-            const int _idx = {{_eventspace}}[_j];
+            const size_t _idx = {{_eventspace}}[_j];
             if (_idx >= _source_start) {
                 _start_idx = _j;
                 break;
             }
         }
-        for(int _j=_num_events-1; _j>=_start_idx; _j--)
+        for(size_t _j=_num_events-1; _j>=_start_idx; _j--)
         {
-            const int _idx = {{_eventspace}}[_j];
+            const size_t _idx = {{_eventspace}}[_j];
             if (_idx < _source_stop) {
                 break;
             }
@@ -46,10 +46,10 @@
             {{c_data_type(var.dtype)}}* _{{varname}}_data = ({{c_data_type(var.dtype)}}*)(((PyArrayObject*)(PyObject*){{get_array_name(var, access_data=False)}}.attr("data"))->data);
             {% endfor %}
             // Copy the values across
-            for(int _j=_start_idx; _j<_end_idx; _j++)
+            for(size_t _j=_start_idx; _j<_end_idx; _j++)
             {
-                const int _idx = {{_eventspace}}[_j];
-                const int _vectorisation_idx = _idx;
+                const size_t _idx = {{_eventspace}}[_j];
+                const size_t _vectorisation_idx = _idx;
                 {{vector_code|autoindent}}
                 {% for varname in record_variables | sort%}
                 _{{varname}}_data[_curlen + _j - _start_idx] = _to_record_{{varname}};

--- a/brian2/codegen/runtime/weave_rt/templates/statemonitor.cpp
+++ b/brian2/codegen/runtime/weave_rt/templates/statemonitor.cpp
@@ -4,7 +4,7 @@
     {# USES_VARIABLES { t, _clock_t, _indices, N } #}
 
     // Get the current length and new length of t and value arrays
-    const int _new_len = {{N}} + 1;
+    const size_t _new_len = {{N}} + 1;
 
     // Resize the recorded times and get the (potentially changed) reference to
     // the underlying data
@@ -14,8 +14,8 @@
 
 
     // scalar code
-	const int _vectorisation_idx = 1;
-	{{scalar_code|autoindent}}
+    const size_t _vectorisation_idx = 1;
+    {{scalar_code|autoindent}}
 
     {% for varname, var in _recorded_variables | dictsort %}
     {%set c_type = c_data_type(variables[varname].dtype) %}
@@ -25,11 +25,11 @@
         PyObject_CallMethod(_var_{{varname}}, "resize", "((ii))", _new_len, _num_indices);
         PyArrayObject *_record_data = (((PyArrayObject*)(PyObject*){{get_array_name(var, access_data=False)}}.attr("data")));
         const npy_intp* _record_strides = _record_data->strides;
-        for (int _i = 0; _i < _num_indices; _i++)
+        for (size_t _i = 0; _i < _num_indices; _i++)
         {
             // vector code
-            const int _idx = {{_indices}}[_i];
-            const int _vectorisation_idx = _idx;
+            const size_t _idx = {{_indices}}[_i];
+            const size_t _vectorisation_idx = _idx;
             {{ super() }}
 
             {{c_type}} *recorded_entry = ({{c_type}}*)(_record_data->data + (_new_len - 1)*_record_strides[0] + _i*_record_strides[1]);

--- a/brian2/codegen/runtime/weave_rt/templates/stateupdate.cpp
+++ b/brian2/codegen/runtime/weave_rt/templates/stateupdate.cpp
@@ -3,19 +3,19 @@
 {# ALLOWS_SCALAR_WRITE #}
 
 {% block maincode %}
-	//// MAIN CODE ////////////
+    //// MAIN CODE ////////////
 
     // This allows everything to work correctly for synapses where N is not a
     // constant
-    const int _N = {{constant_or_scalar('N', variables['N'])}};
-	// scalar code
-	const int _vectorisation_idx = 1;
-	{{scalar_code|autoindent}}
+    const size_t _N = {{constant_or_scalar('N', variables['N'])}};
+    // scalar code
+    const size_t _vectorisation_idx = 1;
+    {{scalar_code|autoindent}}
 
-	for(int _idx=0; _idx<_N; _idx++)
-	{
-	    // vector code
-		const int _vectorisation_idx = _idx;
-		{{ super() }}
-	}
+    for(size_t _idx=0; _idx<_N; _idx++)
+    {
+        // vector code
+        const size_t _vectorisation_idx = _idx;
+        {{ super() }}
+    }
 {% endblock %}

--- a/brian2/codegen/runtime/weave_rt/templates/summed_variable.cpp
+++ b/brian2/codegen/runtime/weave_rt/templates/summed_variable.cpp
@@ -1,26 +1,26 @@
 {% extends 'common_group.cpp' %}
 {% block maincode %}
     {# USES_VARIABLES { N } #}
-	//// MAIN CODE ////////////
-	{% set _target_var_array = get_array_name(_target_var) %}
-	{% set _index_array = get_array_name(_index_var) %}
+    //// MAIN CODE ////////////
+    {% set _target_var_array = get_array_name(_target_var) %}
+    {% set _index_array = get_array_name(_index_var) %}
 
     {# This enables summed variables for connections to a synapse #}
-    const int _target_size = {{constant_or_scalar(_target_size_name, variables[_target_size_name])}};
+    const size_t _target_size = {{constant_or_scalar(_target_size_name, variables[_target_size_name])}};
 
-	// Set all the target variable values to zero
-	for (int _target_idx=0; _target_idx<_target_size; _target_idx++)
-	    {{_target_var_array}}[_target_idx + {{_target_start}}] = 0;
+    // Set all the target variable values to zero
+    for (size_t _target_idx=0; _target_idx<_target_size; _target_idx++)
+        {{_target_var_array}}[_target_idx + {{_target_start}}] = 0;
 
     // scalar code
-	const int _vectorisation_idx = 1;
-	{{scalar_code|autoindent}}
+    const size_t _vectorisation_idx = 1;
+    {{scalar_code|autoindent}}
 
-	for(int _idx=0; _idx<{{N}}; _idx++)
-	{
-	    // vector_code
-	    const int vectorisation_idx = _idx;
-	    {{ super() }}
-		{{_target_var_array}}[{{_index_array}}[_idx]] += _synaptic_var;
-	}
+    for(size_t _idx=0; _idx<{{N}}; _idx++)
+    {
+        // vector_code
+        const size_t vectorisation_idx = _idx;
+        {{ super() }}
+        {{_target_var_array}}[{{_index_array}}[_idx]] += _synaptic_var;
+    }
 {% endblock %}

--- a/brian2/codegen/runtime/weave_rt/templates/synapses.cpp
+++ b/brian2/codegen/runtime/weave_rt/templates/synapses.cpp
@@ -6,19 +6,19 @@
     // Get the spikes
     const PyArrayObject *_spiking_synapses_obj = (PyArrayObject *)PyObject_CallMethod(_queue, "peek", "");
     const npy_int32 *_spiking_synapses = (npy_int32 *)_spiking_synapses_obj->data;
-    const int _num_spiking_synapses = _spiking_synapses_obj->dimensions[0];
+    const size_t _num_spiking_synapses = _spiking_synapses_obj->dimensions[0];
 
     // scalar code
-    const int _vectorisation_idx = 1;
+    const size_t _vectorisation_idx = 1;
     {{scalar_code|autoindent}}
 
-    for(int _spiking_synapse_idx=0;
+    for(size_t _spiking_synapse_idx=0;
         _spiking_synapse_idx<_num_spiking_synapses;
         _spiking_synapse_idx++)
     {
         // vector code
-        const int _idx = _spiking_synapses[_spiking_synapse_idx];
-        const int _vectorisation_idx = _idx;
+        const size_t _idx = _spiking_synapses[_spiking_synapse_idx];
+        const size_t _vectorisation_idx = _idx;
         {{vector_code|autoindent}}
     }
 

--- a/brian2/codegen/runtime/weave_rt/templates/synapses_create_array.cpp
+++ b/brian2/codegen/runtime/weave_rt/templates/synapses_create_array.cpp
@@ -19,13 +19,13 @@ _arg_tuple_new[0] = _new_num_synapses;
 int *_synaptic_pre_data = (int*)(((PyArrayObject*)(PyObject*){{_dynamic__synaptic_pre}}.attr("data"))->data);
 int *_synaptic_post_data = (int*)(((PyArrayObject*)(PyObject*){{_dynamic__synaptic_post}}.attr("data"))->data);
 
-for (int _idx=0; _idx<_numsources; _idx++) {
+for (size_t _idx=0; _idx<_numsources; _idx++) {
     {# After this code has been executed, the arrays _real_sources and
        _real_variables contain the final indices. Having any code here it all is
        only necessary for supporting subgroups #}
     {{vector_code|autoindent}}
-    _synaptic_pre_data[_idx + _old_num_synapses] = _real_sources;
-    _synaptic_post_data[_idx + _old_num_synapses] = _real_targets;
+    _synaptic_pre_data[_idx + {{N}}] = _real_sources;
+    _synaptic_post_data[_idx + {{N}}] = _real_targets;
 }
 
 // now we need to resize all registered variables and set the total number of
@@ -33,6 +33,6 @@ for (int _idx=0; _idx<_numsources; _idx++) {
 _owner.mcall("_resize", _arg_tuple_new);
 
 // And update N_incoming, N_outgoing and synapse_number
-//_arg_tuple[0] = _old_num_synapses;
+//_arg_tuple[0] = {{N}};
 _owner.mcall("_update_synapse_numbers", _arg_tuple_old);
 {% endblock %}

--- a/brian2/codegen/runtime/weave_rt/templates/synapses_create_generator.cpp
+++ b/brian2/codegen/runtime/weave_rt/templates/synapses_create_generator.cpp
@@ -13,18 +13,18 @@
     int *const _prebuf = new int[_buffer_size];
     int *const _postbuf = new int[_buffer_size];
     int _curbuf = 0;
-    const int _N_pre = {{constant_or_scalar('N_pre', variables['N_pre'])}};
-    const int _N_post = {{constant_or_scalar('N_post', variables['N_post'])}};
+    const size_t _N_pre = {{constant_or_scalar('N_pre', variables['N_pre'])}};
+    const size_t _N_post = {{constant_or_scalar('N_post', variables['N_post'])}};
     int _raw_pre_idx, _raw_post_idx;
     const int oldsize = {{_dynamic__synaptic_pre}}.size();
 
     // scalar code
-    const int _vectorisation_idx = 1;
+    const size_t _vectorisation_idx = 1;
     {{scalar_code['setup_iterator']|autoindent}}
     {{scalar_code['create_j']|autoindent}}
     {{scalar_code['create_cond']|autoindent}}
     {{scalar_code['update_post']|autoindent}}
-    for(int _i=0; _i<_N_pre; _i++)
+    for(size_t _i=0; _i<_N_pre; _i++)
     {
         bool __cond, _cond;
         _raw_pre_idx = _i + _source_offset;
@@ -66,7 +66,7 @@
             {% endif %}
         }
         {% if iterator_func=='range' %}
-        for(int {{iteration_variable}}=_uiter_low; {{iteration_variable}}<_uiter_high; {{iteration_variable}}+=_uiter_step)
+        for(long {{iteration_variable}}=_uiter_low; {{iteration_variable}}<_uiter_high; {{iteration_variable}}+=_uiter_step)
         {
         {% elif iterator_func=='sample' %}
         if(_uiter_p==0) continue;
@@ -77,19 +77,19 @@
         else
             _log1p = 1.0; // will be ignored
         const double _pconst = 1.0/_log1p;
-        for(int {{iteration_variable}}=_uiter_low; {{iteration_variable}}<_uiter_high; {{iteration_variable}}++)
+        for(long {{iteration_variable}}=_uiter_low; {{iteration_variable}}<_uiter_high; {{iteration_variable}}++)
         {
             if(_jump_algo) {
                 const double _r = _rand(_vectorisation_idx);
                 if(_r==0.0) break;
-                const int _jump = floor(log(_r)*_pconst)*_uiter_step;
+                const size_t _jump = floor(log(_r)*_pconst)*_uiter_step;
                 {{iteration_variable}} += _jump;
                 if({{iteration_variable}}>=_uiter_high) continue;
             } else {
                 if(_rand(_vectorisation_idx)>=_uiter_p) continue;
             }
         {% endif %}
-            long __j, _j, _pre_idx, __pre_idx;
+            size_t __j, _j, _pre_idx, __pre_idx;
             {
                 {{vector_code['create_j']|autoindent}}
                 __j = _j; // pick up the locally scoped _j and store in __j
@@ -136,7 +136,7 @@
             {% endif %}
             {{vector_code['update_post']|autoindent}}
 
-            for (int _repetition=0; _repetition<_n; _repetition++) {
+            for (size_t _repetition=0; _repetition<_n; _repetition++) {
                 _prebuf[_curbuf] = (int)_pre_idx;
                 _postbuf[_curbuf] = (int)_post_idx;
                 _curbuf++;

--- a/brian2/codegen/runtime/weave_rt/templates/threshold.cpp
+++ b/brian2/codegen/runtime/weave_rt/templates/threshold.cpp
@@ -2,34 +2,34 @@
 {# USES_VARIABLES { N } #}
 
 {% block maincode %}
-	{# t, not_refractory and lastspike are added as needed_variables in the
-	   Thresholder class, we cannot use the USES_VARIABLE mechanism
-	   conditionally.
-	   Same goes for "eventspace" (e.g. spikespace) which depends on the type of
+    {# t, not_refractory and lastspike are added as needed_variables in the
+       Thresholder class, we cannot use the USES_VARIABLE mechanism
+       conditionally.
+       Same goes for "eventspace" (e.g. spikespace) which depends on the type of
        event #}
 
-	//// MAIN CODE ////////////
-	// scalar code
-	const int _vectorisation_idx = 1;
-	{{scalar_code|autoindent}}
+    //// MAIN CODE ////////////
+    // scalar code
+    const size_t _vectorisation_idx = 1;
+    {{scalar_code|autoindent}}
 
-	long _cpp_numevents = 0;
+    size_t _cpp_numevents = 0;
 
-	{#  Get the name of the array that stores these events (e.g. the spikespace array) #}
+    {#  Get the name of the array that stores these events (e.g. the spikespace array) #}
     {% set _eventspace = get_array_name(eventspace_variable) %}
 
-	for(int _idx=0; _idx<N; _idx++)
-	{
-	    // vector code
-	    const int _vectorisation_idx = _idx;
-		{{ super() }}
-		if(_cond) {
-			{{_eventspace}}[_cpp_numevents++] = _idx;
-			{% if _uses_refractory %}
-			{{not_refractory}}[_idx] = false;
-			{{lastspike}}[_idx] = {{t}};
-			{% endif %}
-		}
-	}
-	{{_eventspace}}[N] = _cpp_numevents;
+    for(size_t _idx=0; _idx<N; _idx++)
+    {
+        // vector code
+        const size_t _vectorisation_idx = _idx;
+        {{ super() }}
+        if(_cond) {
+            {{_eventspace}}[_cpp_numevents++] = _idx;
+            {% if _uses_refractory %}
+            {{not_refractory}}[_idx] = false;
+            {{lastspike}}[_idx] = {{t}};
+            {% endif %}
+        }
+    }
+    {{_eventspace}}[N] = _cpp_numevents;
 {% endblock %}

--- a/brian2/devices/cpp_standalone/device.py
+++ b/brian2/devices/cpp_standalone/device.py
@@ -763,11 +763,11 @@ class CPPStandaloneDevice(Device):
                                 line = line.format(c_type=c_data_type(v.dtype), array_name=array_name,
                                                    dyn_array_name=dyn_array_name)
                                 lines.append(line)
-                                line = 'const int _num{k} = {dyn_array_name}.size();'
+                                line = 'const size_t _num{k} = {dyn_array_name}.size();'
                                 line = line.format(k=k, dyn_array_name=dyn_array_name)
                                 lines.append(line)
                         else:
-                            lines.append('const int _num%s = %s;' % (k, v.size))
+                            lines.append('const size_t _num%s = %s;' % (k, v.size))
                     except TypeError:
                         pass
             for line in lines:

--- a/brian2/devices/cpp_standalone/templates/common_group.cpp
+++ b/brian2/devices/cpp_standalone/templates/common_group.cpp
@@ -47,9 +47,9 @@ void _run_{{codeobj_name}}()
     {# N is a constant in most cases (NeuronGroup, etc.), but a scalar array for
        synapses, we therefore have to take care to get its value in the right
        way. #}
-	const size_t _N = {{constant_or_scalar('N', variables['N'])}};
+	const int _N = {{constant_or_scalar('N', variables['N'])}};
 	{{openmp_pragma('parallel-static')}}
-	for(size_t _idx=0; _idx<_N; _idx++)
+	for(int _idx=0; _idx<_N; _idx++)
 	{
 	    // vector code
 		const size_t _vectorisation_idx = _idx;

--- a/brian2/devices/cpp_standalone/templates/common_group.cpp
+++ b/brian2/devices/cpp_standalone/templates/common_group.cpp
@@ -41,18 +41,18 @@ void _run_{{codeobj_name}}()
 	{% block maincode %}
 	//// MAIN CODE ////////////
 	// scalar code
-	const int _vectorisation_idx = -1;
+	const size_t _vectorisation_idx = -1;
 	{{scalar_code|autoindent}}
 
     {# N is a constant in most cases (NeuronGroup, etc.), but a scalar array for
        synapses, we therefore have to take care to get its value in the right
        way. #}
-	const int _N = {{constant_or_scalar('N', variables['N'])}};
+	const size_t _N = {{constant_or_scalar('N', variables['N'])}};
 	{{openmp_pragma('parallel-static')}}
-	for(int _idx=0; _idx<_N; _idx++)
+	for(size_t _idx=0; _idx<_N; _idx++)
 	{
 	    // vector code
-		const int _vectorisation_idx = _idx;
+		const size_t _vectorisation_idx = _idx;
 		{% block maincode_inner %}
         {{vector_code|autoindent}}
 		{% endblock %}

--- a/brian2/devices/cpp_standalone/templates/group_variable_set.cpp
+++ b/brian2/devices/cpp_standalone/templates/group_variable_set.cpp
@@ -8,7 +8,7 @@
     {{scalar_code|autoindent}}
 
     {{ openmp_pragma('parallel-static') }}
-	for(size_t _idx_group_idx=0; _idx_group_idx<_num_group_idx; _idx_group_idx++)
+	for(int _idx_group_idx=0; _idx_group_idx<(int)_num_group_idx; _idx_group_idx++)
 	{
 	    // vector code
 		const size_t _idx = {{_group_idx}}[_idx_group_idx];

--- a/brian2/devices/cpp_standalone/templates/group_variable_set.cpp
+++ b/brian2/devices/cpp_standalone/templates/group_variable_set.cpp
@@ -4,15 +4,15 @@
 	{# USES_VARIABLES { _group_idx } #}
 	//// MAIN CODE ////////////
 	// scalar code
-    const int _vectorisation_idx = -1;
+    const size_t _vectorisation_idx = -1;
     {{scalar_code|autoindent}}
 
     {{ openmp_pragma('parallel-static') }}
-	for(int _idx_group_idx=0; _idx_group_idx<_num_group_idx; _idx_group_idx++)
+	for(size_t _idx_group_idx=0; _idx_group_idx<_num_group_idx; _idx_group_idx++)
 	{
 	    // vector code
-		const int _idx = {{_group_idx}}[_idx_group_idx];
-		const int _vectorisation_idx = _idx;
+		const size_t _idx = {{_group_idx}}[_idx_group_idx];
+		const size_t _vectorisation_idx = _idx;
         {{vector_code|autoindent}}
 	}
 {% endblock %}

--- a/brian2/devices/cpp_standalone/templates/group_variable_set_conditional.cpp
+++ b/brian2/devices/cpp_standalone/templates/group_variable_set_conditional.cpp
@@ -43,10 +43,10 @@ void _run_{{codeobj_name}}()
     {# N is a constant in most cases (NeuronGroup, etc.), but a scalar array for
        synapses, we therefore have to take care to get its value in the right
        way. #}
-	const size_t _N = {{constant_or_scalar('N', variables['N'])}};
+	const int _N = {{constant_or_scalar('N', variables['N'])}};
 
 	{{ openmp_pragma('parallel-static') }}
-	for(size_t _idx=0; _idx<_N; _idx++)
+	for(int _idx=0; _idx<_N; _idx++)
 	{
 	    // vector code
 		const size_t _vectorisation_idx = _idx;

--- a/brian2/devices/cpp_standalone/templates/group_variable_set_conditional.cpp
+++ b/brian2/devices/cpp_standalone/templates/group_variable_set_conditional.cpp
@@ -32,7 +32,7 @@ void _run_{{codeobj_name}}()
 	{% block maincode %}
 	//// MAIN CODE ////////////
 	// scalar code
-	const int _vectorisation_idx = -1;
+	const size_t _vectorisation_idx = -1;
 	{# Note that the scalar_code['statement'] will not write to any scalar
 	   variables (except if the condition is simply 'True' and no vector code
 	   is present), it will only read in scalar variables that are used by the
@@ -43,13 +43,13 @@ void _run_{{codeobj_name}}()
     {# N is a constant in most cases (NeuronGroup, etc.), but a scalar array for
        synapses, we therefore have to take care to get its value in the right
        way. #}
-	const int _N = {{constant_or_scalar('N', variables['N'])}};
+	const size_t _N = {{constant_or_scalar('N', variables['N'])}};
 
 	{{ openmp_pragma('parallel-static') }}
-	for(int _idx=0; _idx<_N; _idx++)
+	for(size_t _idx=0; _idx<_N; _idx++)
 	{
 	    // vector code
-		const int _vectorisation_idx = _idx;
+		const size_t _vectorisation_idx = _idx;
 		{{vector_code['condition']|autoindent}}
 		if (_cond)
 		{

--- a/brian2/devices/cpp_standalone/templates/network.cpp
+++ b/brian2/devices/cpp_standalone/templates/network.cpp
@@ -66,7 +66,7 @@ void Network::run(const double duration, void (*report_func)(const double, const
     {
         t = clock->t[0];
 
-        for(int i=0; i<objects.size(); i++)
+        for(size_t i=0; i<objects.size(); i++)
         {
             if (report_func)
             {

--- a/brian2/devices/cpp_standalone/templates/ratemonitor.cpp
+++ b/brian2/devices/cpp_standalone/templates/ratemonitor.cpp
@@ -4,14 +4,14 @@
 	{# USES_VARIABLES { N, rate, t, _spikespace, _clock_t, _clock_dt,
 	                    _num_source_neurons, _source_start, _source_stop } #}
     {# WRITES_TO_READ_ONLY_VARIABLES { N } #}
-	int _num_spikes = {{_spikespace}}[_num_spikespace-1];
+	size_t _num_spikes = {{_spikespace}}[_num_spikespace-1];
 	// For subgroups, we do not want to record all spikes
     // We assume that spikes are ordered
     int _start_idx = -1;
     int _end_idx = -1;
-    for(int _j=0; _j<_num_spikes; _j++)
+    for(size_t _j=0; _j<_num_spikes; _j++)
     {
-        const int _idx = {{_spikespace}}[_j];
+        const size_t _idx = {{_spikespace}}[_j];
         if (_idx >= _source_start) {
             _start_idx = _j;
             break;
@@ -19,9 +19,9 @@
     }
     if (_start_idx == -1)
         _start_idx = _num_spikes;
-    for(int _j=_start_idx; _j<_num_spikes; _j++)
+    for(size_t _j=_start_idx; _j<_num_spikes; _j++)
     {
-        const int _idx = {{_spikespace}}[_j];
+        const size_t _idx = {{_spikespace}}[_j];
         if (_idx >= _source_stop) {
             _end_idx = _j;
             break;

--- a/brian2/devices/cpp_standalone/templates/reset.cpp
+++ b/brian2/devices/cpp_standalone/templates/reset.cpp
@@ -13,7 +13,7 @@
 	{{scalar_code|autoindent}}
 
 	{{ openmp_pragma('parallel-static') }}
-	for(size_t _index_events=0; _index_events<_num_events; _index_events++)
+	for(int32_t _index_events=0; _index_events<_num_events; _index_events++)
 	{
 	    // vector code
 		const size_t _idx = _events[_index_events];

--- a/brian2/devices/cpp_standalone/templates/reset.cpp
+++ b/brian2/devices/cpp_standalone/templates/reset.cpp
@@ -9,15 +9,15 @@
 
 	//// MAIN CODE ////////////	
 	// scalar code
-	const int _vectorisation_idx = -1;
+	const size_t _vectorisation_idx = -1;
 	{{scalar_code|autoindent}}
 
 	{{ openmp_pragma('parallel-static') }}
-	for(int _index_events=0; _index_events<_num_events; _index_events++)
+	for(size_t _index_events=0; _index_events<_num_events; _index_events++)
 	{
 	    // vector code
-		const int _idx = _events[_index_events];
-		const int _vectorisation_idx = _idx;
+		const size_t _idx = _events[_index_events];
+		const size_t _vectorisation_idx = _idx;
         {{vector_code|autoindent}}
 	}
 {% endblock %}

--- a/brian2/devices/cpp_standalone/templates/spatialneuron_prepare.cpp
+++ b/brian2/devices/cpp_standalone/templates/spatialneuron_prepare.cpp
@@ -11,7 +11,7 @@
         {{_invr}}[_i] = 1.0/(_Ri*(1/{{r_length_2}}[_i-1] + 1/{{r_length_1}}[_i]));
     // Cut sections
     {{ openmp_pragma('parallel-static') }}
-    for (size_t _i=0; _i<_num_starts; _i++)
+    for (int _i=0; _i<(int)_num_starts; _i++)
         {{_invr}}[{{_starts}}[_i]] = 0;
 
     // Linear systems

--- a/brian2/devices/cpp_standalone/templates/spatialneuron_prepare.cpp
+++ b/brian2/devices/cpp_standalone/templates/spatialneuron_prepare.cpp
@@ -11,7 +11,7 @@
         {{_invr}}[_i] = 1.0/(_Ri*(1/{{r_length_2}}[_i-1] + 1/{{r_length_1}}[_i]));
     // Cut sections
     {{ openmp_pragma('parallel-static') }}
-    for (int _i=0; _i<_num_starts; _i++)
+    for (size_t _i=0; _i<_num_starts; _i++)
         {{_invr}}[{{_starts}}[_i]] = 0;
 
     // Linear systems
@@ -29,7 +29,7 @@
     }
 
     // Set the boundary conditions
-    for (int _counter=0; _counter<_num_starts; _counter++)
+    for (size_t _counter=0; _counter<_num_starts; _counter++)
     {
         const int _first = {{_starts}}[_counter];
         const int _last = {{_ends}}[_counter] - 1;  // the compartment indices are in the interval [starts, ends[

--- a/brian2/devices/cpp_standalone/templates/spatialstateupdate.cpp
+++ b/brian2/devices/cpp_standalone/templates/spatialstateupdate.cpp
@@ -38,7 +38,7 @@
     // (independent: branches)
 
     {{ openmp_pragma('parallel-static') }}
-    for (size_t _i=0; _i<_num_B - 1; _i++)
+    for (int _i=0; _i<(int)_num_B - 1; _i++)
     {
         // first and last index of the i-th section
         const int _j_start = {{_starts}}[_i];

--- a/brian2/devices/cpp_standalone/templates/spatialstateupdate.cpp
+++ b/brian2/devices/cpp_standalone/templates/spatialstateupdate.cpp
@@ -135,7 +135,7 @@
     // use efficient O(n) solution of the sparse linear system (structure-specific Gaussian elemination)
 
     // part 1: lower triangularization
-    for (size_t _i=_num_B-1; _i>=0; _i--) {
+    for (int _i=_num_B-1; _i>=0; _i--) {
         const int _num_children = {{_morph_children_num}}[_i];
         
         // for every child eliminate the corresponding matrix element of row i

--- a/brian2/devices/cpp_standalone/templates/spatialstateupdate.cpp
+++ b/brian2/devices/cpp_standalone/templates/spatialstateupdate.cpp
@@ -38,7 +38,7 @@
     // (independent: branches)
 
     {{ openmp_pragma('parallel-static') }}
-    for (int _i=0; _i<_num_B - 1; _i++)
+    for (size_t _i=0; _i<_num_B - 1; _i++)
     {
         // first and last index of the i-th section
         const int _j_start = {{_starts}}[_i];
@@ -91,7 +91,7 @@
     // _P_children contains the super diagonal entries
     // _P_parent contains the single sub diagonal entry for each row
     // _B contains the right hand side
-    for (int _i=0; _i<_num_B - 1; _i++)
+    for (size_t _i=0; _i<_num_B - 1; _i++)
     {
         const int _i_parent = {{_morph_parent_i}}[_i];
         const int _i_childind = {{_morph_idxchild}}[_i];
@@ -135,11 +135,11 @@
     // use efficient O(n) solution of the sparse linear system (structure-specific Gaussian elemination)
 
     // part 1: lower triangularization
-    for (int _i=_num_B-1; _i>=0; _i--) {
+    for (size_t _i=_num_B-1; _i>=0; _i--) {
         const int _num_children = {{_morph_children_num}}[_i];
         
         // for every child eliminate the corresponding matrix element of row i
-        for (int _k=0; _k<_num_children; _k++) {
+        for (size_t _k=0; _k<_num_children; _k++) {
             int _j = {{_morph_children}}[_IDX_C(_i,_k)]; // child index
             
             // subtracting _subfac times the j-th from the i-th row
@@ -166,7 +166,7 @@
 
     // STEP 4: for each section compute the final solution by linear
     // combination of the general solution (independent: sections & compartments)
-    for (int _i=0; _i<_num_B - 1; _i++)
+    for (size_t _i=0; _i<_num_B - 1; _i++)
     {
         const int _i_parent = {{_morph_parent_i}}[_i];
         const int _j_start = {{_starts}}[_i];

--- a/brian2/devices/cpp_standalone/templates/spikegenerator.cpp
+++ b/brian2/devices/cpp_standalone/templates/spikegenerator.cpp
@@ -16,7 +16,7 @@
 
     int32_t _cpp_numspikes = 0;
 
-    for(int _idx={{_lastindex}}; _idx < _num_timebins; _idx++)
+    for(size_t _idx={{_lastindex}}; _idx < _num_timebins; _idx++)
     {
         if ({{_timebins}}[_idx] > _timebin)
             break;

--- a/brian2/devices/cpp_standalone/templates/spikemonitor.cpp
+++ b/brian2/devices/cpp_standalone/templates/spikemonitor.cpp
@@ -12,9 +12,9 @@
 
     if (_num_events > 0)
     {
-        int _start_idx = _num_events;
-        int _end_idx = _num_events;
-        for(int _j=0; _j<_num_events; _j++)
+        size_t _start_idx = _num_events;
+        size_t _end_idx = _num_events;
+        for(size_t _j=0; _j<_num_events; _j++)
         {
             const int _idx = {{_eventspace}}[_j];
             if (_idx >= _source_start) {
@@ -22,7 +22,7 @@
                 break;
             }
         }
-        for(int _j=_num_events-1; _j>=_start_idx; _j--)
+        for(size_t _j=_num_events-1; _j>=_start_idx; _j--)
         {
             const int _idx = {{_eventspace}}[_j];
             if (_idx < _source_stop) {
@@ -32,12 +32,12 @@
         }
         _num_events = _end_idx - _start_idx;
         if (_num_events > 0) {
-             const int _vectorisation_idx = 1;
+            const size_t _vectorisation_idx = 1;
             {{scalar_code|autoindent}}
-            for(int _j=_start_idx; _j<_end_idx; _j++)
+            for(size_t _j=_start_idx; _j<_end_idx; _j++)
             {
-                const int _idx = {{_eventspace}}[_j];
-                const int _vectorisation_idx = _idx;
+                const size_t _idx = {{_eventspace}}[_j];
+                const size_t _vectorisation_idx = _idx;
                 {{vector_code|autoindent}}
                 {% for varname, var in record_variables | dictsort %}
                 {{get_array_name(var, access_data=False)}}.push_back(_to_record_{{varname}});

--- a/brian2/devices/cpp_standalone/templates/statemonitor.cpp
+++ b/brian2/devices/cpp_standalone/templates/statemonitor.cpp
@@ -17,7 +17,7 @@
     {{scalar_code|autoindent}}
 
     {{ openmp_pragma('parallel-static') }}
-    for (size_t _i = 0; _i < _num_indices; _i++)
+    for (int _i = 0; _i < (int)_num_indices; _i++)
     {
         // vector code
         const size_t _idx = {{_indices}}[_i];

--- a/brian2/devices/cpp_standalone/templates/statemonitor.cpp
+++ b/brian2/devices/cpp_standalone/templates/statemonitor.cpp
@@ -5,7 +5,7 @@
     {# WRITES_TO_READ_ONLY_VARIABLES { t, N } #}
     {{_dynamic_t}}.push_back({{_clock_t}});
 
-    const int _new_size = {{_dynamic_t}}.size();
+    const size_t _new_size = {{_dynamic_t}}.size();
     // Resize the dynamic arrays
     {% for varname, var in _recorded_variables | dictsort %}
     {% set _recorded =  get_array_name(var, access_data=False) %}
@@ -13,15 +13,15 @@
     {% endfor %}
 
     // scalar code
-    const int _vectorisation_idx = -1;
+    const size_t _vectorisation_idx = -1;
     {{scalar_code|autoindent}}
 
     {{ openmp_pragma('parallel-static') }}
-    for (int _i = 0; _i < _num_indices; _i++)
+    for (size_t _i = 0; _i < _num_indices; _i++)
     {
         // vector code
-        const int _idx = {{_indices}}[_i];
-        const int _vectorisation_idx = _idx;
+        const size_t _idx = {{_indices}}[_i];
+        const size_t _vectorisation_idx = _idx;
         {% block maincode_inner %}
             {{ super() }}
 

--- a/brian2/devices/cpp_standalone/templates/summed_variable.cpp
+++ b/brian2/devices/cpp_standalone/templates/summed_variable.cpp
@@ -6,23 +6,23 @@
     {% set _index_array = get_array_name(_index_var) %}
     //// MAIN CODE ////////////
     {# This enables summed variables for connections to a synapse #}
-    const int _target_size = {{constant_or_scalar(_target_size_name, variables[_target_size_name])}};
+    const size_t _target_size = {{constant_or_scalar(_target_size_name, variables[_target_size_name])}};
 
     // Set all the target variable values to zero
     {{ openmp_pragma('parallel-static') }}
-    for (int _target_idx=0; _target_idx<_target_size; _target_idx++)
+    for (size_t _target_idx=0; _target_idx<_target_size; _target_idx++)
     {
         {{_target_var_array}}[_target_idx + {{_target_start}}] = 0;
     }
 
     // scalar code
-    const int _vectorisation_idx = -1;
+    const size_t _vectorisation_idx = -1;
     {{scalar_code|autoindent}}
 
     for(int _idx=0; _idx<{{N}}; _idx++)
     {
         // vector code
-        const int _vectorisation_idx = _idx;
+        const size_t _vectorisation_idx = _idx;
         {{vector_code|autoindent}}
         {{_target_var_array}}[{{_index_array}}[_idx]] += _synaptic_var;
     }

--- a/brian2/devices/cpp_standalone/templates/summed_variable.cpp
+++ b/brian2/devices/cpp_standalone/templates/summed_variable.cpp
@@ -6,11 +6,11 @@
     {% set _index_array = get_array_name(_index_var) %}
     //// MAIN CODE ////////////
     {# This enables summed variables for connections to a synapse #}
-    const size_t _target_size = {{constant_or_scalar(_target_size_name, variables[_target_size_name])}};
+    const int _target_size = {{constant_or_scalar(_target_size_name, variables[_target_size_name])}};
 
     // Set all the target variable values to zero
     {{ openmp_pragma('parallel-static') }}
-    for (size_t _target_idx=0; _target_idx<_target_size; _target_idx++)
+    for (int _target_idx=0; _target_idx<_target_size; _target_idx++)
     {
         {{_target_var_array}}[_target_idx + {{_target_start}}] = 0;
     }

--- a/brian2/devices/cpp_standalone/templates/synapses.cpp
+++ b/brian2/devices/cpp_standalone/templates/synapses.cpp
@@ -10,42 +10,42 @@
 
 {% block maincode %}
 
-	// This is only needed for the _debugmsg function below	
-	{# USES_VARIABLES { _synaptic_pre } #}	
+    // This is only needed for the _debugmsg function below
+    {# USES_VARIABLES { _synaptic_pre } #}
 
-	// scalar code
-	const int _vectorisation_idx = -1;
-	{{scalar_code|autoindent}}
+    // scalar code
+    const size_t _vectorisation_idx = -1;
+    {{scalar_code|autoindent}}
 
-	{{ openmp_pragma('parallel') }}
-	{
-	std::vector<int> *_spiking_synapses = {{pathway.name}}.peek();
-	const unsigned int _num_spiking_synapses = _spiking_synapses->size();
+    {{ openmp_pragma('parallel') }}
+    {
+    std::vector<int> *_spiking_synapses = {{pathway.name}}.peek();
+    const size_t _num_spiking_synapses = _spiking_synapses->size();
 
-	{% if _non_synaptic %}
-	{{ openmp_pragma('master') }}
-	{
-		for(unsigned int _spiking_synapse_idx=0;
-			_spiking_synapse_idx<_num_spiking_synapses;
-			_spiking_synapse_idx++)
-		{
-			const int _idx = (*_spiking_synapses)[_spiking_synapse_idx];
-			const int _vectorisation_idx = _idx;
-			{{vector_code|autoindent}}
-		}
-	}
-	{% else %}
-	{{ openmp_pragma('static') }}
-	for(int _spiking_synapse_idx=0;
-		_spiking_synapse_idx<_num_spiking_synapses;
-		_spiking_synapse_idx++)
-	{
-		const int _idx = (*_spiking_synapses)[_spiking_synapse_idx];
-		const int _vectorisation_idx = _idx;
-		{{vector_code|autoindent}}
-	}
+    {% if _non_synaptic %}
+    {{ openmp_pragma('master') }}
+    {
+        for(size_t _spiking_synapse_idx=0;
+            _spiking_synapse_idx<_num_spiking_synapses;
+            _spiking_synapse_idx++)
+        {
+            const size_t _idx = (*_spiking_synapses)[_spiking_synapse_idx];
+            const size_t _vectorisation_idx = _idx;
+            {{vector_code|autoindent}}
+        }
+    }
+    {% else %}
+    {{ openmp_pragma('static') }}
+    for(size_t _spiking_synapse_idx=0;
+        _spiking_synapse_idx<_num_spiking_synapses;
+        _spiking_synapse_idx++)
+    {
+        const size_t _idx = (*_spiking_synapses)[_spiking_synapse_idx];
+        const size_t _vectorisation_idx = _idx;
+        {{vector_code|autoindent}}
+    }
 
-	{% endif %}
+    {% endif %}
     }
 {% endblock %}
 
@@ -53,8 +53,8 @@
 {% block extra_functions_cpp %}
 void _debugmsg_{{codeobj_name}}()
 {
-	using namespace brian;
-	std::cout << "Number of synapses: " << {{_dynamic__synaptic_pre}}.size() << endl;
+    using namespace brian;
+    std::cout << "Number of synapses: " << {{_dynamic__synaptic_pre}}.size() << endl;
 }
 {% endblock %}
 

--- a/brian2/devices/cpp_standalone/templates/synapses.cpp
+++ b/brian2/devices/cpp_standalone/templates/synapses.cpp
@@ -20,12 +20,12 @@
     {{ openmp_pragma('parallel') }}
     {
     std::vector<int> *_spiking_synapses = {{pathway.name}}.peek();
-    const size_t _num_spiking_synapses = _spiking_synapses->size();
+    const int _num_spiking_synapses = _spiking_synapses->size();
 
     {% if _non_synaptic %}
     {{ openmp_pragma('master') }}
     {
-        for(size_t _spiking_synapse_idx=0;
+        for(int _spiking_synapse_idx=0;
             _spiking_synapse_idx<_num_spiking_synapses;
             _spiking_synapse_idx++)
         {
@@ -36,7 +36,7 @@
     }
     {% else %}
     {{ openmp_pragma('static') }}
-    for(size_t _spiking_synapse_idx=0;
+    for(int _spiking_synapse_idx=0;
         _spiking_synapse_idx<_num_spiking_synapses;
         _spiking_synapse_idx++)
     {

--- a/brian2/devices/cpp_standalone/templates/synapses_create_array.cpp
+++ b/brian2/devices/cpp_standalone/templates/synapses_create_array.cpp
@@ -9,17 +9,17 @@
                                    N_incoming, N_outgoing, N}
 #}
 
-const int _old_num_synapses = {{N}};
-const int _new_num_synapses = _old_num_synapses + _numsources;
+const size_t _old_num_synapses = {{N}};
+const size_t _new_num_synapses = _old_num_synapses + _numsources;
 
 {# Get N_post and N_pre in the correct way, regardless of whether they are
 constants or scalar arrays#}
-const int _N_pre = {{constant_or_scalar('N_pre', variables['N_pre'])}};
-const int _N_post = {{constant_or_scalar('N_post', variables['N_post'])}};
+const size_t _N_pre = {{constant_or_scalar('N_pre', variables['N_pre'])}};
+const size_t _N_post = {{constant_or_scalar('N_post', variables['N_post'])}};
 {{_dynamic_N_incoming}}.resize(_N_post + _target_offset);
 {{_dynamic_N_outgoing}}.resize(_N_pre + _source_offset);
 
-for (int _idx=0; _idx<_numsources; _idx++) {
+for (size_t _idx=0; _idx<_numsources; _idx++) {
     {# After this code has been executed, the arrays _real_sources and
        _real_variables contain the final indices. Having any code here it all is
        only necessary for supporting subgroups #}
@@ -33,7 +33,7 @@ for (int _idx=0; _idx<_numsources; _idx++) {
 }
 
 // now we need to resize all registered variables
-const int newsize = {{_dynamic__synaptic_pre}}.size();
+const size_t newsize = {{_dynamic__synaptic_pre}}.size();
 {% for varname in owner._registered_variables | variables_to_array_names(access_data=False) | sort %}
 {{varname}}.resize(newsize);
 {% endfor %}
@@ -44,7 +44,7 @@ const int newsize = {{_dynamic__synaptic_pre}}.size();
 // Update the "synapse number" (number of synapses for the same
 // source-target pair)
 std::map<std::pair<int32_t, int32_t>, int32_t> source_target_count;
-for (int _i=0; _i<newsize; _i++)
+for (size_t _i=0; _i<newsize; _i++)
 {
     // Note that source_target_count will create a new entry initialized
     // with 0 when the key does not exist yet

--- a/brian2/devices/cpp_standalone/templates/synapses_create_generator.cpp
+++ b/brian2/devices/cpp_standalone/templates/synapses_create_generator.cpp
@@ -12,18 +12,18 @@
 
     {# Get N_post and N_pre in the correct way, regardless of whether they are
     constants or scalar arrays#}
-    const int _N_pre = {{constant_or_scalar('N_pre', variables['N_pre'])}};
-    const int _N_post = {{constant_or_scalar('N_post', variables['N_post'])}};
+    const size_t _N_pre = {{constant_or_scalar('N_pre', variables['N_pre'])}};
+    const size_t _N_post = {{constant_or_scalar('N_post', variables['N_post'])}};
     {{_dynamic_N_incoming}}.resize(_N_post + _target_offset);
     {{_dynamic_N_outgoing}}.resize(_N_pre + _source_offset);
-    int _raw_pre_idx, _raw_post_idx;
+    size_t _raw_pre_idx, _raw_post_idx;
     // scalar code
-    const int _vectorisation_idx = -1;
+    const size_t _vectorisation_idx = -1;
     {{scalar_code['setup_iterator']|autoindent}}
     {{scalar_code['create_j']|autoindent}}
     {{scalar_code['create_cond']|autoindent}}
     {{scalar_code['update_post']|autoindent}}
-    for(int _i=0; _i<_N_pre; _i++)
+    for(size_t _i=0; _i<_N_pre; _i++)
     {
         bool __cond, _cond;
         _raw_pre_idx = _i + _source_offset;
@@ -65,7 +65,7 @@
             {% endif %}
         }
         {% if iterator_func=='range' %}
-        for(int {{iteration_variable}}=_uiter_low; {{iteration_variable}}<_uiter_high; {{iteration_variable}}+=_uiter_step)
+        for(long {{iteration_variable}}=_uiter_low; {{iteration_variable}}<_uiter_high; {{iteration_variable}}+=_uiter_step)
         {
         {% elif iterator_func=='sample' %}
         if(_uiter_p==0) continue;
@@ -76,7 +76,7 @@
         else
             _log1p = 1.0; // will be ignored
         const double _pconst = 1.0/log(1-_uiter_p);
-        for(int {{iteration_variable}}=_uiter_low; {{iteration_variable}}<_uiter_high; {{iteration_variable}}++)
+        for(long {{iteration_variable}}=_uiter_low; {{iteration_variable}}<_uiter_high; {{iteration_variable}}++)
         {
             if(_jump_algo) {
                 const double _r = _rand(_vectorisation_idx);
@@ -136,7 +136,7 @@
             {% endif %}
             {{vector_code['update_post']|autoindent}}
 
-            for (int _repetition=0; _repetition<_n; _repetition++) {
+            for (size_t _repetition=0; _repetition<_n; _repetition++) {
                 {{_dynamic_N_outgoing}}[_pre_idx] += 1;
                 {{_dynamic_N_incoming}}[_post_idx] += 1;
                 {{_dynamic__synaptic_pre}}.push_back(_pre_idx);
@@ -157,7 +157,7 @@
     // Update the "synapse number" (number of synapses for the same
     // source-target pair)
     std::map<std::pair<int32_t, int32_t>, int32_t> source_target_count;
-    for (int _i=0; _i<newsize; _i++)
+    for (size_t _i=0; _i<newsize; _i++)
     {
         // Note that source_target_count will create a new entry initialized
         // with 0 when the key does not exist yet

--- a/brian2/devices/cpp_standalone/templates/synapses_initialise_queue.cpp
+++ b/brian2/devices/cpp_standalone/templates/synapses_initialise_queue.cpp
@@ -9,8 +9,8 @@ void _run_{{codeobj_name}}() {
     std::vector<{{scalar}}> &real_delays = {{get_array_name(owner.variables['delay'], access_data=False)}};
     {{scalar}}* real_delays_data = real_delays.empty() ? 0 : &(real_delays[0]);
     int32_t* sources = {{pathobj}}.sources.empty() ? 0 : &({{pathobj}}.sources[0]);
-    const unsigned int n_delays = real_delays.size();
-    const unsigned int n_synapses = {{pathobj}}.sources.size();
+    const size_t n_delays = real_delays.size();
+    const size_t n_synapses = {{pathobj}}.sources.size();
     {{pathobj}}.prepare({{constant_or_scalar('_n_sources', variables['_n_sources'])}},
                         {{constant_or_scalar('_n_targets', variables['_n_targets'])}},
                         real_delays_data, n_delays, sources,

--- a/brian2/devices/cpp_standalone/templates/threshold.cpp
+++ b/brian2/devices/cpp_standalone/templates/threshold.cpp
@@ -16,9 +16,9 @@
     {% set _eventspace = get_array_name(eventspace_variable) %}
 
     long _count = 0;
-    for(int _idx=0; _idx<N; _idx++)
+    for(size_t _idx=0; _idx<N; _idx++)
     {
-        const int _vectorisation_idx = _idx;
+        const size_t _vectorisation_idx = _idx;
         {{vector_code|autoindent}}
         if(_cond) {
             {{_eventspace}}[_count++] = _idx;

--- a/brian2/tests/__init__.py
+++ b/brian2/tests/__init__.py
@@ -28,7 +28,8 @@ try:
                 # Check the object for exclusion from doctests
                 full_name = item.name.split('.')
                 test_name = []
-                while full_name[-1] != os.path.splitext(self.name)[0]:
+                module_name = os.path.splitext(os.path.basename(self.name))[0]
+                while full_name[-1] != module_name:
                     test_name.append(full_name.pop())
                 tested_obj = self.obj
                 for name in reversed(test_name):

--- a/docs_sphinx/developer/variables_indices.rst
+++ b/docs_sphinx/developer/variables_indices.rst
@@ -19,7 +19,7 @@ content for a simple example::
     >>> tau = 10*ms
     >>> G = NeuronGroup(10, 'dv/dt = -v / tau : volt')
     >>> for name, var in sorted(G.variables.items()):
-    ...     print('%s : %s' % (name, var))
+    ...     print('%s : %s' % (name, var))  # doctest: +SKIP
     ...
     N : <Constant(dimensions=Dimension(),  dtype=int64, scalar=True, constant=True, read_only=True)>
     dt : <ArrayVariable(dimensions=second,  dtype=float, scalar=True, constant=True, read_only=True)>


### PR DESCRIPTION
This PR replaces `int` by `size_t` in several places where a variable is used for indexing. This should fix  #1136, i.e. avoid crashes for indexes bigger than 2^31. Note that the main focus here is on getting rid of the 32bit limitation for variables in monitors, where this issue can appear comparatively easily. It does *not* lift the limitation of a maximum of 2^31 neurons or synapses, for example. These would be more difficult to handle, since we do not want in general to use 64bit integers for neuron indices, for example (this would significantly increase the memory needed to store synapses).

Note that in C++ standalone mode, loops that we parallelize with OpenMP cannot use `size_t`, since OpenMP requires the use of signed integer types (at least on Windows, but potentially also on Linux with older OpenMP versions).

@Debilski Can you confirm that this branch (`index_data_type`) fixes the issue that you were seeing in #1136?