### PR TITLE
Do not allow N_incoming/N_outgoing in Synapses.connect

### DIFF
--- a/brian2/synapses/synapses.py
+++ b/brian2/synapses/synapses.py
@@ -1630,6 +1630,14 @@ class Synapses(Group):
         parsed = parse_synapse_generator(j)
         self._check_parsed_synapses_generator(parsed, namespace)
 
+        # Referring to N_incoming/N_outgoing in the connect statement is
+        # ill-defined (see github issue #1227)
+        identifiers = get_identifiers_recursively([j], self.variables)
+        for var in ['N_incoming', 'N_outgoing']:
+            if var in identifiers:
+                raise ValueError(f'The connect statement cannot refer to '
+                                 f'\'{var}\'.')
+
         template_kwds, needed_variables = self._get_multisynaptic_indices()
         template_kwds.update(parsed)
         template_kwds['skip_if_invalid'] = skip_if_invalid

--- a/brian2/tests/test_synapses.py
+++ b/brian2/tests/test_synapses.py
@@ -2644,6 +2644,22 @@ def test_synaptic_subgroups():
     assert connections == {(1, 0), (1, 1), (2, 0), (2, 1)}
 
 
+@pytest.mark.codegen_independent
+def test_incorrect_connect_N_incoming_outgoing():
+    # See github issue #1227
+    source = NeuronGroup(5, '')
+    target = NeuronGroup(3, '')
+    syn = Synapses(source, target)
+
+    with pytest.raises(ValueError) as ex:
+        syn.connect('N_incoming < 5')
+        assert 'N_incoming' in str(ex)
+
+    with pytest.raises(ValueError) as ex:
+        syn.connect('N_outgoing < 5')
+        assert 'N_outgoing' in str(ex)
+
+
 if __name__ == '__main__':
     SANITY_CHECK_PERMUTATION_ANALYSIS_EXAMPLE = True
     from brian2 import prefs
@@ -2740,4 +2756,5 @@ if __name__ == '__main__':
     test_missing_lastupdate_error_syn_pathway()
     test_missing_lastupdate_error_run_regularly()
     test_synaptic_subgroups()
+    test_incorrect_connect_N_incoming_outgoing()
     print('Tests took', time.time()-start)


### PR DESCRIPTION
See comments in #1227. I don't think `N_incoming`/`N_outgoing` in the `connect` statement is something that we should support (but we *should* fix #664 at some point...).

Closes #1227 
