### PR TITLE
[MRG] Correctly handle point currents marked as constant over dt

### DIFF
--- a/brian2/equations/equations.py
+++ b/brian2/equations/equations.py
@@ -429,7 +429,7 @@ class SingleEquation(Hashable, CacheKey):
         if flags is None:
             self.flags = []
         else:
-            self.flags = flags
+            self.flags = list(flags)
 
         # will be set later in the sort_subexpressions method of Equations
         self.update_order = -1
@@ -1151,10 +1151,7 @@ def extract_constant_subexpressions(eqs):
     const_subexpressions = []
     for eq in eqs.ordered:
         if eq.type == SUBEXPRESSION and 'constant over dt' in eq.flags:
-            if 'shared' in eq.flags:
-                flags = ['shared']
-            else:
-                flags = None
+            flags = set(eq.flags) - {'constant over dt'}
             without_const_subexpressions.append(SingleEquation(PARAMETER,
                                                                eq.varname,
                                                                eq.dim,

--- a/brian2/tests/test_spatialneuron.py
+++ b/brian2/tests/test_spatialneuron.py
@@ -811,6 +811,17 @@ def test_spatialneuron_capacitive_currents():
                     atol=1e6)
 
 
+@pytest.mark.codegen_independent
+def test_point_current():
+    soma = Soma(10*um)
+    eqs = '''Im = 0*nA/cm**2 : amp/meter**2
+             I1 = 1*nA : amp (point current)
+             I2 = 1*nA : amp (point current, constant over dt)'''
+    neuron = SpatialNeuron(soma, eqs)
+    assert 'I1/area' in neuron.equations['Im'].expr.code
+    assert 'I2/area' in neuron.equations['Im'].expr.code  # see issue #1160
+
+
 if __name__ == '__main__':
     test_custom_events()
     test_construction()

--- a/docs_sphinx/introduction/release_notes.rst
+++ b/docs_sphinx/introduction/release_notes.rst
@@ -12,7 +12,8 @@ Selected improvements and bug fixes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 * Removing objects from networks no longer fails (:issue:`1151`). Thanks to Wilhelm
   Braun for reporting the issue.
-
+* Point currents marked as ``constant over dt`` are now correctly handled
+  (:issue:`1160`). Thanks to Andrew Brughera for reporting the issue.
 
 Contributions
 ~~~~~~~~~~~~~
@@ -25,6 +26,7 @@ TODO
 Other contributions outside of github (ordered alphabetically, apologies to
 anyone we forgot...):
 
+* Andrew Brughera
 * Wilhelm Braun
 * Willam Xavier
 


### PR DESCRIPTION
We previously removed the `point currents` flag when converting a `constant over dt` subexpression into a parameter. With this PR, all flags are conserved.

Fixes #1160