### PR TITLE
[MRG] Resolve variable/function names before creating abstract code in Synapses

### DIFF
--- a/brian2/synapses/synapses.py
+++ b/brian2/synapses/synapses.py
@@ -63,10 +63,21 @@ class StateUpdater(CodeRunner):
                             check_units=False,
                             generate_empty_code=False)
     
-    def update_abstract_code(self, run_namespace=None, level=0):
+    def update_abstract_code(self, run_namespace):
         if len(self.group.equations) > 0:
+            # Resolve variables in the equations to correctly perform checks
+            # for repeated stateful functions (e.g. rand() calls)
+            names = self.group.equations.names
+            external_names = self.group.equations.identifiers | {'dt'}
+
+            variables = self.group.resolve_all(names | external_names,
+                                               run_namespace,
+                # we don't need to raise any warnings
+                # for the user here, warnings will
+                # be raised in create_runner_codeobj
+                user_identifiers=set())
             stateupdate_output = StateUpdateMethod.apply_stateupdater(self.group.equations,
-                                                                      self.group.variables,
+                                                                      variables,
                                                                       self.method_choice,
                                                                       method_options=self.method_options,
                                                                       group_name=self.group.name)

--- a/brian2/tests/test_functions.py
+++ b/brian2/tests/test_functions.py
@@ -852,6 +852,13 @@ def test_multiple_stateless_function_calls():
     net3 = Network(G3)
     with pytest.raises(NotImplementedError):
         net3.run(0*ms)
+    G4 = NeuronGroup(1, 'x : 1')
+    # Verify that synaptic equations are checked as well, see #1146
+    S = Synapses(G4, G4, 'dy/dt = (rand() - rand())/second : 1 (clock-driven)')
+    S.connect()
+    net = Network(G4, S)
+    with pytest.raises(NotImplementedError):
+        net.run(0 * ms)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This makes sure that checks like `check_expression_for_multiple_stateful_functions` work.
Closes #1146