### PR TITLE
[Gsoc 2020]Add example for printing text based progress bar in standalone mode in documentation

### DIFF
--- a/brian2/devices/cpp_standalone/device.py
+++ b/brian2/devices/cpp_standalone/device.py
@@ -1397,7 +1397,7 @@ class CPPStandaloneDevice(Device):
                     {
                         text += " ";
                     }
-                    text += (to_string(time_to_represent)+letters[i]);
+                    text += (std::to_string(time_to_represent)+letters[i]);
                 }
             }
             //less than one second

--- a/brian2/devices/cpp_standalone/device.py
+++ b/brian2/devices/cpp_standalone/device.py
@@ -1381,6 +1381,32 @@ class CPPStandaloneDevice(Device):
 
         # Code for a progress reporting function
         standard_code = '''
+        string _format_time(float time_in_s)
+        {
+            float divisors[] = {24*60*60, 60*60, 60, 1};
+            char letters[] = {'d', 'h', 'm', 's'};
+            float remaining = time_in_s;
+            string text = "";
+            for (int i =0; i < sizeof(divisors)/sizeof(float); i++)
+            {
+                int time_to_represent = int(remaining / divisors[i]);
+                remaining -= time_to_represent * divisors[i];
+                if (time_to_represent > 0 || text.length())
+                {
+                    if(text.length() > 0)
+                    {
+                        text += " ";
+                    }
+                    text += (to_string(time_to_represent)+letters[i]);
+                }
+            }
+            //less than one second
+            if(text.length() == 0) 
+            {
+                text = "< 1s";
+            }
+            return text;
+        }
         void report_progress(const double elapsed, const double completed, const double start, const double duration)
         {
             if (completed == 0.0)
@@ -1388,11 +1414,11 @@ class CPPStandaloneDevice(Device):
                 %STREAMNAME% << "Starting simulation at t=" << start << " s for duration " << duration << " s";
             } else
             {
-                %STREAMNAME% << completed*duration << " s (" << (int)(completed*100.) << "%) simulated in " << elapsed << " s";
+                %STREAMNAME% << completed*duration << " s (" << (int)(completed*100.) << "%) simulated in " << _format_time(elapsed);
                 if (completed < 1.0)
                 {
                     const int remaining = (int)((1-completed)/completed*elapsed+0.5);
-                    %STREAMNAME% << ", estimated " << remaining << " s remaining.";
+                    %STREAMNAME% << ", estimated " << _format_time(remaining) << " remaining.";
                 }
             }
 

--- a/brian2/devices/cpp_standalone/device.py
+++ b/brian2/devices/cpp_standalone/device.py
@@ -1383,7 +1383,6 @@ class CPPStandaloneDevice(Device):
         standard_code = '''
         std::string _format_time(float time_in_s)
         {
-            std::cout<<("hiiii");
             float divisors[] = {24*60*60, 60*60, 60, 1};
             char letters[] = {'d', 'h', 'm', 's'};
             float remaining = time_in_s;

--- a/brian2/devices/cpp_standalone/device.py
+++ b/brian2/devices/cpp_standalone/device.py
@@ -1381,12 +1381,13 @@ class CPPStandaloneDevice(Device):
 
         # Code for a progress reporting function
         standard_code = '''
-        string _format_time(float time_in_s)
+        std::string _format_time(float time_in_s)
         {
+            std::cout<<("hiiii");
             float divisors[] = {24*60*60, 60*60, 60, 1};
             char letters[] = {'d', 'h', 'm', 's'};
             float remaining = time_in_s;
-            string text = "";
+            std::string text = "";
             for (int i =0; i < sizeof(divisors)/sizeof(float); i++)
             {
                 int time_to_represent = int(remaining / divisors[i]);

--- a/brian2/devices/cpp_standalone/device.py
+++ b/brian2/devices/cpp_standalone/device.py
@@ -1381,15 +1381,21 @@ class CPPStandaloneDevice(Device):
 
         # Code for a progress reporting function
         standard_code = '''
+        std::string to_str(int n){
+            std::ostringstream stm ;
+            stm << n ;
+            return stm.str() ;
+        }
         std::string _format_time(float time_in_s)
         {
             float divisors[] = {24*60*60, 60*60, 60, 1};
             char letters[] = {'d', 'h', 'm', 's'};
             float remaining = time_in_s;
             std::string text = "";
+            int time_to_represent;
             for (int i =0; i < sizeof(divisors)/sizeof(float); i++)
             {
-                int time_to_represent = int(remaining / divisors[i]);
+                time_to_represent = int(remaining / divisors[i]);
                 remaining -= time_to_represent * divisors[i];
                 if (time_to_represent > 0 || text.length())
                 {
@@ -1397,7 +1403,7 @@ class CPPStandaloneDevice(Device):
                     {
                         text += " ";
                     }
-                    text += (std::to_string(time_to_represent)+letters[i]);
+                    text += (to_str(time_to_represent)+letters[i]);
                 }
             }
             //less than one second

--- a/brian2/devices/cpp_standalone/templates/main.cpp
+++ b/brian2/devices/cpp_standalone/templates/main.cpp
@@ -18,6 +18,7 @@
 #include <iostream>
 #include <fstream>
 #include <sstream>
+#include<string>
 
 {{report_func|autoindent}}
 

--- a/brian2/devices/cpp_standalone/templates/main.cpp
+++ b/brian2/devices/cpp_standalone/templates/main.cpp
@@ -17,6 +17,7 @@
 
 #include <iostream>
 #include <fstream>
+#include <sstream>
 
 {{report_func|autoindent}}
 

--- a/brian2/devices/cpp_standalone/templates/network.cpp
+++ b/brian2/devices/cpp_standalone/templates/network.cpp
@@ -5,6 +5,8 @@
 #include<iostream>
 #include <ctime>
 #include<utility>
+#include<string>
+
 {{ openmp_pragma('include') }}
 
 #define Clock_epsilon 1e-14

--- a/brian2/devices/cpp_standalone/templates/network.cpp
+++ b/brian2/devices/cpp_standalone/templates/network.cpp
@@ -6,6 +6,7 @@
 #include <ctime>
 #include<utility>
 #include<string>
+#include <sstream>
 
 {{ openmp_pragma('include') }}
 

--- a/docs_sphinx/advanced/scheduling.rst
+++ b/docs_sphinx/advanced/scheduling.rst
@@ -70,3 +70,37 @@ Adapted from http://stackoverflow.com/questions/3160699/python-progress-bar
                 sys.stdout.write("\n")
 
     net.run(duration, report=ProgressBar(), report_period=1*second)
+
+
+**"Standalone Mode" Text based progress bar on console**
+
+This needs a "normal" Linux console, i.e. it might not work in an integrated
+console in an IDE.
+
+Adapted from https://stackoverflow.com/questions/14539867/how-to-display-a-progress-indicator-in-pure-c-c-cout-printf
+
+::
+
+    from brian2 import *
+    set_device('cpp_standalone', directory='STDP_standalone')
+
+    str = '''
+        int remaining = (int)((1-completed)/completed*elapsed+0.5);
+        if (completed == 0.0)
+        {
+            std::cout << "Starting simulation at t=" << start << " s for duration " << duration << " s"<<std::flush;
+        }
+        else
+        {
+            int barWidth = 70;
+            std::cout << "\\r[";
+            int pos = barWidth * completed;
+            for (int i = 0; i < barWidth; ++i) {
+                    if (i < pos) std::cout << "=";
+                    else if (i == pos) std::cout << ">";
+                    else std::cout << " ";
+            }
+            std::cout << "] " << int(completed * 100.0) << "% completed. | "<<int(remaining) <<"s remaining"<<std::flush;
+        }
+    '''
+    run(100*second, report=str)


### PR DESCRIPTION
you can try running this example by adding this piece of code in standalone.py in the examples folder

#1162 