### PR TITLE
Synapse connect errors

### DIFF
--- a/brian2/parsing/expressions.py
+++ b/brian2/parsing/expressions.py
@@ -235,7 +235,7 @@ def parse_expression_dimensions(expr, variables):
             raise SyntaxError('%s was used like a variable/constant, but it is '
                               'a function.' % name)
         if name in variables:
-            return variables[name].dim
+            return get_dimensions(variables[name])
         elif name in ['True', 'False']:
             return DIMENSIONLESS
         else:

--- a/brian2/parsing/expressions.py
+++ b/brian2/parsing/expressions.py
@@ -382,7 +382,8 @@ def parse_expression_dimensions(expr, variables, orig_expr=None):
             raise SyntaxError("Unsupported operation "+op,
                               ("<string>",
                                expr.lineno,
-                               expr.left.end_col_offset + 1,
+                               getattr(expr.left, 'end_col_offset',
+                                       len(NodeRenderer().render_node(expr.left))) + 1,
                                orig_expr)
                               )
         return u

--- a/brian2/synapses/synapses.py
+++ b/brian2/synapses/synapses.py
@@ -29,7 +29,7 @@ from brian2.parsing.expressions import is_boolean_expression, parse_expression_d
 from brian2.stateupdaters.base import (StateUpdateMethod,
                                        UnsupportedEquationsException)
 from brian2.stateupdaters.exact import linear, independent
-from brian2.units.fundamentalunits import (Quantity, DIMENSIONLESS,
+from brian2.units.fundamentalunits import (Quantity, DIMENSIONLESS, DimensionMismatchError,
                                            fail_for_dimension_mismatch)
 from brian2.units.allunits import second
 from brian2.utils.logger import get_logger
@@ -1353,6 +1353,9 @@ class Synapses(Group):
                 else:
                     j = None
                     if isinstance(p, str):
+                        dim = parse_expression_dimensions(p, variables)
+                        if dim is not DIMENSIONLESS:
+                            raise DimensionMismatchError('Expression for p should be dimensionless.')
                         p_dep = self._expression_index_dependence(p, namespace=namespace)
                         if '_postsynaptic_idx' in p_dep or '_iterator_idx' in p_dep:
                             j = ('_k for _k in range(N_post) '

--- a/brian2/synapses/synapses.py
+++ b/brian2/synapses/synapses.py
@@ -1315,11 +1315,9 @@ class Synapses(Group):
 
         self._connect_called = True
 
-        # Get namespace information and merge it with the variables
+        # Get namespace information
         if namespace is None:
             namespace = get_local_namespace(level=level + 2)
-        variables = dict(namespace)
-        variables.update(self.variables)
 
         # which connection case are we in?
         if condition is None and i is None and j is None:
@@ -1335,6 +1333,8 @@ class Synapses(Group):
                 if condition is True:
                     condition = 'True'
                 # Check that the condition is a boolean expresion
+                identifiers = get_identifiers(condition)
+                variables = self.resolve_all(identifiers, namespace)
                 if not is_boolean_expression(condition, variables):
                     raise TypeError(f'Condition \'{condition}\' is not a '
                                     f'boolean condition')
@@ -1353,6 +1353,8 @@ class Synapses(Group):
                 else:
                     j = None
                     if isinstance(p, str):
+                        identifiers = get_identifiers(p)
+                        variables = self.resolve_all(identifiers, namespace)
                         dim = parse_expression_dimensions(p, variables)
                         if dim is not DIMENSIONLESS:
                             raise DimensionMismatchError('Expression for p should be dimensionless.')

--- a/brian2/tests/test_synapses.py
+++ b/brian2/tests/test_synapses.py
@@ -94,6 +94,14 @@ def test_connect_errors():
     with pytest.raises(SyntaxError):
         S.connect('sin(3, 4) > 1')
 
+    # Unit error in p argument
+    with pytest.raises(TypeError):
+        S.connect('1*mV')
+
+    # Syntax error in p argument
+    with pytest.raises(SyntaxError):
+        S.connect(p='sin(3, 4)')
+
 
 @pytest.mark.codegen_independent
 def test_name_clashes():

--- a/brian2/tests/test_synapses.py
+++ b/brian2/tests/test_synapses.py
@@ -76,6 +76,25 @@ def test_creation_errors():
     with pytest.raises(TypeError):
         Synapses(G, G, 'w:1', post='v+=w', on_post='v+=w', connect=True)
 
+
+@pytest.mark.codegen_independent
+def test_connect_errors():
+    G = NeuronGroup(42, '')
+    S = Synapses(G, G)
+
+    # Not a boolean condition
+    with pytest.raises(TypeError):
+        S.connect('i*2')
+
+    # Unit error
+    with pytest.raises(DimensionMismatchError):
+        S.connect('i > 3*mV')
+
+    # Syntax error
+    with pytest.raises(SyntaxError):
+        S.connect('sin(3, 4) > 1')
+
+
 @pytest.mark.codegen_independent
 def test_name_clashes():
     # Using identical names for synaptic and pre- or post-synaptic variables


### PR DESCRIPTION
This fixes #1218 (see comments in there). If a string condition or a probability as a string expression is provided to `Synapses.connect`, these will now be checked for syntax/unit correctness.

As a little bonus, `SyntaxError`s that are raised (e.g. about an incorrect number of arguments), now mention the full expression that caused them together with the little `^` arrow pointing at the place where it happened. 