### PR TITLE
Make GSL tests optional

### DIFF
--- a/brian2/tests/pytest.ini
+++ b/brian2/tests/pytest.ini
@@ -10,6 +10,7 @@ markers =
     standalone_only: tests that are only meant for standalone mode
     cpp_standalone: tests should be run with standalone_only, to be used with standalone_only marker
     openmp: standalone tests using OpenMP for parallel execution on multiple CPUs
+    gsl : tests requiring the GSL
 
 # Ignore the warning "BaseException.message has been deprecated as of Python 2.6"
 # that occurs because we copy over all exception attributes in brian_object_exception,

--- a/brian2/tests/test_GSL.py
+++ b/brian2/tests/test_GSL.py
@@ -1,6 +1,3 @@
-
-
-
 import functools
 
 import pytest
@@ -13,6 +10,7 @@ from brian2.stateupdaters.base import UnsupportedEquationsException
 
 max_difference = .1*mV
 
+pytestmark = pytest.mark.gsl
 
 def skip_if_not_implemented(func):
     @functools.wraps(func)

--- a/dev/continuous-integration/run_test_suite.py
+++ b/dev/continuous-integration/run_test_suite.py
@@ -53,14 +53,16 @@ if standalone:
                          test_openmp=openmp,
                          test_in_parallel=in_parallel,
                          reset_preferences=reset_preferences,
-                         float_dtype=float_dtype)
+                         float_dtype=float_dtype,
+                         test_GSL=True)
 else:
     result = brian2.test(targets,
                          test_codegen_independent=independent,
                          test_standalone=None,
                          test_in_parallel=in_parallel,
                          reset_preferences=reset_preferences,
-                         float_dtype=float_dtype)
+                         float_dtype=float_dtype,
+                         test_GSL=True)
 
 if not result:
     sys.exit(1)


### PR DESCRIPTION
Users running `brian2.test()` will see many errors if the GSL is not correctly installed. It gets automatically installed with the conda package, but if you install via pip it is up to you to install it. While the error message clearly states that you need to install the GSL, it's not great for users to see tens of tests failing for an optional dependency that only a few of them will ever use.

With this PR, all GSL tests are marked with a pytest `gsl` attribute and excluded if you run `brian2.test()`, you'll have to explicitly ask for them with `brian2.test(test_GSL=True)`. Nothing changes on the test servers, we simply switch on the `test_GSL` option in the `run_test_suite.py` script that we use there.