### PR TITLE
Brian obj exception

### DIFF
--- a/brian2/codegen/codeobject.py
+++ b/brian2/codegen/codeobject.py
@@ -396,7 +396,7 @@ def create_runner_codeobj(group, code, template_name,
                 check_units_statements(c, variables)
             except (SyntaxError, ValueError) as ex:
                 error_msg = _error_msg(c, name)
-                raise ValueError(error_msg + str(ex))
+                raise ValueError(error_msg) from ex
 
     all_variable_indices = copy.copy(group.variables.indices)
     if additional_variables is not None:
@@ -423,7 +423,7 @@ def create_runner_codeobj(group, code, template_name,
                     value.implementations.add_numpy_implementation(value.pyfunc)
                 else:
                     raise NotImplementedError(('Cannot use function '
-                                               '%s: %s') % (varname, ex))
+                                               '%s: %s') % (varname, ex)) from ex
 
     # Gather the additional compiler arguments declared by function
     # implementations

--- a/brian2/codegen/runtime/cython_rt/cython_rt.py
+++ b/brian2/codegen/runtime/cython_rt/cython_rt.py
@@ -4,6 +4,7 @@ import sys
 
 import numpy
 
+from brian2.core.base import BrianObjectException
 from brian2.core.variables import (DynamicArrayVariable, ArrayVariable,
                                    AuxiliaryVariable, Subexpression)
 from brian2.core.functions import Function
@@ -155,7 +156,12 @@ class CythonCodeObject(NumpyCodeObject):
     def run_block(self, block):
         compiled_code = self.compiled_code[block]
         if compiled_code:
-            return compiled_code.main(self.namespace)
+            try:
+                return compiled_code.main(self.namespace)
+            except Exception as exc:
+                message = ('An exception occured during the execution of the {} '
+                           'block of code object {}.\n').format(block, self.name)
+                raise BrianObjectException(message, self.owner) from exc
 
     def _insert_func_namespace(self, func):
         impl = func.implementations[self]

--- a/brian2/codegen/runtime/numpy_rt/numpy_rt.py
+++ b/brian2/codegen/runtime/numpy_rt/numpy_rt.py
@@ -255,7 +255,7 @@ class NumpyCodeObject(CodeObject):
             _, _, tb = sys.exc_info()
             tb = tb.tb_next  # Line in the code object's code
             message += lines[tb.tb_lineno - 1] + '\n'
-            raise BrianObjectException(message, self.owner)
+            raise BrianObjectException(message, self.owner) from exc
         # output variables should land in the variable name _return_values
         if '_return_values' in self.namespace:
             return self.namespace['_return_values']

--- a/brian2/codegen/runtime/numpy_rt/numpy_rt.py
+++ b/brian2/codegen/runtime/numpy_rt/numpy_rt.py
@@ -7,7 +7,7 @@ from collections.abc import Iterable
 
 import numpy as np
 
-from brian2.core.base import brian_object_exception
+from brian2.core.base import BrianObjectException
 from brian2.core.preferences import prefs, BrianPreference
 from brian2.core.variables import (DynamicArrayVariable, ArrayVariable,
                                    AuxiliaryVariable, Subexpression)
@@ -255,7 +255,7 @@ class NumpyCodeObject(CodeObject):
             _, _, tb = sys.exc_info()
             tb = tb.tb_next  # Line in the code object's code
             message += lines[tb.tb_lineno - 1] + '\n'
-            raise brian_object_exception(message, self.owner, exc)
+            raise BrianObjectException(message, self.owner)
         # output variables should land in the variable name _return_values
         if '_return_values' in self.namespace:
             return self.namespace['_return_values']

--- a/brian2/core/base.py
+++ b/brian2/core/base.py
@@ -294,10 +294,6 @@ class BrianObjectException(Exception):
     `BrianObject` was defined to better enable users to locate the source of
     problems.
 
-    You should use the `brian_object_exception` function to raise this, and
-    it should only be raised in an ``except`` block handling a prior
-    exception.
-
     Parameters
     ----------
 
@@ -308,26 +304,20 @@ class BrianObjectException(Exception):
     original_exception : Exception
         The original exception that was raised.
     '''
-    def __init__(self, message, brianobj, original_exception):
+    def __init__(self, message, brianobj):
         self._brian_message = message
         self._brian_objname = brianobj.name
-        self._brian_origexc = '\n'.join(traceback.format_exception_only(type(original_exception),
-                                                                        original_exception))
-        self._brian_origtb = traceback.format_exc()
         self._brian_objcreate = brianobj._creation_stack
         logger.diagnostic('Error was encountered with object "{objname}":\n{fullstack}'.format(
             objname=self._brian_objname,
             fullstack=brianobj._full_creation_stack))
 
     def __str__(self):
-        return ('Original error and traceback:\n{origtb}\n'
-                'Error encountered with object named "{objname}".\n'
+        return ('Error encountered with object named "{objname}".\n'
                 '{objcreate}\n\n'
-                '{message} {origexc}'
+                '{message}'
                 '(See above for original error message and traceback.)'
-                ).format(origtb=self._brian_origtb,
-                         origexc=self._brian_origexc,
-                         objname=self._brian_objname, message=self._brian_message,
+                ).format(objname=self._brian_objname, message=self._brian_message,
                          objcreate=self._brian_objcreate)
 
 
@@ -341,16 +331,6 @@ def brian_object_exception(message, brianobj, original_exception):
 
     See `BrianObjectException` for arguments and notes.
     '''
-    DerivedBrianObjectException = type('BrianObjectException',
-                                       (BrianObjectException, original_exception.__class__),
-                                       {})
-    new_exception = DerivedBrianObjectException(message, brianobj, original_exception)
-    # Copy over all exception attributes
-    for attribute in dir(original_exception):
-        if attribute.startswith('_'):
-            continue
-        try:
-            setattr(new_exception, attribute, getattr(original_exception, attribute))
-        except AttributeError:  # some attributes cannot be set
-            pass
-    return new_exception
+
+    raise NotImplementedError('The brian_object_exception function is no longer used. '
+                              'Raise a BrianObjectException directly.')

