### PR TITLE
Make RNG seed test standalone compatible

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -98,9 +98,9 @@ install:
        conda install --yes --quiet anaconda-client conda-build jinja2;
     fi
   - if [[ $MINIMAL_VERSIONS == 'yes' ]]; then
-    PYTHON_PACKAGES="python=$PYTHON numpy==1.15 scipy==0.16 libgfortran==1 pytest "pytest-xdist<2" sphinx==1.8 ipython sympy==1.2 jinja2==2.7 pyparsing setuptools coverage<5 gsl>1.15 cython";
+    PYTHON_PACKAGES="python=$PYTHON numpy==1.15 scipy==0.16 libgfortran==1 pytest pytest-xdist<2 sphinx==1.8 ipython sympy==1.2 jinja2==2.7 pyparsing setuptools coverage<5 gsl>1.15 cython";
     else
-    PYTHON_PACKAGES="python=$PYTHON numpy pytest "pytest-xdist<2" sphinx>=1.8 ipython sympy>=1.2 pyparsing jinja2 setuptools coverage<5 gsl>1.15 cython";
+    PYTHON_PACKAGES="python=$PYTHON numpy pytest pytest-xdist<2 sphinx>=1.8 ipython sympy>=1.2 pyparsing jinja2 setuptools coverage<5 gsl>1.15 cython";
     fi
   - PYTHON_PACKAGES="$PYTHON_PACKAGES scipy";
   - if [[ $REPORT_COVERAGE == 'yes' ]]; then PYTHON_PACKAGES="$PYTHON_PACKAGES pytest-cov coveralls"; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -98,9 +98,9 @@ install:
        conda install --yes --quiet anaconda-client conda-build jinja2;
     fi
   - if [[ $MINIMAL_VERSIONS == 'yes' ]]; then
-    PYTHON_PACKAGES="python=$PYTHON numpy==1.15 scipy==0.16 libgfortran==1 pytest pytest-xdist sphinx==1.8 ipython sympy==1.2 jinja2==2.7 pyparsing setuptools coverage<5 gsl>1.15 cython";
+    PYTHON_PACKAGES="python=$PYTHON numpy==1.15 scipy==0.16 libgfortran==1 pytest "pytest-xdist<2" sphinx==1.8 ipython sympy==1.2 jinja2==2.7 pyparsing setuptools coverage<5 gsl>1.15 cython";
     else
-    PYTHON_PACKAGES="python=$PYTHON numpy pytest pytest-xdist sphinx>=1.8 ipython sympy>=1.2 pyparsing jinja2 setuptools coverage<5 gsl>1.15 cython";
+    PYTHON_PACKAGES="python=$PYTHON numpy pytest "pytest-xdist<2" sphinx>=1.8 ipython sympy>=1.2 pyparsing jinja2 setuptools coverage<5 gsl>1.15 cython";
     fi
   - PYTHON_PACKAGES="$PYTHON_PACKAGES scipy";
   - if [[ $REPORT_COVERAGE == 'yes' ]]; then PYTHON_PACKAGES="$PYTHON_PACKAGES pytest-cov coveralls"; fi

--- a/brian2/tests/test_neurongroup.py
+++ b/brian2/tests/test_neurongroup.py
@@ -204,9 +204,9 @@ def test_variableview_inplace_calculations():
 
     # Floor division
     G.x //= 2
