### PR TITLE
Change time format of standalone mode to standard mode(hours/minutes/second), Gsoc 2020

### DIFF
--- a/brian2/devices/cpp_standalone/device.py
+++ b/brian2/devices/cpp_standalone/device.py
@@ -1381,6 +1381,32 @@ class CPPStandaloneDevice(Device):
 
         # Code for a progress reporting function
         standard_code = '''
+        string _format_time(float time_in_s)
+        {
+            float divisors[] = {24*60*60, 60*60, 60, 1};
+            char letters[] = {'d', 'h', 'm', 's'};
+            float remaining = time_in_s;
+            string text = "";
+            for (int i =0; i < sizeof(divisors)/sizeof(float); i++)
+            {
+                int time_to_represent = int(remaining / divisors[i]);
+                remaining -= time_to_represent * divisors[i];
+                if (time_to_represent > 0 || text.length())
+                {
+                    if(text.length() > 0)
+                    {
+                        text += " ";
+                    }
+                    text += (to_string(time_to_represent)+letters[i]);
+                }
+            }
+            //less than one second
+            if(text.length() == 0) 
+            {
+                text = "< 1s";
+            }
+            return text;
+        }
         void report_progress(const double elapsed, const double completed, const double start, const double duration)
         {
             if (completed == 0.0)
@@ -1388,11 +1414,11 @@ class CPPStandaloneDevice(Device):
                 %STREAMNAME% << "Starting simulation at t=" << start << " s for duration " << duration << " s";
             } else
             {
-                %STREAMNAME% << completed*duration << " s (" << (int)(completed*100.) << "%) simulated in " << elapsed << " s";
+                %STREAMNAME% << completed*duration << " s (" << (int)(completed*100.) << "%) simulated in " << _format_time(elapsed);
                 if (completed < 1.0)
                 {
                     const int remaining = (int)((1-completed)/completed*elapsed+0.5);
-                    %STREAMNAME% << ", estimated " << remaining << " s remaining.";
+                    %STREAMNAME% << ", estimated " << _format_time(remaining) << " remaining.";
                 }
             }
 


### PR DESCRIPTION
Fixes issue #1162
For GSoC 2020