--- a/brian2/core/base.py
+++ b/brian2/core/base.py
@@ -315,7 +315,7 @@ class BrianObjectException(Exception):
     def __str__(self):
         return ('Error encountered with object named "{objname}".\n'
                 '{objcreate}\n\n'
-                '{message}'
+                '{message} '
                 '(See above for original error message and traceback.)'
                 ).format(objname=self._brian_objname, message=self._brian_message,
                          objcreate=self._brian_objcreate)

--- a/brian2/core/base.py
+++ b/brian2/core/base.py
@@ -316,6 +316,7 @@ class BrianObjectException(Exception):
         return ('Error encountered with object named "{objname}".\n'
                 '{objcreate}\n\n'
                 '{message}'
+                '(See above for original error message and traceback.)'
                 ).format(objname=self._brian_objname, message=self._brian_message,
                          objcreate=self._brian_objcreate)
 

--- a/brian2/core/base.py
+++ b/brian2/core/base.py
@@ -316,7 +316,6 @@ class BrianObjectException(Exception):
         return ('Error encountered with object named "{objname}".\n'
                 '{objcreate}\n\n'
                 '{message}'
-                '(See above for original error message and traceback.)'
                 ).format(objname=self._brian_objname, message=self._brian_message,
                          objcreate=self._brian_objcreate)
 

--- a/brian2/core/network.py
+++ b/brian2/core/network.py
@@ -18,7 +18,7 @@ import pickle as pickle
 from brian2.synapses.synapses import SummedVariableUpdater
 from brian2.utils.logger import get_logger
 from brian2.core.names import Nameable
-from brian2.core.base import BrianObject, brian_object_exception
+from brian2.core.base import BrianObject, BrianObjectException
 from brian2.core.clocks import Clock, defaultclock
 from brian2.devices.device import get_device, all_devices, RuntimeDevice
 from brian2.groups.group import Group
@@ -896,7 +896,7 @@ class Network(Nameable):
                 try:
                     obj.before_run(run_namespace)
                 except Exception as ex:
-                    raise brian_object_exception("An error occurred when preparing an object.", obj, ex)
+                    raise BrianObjectException("An error occurred when preparing an object.", obj)
 
         # Check that no object has been run as part of another network before
         for obj in all_objects:

--- a/brian2/core/network.py
+++ b/brian2/core/network.py
@@ -896,7 +896,7 @@ class Network(Nameable):
                 try:
                     obj.before_run(run_namespace)
                 except Exception as ex:
-                    raise BrianObjectException("An error occurred when preparing an object.", obj)
+                    raise BrianObjectException("An error occurred when preparing an object.", obj) from ex
 
         # Check that no object has been run as part of another network before
         for obj in all_objects:

--- a/brian2/equations/equations.py
+++ b/brian2/equations/equations.py
@@ -348,7 +348,7 @@ def parse_string_equations(eqns):
         parsed = EQUATIONS.parseString(eqns, parseAll=True)
     except ParseException as p_exc:
         raise EquationError('Parsing failed: \n' + str(p_exc.line) + '\n' +
-                            ' ' * (p_exc.column - 1) + '^\n' + str(p_exc))
+                            ' ' * (p_exc.column - 1) + '^\n' + str(p_exc)) from p_exc
     for eq in parsed:
         eq_type = eq.getName()
         eq_content = dict(eq.items())
@@ -961,7 +961,7 @@ class Equations(Hashable, Mapping):
                                                   'defining variable %s:'
                                                   '\n%s') % (eq.varname,
                                                              ex.desc),
-                                                 *ex.dims)
+                                                 *ex.dims) from ex
             elif eq.type == SUBEXPRESSION:
                 try:
                     check_dimensions(str(eq.expr), self.dimensions[var],
@@ -971,7 +971,7 @@ class Equations(Hashable, Mapping):
                                                   'subexpression %s:'
                                                   '\n%s') % (eq.varname,
                                                              ex.desc),
-                                                 *ex.dims)
+                                                 *ex.dims) from ex
             else:
                 raise AssertionError('Unknown equation type: "%s"' % eq.type)
 

--- a/brian2/groups/group.py
+++ b/brian2/groups/group.py
@@ -353,8 +353,8 @@ class VariableOwner(Nameable):
         '''
         try:
             var = self.variables[name]
-        except KeyError:
-            raise KeyError("State variable "+name+" not found.")
+        except KeyError as exc:
+            raise KeyError("State variable "+name+" not found.") from exc
 
         if use_units:
             return var.get_addressable_value_with_unit(name=name, group=self)

--- a/brian2/tests/test_GSL.py
+++ b/brian2/tests/test_GSL.py
@@ -420,7 +420,7 @@ def test_GSL_fixed_timestep_big_dt_small_error():
     neuron.I = 0.7*nA/(20000*umetre**2)
     neuron.v = HH_namespace['El']
     net = Network(neuron)
-    with pytest.raises((RuntimeError, IntegrationError)):
+    with pytest.raises((BrianObjectException, RuntimeError)):
         net.run(10*ms)
 
 

--- a/brian2/tests/test_GSL.py
+++ b/brian2/tests/test_GSL.py
@@ -19,7 +19,10 @@ def skip_if_not_implemented(func):
     def wrapped():
         try:
             func()
-        except NotImplementedError:
+        except (BrianObjectException, NotImplementedError) as exc:
+            if not (isinstance(exc, NotImplementedError) or
+                    isinstance(exc.__cause__, NotImplementedError)):
+                raise
             pytest.skip('GSL support for numpy has not been implemented yet')
     return wrapped
 
@@ -181,9 +184,10 @@ def test_GSL_stochastic():
     '''
     neuron = NeuronGroup(1, eqs, method='gsl')
     net = Network(neuron)
-    with pytest.raises(UnsupportedEquationsException):
-                  net.run(0*ms, namespace={'tau': tau,
-                                           'sigma': sigma})
+    with pytest.raises(BrianObjectException) as exc:
+        net.run(0*ms, namespace={'tau': tau,
+                                 'sigma': sigma})
+        assert exc.errisinstance(UnsupportedEquationsException)
 
 @pytest.mark.standalone_compatible
 @skip_if_not_implemented
@@ -196,8 +200,9 @@ def test_GSL_error_dimension_mismatch_unit():
     neuron = NeuronGroup(1, eqs, threshold='v > 10*mV', reset='v = 0*mV',
                          method='gsl', method_options=options)
     net = Network(neuron)
