### PR TITLE
[WIP/discuss] More strict check that equation is conditionally linear

### DIFF
--- a/brian2/stateupdaters/exponential_euler.py
+++ b/brian2/stateupdaters/exponential_euler.py
@@ -56,13 +56,16 @@ def get_conditionally_linear_system(eqs, variables=None):
             s_expr = sp.collect(s_expr,
                                 var, evaluate=False)
 
-            if len(s_expr) > 2 or var not in s_expr:
+            if (len(s_expr) > 2 or
+                    var not in s_expr or
+                    s_expr.get(sp.S.One, sp.S.Zero).has(var)
+            ):
                 raise ValueError(('The expression "%s", defining the variable %s, '
                                  'could not be separated into linear components') %
                                  (expr, name))
-            coefficients[name] = (s_expr[var], s_expr.get(1, 0))
+            coefficients[name] = (s_expr[var], s_expr.get(sp.S.One, sp.S.Zero))
         else:
-            coefficients[name] = (0, s_expr)
+            coefficients[name] = (sp.S.Zero, s_expr)
 
     return coefficients
 

--- a/brian2/tests/test_stateupdaters.py
+++ b/brian2/tests/test_stateupdaters.py
@@ -398,6 +398,17 @@ def test_priority():
 
     check_integration(eqs, variables, can_integrate)
 
+    # Equation that both linearly and non-linearly depends on the variable,
+    # and is therefore not "conditionally linear". The exponential Euler updater
+    # should therefore decline to integrate the equations.
+    param = 1
+    eqs = Equations('''dv/dt = (-v + exp(-v) + 1.0)/tau : 1''')
+    updater(eqs, variables)  # should not raise an error
+    can_integrate = {linear: False, euler: True, exponential_euler: False,
+                     rk2: True, rk4: True, heun: True, milstein: True}
+
+    check_integration(eqs, variables, can_integrate)
+
     # Equations resulting in complex linear solution for older versions of sympy
     eqs = Equations('''dv/dt      = (ge+gi-(v+49*mV))/(20*ms) : volt
             dge/dt     = -ge/(5*ms) : volt


### PR DESCRIPTION
@romainbrette noticed that while we claim that the exponential Euler algorithm requires that equations are conditionally linear (linear in the integrated variable, potentially non-linear in all other variables), our implementation actually allows for equations that are non-linear in the integrated variable itself. This is because we simply separate the equation into a linear and a non-linear part, and the non-linear part might still depend on the integrated variable. So currently, you *can* integrate the following with exponential Euler:
```Python
eqs = 'dv/dt = (-v + exp(-v))/tau : 1
```
This PR fixes this by checking that the non-linear part does not include the variable.

However, after implementing this I started to have some doubts (also because applying the exponential Euler algorithm to these kind of equations gives somewhat reasonable results). There are certainly better sources, but from [Wikipedia](https://en.wikipedia.org/wiki/Numerical_methods_for_ordinary_differential_equations#First-order_exponential_integrator_method), the algorithm requires the equation to decompose as:
![image](https://user-images.githubusercontent.com/1381982/71184851-a9e60500-227a-11ea-9c21-fa515f7eb7af.png)

The exact solution is then:
![image](https://user-images.githubusercontent.com/1381982/71184919-bff3c580-227a-11ea-852a-7f6c6bc79178.png)

And you can use a first-order approximation by considering the non-linear part to be constant over the time step, yielding
![image](https://user-images.githubusercontent.com/1381982/71184980-d9950d00-227a-11ea-8613-feb5a87ba4d9.png)

which is I think exactly what we are doing. Note that this contains an arbitrary non-linear term 
![image](https://user-images.githubusercontent.com/1381982/71185082-0fd28c80-227b-11ea-82f3-394d795cb75d.png) which is a function of *y*, so it seems to be fine to have a non-linear dependence on the integrated variable. Am I missing something here?

