### PR TITLE
Synapse information

### DIFF
--- a/brian2/synapses/synapses.py
+++ b/brian2/synapses/synapses.py
@@ -490,6 +490,8 @@ class SynapticSubgroup(object):
                                 'synaptic subgroup has been created'))
         return self._stored_indices
 
+    def __len__(self):
+        return len(self._stored_indices)
 
     def __repr__(self):
         return '<%s, storing %d indices of %s>' % (self.__class__.__name__,

--- a/brian2/synapses/synapses.py
+++ b/brian2/synapses/synapses.py
@@ -943,6 +943,13 @@ class Synapses(Group):
         # Activate name attribute access
         self._enable_group_attributes()
 
+    N_outgoing_pre = property(fget= lambda self: self.variables['N_outgoing'].get_value(),
+                              doc='The number of outgoing synapses for each neuron in the '
+                                  'pre-synaptic group.')
+    N_incoming_post = property(fget=lambda self: self.variables['N_incoming'].get_value(),
+                               doc='The number of incoming synapses for each neuron in the '
+                                   'post-synaptic group.')
+
     def __getitem__(self, item):
         indices = self.indices[item]
         return SynapticSubgroup(self, indices)

--- a/brian2/tests/test_synapses.py
+++ b/brian2/tests/test_synapses.py
@@ -2588,6 +2588,30 @@ def test_missing_lastupdate_error_run_regularly():
         exc.match('lastupdate : second')
 
 
+@pytest.mark.codegen_independent
+def test_synaptic_subgroups():
+    source = NeuronGroup(5, '')
+    target = NeuronGroup(3, '')
+    syn = Synapses(source, target)
+    syn.connect()
+    assert len(syn) == 15
+
+    from_3 = syn[3, :]
+    assert len(from_3) == 3
+    assert all(syn.i[from_3] == 3)
+    assert_array_equal(syn.j[from_3], np.arange(3))
+
+    to_2 = syn[:, 2]
+    assert len(to_2) == 5
+    assert all(syn.j[to_2] == 2)
+    assert_array_equal(syn.i[to_2], np.arange(5))
+
+    mixed = syn[1:3, :2]
+    assert len(mixed) == 4
+    connections = {(i, j) for i, j in zip(syn.i[mixed], syn.j[mixed])}
+    assert connections == {(1, 0), (1, 1), (2, 0), (2, 1)}
+
+
 if __name__ == '__main__':
     SANITY_CHECK_PERMUTATION_ANALYSIS_EXAMPLE = True
     from brian2 import prefs
@@ -2683,4 +2707,5 @@ if __name__ == '__main__':
     test_synapse_generator_range_noint()
     test_missing_lastupdate_error_syn_pathway()
     test_missing_lastupdate_error_run_regularly()
+    test_synaptic_subgroups()
     print('Tests took', time.time()-start)

--- a/brian2/tests/test_synapses.py
+++ b/brian2/tests/test_synapses.py
@@ -34,7 +34,10 @@ def _compare(synapses, expected):
     incoming = conn_matrix.sum(axis=0)
     outgoing = conn_matrix.sum(axis=1)
     assert all(synapses.N_outgoing[:] == outgoing[synapses.i[:]]), 'N_outgoing returned an incorrect value'
+    assert_array_equal(synapses.N_outgoing_pre, outgoing), 'N_outgoing_pre returned an incorrect value'
     assert all(synapses.N_incoming[:] == incoming[synapses.j[:]]), 'N_incoming returned an incorrect value'
+    assert_array_equal(synapses.N_incoming_post, incoming), 'N_incoming_post returned an incorrect value'
+
     # Compare the "synapse number" if it exists
     if synapses.multisynaptic_index is not None:
         # Build an array of synapse numbers by counting the number of times
@@ -129,12 +132,14 @@ def test_incoming_outgoing():
     assert all(S.N_outgoing[1, :] == 2)
     assert all(S.N_outgoing[2, :] == 1)
     assert all(S.N_outgoing[3:, :] == 0)
+    assert_array_equal(S.N_outgoing_pre, [3, 2, 1, 0, 0])
     # First target neuron receives 1 input, the second+third each 2, the fourth receives 1
     assert all(S.N_incoming[:, 0] == 1)
     assert all(S.N_incoming[:, 1] == 2)
     assert all(S.N_incoming[:, 2] == 2)
     assert all(S.N_incoming[:, 3] == 1)
     assert all(S.N_incoming[:, 4:] == 0)
+    assert_array_equal(S.N_incoming_post, [1, 2, 2, 1, 0])
 
 
 @pytest.mark.standalone_compatible

--- a/docs_sphinx/user/synapses.rst
+++ b/docs_sphinx/user/synapses.rst
@@ -235,6 +235,15 @@ Note that it is also possible to index synaptic variables with a single index
 (integer, slice, or array), but in this case synaptic indices have to be
 provided.
 
+The ``N_incoming`` and ``N_outgoing`` variables give access to the
+total number of incoming/outgoing synapses for a neuron, but this access is given
+for each *synapse*. This is necessary to apply it to individual synapses as in
+the statement to normalize synaptic weights mentioned above. To access these
+values per *neuron* instead, `.Synapses.N_incoming_post` and
+`.Synapses.N_outgoing_pre` can be used. Note that synaptic equations or
+``on_pre``/``on_post`` statements should always refer to ``N_incoming`` and
+``N_outgoing`` without ``pre``/``post`` suffix.
+
 Delays
 ------
 There is a special synaptic variable that is automatically created: ``delay``. It is the propagation delay

--- a/docs_sphinx/user/synapses.rst
+++ b/docs_sphinx/user/synapses.rst
@@ -239,10 +239,30 @@ The ``N_incoming`` and ``N_outgoing`` variables give access to the
 total number of incoming/outgoing synapses for a neuron, but this access is given
 for each *synapse*. This is necessary to apply it to individual synapses as in
 the statement to normalize synaptic weights mentioned above. To access these
-values per *neuron* instead, `.Synapses.N_incoming_post` and
-`.Synapses.N_outgoing_pre` can be used. Note that synaptic equations or
+values per *neuron* instead, `~.Synapses.N_incoming_post` and
+`~.Synapses.N_outgoing_pre` can be used. Note that synaptic equations or
 ``on_pre``/``on_post`` statements should always refer to ``N_incoming`` and
 ``N_outgoing`` without ``pre``/``post`` suffix.
+
+Here's a little example illustrating the use of these variables::
+
+    >>> group1 = NeuronGroup(3, '')
+    >>> group2 = NeuronGroup(3, '')
+    >>> syn = Synapses(group1, group2)
+    >>> syn.connect(i=[0, 0, 1, 2], j=[1, 2, 2, 2])
+    >>> print(syn.N_outgoing_pre)  # for each presynaptic neuron
+    [2 1 1]
+    >>> print(syn.N_outgoing[:])  # same numbers, but indexed by synapse
+    [2 2 1 1]
+    >>> print(syn.N_incoming_post)
+    [0 1 3]
+    >>> print(syn.N_incoming[:])
+    [1 3 3 3]
+
+Note that `~.Synapses.N_incoming_post` and `~.Synapses.N_outgoing_pre` can contain zeros for neurons
+that do not have any incoming respectively outgoing synapses. In contrast, `~.Synapses.N_incoming`
+and `~.Synapses.N_outgoing` will never contain zeros, because unconnected neurons are not represented
+in the list of synapses.
 
 Delays
 ------


### PR DESCRIPTION
See my comment in this [briansupport thread](https://groups.google.com/g/briansupport/c/aJK29Kiloxw/m/T1eadGyFBQAJ). This adds support for:
* `len(S[0, :])` and similar expressions (before only e.g. `len(S[0, :].i)` worked)
* support for `N_outgoing_pre` and `N_incoming_post` as attributes of `Synapses`, which give access to the same information as `N_incoming` and `N_outgoing`, but on a per-neuron instead of on a per-synapse basis. The implementation is simple – in principle we could also use something fancier using a reference and indicies, but then the variables would be available to use in code where you cannot use them correctly (synaptic code will always loop over synapses, not over neurons)