-    with pytest.raises(DimensionMismatchError):
+    with pytest.raises(BrianObjectException) as exc:
         net.run(0*ms, namespace={})
+        assert exc.errisinstance(DimensionMismatchError)
 
 
 @pytest.mark.standalone_compatible
@@ -211,8 +216,9 @@ def test_GSL_error_dimension_mismatch_dimensionless1():
     neuron = NeuronGroup(1, eqs, threshold='v > 10', reset='v = 0',
                          method='gsl', method_options=options)
     net = Network(neuron)
-    with pytest.raises(DimensionMismatchError):
+    with pytest.raises(BrianObjectException) as exc:
         net.run(0*ms, namespace={})
+        assert exc.errisinstance(DimensionMismatchError)
 
 
 @pytest.mark.standalone_compatible
@@ -226,8 +232,9 @@ def test_GSL_error_dimension_mismatch_dimensionless2():
     neuron = NeuronGroup(1, eqs, threshold='v > 10*mV', reset='v = 0*mV',
                          method='gsl', method_options=options)
     net = Network(neuron)
-    with pytest.raises(DimensionMismatchError):
+    with pytest.raises(BrianObjectException) as exc:
         net.run(0*ms, namespace={})
+        assert exc.errisinstance(DimensionMismatchError)
 
 
 @pytest.mark.standalone_compatible
@@ -241,8 +248,9 @@ def test_GSL_error_nonexisting_variable():
     neuron = NeuronGroup(1, eqs, threshold='v > 10*mV', reset='v = 0*mV',
                          method='gsl', method_options=options)
     net = Network(neuron)
-    with pytest.raises(KeyError):
+    with pytest.raises(BrianObjectException) as exc:
         net.run(0*ms, namespace={})
+        assert exc.errisinstance(KeyError)
 
 
 @pytest.mark.standalone_compatible
@@ -260,10 +268,12 @@ def test_GSL_error_incorrect_error_format():
     neuron2 = NeuronGroup(1, eqs, threshold='v > 10*mV', reset='v = 0*mV',
                          method='gsl', method_options=options2)
     net2 = Network(neuron2)
-    with pytest.raises(TypeError):
+    with pytest.raises(BrianObjectException) as exc:
         net.run(0*ms, namespace={})
-    with pytest.raises(TypeError):
-        net2.run(0 * ms, namespace={})
+        assert exc.errisinstance(TypeError)
+    with pytest.raises(BrianObjectException) as exc:
+        net2.run(0*ms, namespace={})
+        assert exc.errisinstance(TypeError)
 
 
 @pytest.mark.standalone_compatible
@@ -277,8 +287,9 @@ def test_GSL_error_nonODE_variable():
     neuron = NeuronGroup(1, eqs, threshold='v > 10*mV', reset='v = 0*mV',
                          method='gsl', method_options=options)
     net = Network(neuron)
-    with pytest.raises(KeyError):
+    with pytest.raises(BrianObjectException) as exc:
         net.run(0*ms, namespace={})
+        assert exc.errisinstance(KeyError)
 
 
 @pytest.mark.standalone_compatible

--- a/brian2/tests/test_functions.py
+++ b/brian2/tests/test_functions.py
@@ -287,8 +287,9 @@ def test_manual_user_defined_function():
                        x : 1
                        y : 1''')
     net = Network(group)
-    with pytest.raises(DimensionMismatchError):
+    with pytest.raises(BrianObjectException) as exc:
         net.run(0*ms, namespace={ 'foo': foo})
+        assert exc.errisinstance(DimensionMismatchError)
 
     # Incorrect output unit
     group = NeuronGroup(1, '''
@@ -296,8 +297,9 @@ def test_manual_user_defined_function():
                        x : volt
                        y : volt''')
     net = Network(group)
-    with pytest.raises(DimensionMismatchError):
+    with pytest.raises(BrianObjectException) as exc:
         net.run(0*ms, namespace={'foo': foo})
+        assert exc.errisinstance(DimensionMismatchError)
 
     G = NeuronGroup(1, '''
                        func = foo(x, y) : volt
@@ -448,8 +450,9 @@ def test_manual_user_defined_function_cython_wrong_compiler_args1():
                        y : volt''')
     mon = StateMonitor(G, 'func', record=True)
     net = Network(G, mon)
-    with pytest.raises(ValueError):
+    with pytest.raises(BrianObjectException) as exc:
         net.run(defaultclock.dt, namespace={'foo': foo})
+        assert exc.errisinstance(ValueError)
 
 
 def test_manual_user_defined_function_cython_wrong_compiler_args2():
@@ -470,8 +473,9 @@ def test_manual_user_defined_function_cython_wrong_compiler_args2():
                        y : volt''')
     mon = StateMonitor(G, 'func', record=True)
     net = Network(G, mon)
-    with pytest.raises(TypeError):
+    with pytest.raises(BrianObjectException) as exc:
         net.run(defaultclock.dt, namespace={'foo': foo})
+        assert exc.errisinstance(TypeError)
 
 
 def test_external_function_cython():
@@ -817,8 +821,9 @@ def test_declare_types():
         '''
         G = NeuronGroup(1, eqs)
         Network(G).run(1*ms)
-    with pytest.raises(TypeError):
+    with pytest.raises(BrianObjectException) as exc:
         bad_units()
+        assert exc.errisinstance(TypeError)
 
     def bad_type():
         @implementation('numpy', discard_units=True)
@@ -832,8 +837,9 @@ def test_declare_types():
         '''
         G = NeuronGroup(1, eqs)
         Network(G).run(1*ms)
-    with pytest.raises(TypeError):
+    with pytest.raises(BrianObjectException) as exc:
         bad_type()
+        assert exc.errisinstance(TypeError)
 
 
 def test_multiple_stateless_function_calls():
@@ -841,24 +847,28 @@ def test_multiple_stateless_function_calls():
     # simplified to 2*rand()) raise an error
     G = NeuronGroup(1, 'dv/dt = (rand() - rand())/second : 1')
     net = Network(G)
-    with pytest.raises(NotImplementedError):
+    with pytest.raises(BrianObjectException) as exc:
         net.run(0*ms)
+        assert exc.errisinstance(NotImplementedError)
     G2 = NeuronGroup(1, 'v:1', threshold='v>1', reset='v=rand() - rand()')
     net2 = Network(G2)
