### PR TITLE
Handle sympy integers

### DIFF
--- a/brian2/codegen/translation.py
+++ b/brian2/codegen/translation.py
@@ -246,7 +246,10 @@ def make_statements(code, variables, dtype, optimise=True, blockname=''):
                     variables[var] = new_var
             elif not variables[var].is_boolean:
                 sympy_expr = str_to_sympy(expr, variables)
-                sympy_var = sympy.Symbol(var, real=True)
+                if variables[var].is_integer:
+                    sympy_var = sympy.Symbol(var, integer=True)
+                else:
+                    sympy_var = sympy.Symbol(var, real=True)
                 try:
                     collected = sympy.collect(sympy_expr, sympy_var,
                                               exact=True, evaluate=False)

--- a/brian2/equations/equations.py
+++ b/brian2/equations/equations.py
@@ -768,7 +768,11 @@ class Equations(Hashable, Mapping):
                 expr = Expression(new_str_expr)
 
                 if eq.type == SUBEXPRESSION:
-                    substitutions.update({sympy.Symbol(eq.varname, real=True): str_to_sympy(expr.code, variables)})
+                    if eq.var_type == INTEGER:
+                        sympy_var = sympy.Symbol(eq.varname, integer=True)
+                    else:
+                        sympy_var = sympy.Symbol(eq.varname, real=True)
+                    substitutions.update({sympy_var: str_to_sympy(expr.code, variables)})
                     self._substituted_expressions.append((eq.varname, expr))
                 elif eq.type == DIFFERENTIAL_EQUATION:
                     #  a differential equation that we have to check

--- a/brian2/parsing/bast.py
+++ b/brian2/parsing/bast.py
@@ -129,7 +129,6 @@ class BrianASTRenderer(object):
         try:
             return getattr(self, methname)(node)
         except AttributeError:
-            raise
             raise SyntaxError("Unknown syntax: " + nodename)
 
     def render_NameConstant(self, node):

--- a/brian2/parsing/rendering.py
+++ b/brian2/parsing/rendering.py
@@ -1,5 +1,5 @@
-
 import ast
+import numbers
 
 import sympy
 
@@ -265,7 +265,10 @@ class SympyNodeRenderer(NodeRenderer):
             return str(node.value)
 
     def render_Num(self, node):
-        return sympy.Float(node.n)
+        if isinstance(node.n, numbers.Integral):
+            return sympy.Integer(node.n)
+        else:
+            return sympy.Float(node.n)
 
     def render_BinOp(self, node):
         op_name = node.op.__class__.__name__

--- a/brian2/stateupdaters/explicit.py
+++ b/brian2/stateupdaters/explicit.py
@@ -570,10 +570,10 @@ class ExplicitStateUpdater(StateUpdateMethod):
         v = _v
         >>> print(rk4(eqs))
         __k_1_v = -dt*v/tau
-        __k_2_v = -dt*(0.5*__k_1_v + v)/tau
-        __k_3_v = -dt*(0.5*__k_2_v + v)/tau
+        __k_2_v = -dt*(__k_1_v/2 + v)/tau
+        __k_3_v = -dt*(__k_2_v/2 + v)/tau
         __k_4_v = -dt*(__k_3_v + v)/tau
-        _v = 0.166666666666667*__k_1_v + 0.333333333333333*__k_2_v + 0.333333333333333*__k_3_v + 0.166666666666667*__k_4_v + v
+        _v = __k_1_v/6 + __k_2_v/3 + __k_3_v/3 + __k_4_v/6 + v
         v = _v
         '''
         method_options = extract_method_options(method_options, {})

--- a/brian2/stateupdaters/exponential_euler.py
+++ b/brian2/stateupdaters/exponential_euler.py
@@ -33,7 +33,7 @@ def get_conditionally_linear_system(eqs, variables=None):
     --------
     >>> from brian2 import Equations
     >>> eqs = Equations("""
-    ... dv/dt = (-v + w**2) / tau : 1
+    ... dv/dt = (-v + w**2.0) / tau : 1
     ... dw/dt = -w / tau : 1
     ... """)
     >>> system = get_conditionally_linear_system(eqs)

--- a/brian2/tests/test_codegen.py
+++ b/brian2/tests/test_codegen.py
@@ -389,19 +389,19 @@ def test_automatic_augmented_assignments():
         # examples that should be rewritten
         # Note that using our approach, we will never get -= or /= but always
         # the equivalent += or *= statements
-        ('x = x + 1', 'x += 1'),
-        ('x = 2 * x', 'x *= 2'),
-        ('x = x - 3', 'x += -3'),
-        ('x = x/2', 'x *= 0.5'),
-        ('x = y + (x + 1)', 'x += y + 1'),
-        ('x = x + x', 'x *= 2'),
+        ('x = x + 1.0', 'x += 1.0'),
+        ('x = 2.0 * x', 'x *= 2.0'),
+        ('x = x - 3.0', 'x += -3.0'),
+        ('x = x/2.0', 'x *= 0.5'),
+        ('x = y + (x + 1.0)', 'x += y + 1.0'),
+        ('x = x + x', 'x *= 2.0'),
         ('x = x + y + z', 'x += y + z'),
         ('x = x + y + z', 'x += y + z'),
         # examples that should not be rewritten
-        ('x = 1/x', 'x = 1/x'),
-        ('x = 1', 'x = 1'),
-        ('x = 2*(x + 1)', 'x = 2*(x + 1)'),
-        ('x = clip(x + y, 0, inf)', 'x = clip(x + y, 0, inf)'),
+        ('x = 1.0/x', 'x = 1.0/x'),
+        ('x = 1.0', 'x = 1.0'),
+        ('x = 2.0*(x + 1.0)', 'x = 2.0*(x + 1.0)'),
+        ('x = clip(x + y, 0.0, inf)', 'x = clip(x + y, 0.0, inf)'),
         ('b = b or False', 'b = b or False')
     ]
     for orig, rewritten in statements:


### PR DESCRIPTION
As noted in #812 , we always converted integers to float whenever we use sympy (most importantly for differential equations). Back in the days we could not fix it because it led to problems with floor division. This has been fixed in sympy quite a while ago, in sympy 1.1 (we already require sympy >=1.2), so this is no longer an issue. With this PR, we take care to represent integers as integers in sympy, which fixes #1199 .

Note that there are still places where we convert integers to floats that are unrelated to sympy. For an expression `x + 1`, where `x` is a floating point variable (and therefore the whole expression is floating point), we try to rearrange things during the optimization step (e.g. to replace `x + 0` by `x`), which leads to the expression being converted to `x + 1.0`. Changing this would be quite some work, but I don't think it is necessary. 