### PR TITLE
Remove unused get_array_name argument

### DIFF
--- a/brian2/codegen/generators/cpp_generator.py
+++ b/brian2/codegen/generators/cpp_generator.py
@@ -248,7 +248,7 @@ class CPPCodeGenerator(CodeGenerator):
             else:
                 line = ''
             line = line + self.c_data_type(var.dtype) + ' ' + varname + ' = '
-            line = line + self.get_array_name(var, self.variables) + '[' + index_var + '];'
+            line = line + self.get_array_name(var) + '[' + index_var + '];'
             lines.append(line)
         return lines
 
@@ -282,7 +282,7 @@ class CPPCodeGenerator(CodeGenerator):
         for varname in write:
             index_var = self.variable_indices[varname]
             var = self.variables[varname]
-            line = self.get_array_name(var, self.variables) + '[' + index_var + '] = ' + varname + ';'
+            line = self.get_array_name(var) + '[' + index_var + '] = ' + varname + ';'
             lines.append(line)
         return lines
 


### PR DESCRIPTION
Just a wrong function argument that had no effect other than confusing me for a bit.