-    with pytest.raises(NotImplementedError):
+    with pytest.raises(BrianObjectException) as exc:
         net2.run(0*ms)
+        assert exc.errisinstance(NotImplementedError)
     G3 = NeuronGroup(1, 'v:1')
     G3.run_regularly('v = rand() - rand()')
     net3 = Network(G3)
-    with pytest.raises(NotImplementedError):
+    with pytest.raises(BrianObjectException) as exc:
         net3.run(0*ms)
+        assert exc.errisinstance(NotImplementedError)
     G4 = NeuronGroup(1, 'x : 1')
     # Verify that synaptic equations are checked as well, see #1146
     S = Synapses(G4, G4, 'dy/dt = (rand() - rand())/second : 1 (clock-driven)')
     S.connect()
     net = Network(G4, S)
-    with pytest.raises(NotImplementedError):
-        net.run(0 * ms)
+    with pytest.raises(BrianObjectException) as exc:
+        net.run(0*ms)
+        assert exc.errisinstance(NotImplementedError)
 
 
 if __name__ == '__main__':

--- a/brian2/tests/test_functions.py
+++ b/brian2/tests/test_functions.py
@@ -379,8 +379,9 @@ def test_manual_user_defined_function_cpp_standalone_wrong_compiler_args1():
                        y : volt''')
     mon = StateMonitor(G, 'func', record=True)
     net = Network(G, mon)
-    with pytest.raises(ValueError):
+    with pytest.raises(BrianObjectException) as exc:
         net.run(defaultclock.dt, namespace={'foo': foo})
+        assert exc.errisinstance(ValueError)
 
 
 @pytest.mark.cpp_standalone
@@ -403,8 +404,9 @@ def test_manual_user_defined_function_cpp_standalone_wrong_compiler_args2():
                        y : volt''')
     mon = StateMonitor(G, 'func', record=True)
     net = Network(G, mon)
-    with pytest.raises(TypeError):
+    with pytest.raises(BrianObjectException) as exc:
         net.run(defaultclock.dt, namespace={'foo': foo})
+        assert exc.errisinstance(TypeError)
 
 
 def test_manual_user_defined_function_cython_compiler_args():

--- a/brian2/tests/test_numpy_codegen.py
+++ b/brian2/tests/test_numpy_codegen.py
@@ -15,12 +15,10 @@ def test_error_message():
 
     G = NeuronGroup(1, 'v : 1')
     G.run_regularly('v = foo(3)')
-    try:
+    with pytest.raises(BrianObjectException) as exc:
         run(defaultclock.dt)
-        raise AssertionError('Expected the run to raise a ValueError')
-    except ValueError as exc:
         # The actual code line should be mentioned in the error message
-        assert 'v = foo(3)' in str(exc)
+        exc.match('v = foo(3)')
 
 
 if __name__ == '__main__':

--- a/brian2/tests/test_poissongroup.py
+++ b/brian2/tests/test_poissongroup.py
@@ -41,13 +41,16 @@ def test_rate_unit_check():
         PoissonGroup(1, np.array([1, 2])*ms)
     P = PoissonGroup(1, 'i*mV')
     net = Network(P)
-    with pytest.raises(DimensionMismatchError):
+    with pytest.raises(BrianObjectException) as exc:
         net.run(0*ms)
+        assert exc.errisinstance(DimensionMismatchError)
 
     P = PoissonGroup(1, 'i')
     net = Network(P)
-    with pytest.raises(DimensionMismatchError):
-        net.run(0 * ms)
+    with pytest.raises(BrianObjectException) as exc:
+        net.run(0*ms)
+        assert exc.errisinstance(DimensionMismatchError)
+
 
 @pytest.mark.standalone_compatible
 def test_time_dependent_rate():

--- a/brian2/tests/test_poissoninput.py
+++ b/brian2/tests/test_poissoninput.py
@@ -66,8 +66,9 @@ def test_poissoninput_errors():
     inp = PoissonInput(G, 'x', 100, 100*Hz, weight=1*volt)
     defaultclock.dt = 2 * old_dt
     net = Network(collect())
-    with pytest.raises(NotImplementedError):
+    with pytest.raises(BrianObjectException) as exc:
         net.run(0*ms)
+        assert exc.errisinstance(NotImplementedError)
     defaultclock.dt = old_dt
 
 

--- a/brian2/tests/test_refractory.py
+++ b/brian2/tests/test_refractory.py
@@ -179,17 +179,21 @@ def test_refractoriness_threshold():
 def test_refractoriness_types():
     # make sure that using a wrong type of refractoriness does not work
     group = NeuronGroup(1, '', refractory='3*Hz')
-    with pytest.raises(TypeError):
+    with pytest.raises(BrianObjectException) as exc:
         Network(group).run(0*ms)
+        assert exc.errisinstance(TypeError)
     group = NeuronGroup(1, 'ref: Hz', refractory='ref')
-    with pytest.raises(TypeError):
+    with pytest.raises(BrianObjectException) as exc:
         Network(group).run(0*ms)
+        assert exc.errisinstance(TypeError)
     group = NeuronGroup(1, '', refractory='3')
-    with pytest.raises(TypeError):
+    with pytest.raises(BrianObjectException) as exc:
         Network(group).run(0*ms)
+        assert exc.errisinstance(TypeError)
     group = NeuronGroup(1, 'ref: 1', refractory='ref')
-    with pytest.raises(TypeError):
+    with pytest.raises(BrianObjectException) as exc:
         Network(group).run(0*ms)
+        assert exc.errisinstance(TypeError)
 
 @pytest.mark.codegen_independent
 def test_conditional_write_set():

--- a/brian2/tests/test_spikegenerator.py
+++ b/brian2/tests/test_spikegenerator.py
@@ -129,8 +129,9 @@ def test_spikegenerator_period_rounding():
     s = SpikeGeneratorGroup(1, [0, 0, 0], [0*ms, .9*ms, .96*ms],
                             period=1*ms, dt=0.1*ms)
     net = Network(s)
-    with pytest.raises(ValueError):
+    with pytest.raises(BrianObjectException) as exc:
         net.run(0*ms)
+        assert exc.errisinstance(ValueError)
 
 
 def test_spikegenerator_period_repeat():
