### PR TITLE
Variableview operations

### DIFF
--- a/brian2/tests/test_neurongroup.py
+++ b/brian2/tests/test_neurongroup.py
@@ -215,9 +215,9 @@ def test_variableview_inplace_calculations():
 
     # Modulo
     G.x %= 2
-    G.y %= 2*mV
+    G.y %= 3.3*mV
     assert_allclose(G.x[:], x_vals % 2)
-    assert_allclose(G.y[:], y_vals % (2*mV))
+    assert_allclose(G.y[:], y_vals % (3.3*mV))
     with pytest.raises(DimensionMismatchError):
         G.y %= 2
     with pytest.raises(DimensionMismatchError):


### PR DESCRIPTION
We implement arithmetic operations on `VariableView`, so that `group.v + 3*mV` does not raise an error due to `group.v` being a `VariableView` (with support for `group.v['v > -70*mV']`, etc.) and not a `Quantity`. As @romainbrette noticed, we did not implement the power operation, so while `group.v * group.v` would work, `group.v ** 2` would not (but you could always use the workaround `group.v[:]**2`).
This PR adds the support for the power operation and – rather for completeness than for usefulness – also for the in-place operations `//=`, `%=`, and `**=`. I also realized that we did not have any tests for the in-place operations, so I've added them as well.

This is ready-to-merge. I think I'll stop using the `[MRG]` or `[WIP]` markers in the title of the pull requests now that github has the option to open PRs as "drafts" – if I don't open it as a draft, consider it a PR ready for review :) 