-    G.y //= 0.001
+    G.y //= 0.01
     assert_allclose(G.x[:], x_vals // 2)
-    assert_allclose(G.y[:], y_vals // 0.001)
+    assert_allclose(G.y[:], y_vals // 0.01)
     with pytest.raises(DimensionMismatchError):
         G.x //= 2*mV
     with pytest.raises(DimensionMismatchError):
@@ -1628,6 +1628,7 @@ def test_random_values_fixed_seed():
 @pytest.mark.standalone_compatible
 @pytest.mark.multiple_runs
 def test_random_values_fixed_and_random():
+    prefs.core.default_float_dtype = np.float32
     G = NeuronGroup(10, 'dv/dt = -v/(10*ms) + 0.1*xi/sqrt(ms) : 1')
     mon = StateMonitor(G, 'v', record=True)
 

--- a/brian2/tests/test_neurongroup.py
+++ b/brian2/tests/test_neurongroup.py
@@ -204,9 +204,11 @@ def test_variableview_inplace_calculations():
 
     # Floor division
     G.x //= 2
-    G.y //= 0.01
+    # This is very sensitive to rounding issues, so increase the value a bit
+    G.y += 0.01*mV
+    G.y //= 0.001
     assert_allclose(G.x[:], x_vals // 2)
-    assert_allclose(G.y[:], y_vals // 0.01)
+    assert_allclose(G.y[:], y_vals // 0.001)
     with pytest.raises(DimensionMismatchError):
         G.x //= 2*mV
     with pytest.raises(DimensionMismatchError):

--- a/brian2/tests/test_neurongroup.py
+++ b/brian2/tests/test_neurongroup.py
@@ -1630,7 +1630,6 @@ def test_random_values_fixed_seed():
 @pytest.mark.standalone_compatible
 @pytest.mark.multiple_runs
 def test_random_values_fixed_and_random():
-    prefs.core.default_float_dtype = np.float32
     G = NeuronGroup(10, 'dv/dt = -v/(10*ms) + 0.1*xi/sqrt(ms) : 1')
     mon = StateMonitor(G, 'v', record=True)
 

--- a/brian2/tests/test_neurongroup.py
+++ b/brian2/tests/test_neurongroup.py
@@ -1630,7 +1630,8 @@ def test_random_values_fixed_seed():
 @pytest.mark.standalone_compatible
 @pytest.mark.multiple_runs
 def test_random_values_fixed_and_random():
-    G = NeuronGroup(10, 'dv/dt = -v/(10*ms) + 0.1*xi/sqrt(ms) : 1')
+    G = NeuronGroup(10, 'dv/dt = -v/(10*ms) + 0.1*xi/sqrt(ms) : 1',
+                    method='euler')
     mon = StateMonitor(G, 'v', record=True)
 
     # first run
@@ -1651,10 +1652,10 @@ def test_random_values_fixed_and_random():
     second_run_values = np.array(mon.v[:, [2, 3]])
 
     # First time step should be identical (same seed)
-    assert_allclose(first_run_values[:, 0], second_run_values[:, 0])
-    # Second should be different (random seed)
-    assert_raises(AssertionError, assert_allclose,
-                  first_run_values[:, 1], second_run_values[:, 1])
+    assert all(abs((first_run_values[:, 0] - second_run_values[:, 0])) < 0.0001)
+    # Increase in second time step should be different (random seed)
+    assert all(abs((first_run_values[:, 1] - first_run_values[:, 0]) -
+                   (second_run_values[:, 1] - second_run_values[:, 0])) > 0.0001)
 
 
 @pytest.mark.codegen_independent

--- a/brian2/tests/test_parsing.py
+++ b/brian2/tests/test_parsing.py
@@ -97,7 +97,7 @@ def parse_expressions(renderer, evaluator, numvalues=10):
             try:
                 # Use all close because we can introduce small numerical
                 # difference through sympy's rearrangements
-                assert_allclose(r1, r2, atol=10)
+                assert_allclose(r1, r2, atol=1e-8)
             except AssertionError as e:
                 raise AssertionError("In expression " + str(expr) +
                                      " translated to " + str(pexpr) +

--- a/brian2/tests/test_spatialneuron.py
+++ b/brian2/tests/test_spatialneuron.py
@@ -156,7 +156,6 @@ def test_infinitecable():
     Test simulation of an infinite cable vs. theory for current pulse (Green function)
     '''
     BrianLogger.suppress_name('resolution_conflict')
-
     defaultclock.dt = 0.001*ms
 
     # Morphology
@@ -191,15 +190,14 @@ def test_infinitecable():
     theory = 1./(la*Cm*pi*diameter)*sqrt(taum/(4*pi*(t+defaultclock.dt)))*\
                  exp(-(t+defaultclock.dt)/taum-taum/(4*(t+defaultclock.dt))*(x/la)**2)
     theory = theory*1*nA*0.02*ms
-    assert_allclose(v[t>0.5*ms], theory[t>0.5*ms], rtol=1e14, atol=1e10) # high error tolerance (not exact because not infinite cable)
+    assert_allclose(v[t>0.5*ms], theory[t>0.5*ms],
+                    atol=float(6.32*uvolt)) # high error tolerance (not exact because not infinite cable)
 
 @pytest.mark.standalone_compatible
 def test_finitecable():
     '''
     Test simulation of short cylinder vs. theory for constant current.
     '''
-    if prefs.core.default_float_dtype is np.float32:
-        pytest.skip('Need double precision for this test')
     BrianLogger.suppress_name('resolution_conflict')
 
     defaultclock.dt = 0.01*ms
@@ -210,12 +208,12 @@ def test_finitecable():
     Cm = 1 * uF / cm ** 2
     Ri = 150 * ohm * cm
     N = 200
-    morpho=Cylinder(diameter=diameter, length=length, n=N)
+    morpho = Cylinder(diameter=diameter, length=length, n=N)
 
     # Passive channels
-    gL=1e-4*siemens/cm**2
-    EL=-70*mV
-    eqs='''
+    gL = 1e-4*siemens/cm**2
+    EL = -70*mV
+    eqs = '''
     Im=gL*(EL-v) : amp/meter**2
     I : amp (point current)
     '''
@@ -223,7 +221,7 @@ def test_finitecable():
     neuron = SpatialNeuron(morphology=morpho, model=eqs, Cm=Cm, Ri=Ri)
     neuron.v = EL
 
-    neuron.I[0]=0.02*nA # injecting at the left end
+    neuron.I[0] = 0.02*nA  # injecting at the left end
 
     run(100*ms)
 
@@ -233,7 +231,7 @@ def test_finitecable():
     la = neuron.space_constant[0]
     ra = la*4*Ri/(pi*diameter**2)
     theory = EL+ra*neuron.I[0]*cosh((length-x)/la)/sinh(length/la)
-    assert_allclose(v-EL, theory-EL, rtol=1e12, atol=1e8)
+    assert_allclose(v-EL, theory-EL, atol=1e-6)
 
 @pytest.mark.standalone_compatible
 def test_rallpack1():
@@ -466,8 +464,6 @@ def test_rall():
     '''
     Test simulation of a cylinder plus two branches, with diameters according to Rall's formula
     '''
-    if prefs.core.default_float_dtype is np.float32:
-        pytest.skip('Need double precision for this test')
     BrianLogger.suppress_name('resolution_conflict')
 
     defaultclock.dt = 0.01*ms
@@ -521,15 +517,16 @@ def test_rall():
     l = length/la + L1/l1
     theory = EL+ra*neuron.I[0]*cosh(l-x/la)/sinh(l)
     v = neuron.main.v
-    assert_allclose(v-EL, theory-EL, rtol=1e12, atol=1e8)
+    assert_allclose(v-EL, theory-EL, atol=2e-6)
     x = neuron.L.distance
     theory = EL+ra*neuron.I[0]*cosh(l-neuron.main.distance[-1]/la-(x-neuron.main.distance[-1])/l1)/sinh(l)
     v = neuron.L.v
-    assert_allclose(v-EL, theory-EL, rtol=1e12, atol=1e8)
+    assert_allclose(v-EL, theory-EL, atol=2e-6)
     x = neuron.R.distance
     theory = EL+ra*neuron.I[0]*cosh(l-neuron.main.distance[-1]/la-(x-neuron.main.distance[-1])/l2)/sinh(l)
     v = neuron.R.v
-    assert_allclose(v-EL, theory-EL, rtol=1e12, atol=1e8)
+    assert_allclose(v-EL, theory-EL, atol=2e-6)
+
 
 @pytest.mark.standalone_compatible
 def test_basic_diffusion():

--- a/brian2/tests/test_synapses.py
+++ b/brian2/tests/test_synapses.py
@@ -1853,8 +1853,6 @@ def test_vectorisation():
 
 @pytest.mark.standalone_compatible
 def test_vectorisation_STDP_like():
-    if prefs.core.default_float_dtype is np.float32:
-        pytest.skip('Need double precision for this test')
     # Test the use of pre- and post-synaptic traces that are stored in the
     # pre/post group instead of in the synapses
     w_max = 10
@@ -1888,18 +1886,18 @@ def test_vectorisation_STDP_like():
     assert_allclose(syn.w_dep[:][indices],
                     [1.29140162, 1.16226149, 1.04603529, 1.16226149, 1.04603529,
                      0.94143176, 1.04603529, 0.94143176, 6.2472887],
-                    rtol=1e9, atol=1e4)
+                    atol=0.0001)
     assert_allclose(syn.w_fac[:][indices],
                     [5.06030369, 5.62256002, 6.2472887, 5.62256002, 6.2472887,
                      6.941432, 6.2472887, 6.941432, 1.04603529],
-                    rtol=1e9, atol=1e4)
+                    atol=0.0001)
     assert_allclose(neurons.A[:],
                     [1.69665715, 1.88517461, 2.09463845, 2.32737606, 2.09463845,
                      1.88517461],
-                    rtol=1e9, atol=1e4)
+                    atol=0.0001)
     assert_allclose(neurons.ge[:],
                     [0., 0., 0., -7.31700015, -8.13000011, -4.04603529],
-                    rtol=1e9, atol=1e4)
+                    atol=0.0001)
 
 
 @pytest.mark.standalone_compatible

--- a/brian2/tests/test_synapses.py
+++ b/brian2/tests/test_synapses.py
@@ -928,7 +928,8 @@ def test_transmission_simple():
 @pytest.mark.standalone_compatible
 def test_transmission_custom_event():
     source = NeuronGroup(2, '',
-                         events={'custom': 't>=(2-i)*ms and t<(2-i)*ms + dt'})
+                         events={'custom': 'timestep(t,dt)>=timestep((2-i)*ms, dt) '
+                                           'and timestep(t,dt)<timestep((2-i)*ms + dt, dt)'})
     target = NeuronGroup(2, 'v : 1')
     syn = Synapses(source, target, on_pre='v += 1',
                    on_event='custom')
@@ -943,7 +944,8 @@ def test_transmission_custom_event():
 @pytest.mark.codegen_independent
 def test_invalid_custom_event():
     group1 = NeuronGroup(2, 'v : 1',
-                         events={'custom': 't>=(2-i)*ms and t<(2-i)*ms + dt'})
+                         events={'custom': 'timestep(t,dt)>=timesteep((2-i)*ms,dt) '
+                                           'and timestep(t, dt)<timestep((2-i)*ms + dt, dt)'})
     group2 = NeuronGroup(2, 'v : 1', threshold='v>1')
     with pytest.raises(ValueError):
         Synapses(group1, group1, on_pre='v+=1', on_event='spike')

--- a/brian2/tests/utils.py
+++ b/brian2/tests/utils.py
@@ -21,11 +21,9 @@ def assert_allclose(actual, desired, rtol=4.5e8, atol=0, **kwds):
         The relative tolerance which will be multiplied with the machine epsilon of the type set as
         `core.default_float_type`.
     atol : float, optional
-        The absolute tolerance which will be multiplied with the machine epsilon of the type set as
-        `core.default_float_type`.
+        The absolute tolerance
     '''
     assert have_same_dimensions(actual, desired)
     eps = np.finfo(prefs['core.default_float_dtype']).eps
     rtol = eps*rtol
-    atol = eps*atol
     numpy_allclose(np.asarray(actual), np.asarray(desired), rtol=rtol, atol=atol, **kwds)

--- a/brian2/tests/utils.py
+++ b/brian2/tests/utils.py
@@ -18,14 +18,20 @@ def assert_allclose(actual, desired, rtol=4.5e8, atol=0, **kwds):
     desired : `numpy.ndarray`
         The expected results.
     rtol : float, optional
-        The relative tolerance which will be multiplied with the machine epsilon of the type set as
-        `core.default_float_type`.
+        The relative tolerance. Will be multiplied with the machine epsilon for 64bit float numbers, and adjusted
+        to be the same tolerance in logarithmic terms for 32 bit numbers. For example. the default value of 4.5e8 leads
+        to a tolerance of 1e-7 for 64 bit floating point numbers, where the machine epsilon is on the order of 1e-16. It
+        therefore corresponds to about half of the available decimals in a 64 bit float. For 32 bit floating point
+        numbers, where the machine epsilon is on the order of 1e-7, the tolerance will then be about 8e-4.
     atol : float, optional
         The absolute tolerance which will be multiplied with the machine epsilon of the type set as
         `core.default_float_type`.
     '''
     assert have_same_dimensions(actual, desired)
-    eps = np.finfo(prefs['core.default_float_dtype']).eps
-    rtol = eps*rtol
+    float_dtype = prefs['core.default_float_dtype']
+    reference_eps = np.finfo(np.float64).eps
+    eps = np.finfo(float_dtype).eps
+    rel_precision = (np.log10(rtol * reference_eps)) / np.log10(reference_eps)
+    rtol = 10**(rel_precision * np.log10(eps))
     atol = eps*atol
     numpy_allclose(np.asarray(actual), np.asarray(desired), rtol=rtol, atol=atol, **kwds)

--- a/brian2/tests/utils.py
+++ b/brian2/tests/utils.py
@@ -18,20 +18,14 @@ def assert_allclose(actual, desired, rtol=4.5e8, atol=0, **kwds):
     desired : `numpy.ndarray`
         The expected results.
     rtol : float, optional
-        The relative tolerance. Will be multiplied with the machine epsilon for 64bit float numbers, and adjusted
-        to be the same tolerance in logarithmic terms for 32 bit numbers. For example. the default value of 4.5e8 leads
-        to a tolerance of 1e-7 for 64 bit floating point numbers, where the machine epsilon is on the order of 1e-16. It
-        therefore corresponds to about half of the available decimals in a 64 bit float. For 32 bit floating point
-        numbers, where the machine epsilon is on the order of 1e-7, the tolerance will then be about 8e-4.
+        The relative tolerance which will be multiplied with the machine epsilon of the type set as
+        `core.default_float_type`.
     atol : float, optional
         The absolute tolerance which will be multiplied with the machine epsilon of the type set as
         `core.default_float_type`.
     '''
     assert have_same_dimensions(actual, desired)
-    float_dtype = prefs['core.default_float_dtype']
-    reference_eps = np.finfo(np.float64).eps
-    eps = np.finfo(float_dtype).eps
-    rel_precision = (np.log10(rtol * reference_eps)) / np.log10(reference_eps)
-    rtol = 10**(rel_precision * np.log10(eps))
+    eps = np.finfo(prefs['core.default_float_dtype']).eps
+    rtol = eps*rtol
     atol = eps*atol
     numpy_allclose(np.asarray(actual), np.asarray(desired), rtol=rtol, atol=atol, **kwds)

--- a/dev/tools/run_tests.py
+++ b/dev/tools/run_tests.py
@@ -6,5 +6,6 @@ import sys
 import brian2
 
 if __name__ == '__main__':
-    if not brian2.test():  # If the test fails, exit with a non-zero error code
+    import numpy as np
+    if not brian2.test(float_dtype=np.float32):  # If the test fails, exit with a non-zero error code
         sys.exit(1)

--- a/dev/tools/run_tests.py
+++ b/dev/tools/run_tests.py
@@ -7,5 +7,5 @@ import brian2
 
 if __name__ == '__main__':
     import numpy as np
-    if not brian2.test(float_dtype=np.float32):  # If the test fails, exit with a non-zero error code
+    if not brian2.test():  # If the test fails, exit with a non-zero error code
         sys.exit(1)

--- a/dev/tools/run_tests_standalone.py
+++ b/dev/tools/run_tests_standalone.py
@@ -13,6 +13,5 @@ if __name__ == '__main__':
             sys.exit(1)
     else:
         if not brian2.test([], test_codegen_independent=False,
-                           test_standalone='cpp_standalone',
-                           long_tests=True):  # If the test fails, exit with a non-zero error code
+                           test_standalone='cpp_standalone'):  # If the test fails, exit with a non-zero error code
             sys.exit(1)


### PR DESCRIPTION
Hey there,

I just adapted one of the brian2 tests to make it standalone compatible. I don't think this changes anything for what is tested here. In general, I sometimes come across a brian2 test that could be made standalone compatible. In the past I just added those tests to the brian2cuda tests. But I could also just add them to brian2 as here, would you want that?

And I am currently adding more tests for setting the RNG seed. In brian2cuda the random number generation is quite different depending on where it is used (synapse connection conditions use host side RNG, stateupdaters etc. use a device side random number buffer and binomial uses on the fly device side RNG). Do you want such tests in the brian2 test suite or should I keep them in brian2cuda? I guess brian2 uses the same RNG mechanism everywhere? I can post the tests I added here once they are pushed.