@@ -243,18 +244,21 @@ def test_spikegenerator_incorrect_period():
     # Period is not an integer multiple of dt
     SG = SpikeGeneratorGroup(1, [], []*second, period=1.25*ms, dt=0.1*ms)
     net = Network(SG)
-    with pytest.raises(NotImplementedError):
+    with pytest.raises(BrianObjectException) as exc:
         net.run(0*ms)
+        assert exc.errisinstance(NotImplementedError)
 
     SG = SpikeGeneratorGroup(1, [], [] * second, period=0.101 * ms, dt=0.1 * ms)
     net = Network(SG)
-    with pytest.raises(NotImplementedError):
-        net.run(0 * ms)
+    with pytest.raises(BrianObjectException) as exc:
+        net.run(0*ms)
+        assert exc.errisinstance(NotImplementedError)
 
     SG = SpikeGeneratorGroup(1, [], [] * second, period=3.333 * ms, dt=0.1 * ms)
     net = Network(SG)
-    with pytest.raises(NotImplementedError):
-        net.run(0 * ms)
+    with pytest.raises(BrianObjectException) as exc:
+        net.run(0*ms)
+        assert exc.errisinstance(NotImplementedError)
 
     # This should not raise an error (see #1041)
     SG = SpikeGeneratorGroup(1, [], []*ms, period=150*ms, dt=0.1*ms)
@@ -264,8 +268,9 @@ def test_spikegenerator_incorrect_period():
     # Period is smaller than dt
     SG = SpikeGeneratorGroup(1, [], []*second, period=1*ms, dt=2*ms)
     net = Network(SG)
-    with pytest.raises(ValueError):
+    with pytest.raises(BrianObjectException) as exc:
         net.run(0*ms)
+        assert exc.errisinstance(ValueError)
 
 
 def test_spikegenerator_rounding():
@@ -346,8 +351,9 @@ def test_spikegenerator_multiple_spikes_per_bin():
     # This should raise an error
     SG = SpikeGeneratorGroup(2, [0, 0], [0, 0.05]*ms, dt=0.1*ms)
     net = Network(SG)
-    with pytest.raises(ValueError):
+    with pytest.raises(BrianObjectException) as exc:
         net.run(0*ms)
+        assert exc.errisinstance(NotImplementedError)
 
     # More complicated scenario where dt changes between runs
     defaultclock.dt = 0.1*ms
@@ -355,8 +361,9 @@ def test_spikegenerator_multiple_spikes_per_bin():
     net = Network(SG)
     net.run(0*ms)  # all is fine
     defaultclock.dt = 0.2*ms  # Now the two spikes fall into the same bin
-    with pytest.raises(ValueError):
+    with pytest.raises(BrianObjectException) as exc:
         net.run(0*ms)
+        assert exc.errisinstance(NotImplementedError)
 
 
 @pytest.mark.standalone_compatible

--- a/brian2/tests/test_stateupdaters.py
+++ b/brian2/tests/test_stateupdaters.py
@@ -766,8 +766,8 @@ def test_check_for_invalid_values_linear_integrator():
                 assert 'invalid_values' in repr(clog)
             else:
                 assert G.x[0] != 0
-        except BrianObjectException:
-            pass
+        except BrianObjectException as exc:
+            assert isinstance(exc.__cause__, UnsupportedEquationsException)
 
 
 if __name__ == '__main__':

--- a/brian2/tests/test_stateupdaters.py
+++ b/brian2/tests/test_stateupdaters.py
@@ -170,39 +170,44 @@ def test_multiplicative_noise():
     Eq1 = Equations('dv/dt = v*xi*(5*ms)**-0.5 :1')
     group1 = NeuronGroup(1, Eq1, method='euler')
     net1 = Network(group1)
-    with pytest.raises(UnsupportedEquationsException):
+    with pytest.raises(BrianObjectException) as exc:
         net1.run(0*ms)
+        assert exc.errisinstance(UnsupportedEquationsException)
 
     # Noise is multiplicative (multiplied with time)
     Eq2 = Equations('dv/dt = (t/ms)*xi*(5*ms)**-0.5 :1')
     group2 = NeuronGroup(1, Eq2, method='euler')
     net2 = Network(group2)
-    with pytest.raises(UnsupportedEquationsException):
+    with pytest.raises(BrianObjectException) as exc:
         net2.run(0*ms)
+        assert exc.errisinstance(UnsupportedEquationsException)
 
     # Noise is multiplicative (multiplied with time-varying variable)
     Eq3 = Equations('''dv/dt = w*xi*(5*ms)**-0.5 :1
                        dw/dt = -w/(10*ms) : 1''')
     group3 = NeuronGroup(1, Eq3, method='euler')
     net3 = Network(group3)
-    with pytest.raises(UnsupportedEquationsException):
+    with pytest.raises(BrianObjectException) as exc:
         net3.run(0*ms)
+        assert exc.errisinstance(UnsupportedEquationsException)
 
     # One of the equations has multiplicative noise
     Eq4 = Equations('''dv/dt = xi_1*(5*ms)**-0.5 : 1
                        dw/dt = (t/ms)*xi_2*(5*ms)**-0.5 :1''')
     group4 = NeuronGroup(1, Eq4, method='euler')
     net4 = Network(group4)
-    with pytest.raises(UnsupportedEquationsException):
+    with pytest.raises(BrianObjectException) as exc:
         net4.run(0*ms)
+        assert exc.errisinstance(UnsupportedEquationsException)
 
     # One of the equations has multiplicative noise
     Eq5 = Equations('''dv/dt = xi_1*(5*ms)**-0.5 : 1
                        dw/dt = v*xi_2*(5*ms)**-0.5 :1''')
     group5 = NeuronGroup(1, Eq5, method='euler')
     net5 = Network(group4)
-    with pytest.raises(UnsupportedEquationsException):
+    with pytest.raises(BrianObjectException) as exc:
         net5.run(0*ms)
+        assert exc.errisinstance(UnsupportedEquationsException)
 
 
 def test_pure_noise_deterministic(fake_randn_randn_fixture):
@@ -643,8 +648,9 @@ def test_locally_constant_check():
         else:
             # This should not
             with catch_logs():
-                with pytest.raises(UnsupportedEquationsException):
-                    net.run(0*ms)
+                with pytest.raises(BrianObjectException) as exc:
+                    net.run(0 * ms)
+                    assert exc.errisinstance(UnsupportedEquationsException)
 
         # multiplicative
         G = NeuronGroup(1, 'dv/dt = -v*ta(t)/(10*ms) : 1',
@@ -656,42 +662,48 @@ def test_locally_constant_check():
         else:
             # This should not
             with catch_logs():
-                with pytest.raises(UnsupportedEquationsException):
+                with pytest.raises(BrianObjectException) as exc:
                     net.run(0*ms)
+                    assert exc.errisinstance(UnsupportedEquationsException)
 
     # If the argument is more than just "t", we cannot guarantee that it is
     # actually locally constant
     G = NeuronGroup(1, 'dv/dt = -v*ta(t/2.0)/(10*ms) : 1',
                         method='exact', namespace={'ta': ta0})
     net = Network(G)
-    with pytest.raises(UnsupportedEquationsException):
+    with pytest.raises(BrianObjectException) as exc:
         net.run(0*ms)
+        assert exc.errisinstance(UnsupportedEquationsException)
 
     # Arbitrary functions are not constant over a time step
     G = NeuronGroup(1, 'dv/dt = -v/(10*ms) + sin(2*pi*100*Hz*t)*Hz : 1',
                     method='exact')
     net = Network(G)
-    with pytest.raises(UnsupportedEquationsException):
+    with pytest.raises(BrianObjectException) as exc:
         net.run(0*ms)
+        assert exc.errisinstance(UnsupportedEquationsException)
 
     # Stateful functions aren't either
     G = NeuronGroup(1, 'dv/dt = -v/(10*ms) + rand()*Hz : 1',
                     method='exact')
     net = Network(G)
-    with pytest.raises(UnsupportedEquationsException):
+    with pytest.raises(BrianObjectException) as exc:
         net.run(0*ms)
+        assert exc.errisinstance(UnsupportedEquationsException)
 
     # Neither is "t" itself
     G = NeuronGroup(1, 'dv/dt = -v/(10*ms) + t/second**2 : 1', method='exact')
     net = Network(G)
-    with pytest.raises(UnsupportedEquationsException):
+    with pytest.raises(BrianObjectException) as exc:
         net.run(0*ms)
+        assert exc.errisinstance(UnsupportedEquationsException)
 
     # But if the argument is not referring to t, all should be well
     G = NeuronGroup(1, 'dv/dt = -v/(10*ms) + sin(2*pi*100*Hz*5*second)*Hz : 1',
                     method='exact')
     net = Network(G)
     net.run(0*ms)
+
 
 def test_refractory():
     # Compare integration with and without the addition of refractoriness --
@@ -754,7 +766,7 @@ def test_check_for_invalid_values_linear_integrator():
                 assert 'invalid_values' in repr(clog)
             else:
                 assert G.x[0] != 0
-        except UnsupportedEquationsException:
+        except BrianObjectException:
             pass
 
 

--- a/brian2/utils/logger.py
+++ b/brian2/utils/logger.py
@@ -156,20 +156,7 @@ if 'logging' not in prefs.pref_register:
             of the log file, the mailing list and the github issues.
             
             Defaults to ``True``.'''
-            ),
-        traceback_format=BrianPreference(
-            default='minimal',
-            validator=lambda v: isinstance(v, str) and v.lower() in ['minimal', 'full'],
-            docs='''
-            How to format tracebacks on the console when exceptions occur.
-            Can be either ``'full'``, to use the standard Python formatting
-            with the full traceback, or ``'minimal'``, where Brian tries to
-            reduce the traceback to the information relevant to the user (i.e.,
-            removing all the parts that occur within Brian code). Note that
-            the log file always contains the full traceback.
-            
-            Defaults to ``'minimal'``.'''
-        )
+            )
         )
 
 #===============================================================================
@@ -609,7 +596,7 @@ class BrianLogger(object):
         BrianLogger.console_handler = logging.StreamHandler()
         BrianLogger.console_handler.setLevel(LOG_LEVELS[prefs['logging.console_log_level']])
         BrianLogger.console_handler.setFormatter(
-            BrianConsoleFormatter('%(levelname)-10s %(message)s [%(name)s]'))
+            logging.Formatter('%(levelname)-10s %(message)s [%(name)s]'))
 
         # add the handler to the logger
         logger.addHandler(BrianLogger.console_handler)
@@ -824,35 +811,3 @@ class std_silent(object):
                     os.remove(std_silent.dest_fname_stderr)
                 except (IOError, OSError):
                     pass
-
-
-class BrianConsoleFormatter(logging.Formatter):
-    def format(self, record):
-        # Clean the record's exc_info to make sure our formatter is called
-        record.exc_text = None
-        return super(BrianConsoleFormatter, self).format(record)
-
-    def formatException(self, exc_info):
-        if prefs['logging.traceback_format'] == 'full':
-            return super(BrianConsoleFormatter, self).formatException(exc_info)
-
-        from brian2.core.base import BrianObjectException
-        exc_type, exc_obj, exc_tb = exc_info
-        if exc_type == BrianObjectException:
-            brian_obj_exception_lines = traceback.format_exception(BrianObjectException,
-                                                                   exc_obj,
-                                                                   exc_tb,
-                                                                   limit=1,
-                                                                   chain=False)
-            # Only show the latest "cause"
-            cause_lines = []
-            cause = exc_obj.__cause__
-            cause_lines = traceback.format_exception_only(type(cause), cause)
-            exception_lines = brian_obj_exception_lines + ['\nThis was directly caused by the following exception:\n\n'] + cause_lines
-        else:
-            # If there are "causing exceptions" (e.g. a ParseException causing an EquationError), then
-            # all relevant info is already included in the final exception, so we ignore them here
-            exception_lines = traceback.format_exception(exc_type, exc_obj, exc_tb,
-                                                         limit=1, chain=False)
-
-        return ''.join(exception_lines)

--- a/docs_sphinx/introduction/compatibility.rst
+++ b/docs_sphinx/introduction/compatibility.rst
@@ -1,6 +1,20 @@
 Compatibility and reproducibility
 =================================
 
+Supported Python and numpy versions
+-----------------------------------
+
+We follow the approach outlined in numpy's
+`deprecation policy <https://numpy.org/neps/nep-0029-deprecation_policy.html>`_. This means that Brian supports:
+
+* All minor versions of Python released 42 months prior to Brian, and at minimum the two latest minor versions.
+* All minor versions of numpy released in the 24 months prior to Brian, and at minimum the last three minor versions.
+
+Note that we do not have control about the versions that are supported by the `conda-forge <https://conda-forge.org/>`_
+infrastructure. Therefore, ``brian2`` conda packages might not be provided for all of the supported versions. In this
+case, affected users can chose to either update the Python/numpy version in their conda environment to a version with a
+conda package or to install ``brian2`` via pip.
+
 General policy
 --------------
 
@@ -69,16 +83,11 @@ generation target and the number of threads (for C++ standalone simulations) is 
     random number streams you can either fix the order of elements by specifying the ``order`` or ``name`` argument,
     or make sure that each simulation gets run in a fresh Python process.
 
-Supported Python and numpy versions
------------------------------------
+Python errors
+-------------
 
-We follow the approach outlined in numpy's
-`deprecation policy <https://numpy.org/neps/nep-0029-deprecation_policy.html>`_. This means that Brian supports:
-
-* All minor versions of Python released 42 months prior to Brian, and at minimum the two latest minor versions.
-* All minor versions of numpy released in the 24 months prior to Brian, and at minimum the last three minor versions.
-
-Note that we do not have control about the versions that are supported by the `conda-forge <https://conda-forge.org/>`_
-infrastructure. Therefore, ``brian2`` conda packages might not be provided for all of the supported versions. In this
-case, affected users can chose to either update the Python/numpy version in their conda environment to a version with a
-conda package or to install ``brian2`` via pip.
+While we try to guarantee the reproducibility of simulations (within the limits stated above), we do so only for code
+that does not raise any error. We constantly try to improve the error handling in Brian, and these improvements can
+lead to errors raised at a different time (e.g. when creating an object as opposed to when running the simulation),
+different types of errors being raised (e.g. `DimensionMismatchError` instead of `TypeError`), or simply a different
+error message text. Therefore, Brian scripts should never use ``try``/``except`` blocks to implement program logic.


### PR DESCRIPTION
Fixes #1183 
This replaces our hand-crafted `BrianObjectException` (which inherits from both `BrianObjectException` and the actual exception that was raised, and includes the stacktrace of the original exception) by exception chaining. In Python 2, we did not have another choice, but I think in Python 3 this is clearly an improvement, because:
1. Our exception type sometimes made problems during development (I don't remember the details, but working on Brian itself sometimes lead to errors where the `BrianObjectException` could not be constructed, completely hiding the actual problem).
2. In Python 3 our previous solution leads to a lot of redundancy in the exception traceback (see example below).

The are two open points before merging:
1. The current implementation uses exception chaining in the standard way, but this means that the actual error is not stated in the end, but only higher up in the traceback. The advantage is that it is not repeated, but I think it is properly better to have it clearly stated in the end (when I'm teaching Python, I'm usually telling students to "scroll to the end of the error message").
2. There's a little backwards incompatibility when the code uses `try`/`except`, because the `BrianObjectException` that gets raised is no longer a subclass of the actual error (`DimensionMismatchError`, `TypeError`, ....). I don't think it is a big issue, and I added a section to our compatibility docs to state that users shouldn't rely on `try`/`except` for program logic in Brian code. Not that I'm expecting many users to do, but still... It makes a small difference in our test cases, but that's ok for me. For situations where `BrianObjectException` is raised, i.e. when the error is detected at the start of a run, our tests previously used:
```Python
with pytest.raises(DimensionMismatchError): 
    run(0*ms)
```
Now, it should read:
```Python
with pytest.raises(BrianObjectException) as exc: 
    run(0*ms)
    assert exc.errisinstance(DimensionMismatchError)
```
### Example
For the following code:
```Python
from brian2 import *
group = NeuronGroup(1, 'dv/dt = -v/tau : volt')
tau = 10 # missing units
run(100*ms)
```
<details>
<summary>Error in master</summary>

```pytb
ERROR      Brian 2 encountered an unexpected error. If you think this is bug in Brian 2, please report this issue either to the mailing list at <http://groups.google.com/group/brian-development/>, or to the issue tracker at <https://github.com/brian-team/brian2/issues>. Please include this file with debug information in your report: /tmp/brian_debug_r8d17r7s.log  Additionally, you can also include a copy of the script that was run, available at: /tmp/brian_script_zcmaqkdd.py Thanks! [brian2]
Traceback (most recent call last):
  File "/home/marcel/programming/brian2/brian2/equations/equations.py", line 956, in check_units
    check_dimensions(str(eq.expr), self.dimensions[var] / second.dim,
  File "/home/marcel/programming/brian2/brian2/equations/unitcheck.py", line 45, in check_dimensions
    fail_for_dimension_mismatch(expr_dims, dimensions, err_msg)
  File "/home/marcel/programming/brian2/brian2/units/fundamentalunits.py", line 184, in fail_for_dimension_mismatch
    raise DimensionMismatchError(error_message, dim1)
brian2.units.fundamentalunits.DimensionMismatchError: Expression -v/tau does not have the expected unit metre ** 2 * kilogram * second ** -4 * amp ** -1 (unit is V).

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/marcel/programming/brian2/brian2/core/network.py", line 897, in before_run
    obj.before_run(run_namespace)
  File "/home/marcel/programming/brian2/brian2/groups/neurongroup.py", line 884, in before_run
    self.equations.check_units(self, run_namespace=run_namespace)
  File "/home/marcel/programming/brian2/brian2/equations/equations.py", line 959, in check_units
    raise DimensionMismatchError(('Inconsistent units in '
brian2.units.fundamentalunits.DimensionMismatchError: Inconsistent units in differential equation defining variable v:
Expression -v/tau does not have the expected unit metre ** 2 * kilogram * second ** -4 * amp ** -1 (unit is V).

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/marcel/.config/JetBrains/PyCharm2020.1/scratches/scratch_10.py", line 4, in <module>
    run(100*ms)
  File "/home/marcel/programming/brian2/brian2/units/fundamentalunits.py", line 2385, in new_f
    result = f(*args, **kwds)
  File "/home/marcel/programming/brian2/brian2/core/magic.py", line 373, in run
    return magic_network.run(duration, report=report, report_period=report_period,
  File "/home/marcel/programming/brian2/brian2/core/magic.py", line 231, in run
    Network.run(self, duration, report=report, report_period=report_period,
  File "/home/marcel/programming/brian2/brian2/core/base.py", line 278, in device_override_decorated_function
    return func(*args, **kwds)
  File "/home/marcel/programming/brian2/brian2/units/fundamentalunits.py", line 2385, in new_f
    result = f(*args, **kwds)
  File "/home/marcel/programming/brian2/brian2/core/network.py", line 1008, in run
    self.before_run(namespace)
  File "/home/marcel/programming/brian2/brian2/core/base.py", line 278, in device_override_decorated_function
    return func(*args, **kwds)
  File "/home/marcel/programming/brian2/brian2/core/network.py", line 899, in before_run
    raise brian_object_exception("An error occurred when preparing an object.", obj, ex)
brian2.core.base.BrianObjectException: Original error and traceback:
Traceback (most recent call last):
  File "/home/marcel/programming/brian2/brian2/equations/equations.py", line 956, in check_units
    check_dimensions(str(eq.expr), self.dimensions[var] / second.dim,
  File "/home/marcel/programming/brian2/brian2/equations/unitcheck.py", line 45, in check_dimensions
    fail_for_dimension_mismatch(expr_dims, dimensions, err_msg)
  File "/home/marcel/programming/brian2/brian2/units/fundamentalunits.py", line 184, in fail_for_dimension_mismatch
    raise DimensionMismatchError(error_message, dim1)
brian2.units.fundamentalunits.DimensionMismatchError: Expression -v/tau does not have the expected unit metre ** 2 * kilogram * second ** -4 * amp ** -1 (unit is V).

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/marcel/programming/brian2/brian2/core/network.py", line 897, in before_run
    obj.before_run(run_namespace)
  File "/home/marcel/programming/brian2/brian2/groups/neurongroup.py", line 884, in before_run
    self.equations.check_units(self, run_namespace=run_namespace)
  File "/home/marcel/programming/brian2/brian2/equations/equations.py", line 959, in check_units
    raise DimensionMismatchError(('Inconsistent units in '
brian2.units.fundamentalunits.DimensionMismatchError: Inconsistent units in differential equation defining variable v:
Expression -v/tau does not have the expected unit metre ** 2 * kilogram * second ** -4 * amp ** -1 (unit is V).

Error encountered with object named "neurongroup".
Object was created here (most recent call only, full details in debug log):
  File "/home/marcel/.config/JetBrains/PyCharm2020.1/scratches/scratch_10.py", line 2, in <module>
    group = NeuronGroup(1, 'dv/dt = -v/tau : volt')

An error occurred when preparing an object. brian2.units.fundamentalunits.DimensionMismatchError: Inconsistent units in differential equation defining variable v:
Expression -v/tau does not have the expected unit metre ** 2 * kilogram * second ** -4 * amp ** -1 (unit is V).
(See above for original error message and traceback.)
```
</details>

<details>
<summary>Error in this PR</summary>

```pytb
Traceback (most recent call last):
  File "/home/marcel/programming/brian2/brian2/equations/equations.py", line 956, in check_units
    check_dimensions(str(eq.expr), self.dimensions[var] / second.dim,
  File "/home/marcel/programming/brian2/brian2/equations/unitcheck.py", line 45, in check_dimensions
    fail_for_dimension_mismatch(expr_dims, dimensions, err_msg)
  File "/home/marcel/programming/brian2/brian2/units/fundamentalunits.py", line 184, in fail_for_dimension_mismatch
    raise DimensionMismatchError(error_message, dim1)
brian2.units.fundamentalunits.DimensionMismatchError: Expression -v/tau does not have the expected unit metre ** 2 * kilogram * second ** -4 * amp ** -1 (unit is V).

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/marcel/programming/brian2/brian2/core/network.py", line 897, in before_run
    obj.before_run(run_namespace)
  File "/home/marcel/programming/brian2/brian2/groups/neurongroup.py", line 884, in before_run
    self.equations.check_units(self, run_namespace=run_namespace)
  File "/home/marcel/programming/brian2/brian2/equations/equations.py", line 959, in check_units
    raise DimensionMismatchError(('Inconsistent units in '
brian2.units.fundamentalunits.DimensionMismatchError: Inconsistent units in differential equation defining variable v:
Expression -v/tau does not have the expected unit metre ** 2 * kilogram * second ** -4 * amp ** -1 (unit is V).

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/marcel/.config/JetBrains/PyCharm2020.1/scratches/scratch_10.py", line 4, in <module>
    run(100*ms)
  File "/home/marcel/programming/brian2/brian2/units/fundamentalunits.py", line 2385, in new_f
    result = f(*args, **kwds)
  File "/home/marcel/programming/brian2/brian2/core/magic.py", line 373, in run
    return magic_network.run(duration, report=report, report_period=report_period,
  File "/home/marcel/programming/brian2/brian2/core/magic.py", line 231, in run
    Network.run(self, duration, report=report, report_period=report_period,
  File "/home/marcel/programming/brian2/brian2/core/base.py", line 278, in device_override_decorated_function
    return func(*args, **kwds)
  File "/home/marcel/programming/brian2/brian2/units/fundamentalunits.py", line 2385, in new_f
    result = f(*args, **kwds)
  File "/home/marcel/programming/brian2/brian2/core/network.py", line 1008, in run
    self.before_run(namespace)
  File "/home/marcel/programming/brian2/brian2/core/base.py", line 278, in device_override_decorated_function
    return func(*args, **kwds)
  File "/home/marcel/programming/brian2/brian2/core/network.py", line 899, in before_run
    raise BrianObjectException("An error occurred when preparing an object.", obj) from ex
brian2.core.base.BrianObjectException: Error encountered with object named "neurongroup".
Object was created here (most recent call only, full details in debug log):
  File "/home/marcel/.config/JetBrains/PyCharm2020.1/scratches/scratch_10.py", line 2, in <module>
    group = NeuronGroup(1, 'dv/dt = -v/tau : volt')

An error occurred when preparing an object.(See above for original error message and traceback.)
```
</details>