### PR TITLE
Non-contiguous subgroups

### DIFF
--- a/brian2/codegen/runtime/cython_rt/templates/ratemonitor.pyx
+++ b/brian2/codegen/runtime/cython_rt/templates/ratemonitor.pyx
@@ -1,31 +1,50 @@
-{# USES_VARIABLES { N, t, rate, _clock_t, _clock_dt, _spikespace,
-                    _num_source_neurons, _source_start, _source_stop } #}
+{# USES_VARIABLES { N, t, rate, _clock_t, _clock_dt, _spikespace} #}
 {% extends 'common_group.pyx' %}
 
 {% block maincode %}
 
     cdef size_t _num_spikes = {{_spikespace}}[_num{{_spikespace}}-1]
-    
+    {% if subgroup and not contiguous %}
+    # We use the same data structure as for the eventspace to store the
+    # "filtered" events, i.e. the events that are indexed in the subgroup
+    cdef int[{{source_N}} + 1] _filtered_events
+    cdef size_t _source_index_counter = 0
+    _filtered_events[{{source_N}}] = 0
+    {% endif %}
+    {% if subgroup %}
     # For subgroups, we do not want to record all spikes
+    {% if contiguous %}
     # We assume that spikes are ordered
-    cdef int _start_idx = -1
-    cdef int _end_idx = -1
-    cdef size_t _j
+    _start_idx = _num_spikes
+    _end_idx = _num_spikes
     for _j in range(_num_spikes):
         _idx = {{_spikespace}}[_j]
         if _idx >= _source_start:
             _start_idx = _j
             break
-    if _start_idx == -1:
-        _start_idx = _num_spikes
-    for _j in range(_start_idx, _num_spikes):
+    for _j in range(_num_spikes-1, _start_idx-1, -1):
         _idx = {{_spikespace}}[_j]
-        if _idx >= _source_stop:
-            _end_idx = _j
+        if _idx < _source_stop:
             break
-    if _end_idx == -1:
-        _end_idx =_num_spikes
+        _end_idx = _j
     _num_spikes = _end_idx - _start_idx
+    {% else %}
+    for _j in range(_num_spikes):
+        _idx = {{_spikespace}}[_j]
+        if _idx < {{_source_indices}}[_source_index_counter]:
+            continue
+        while {{_source_indices}}[_source_index_counter] < _idx:
+            _source_index_counter += 1
+        if (_source_index_counter < {{source_N}} and
+                _idx == {{_source_indices}}[_source_index_counter]):
+            _source_index_counter += 1
+            _filtered_events[_filtered_events[{{source_N}}]] = _idx
+            _filtered_events[{{source_N}}] += 1
+        if _source_index_counter == {{source_N}}:
+            break
+    _num_spikes = _filtered_events[{{source_N}}]
+    {% endif %}
+    {% endif %}
     
     # Calculate the new length for the arrays
     cdef size_t _new_len = {{_dynamic_t}}.shape[0] + 1
@@ -36,6 +55,6 @@
 
     # Set the new values
     {{_dynamic_t}}.data[_new_len-1] = {{_clock_t}}
-    {{_dynamic_rate}}.data[_new_len-1] = _num_spikes/{{_clock_dt}}/_num_source_neurons
+    {{_dynamic_rate}}.data[_new_len-1] = _num_spikes/{{_clock_dt}}/{{source_N}}
 
 {% endblock %}

--- a/brian2/codegen/runtime/cython_rt/templates/spikemonitor.pyx
+++ b/brian2/codegen/runtime/cython_rt/templates/spikemonitor.pyx
@@ -43,14 +43,13 @@
                 continue
             while {{_source_indices}}[_source_index_counter] < _idx:
                 _source_index_counter += 1
-                if _source_index_counter == {{source_N}}:
-                    break
-            if _idx == {{_source_indices}}[_source_index_counter]:
+            if (_source_index_counter < {{source_N}} and
+                    _idx == {{_source_indices}}[_source_index_counter]):
                 _source_index_counter += 1
                 _filtered_events[_filtered_events[{{source_N}}]] = _idx
                 _filtered_events[{{source_N}}] += 1
-                if _source_index_counter == {{source_N}}:
-                    break
+            if _source_index_counter == {{source_N}}:
+                break
         _num_events = _filtered_events[{{source_N}}]
         {% endif %}
         {% endif %}

--- a/brian2/codegen/runtime/numpy_rt/templates/ratemonitor.py_
+++ b/brian2/codegen/runtime/numpy_rt/templates/ratemonitor.py_
@@ -1,14 +1,19 @@
-{# USES_VARIABLES { rate, t, _spikespace, _num_source_neurons,
-                    _clock_t, _clock_dt, _source_start, _source_stop, N } #}
+{# USES_VARIABLES { rate, t, _spikespace, _clock_t, _clock_dt, N } #}
 {% extends 'common_group.py_' %}
 
 {% block maincode %}
 _spikes = {{_spikespace}}[:{{_spikespace}}[-1]]
+{% if subgroup %}
 # Take subgroups into account
+{% if contiguous %}
 _spikes = _spikes[(_spikes >= _source_start) & (_spikes < _source_stop)]
+{% else %}
+_spikes = _numpy.intersect1d(_spikes, {{_source_indices}}, assume_unique=True)
+{% endif %}
+{% endif %}
 _new_len = {{N}} + 1
 _owner.resize(_new_len)
 {{N}} = _new_len
 {{_dynamic_t}}[-1] = {{_clock_t}}
-{{_dynamic_rate}}[-1] = 1.0 * len(_spikes) / {{_clock_dt}} / _num_source_neurons
+{{_dynamic_rate}}[-1] = 1.0 * len(_spikes) / {{_clock_dt}} / {{source_N}}
 {% endblock %}

--- a/brian2/codegen/runtime/numpy_rt/templates/spikemonitor.py_
+++ b/brian2/codegen/runtime/numpy_rt/templates/spikemonitor.py_
@@ -1,4 +1,4 @@
-{# USES_VARIABLES {N, count, _clock_t, _source_start, _source_stop, _source_N} #}
+{# USES_VARIABLES {N, count, _clock_t} #}
 {% extends 'common_group.py_' %}
 
 {% block maincode %}
@@ -9,11 +9,15 @@
 _n_events = {{_eventspace}}[-1]
 if _n_events > 0:
     _events = {{_eventspace}}[:_n_events]
+    {% if subgroup %}
     # Take subgroups into account
-    if _source_start != 0 or _source_stop != _source_N:
-        _events = _events[(_events >= _source_start) & (_events < _source_stop)]
-        _n_events = len(_events)
-
+    {% if contiguous %}
+    _events = _events[(_events >= _source_start) & (_events < _source_stop)]
+    {% else %}
+    _events = _numpy.intersect1d(_events, {{_source_indices}}, assume_unique=True)
+    {% endif %}
+    _n_events = len(_events)
+    {% endif %}
     if _n_events > 0:
         _vectorisation_idx = 1
         {{scalar_code|autoindent}}
@@ -28,5 +32,13 @@ if _n_events > 0:
         {% set dynamic_varname = get_array_name(var, access_data=False) %}
         {{dynamic_varname}}[_curlen:_newlen] = _to_record_{{varname}}
         {% endfor %}
+        {% if not subgroup %}
+        {{count}}[_events] += 1
+        {% else %}
+        {% if contiguous %}
         {{count}}[_events - _source_start] += 1
+        {% else %}
+        {{count}}[_to_record_i] += 1
+        {% endif %}
+        {% endif %}
 {% endblock %}

--- a/brian2/devices/cpp_standalone/device.py
+++ b/brian2/devices/cpp_standalone/device.py
@@ -468,7 +468,9 @@ class CPPStandaloneDevice(Device):
                                                       indices)
             staticarrayname_value = self.static_array('_value_'+arrayname,
                                                       value)
-            self.array_cache[variableview.variable] = None
+            # Put values into the cache
+            cache_variable = self.array_cache[variableview.variable]
+            cache_variable[indices] = value
             self.main_queue.append(('set_array_by_array', (arrayname,
                                                            staticarrayname_index,
                                                            staticarrayname_value)))

--- a/brian2/devices/cpp_standalone/templates/ratemonitor.cpp
+++ b/brian2/devices/cpp_standalone/templates/ratemonitor.cpp
@@ -1,36 +1,66 @@
-{# USES_VARIABLES { N, rate, t, _spikespace, _clock_t, _clock_dt,
-                    _num_source_neurons, _source_start, _source_stop } #}
+{# USES_VARIABLES { N, rate, t, _spikespace, _clock_t, _clock_dt} #}
 {# WRITES_TO_READ_ONLY_VARIABLES { N } #}
 {% extends 'common_group.cpp' %}
 
 {% block maincode %}
     size_t _num_spikes = {{_spikespace}}[_num_spikespace-1];
+    {% if subgroup and not contiguous %}
+    // We use the same data structure as for the eventspace to store the
+    // "filtered" events, i.e. the events that are indexed in the subgroup
+    int32_t _filtered_events[{{source_N}} + 1];
+    _filtered_events[{{source_N}}] = 0;
+    size_t _source_index_counter = 0;
+    {% endif %}
+    {% if subgroup %}
     // For subgroups, we do not want to record all spikes
-    // We assume that spikes are ordered
-    int _start_idx = -1;
-    int _end_idx = -1;
-    for(size_t _j=0; _j<_num_spikes; _j++)
+    size_t _start_idx = _num_spikes;
+    size_t _end_idx = _num_spikes;
+    if (_num_spikes > 0)
     {
-        const size_t _idx = {{_spikespace}}[_j];
-        if (_idx >= _source_start) {
-            _start_idx = _j;
-            break;
+        {% if contiguous %}
+        for(size_t _j=0; _j<_num_spikes; _j++)
+        {
+            const int _idx = {{_spikespace}}[_j];
+            if (_idx >= _source_start) {
+                _start_idx = _j;
+                break;
+            }
         }
-    }
-    if (_start_idx == -1)
-        _start_idx = _num_spikes;
-    for(size_t _j=_start_idx; _j<_num_spikes; _j++)
-    {
-        const size_t _idx = {{_spikespace}}[_j];
-        if (_idx >= _source_stop) {
+        for(size_t _j=_num_spikes-1; _j>=_start_idx; _j--)
+        {
+            const int _idx = {{_spikespace}}[_j];
+            if (_idx < _source_stop) {
+                break;
+            }
             _end_idx = _j;
-            break;
         }
+        _num_spikes = _end_idx - _start_idx;
+        {% else %}
+        for (size_t _j=0; _j<_num_spikes; _j++)
+        {
+            const size_t _idx = {{_spikespace}}[_j];
+            if (_idx < {{_source_indices}}[_source_index_counter])
+                continue;
+            while ({{_source_indices}}[_source_index_counter] < _idx)
+            {
+                _source_index_counter++;
+            }
+            if (_source_index_counter < {{source_N}} &&
+                _idx == {{_source_indices}}[_source_index_counter])
+            {
+                _source_index_counter += 1;
+                _filtered_events[_filtered_events[{{source_N}}]++] = _idx;
+                if (_source_index_counter == {{source_N}})
+                    break;
+            }
+            if (_source_index_counter == {{source_N}})
+                break;
+        }
+        _num_spikes = _filtered_events[{{source_N}}];
+        {% endif %}
     }
-    if (_end_idx == -1)
-        _end_idx =_num_spikes;
-    _num_spikes = _end_idx - _start_idx;
-    {{_dynamic_rate}}.push_back(1.0*_num_spikes/{{_clock_dt}}/_num_source_neurons);
+    {% endif %}
+    {{_dynamic_rate}}.push_back(1.0*_num_spikes/{{_clock_dt}}/{{source_N}});
     {{_dynamic_t}}.push_back({{_clock_t}});
     {{N}}++;
 {% endblock %}

--- a/brian2/devices/cpp_standalone/templates/spikemonitor.cpp
+++ b/brian2/devices/cpp_standalone/templates/spikemonitor.cpp
@@ -48,16 +48,17 @@
             while ({{_source_indices}}[_source_index_counter] < _idx)
             {
                 _source_index_counter++;
-                if (_source_index_counter == {{source_N}})
-                    break;
             }
-            if (_idx == {{_source_indices}}[_source_index_counter])
+            if (_source_index_counter < {{source_N}} &&
+                _idx == {{_source_indices}}[_source_index_counter])
             {
                 _source_index_counter += 1;
                 _filtered_events[_filtered_events[{{source_N}}]++] = _idx;
                 if (_source_index_counter == {{source_N}})
                     break;
             }
+            if (_source_index_counter == {{source_N}})
+                break;
         }
         _num_events = _filtered_events[{{source_N}}];
         {% endif %}

--- a/brian2/devices/cpp_standalone/templates/spikemonitor.cpp
+++ b/brian2/devices/cpp_standalone/templates/spikemonitor.cpp
@@ -1,6 +1,5 @@
-{# USES_VARIABLES { N, _clock_t, count,
-                        _source_start, _source_stop} #}
-    {# WRITES_TO_READ_ONLY_VARIABLES { N, count } #}
+{# USES_VARIABLES { N, _clock_t, count} #}
+{# WRITES_TO_READ_ONLY_VARIABLES { N, count } #}
 {% extends 'common_group.cpp' %}
 
 {% block maincode %}
@@ -9,11 +8,20 @@
     {% set _eventspace = get_array_name(eventspace_variable) %}
 
     int32_t _num_events = {{_eventspace}}[_num{{eventspace_variable.name}}-1];
-
+    {% if subgroup and not contiguous %}
+    // We use the same data structure as for the eventspace to store the
+    // "filtered" events, i.e. the events that are indexed in the subgroup
+    int32_t _filtered_events[{{source_N}} + 1];
+    _filtered_events[{{source_N}}] = 0;
+    size_t _source_index_counter = 0;
+    {% endif %}
+    {% if subgroup %}
+    // For subgroups, we do not want to record all spikes
+    size_t _start_idx = _num_events;
+    size_t _end_idx = _num_events;
     if (_num_events > 0)
     {
-        size_t _start_idx = _num_events;
-        size_t _end_idx = _num_events;
+        {% if contiguous %}
         for(size_t _j=0; _j<_num_events; _j++)
         {
             const int _idx = {{_eventspace}}[_j];
@@ -31,21 +39,70 @@
             _end_idx = _j;
         }
         _num_events = _end_idx - _start_idx;
-        if (_num_events > 0) {
-            const size_t _vectorisation_idx = 1;
-            {{scalar_code|autoindent}}
-            for(size_t _j=_start_idx; _j<_end_idx; _j++)
+        {% else %}
+        for (size_t _j=0; _j<_num_events; _j++)
+        {
+            const size_t _idx = {{_eventspace}}[_j];
+            if (_idx < {{_source_indices}}[_source_index_counter])
+                continue;
+            while ({{_source_indices}}[_source_index_counter] < _idx)
             {
-                const size_t _idx = {{_eventspace}}[_j];
-                const size_t _vectorisation_idx = _idx;
-                {{vector_code|autoindent}}
-                {% for varname, var in record_variables | dictsort %}
-                {{get_array_name(var, access_data=False)}}.push_back(_to_record_{{varname}});
-                {% endfor %}
-                {{count}}[_idx-_source_start]++;
+                _source_index_counter++;
+                if (_source_index_counter == {{source_N}})
+                    break;
             }
-            {{N}} += _num_events;
+            if (_idx == {{_source_indices}}[_source_index_counter])
+            {
+                _source_index_counter += 1;
+                _filtered_events[_filtered_events[{{source_N}}]++] = _idx;
+                if (_source_index_counter == {{source_N}})
+                    break;
+            }
         }
+        _num_events = _filtered_events[{{source_N}}];
+        {% endif %}
+    }
+    {% endif %}
+    if (_num_events > 0) {
+        const size_t _vectorisation_idx = 1;
+        {{scalar_code|autoindent}}
+        {% if subgroup %}
+        {% if contiguous %}
+        for(size_t _j=_start_idx; _j<_end_idx; _j++)
+        {
+            const size_t _idx = {{_eventspace}}[_j];
+            const size_t _vectorisation_idx = _idx;
+            {{vector_code|autoindent}}
+            {% for varname, var in record_variables | dictsort %}
+            {{get_array_name(var, access_data=False)}}.push_back(_to_record_{{varname}});
+            {% endfor %}
+            {{count}}[_idx-_source_start]++;
+        }
+        {% else %}
+        for(size_t _j=0; _j < _num_events; _j++)
+        {
+            const size_t _idx = _filtered_events[_j];
+            const size_t _vectorisation_idx = _idx;
+            {{vector_code|autoindent}}
+            {% for varname, var in record_variables | dictsort %}
+            {{get_array_name(var, access_data=False)}}.push_back(_to_record_{{varname}});
+            {% endfor %}
+            {{count}}[_to_record_i]++;
+        }
+        {% endif %}
+        {% else %}
+        for (size_t _j=0; _j < _num_events; _j++)
+        {
+            const size_t _idx = {{_eventspace}}[_j];
+            const size_t _vectorisation_idx = _idx;
+            {{ vector_code|autoindent }}
+            {% for varname, var in record_variables | dictsort %}
+            {{get_array_name(var, access_data=False)}}.push_back(_to_record_{{varname}});
+            {% endfor %}
+            {{count}}[_idx]++;
+        }
+        {% endif %}
+        {{N}} += _num_events;
     }
 
 {% endblock %}

--- a/brian2/groups/group.py
+++ b/brian2/groups/group.py
@@ -312,7 +312,7 @@ class IndexWrapper(object):
             variables.add_auxiliary_variable('_cond', dtype=np.bool)
 
             abstract_code = '_cond = ' + item
-            namespace = get_local_namespace(level=level+1)
+            namespace = get_local_namespace(level=level+2)  # decorated function
             from brian2.devices.device import get_device
             device = get_device()
             codeobj = create_runner_codeobj(self.group,

--- a/brian2/groups/group.py
+++ b/brian2/groups/group.py
@@ -14,7 +14,8 @@ import inspect
 
 import numpy as np
 
-from brian2.core.base import BrianObject, weakproxy_with_fallback
+from brian2.core.base import (BrianObject, weakproxy_with_fallback,
+                              device_override)
 from brian2.core.names import Nameable
 from brian2.core.preferences import prefs
 from brian2.core.variables import (Variables, Constant, Variable,
@@ -303,6 +304,7 @@ class IndexWrapper(object):
     def __getitem__(self, item):
         return self.get_item(item, level=1)
 
+    @device_override('index_wrapper_get_item')
     def get_item(self, item, level):
         if isinstance(item, str):
             variables = Variables(None)

--- a/brian2/groups/neurongroup.py
+++ b/brian2/groups/neurongroup.py
@@ -729,7 +729,7 @@ class NeuronGroup(Group, SpikeSource):
                 Group.__setattr__(self, key, value, level=1)
 
     def __getitem__(self, item):
-        start, stop, indices = to_start_stop_or_index(item, self._N)
+        start, stop, indices = to_start_stop_or_index(item, self, level=1)
         return Subgroup(self, start, stop, indices)
 
     def _create_variables(self, user_dtype, events):

--- a/brian2/groups/neurongroup.py
+++ b/brian2/groups/neurongroup.py
@@ -33,7 +33,7 @@ from brian2.utils.logger import get_logger
 from brian2.utils.stringtools import get_identifiers
 
 from .group import Group, CodeRunner, get_dtype
-from .subgroup import Subgroup
+from .subgroup import Subgroup, to_start_stop_or_index
 
 __all__ = ['NeuronGroup']
 
@@ -91,82 +91,6 @@ def check_identifier_pre_post(identifier):
         raise ValueError('"%s" cannot be used as a variable name, the "_pre" '
                          'and "_post" suffixes are used to refer to pre- and '
                          'post-synaptic variables in synapses.' % identifier)
-
-
-def to_start_stop(item, N):
-    '''
-    Helper function to transform a single number, a slice or an array of
-    contiguous indices to a start and stop value. This is used to allow for
-    some flexibility in the syntax of specifying subgroups in `.NeuronGroup`
-    and `.SpatialNeuron`.
-
-    Parameters
-    ----------
-    item : slice, int or sequence
-        The slice, index, or sequence of indices to use. Note that a sequence
-        of indices has to be a sorted ascending sequence of subsequent integers.
-    N : int
-        The total number of elements in the group.
-
-    Returns
-    -------
-    start : int
-        The start value of the slice.
-    stop : int
-        The stop value of the slice.
-
-    Examples
-    --------
-    >>> from brian2.groups.neurongroup import to_start_stop
-    >>> to_start_stop(slice(3, 6), 10)
-    (3, 6)
-    >>> to_start_stop(slice(3, None), 10)
-    (3, 10)
-    >>> to_start_stop(5, 10)
-    (5, 6)
-    >>> to_start_stop([3, 4, 5], 10)
-    (3, 6)
-    >>> to_start_stop([3, 5, 7], 10)
-    Traceback (most recent call last):
-        ...
-    IndexError: Subgroups can only be constructed using contiguous indices.
-    
-    '''
-    if isinstance(item, slice):
-        start, stop, step = item.indices(N)
-    elif isinstance(item, numbers.Integral):
-        start = item
-        stop = item + 1
-        step = 1
-    elif (isinstance(item, (Sequence, np.ndarray)) and
-          not isinstance(item, str)):
-        if not (len(item) > 0 and np.all(np.diff(item) == 1)):
-            raise IndexError('Subgroups can only be constructed using '
-                             'contiguous indices.')
-        if not np.issubdtype(np.asarray(item).dtype, np.integer):
-            raise TypeError('Subgroups can only be constructed using integer '
-                            'values.')
-        start = int(item[0])
-        stop = int(item[-1]) + 1
-        step = 1
-    else:
-        raise TypeError('Subgroups can only be constructed using slicing '
-                        'syntax, a single index, or an array of contiguous '
-                        'indices.')
-    if step != 1:
-        raise IndexError('Subgroups have to be contiguous')
-    if start >= stop:
-        raise IndexError('Illegal start/end values for subgroup, %d>=%d' %
-                         (start, stop))
-    if start >= N:
-        raise IndexError('Illegal start value for subgroup, %d>=%d' %
-                         (start, N))
-    if stop > N:
-        raise IndexError('Illegal stop value for subgroup, %d>%d' %
-                         (stop, N))
-    if start < 0:
-        raise IndexError('Indices have to be positive.')
-    return start, stop
 
 
 class StateUpdater(CodeRunner):
@@ -805,9 +729,8 @@ class NeuronGroup(Group, SpikeSource):
                 Group.__setattr__(self, key, value, level=1)
 
     def __getitem__(self, item):
-        start, stop = to_start_stop(item, self._N)
-
-        return Subgroup(self, start, stop)
+        start, stop, indices = to_start_stop_or_index(item, self._N)
+        return Subgroup(self, start, stop, indices)
 
     def _create_variables(self, user_dtype, events):
         '''

--- a/brian2/groups/subgroup.py
+++ b/brian2/groups/subgroup.py
@@ -56,7 +56,7 @@ def to_start_stop_or_index(item, group, level=0):
     (3, 6, None)
     >>> to_start_stop_or_index([3, 5, 7], group)  # doctest: +ELLIPSIS
     (None, None, array([3, 5, 7]...))
-    >>> to_start_stop_or_index([-1, -2, -3], group)
+    >>> to_start_stop_or_index([-3, -2, -1], group)
     (7, 10, None)
     '''
     start = stop = None
@@ -66,10 +66,7 @@ def to_start_stop_or_index(item, group, level=0):
         indices = np.array([indices])
 
     if not np.all(indices[:-1] <= indices[1:]):
-        logger.warn('The indices provided to create the subgroup were '
-                    'not sorted. They will be sorted before use.',
-                    name_suffix='unsorted_subgroup_indices')
-        indices.sort()
+        raise TypeError('Subgroups can only be created from ordered indices.')
     if not len(indices) > 0:
         raise IndexError('Cannot create an empty subgroup')
 

--- a/brian2/groups/subgroup.py
+++ b/brian2/groups/subgroup.py
@@ -50,12 +50,12 @@ def to_start_stop_or_index(item, group, level=0):
     (3, 10, None)
     >>> to_start_stop_or_index(5, group)
     (5, 6, None)
-    >>> to_start_stop_or_index(slice(None, None, 2), group)
-    (None, None, array([0, 2, 4, 6, 8]))
+    >>> to_start_stop_or_index(slice(None, None, 2), group)  # doctest: +ELLIPSIS
+    (None, None, array([0, 2, 4, 6, 8]...))
     >>> to_start_stop_or_index([3, 4, 5], group)
     (3, 6, None)
-    >>> to_start_stop_or_index([3, 5, 7], group)
-    (None, None, array([3, 5, 7]))
+    >>> to_start_stop_or_index([3, 5, 7], group)  # doctest: +ELLIPSIS
+    (None, None, array([3, 5, 7]...))
     >>> to_start_stop_or_index([-1, -2, -3], group)
     (7, 10, None)
     '''

--- a/brian2/groups/subgroup.py
+++ b/brian2/groups/subgroup.py
@@ -226,7 +226,8 @@ class Subgroup(Group, SpikeSource):
         else:
             self.variables.add_array('_sub_idx', size=self._N,
                                      dtype=np.int32, values=indices,
-                                     index='_idx')
+                                     index='_idx', constant=True,
+                                     read_only=True, unique=True)
 
         # special indexing for subgroups
         self._indices = Indexing(self, self.variables['_sub_idx'])

--- a/brian2/groups/subgroup.py
+++ b/brian2/groups/subgroup.py
@@ -16,7 +16,7 @@ __all__ = ['Subgroup']
 logger = get_logger(__name__)
 
 
-def to_start_stop_or_index(item, N):
+def to_start_stop_or_index(item, group, level=0):
     '''
     Helper function to transform a single number, a slice or an array of
     indices to a start and stop value (if possible), or to an index of positive
@@ -26,11 +26,11 @@ def to_start_stop_or_index(item, N):
 
     Parameters
     ----------
-    item : slice, int or sequence
-        The slice, index, or sequence of indices to use.
-    N : int
-        The total number of elements in the group.
-
+    item : slice, int, str, or sequence
+        The slice, index, or sequence of indices to use, or a boolean string
+        expression that can be evaluated in the context of the group.
+    group : `Group`
+        The group providing the context for the interpretation.
     Returns
     -------
     start : int or None
@@ -42,73 +42,41 @@ def to_start_stop_or_index(item, N):
 
     Examples
     --------
-    >>> from brian2.groups.neurongroup import to_start_stop_or_index
-    >>> to_start_stop_or_index(slice(3, 6), 10)
+    >>> from brian2.groups.neurongroup import NeuronGroup, to_start_stop_or_index
+    >>> group = NeuronGroup(10, '')
+    >>> to_start_stop_or_index(slice(3, 6), group)
     (3, 6, None)
-    >>> to_start_stop_or_index(slice(3, None), 10)
+    >>> to_start_stop_or_index(slice(3, None), group)
     (3, 10, None)
-    >>> to_start_stop_or_index(5, 10)
+    >>> to_start_stop_or_index(5, group)
     (5, 6, None)
-    >>> to_start_stop_or_index(slice(None, None, 2), 10)
+    >>> to_start_stop_or_index(slice(None, None, 2), group)
     (None, None, array([0, 2, 4, 6, 8]))
-    >>> to_start_stop_or_index([3, 4, 5], 10)
+    >>> to_start_stop_or_index([3, 4, 5], group)
     (3, 6, None)
-    >>> to_start_stop_or_index([3, 5, 7], 10)
+    >>> to_start_stop_or_index([3, 5, 7], group)
     (None, None, array([3, 5, 7]))
-    >>> to_start_stop_or_index([-1, -2, -3], 10)
-    (None, None, array([7, 8, 9]))
+    >>> to_start_stop_or_index([-1, -2, -3], group)
+    (7, 10, None)
     '''
-    start = stop = indices = None
-    if isinstance(item, slice):
-        start, stop, step = item.indices(N)
-        if step != 1:
-            indices = np.arange(start, stop, step)
-            start = stop = None
-    elif isinstance(item, numbers.Integral):
-        start = item
-        stop = item + 1
-        step = 1
-    elif (isinstance(item, (Sequence, np.ndarray)) and
-          not isinstance(item, str)):
-        item = np.asarray(item)
-        if not np.issubdtype(item.dtype, np.integer):
-            raise TypeError('Subgroups can only be constructed using integer '
-                            'values.')
-        if not len(item) > 0:
-            raise IndexError('Cannot create an empty subgroup')
-        if np.min(item) < -N:
-            raise IndexError('Illegal index {} for a group of size '
-                             '{}'.format(np.min(item), N))
-        elif np.max(item) >= N:
-            raise IndexError('Illegal index {} for a group of size '
-                             '{}'.format(np.min(item), N))
-        indices = item % N  # interpret negative indices correctly
+    start = stop = None
+    indices = group.indices.get_item(item, level=level+1)
+    # For convenience, allow subgroups with a single value instead of x:x+1 slice
+    if indices.shape == ():
+        indices = np.array([indices])
 
-        if not np.all(item[:-1] <= item[1:]):
-            logger.warn('The indices provided to create the subgroup were '
-                        'not sorted. They will be sorted before use.',
-                        name_suffix='unsorted_subgroup_indices')
-            indices.sort()
+    if not np.all(indices[:-1] <= indices[1:]):
+        logger.warn('The indices provided to create the subgroup were '
+                    'not sorted. They will be sorted before use.',
+                    name_suffix='unsorted_subgroup_indices')
+        indices.sort()
+    if not len(indices) > 0:
+        raise IndexError('Cannot create an empty subgroup')
 
-        if np.all(np.diff(item) == 1):
-            start = int(item[0])
-            stop = int(item[-1]) + 1
-            indices = None
-
-    else:
-        raise TypeError("Cannot interpret object of type '{}' as index or "
-                        "slice".format(type(item)))
-
-    if indices is None:
-        if start >= stop:
-            raise IndexError('Illegal start/end values for subgroup, %d>=%d' %
-                             (start, stop))
-        if start >= N:
-            raise IndexError('Illegal start value for subgroup, %d>=%d' %
-                             (start, N))
-        if stop > N:
-            raise IndexError('Illegal stop value for subgroup, %d>%d' %
-                             (stop, N))
+    if np.all(np.diff(indices) == 1):
+        start = int(indices[0])
+        stop = int(indices[-1]) + 1
+        indices = None
 
     return start, stop, indices
 
@@ -242,15 +210,8 @@ class Subgroup(Group, SpikeSource):
     spikes = property(lambda self: self.source.spikes)
 
     def __getitem__(self, item):
-        start, stop, indices = to_start_stop_or_index(item, self._N)
-        if self.contiguous:
-            if start is not None:
-                return Subgroup(self.source, self.start + start, self.start + stop)
-            else:
-                return Subgroup(self.source, indices=indices+self.start)
-        else:
-            indices = self.sub_indices[item]
-            return Subgroup(self.source, indices=indices)
+        start, stop, indices = to_start_stop_or_index(item, self, level=1)
+        return Subgroup(self.source, start, stop, indices)
 
     def __repr__(self):
         if self.contiguous:

--- a/brian2/groups/subgroup.py
+++ b/brian2/groups/subgroup.py
@@ -152,27 +152,7 @@ class Subgroup(Group, SpikeSource):
             if len(indices) != len(np.unique(indices)):
                 raise IndexError('sub_indices cannot contain repeated values.')
 
-        # First check if the source is itself a Subgroup
-        # If so, then make this a Subgroup of the original Group
-        if isinstance(source, Subgroup):
-            if source.contiguous:
-                if self.contiguous:
-                    source = source.source
-                    start = start + source.start
-                    stop = stop + source.start
-                else:
-                    if np.max(indices) >= source.stop - source.start:
-                        raise IndexError('Index exceeds range')
-                    indices += source.start
-            else:
-                if self.contiguous:
-                    indices = source.sub_indices[start:stop]
-                    self.contiguous = False
-                else:
-                    indices = source.sub_indices[indices]
-            self.source = source
-        else:
-            self.source = weakproxy_with_fallback(source)
+        self.source = weakproxy_with_fallback(source)
 
         # Store a reference to the source's equations (if any)
         self.equations = None

--- a/brian2/spatialneuron/spatialneuron.py
+++ b/brian2/spatialneuron/spatialneuron.py
@@ -461,13 +461,19 @@ class SpatialNeuron(NeuronGroup):
         if name == 'main':  # Main section, without the subtrees
             indices = neuron.morphology.indices[:]
             start, stop = indices[0], indices[-1]
-            return SpatialSubgroup(neuron, start, stop + 1,
-                                   morphology=neuron.morphology)
+            morpho = neuron.morphology
+            if isinstance(neuron, SpatialSubgroup):
+                # For subtrees, make the new Subgroup a child of the original neuron
+                neuron = neuron.source
+            return SpatialSubgroup(neuron, start, stop + 1, morphology=morpho)
         elif (name != 'morphology') and ((name in getattr(neuron.morphology, 'children', [])) or
                                       all([c in 'LR123456789' for c in name])):  # subtree
             morpho = neuron.morphology[name]
             start = morpho.indices[0]
             stop = SpatialNeuron._find_subtree_end(morpho)
+            if isinstance(neuron, SpatialSubgroup):
+                neuron = neuron.source
+
             return SpatialSubgroup(neuron, start, stop + 1, morphology=morpho)
         else:
             return Group.__getattr__(neuron, name)
@@ -489,15 +495,20 @@ class SpatialNeuron(NeuronGroup):
                 raise DimensionMismatchError('Start and stop should have units '
                                              'of meter', start, stop)
             # Convert to integers (compartment numbers)
-            indices = neuron.morphology.indices[item]
-            start, stop = indices[0], indices[-1] + 1
+            compartment_indices = neuron.morphology.indices[item]
+            start, stop = compartment_indices[0], compartment_indices[-1] + 1
+            indices = None
         elif not isinstance(item, slice) and hasattr(item, 'indices'):
             start, stop, indices = to_start_stop_or_index(item.indices[:],
                                                           neuron._N)
         else:
             start, stop, indices = to_start_stop_or_index(item, neuron._N)
 
-        return Subgroup(neuron, start, stop)
+        if isinstance(neuron, SpatialSubgroup):
+            # For subtrees, make the new Subgroup a child of the original neuron
+            neuron = neuron.source
+
+        return Subgroup(neuron, start, stop, indices)
 
 
 class SpatialSubgroup(Subgroup):
@@ -519,7 +530,7 @@ class SpatialSubgroup(Subgroup):
 
     def __init__(self, source, start, stop, morphology, name=None):
         self.morphology = morphology
-        Subgroup.__init__(self, source, start, stop, name)
+        Subgroup.__init__(self, source, start, stop, name=name)
 
     def __getattr__(self, name):
         return SpatialNeuron.spatialneuron_attribute(self, name)

--- a/brian2/spatialneuron/spatialneuron.py
+++ b/brian2/spatialneuron/spatialneuron.py
@@ -500,9 +500,9 @@ class SpatialNeuron(NeuronGroup):
             indices = None
         elif not isinstance(item, slice) and hasattr(item, 'indices'):
             start, stop, indices = to_start_stop_or_index(item.indices[:],
-                                                          neuron._N)
+                                                          neuron)
         else:
-            start, stop, indices = to_start_stop_or_index(item, neuron._N)
+            start, stop, indices = to_start_stop_or_index(item, neuron)
 
         if isinstance(neuron, SpatialSubgroup):
             # For subtrees, make the new Subgroup a child of the original neuron

--- a/brian2/spatialneuron/spatialneuron.py
+++ b/brian2/spatialneuron/spatialneuron.py
@@ -23,7 +23,7 @@ from brian2.units.stdunits import uF, cm
 from brian2.parsing.sympytools import sympy_to_str, str_to_sympy
 from brian2.utils.logger import get_logger
 from brian2.groups.neurongroup import (NeuronGroup, SubexpressionUpdater,
-                                       to_start_stop)
+                                       to_start_stop_or_index)
 from brian2.groups.subgroup import Subgroup
 from brian2.equations.codestrings import Expression
 
@@ -492,13 +492,10 @@ class SpatialNeuron(NeuronGroup):
             indices = neuron.morphology.indices[item]
             start, stop = indices[0], indices[-1] + 1
         elif not isinstance(item, slice) and hasattr(item, 'indices'):
-            start, stop = to_start_stop(item.indices[:], neuron._N)
+            start, stop, indices = to_start_stop_or_index(item.indices[:],
+                                                          neuron._N)
         else:
-            start, stop = to_start_stop(item, neuron._N)
-
-        if start >= stop:
-            raise IndexError('Illegal start/end values for subgroup, %d>=%d' %
-                             (start, stop))
+            start, stop, indices = to_start_stop_or_index(item, neuron._N)
 
         return Subgroup(neuron, start, stop)
 

--- a/brian2/synapses/synapses.py
+++ b/brian2/synapses/synapses.py
@@ -22,6 +22,7 @@ from brian2.equations.equations import (Equations, SingleEquation,
                                         PARAMETER, INTEGER,
                                         check_subexpressions)
 from brian2.groups.group import Group, CodeRunner, get_dtype
+from brian2.groups.subgroup import Subgroup
 from brian2.groups.neurongroup import (extract_constant_subexpressions,
                                        SubexpressionUpdater,
                                        check_identifier_pre_post)
@@ -1097,6 +1098,9 @@ class Synapses(Group):
         if getattr(self.source, 'start', 0) == 0:
             self.variables.add_reference('i', self, '_synaptic_pre')
         else:
+            if isinstance(self.source, Subgroup) and not self.source.contiguous:
+                raise TypeError('Cannot use a non-contiguous subgroup as a '
+                                'source group for Synapses.')
             self.variables.add_reference('_source_i', self.source.source, 'i',
                                          index='_presynaptic_idx')
             self.variables.add_reference('_source_offset', self.source, '_offset')
@@ -1107,6 +1111,9 @@ class Synapses(Group):
         if getattr(self.target, 'start', 0) == 0:
             self.variables.add_reference('j', self, '_synaptic_post')
         else:
+            if isinstance(self.target, Subgroup) and not self.target.contiguous:
+                raise TypeError('Cannot use a non-contiguous subgroup as a '
+                                'target group for Synapses.')
             self.variables.add_reference('_target_j', self.target.source, 'i',
                                          index='_postsynaptic_idx')
             self.variables.add_reference('_target_offset', self.target, '_offset')

--- a/brian2/tests/test_monitor.py
+++ b/brian2/tests/test_monitor.py
@@ -133,9 +133,8 @@ def test_spike_monitor_subgroups():
     spikes_2 = SpikeMonitor(G[2:4])
     spikes_3 = SpikeMonitor(G[4:])
     spikes_indexed = SpikeMonitor(G[::2])
-    with catch_logs() as l:
-        spikes_indexed_unsorted = SpikeMonitor(G[[4, 0, 2]])  # This should not make a difference
-    assert len(l) == 1 and l[0][1].endswith('.unsorted_subgroup_indices')
+    with pytest.raises(TypeError):
+        SpikeMonitor(G[[4, 0, 2]])  # unsorted
     run(defaultclock.dt)
     # Spikes
     assert_allclose(spikes_all.i, [0, 4, 5])
@@ -148,15 +147,12 @@ def test_spike_monitor_subgroups():
     assert_allclose(spikes_3.t, [0, 0] * ms)
     assert_allclose(spikes_indexed.i, [0, 2])
     assert_allclose(spikes_indexed.t, [0, 0]*ms)
-    assert_allclose(spikes_indexed_unsorted.i, [0, 2])
-    assert_allclose(spikes_indexed_unsorted.t, [0, 0]*ms)
     # Spike count
     assert_allclose(spikes_all.count, [1, 0, 0, 0, 1, 1])
     assert_allclose(spikes_1.count, [1, 0])
     assert_allclose(spikes_2.count, [0, 0])
     assert_allclose(spikes_3.count, [1, 1])
     assert_allclose(spikes_indexed.count, [1, 0, 1])
-    assert_allclose(spikes_indexed_unsorted.count, [1, 0, 1])
 
 
 def test_spike_monitor_bug_824():

--- a/brian2/tests/test_monitor.py
+++ b/brian2/tests/test_monitor.py
@@ -132,7 +132,12 @@ def test_spike_monitor_subgroups():
     spikes_1 = SpikeMonitor(G[:2])
     spikes_2 = SpikeMonitor(G[2:4])
     spikes_3 = SpikeMonitor(G[4:])
+    spikes_indexed = SpikeMonitor(G[::2])
+    with catch_logs() as l:
+        spikes_indexed_unsorted = SpikeMonitor(G[[4, 0, 2]])  # This should not make a difference
+    assert len(l) == 1 and l[0][1].endswith('.unsorted_subgroup_indices')
     run(defaultclock.dt)
+    # Spikes
     assert_allclose(spikes_all.i, [0, 4, 5])
     assert_allclose(spikes_all.t, [0, 0, 0]*ms)
     assert_allclose(spikes_1.i, [0])
@@ -141,6 +146,17 @@ def test_spike_monitor_subgroups():
     assert len(spikes_2.t) == 0
     assert_allclose(spikes_3.i, [0, 1])  # recorded spike indices are relative
     assert_allclose(spikes_3.t, [0, 0] * ms)
+    assert_allclose(spikes_indexed.i, [0, 2])
+    assert_allclose(spikes_indexed.t, [0, 0]*ms)
+    assert_allclose(spikes_indexed_unsorted.i, [0, 2])
+    assert_allclose(spikes_indexed_unsorted.t, [0, 0]*ms)
+    # Spike count
+    assert_allclose(spikes_all.count, [1, 0, 0, 0, 1, 1])
+    assert_allclose(spikes_1.count, [1, 0])
+    assert_allclose(spikes_2.count, [0, 0])
+    assert_allclose(spikes_3.count, [1, 1])
+    assert_allclose(spikes_indexed.count, [1, 0, 1])
+    assert_allclose(spikes_indexed_unsorted.count, [1, 0, 1])
 
 
 def test_spike_monitor_bug_824():

--- a/brian2/tests/test_monitor.py
+++ b/brian2/tests/test_monitor.py
@@ -358,6 +358,41 @@ def test_state_monitor():
     assert_allclose(synapse_mon.w[:], np.tile(S.j[:]*nS,
                                               (synapse_mon.w[:].shape[1], 1)).T)
 
+
+@pytest.mark.standalone_compatible
+def test_state_monitor_subgroups():
+    G = NeuronGroup(10, '''v : volt
+                           step_size : volt (constant)''')
+    G.run_regularly('v += step_size')
+    G.step_size = 'i*mV'
+
+    SG1 = G[3:8]
+    SG2 = G[::2]
+
+    state_mon_full = StateMonitor(G, 'v', record=True)
+
+    # monitor subgroups and record from all
+    state_mon1 = StateMonitor(SG1, 'v', record=True)
+    state_mon2 = StateMonitor(SG2, 'v', record=True)
+
+    # monitor subgroup and use (relative) indices
+    state_mon3 = StateMonitor(SG1, 'v', record=[0, 3])
+    state_mon4 = StateMonitor(SG2, 'v', record=[0, 3])
+
+    # monitor full group and use subgroup as indices
+    state_mon5 = StateMonitor(G, 'v', record=SG1)
+    state_mon6 = StateMonitor(G, 'v', record=SG2)
+
+    run(2*defaultclock.dt)
+
+    assert_allclose(state_mon1.v, state_mon_full.v[3:8])
+    assert_allclose(state_mon2.v, state_mon_full.v[::2])
+    assert_allclose(state_mon3.v, state_mon_full.v[3:8][[0, 3]])
+    assert_allclose(state_mon4.v, state_mon_full.v[::2][[0, 3]])
+    assert_allclose(state_mon5.v, state_mon_full.v[3:8])
+    assert_allclose(state_mon6.v, state_mon_full.v[::2])
+
+
 @pytest.mark.standalone_compatible
 @pytest.mark.multiple_runs
 def test_state_monitor_record_single_timestep():

--- a/brian2/tests/test_monitor.py
+++ b/brian2/tests/test_monitor.py
@@ -569,11 +569,14 @@ def test_rate_monitor_subgroups_2():
     rate_1 = PopulationRateMonitor(G[:2])
     rate_2 = PopulationRateMonitor(G[2:4])
     rate_3 = PopulationRateMonitor(G[4:])
+    rate_indexed = PopulationRateMonitor(G[::2])
     run(2*defaultclock.dt)
     assert_allclose(rate_all.rate, 0.5 / defaultclock.dt)
     assert_allclose(rate_1.rate, 0.5 / defaultclock.dt)
     assert_allclose(rate_2.rate, 0*Hz)
     assert_allclose(rate_3.rate, 1 / defaultclock.dt)
+    assert_allclose(rate_indexed.rate, 2/3*(1/defaultclock.dt))  # 2 out of 3
+
 
 if __name__ == '__main__':
     from _pytest.outcomes import Skipped

--- a/brian2/tests/test_spatialneuron.py
+++ b/brian2/tests/test_spatialneuron.py
@@ -659,6 +659,10 @@ def test_spatialneuron_indexing():
     assert len(neuron[0:1].indices[:]) == 1
     assert len(neuron[sec.sec2.indices[:]]) == 16
     assert len(neuron[sec.sec2]) == 16
+    assert len(neuron[:16:2].indices[:]) == 8
+    assert len(neuron[:8][4:].indices[:]) == 4
+    assert len(neuron[:8][::2].indices[:]) == 4
+    assert len(neuron[::2][:8].indices[:]) == 8
 
 
 @pytest.mark.codegen_independent

--- a/brian2/tests/test_subgroup.py
+++ b/brian2/tests/test_subgroup.py
@@ -17,9 +17,12 @@ def test_str_repr():
     '''
     G = NeuronGroup(10, 'v:1')
     SG = G[5:8]
+    SGi = G[[3, 6, 9]]
     # very basic test, only make sure no error is raised
     assert len(str(SG))
     assert len(repr(SG))
+    assert len(str(SGi))
+    assert len(repr(SGi))
 
 
 def test_state_variables():
@@ -84,6 +87,27 @@ def test_state_variables_simple():
     assert_equal(G.b[:], [0, 0, 0, 0, 1, 2, 6, 0, 0, 0])
     assert_equal(G.c[:], [0, 0, 0, 3, 4, 5, 6, 0, 0, 0])
     assert_equal(G.d[:], [0, 0, 0, 0, 4, 1, 2, 0, 0, 0])
+
+@pytest.mark.standalone_compatible
+def test_state_variables_simple_indexed():
+    G = NeuronGroup(10, '''a : 1
+                           b : 1
+                           c : 1
+                           d : 1
+                           ''')
+    SG = G[[3, 5, 7, 9]]
+    SG.a = 1
+    SG.a['i == 0'] = 2
+    SG.b = 'i'
+    SG.b['i == 3'] = 'i * 2'
+    SG.c = np.arange(3, 7)
+    SG.d[1:2] = 4
+    SG.d[2:4] = [1, 2]
+    run(0*ms)
+    assert_equal(G.a[:], [0, 0, 0, 2, 0, 1, 0, 1, 0, 1])
+    assert_equal(G.b[:], [0, 0, 0, 0, 0, 1, 0, 2, 0, 6])
+    assert_equal(G.c[:], [0, 0, 0, 3, 0, 4, 0, 5, 0, 6])
+    assert_equal(G.d[:], [0, 0, 0, 0, 0, 4, 0, 1, 0, 2])
 
 
 def test_state_variables_string_indices():
@@ -641,42 +665,27 @@ def test_spike_monitor():
 
 
 @pytest.mark.codegen_independent
-def test_wrong_indexing():
+@pytest.mark.parametrize('item', ['string', slice(10, None), slice(3, 2),
+                                  [9, 10], [10, 11], [2.5, 3.5, 4.5],
+                                  [5, 5, 5], []])
+def test_wrong_indexing(item):
     G = NeuronGroup(10, 'v:1')
-    with pytest.raises(TypeError):
-        G['string']
-
-    with pytest.raises(IndexError):
-        G[10]
-    with pytest.raises(IndexError):
-        G[10:]
-    with pytest.raises(IndexError):
-        G[::2]
-    with pytest.raises(IndexError):
-        G[3:2]
-    with pytest.raises(IndexError):
-        G[[5, 4, 3]]
-    with pytest.raises(IndexError):
-        G[[2, 4, 6]]
-    with pytest.raises(IndexError):
-        G[[-1, 0, 1]]
-    with pytest.raises(IndexError):
-        G[[9, 10, 11]]
-    with pytest.raises(IndexError):
-        G[[9, 10]]
-    with pytest.raises(IndexError):
-        G[[10, 11]]
-    with pytest.raises(TypeError):
-        G[[2.5, 3.5, 4.5]]
+    with pytest.raises((TypeError, IndexError)):
+        G[item]
 
 
 @pytest.mark.codegen_independent
-def test_alternative_indexing():
+@pytest.mark.parametrize('item,expected', [(slice(-3, None), np.array([7, 8, 9])),
+                                           (slice(None, None, 2), np.array([0, 2, 4, 6, 8])),
+                                           (3, np.array([3])),
+                                           ([3, 4, 5], np.array([3, 4, 5])),
+                                           ([3, 5, 7], np.array([3, 5, 7])),
+                                           ([7, 5, 3], np.array([7, 5, 3])),
+                                           ([3, -1], np.array([3, 9]))])
+def test_alternative_indexing(item, expected):
     G = NeuronGroup(10, 'v : integer')
     G.v = 'i'
-    assert_equal(G[-3:].v, np.array([7, 8, 9]))
-    assert_equal(G[3].v, np.array([3]))
-    assert_equal(G[[3, 4, 5]].v, np.array([3, 4, 5]))
+    assert_equal(G[item].v, expected)
 
 
 def test_no_reference_1():
@@ -742,10 +751,21 @@ def test_recursive_subgroup():
     G = NeuronGroup(10, 'v : 1')
     G.v = 'i'
     SG = G[3:8]
+    SGi = G[[3, 5, 7, 9]]
     SG2 = SG[2:4]
+    SGi2 = SGi[2:4]
+    SGii = SGi[[1, 3]]
+    SG2i = SG[[1, 3]]
     assert_equal(SG2.v[:], np.array([5, 6]))
     assert_equal(SG2.v[:], SG.v[2:4])
+    assert_equal(SGi2.v[:], np.array([7, 9]))
+    assert_equal(SGii.v[:], np.array([5, 9]))
+    assert_equal(SG2i.v[:], np.array([4, 6]))
     assert SG2.source.name == G.name
+    assert SGi2.source.name == G.name
+    assert SGii.source.name == G.name
+    assert SG2i.source.name == G.name
+
 
 if __name__ == '__main__':
     test_str_repr()

--- a/brian2/tests/test_subgroup.py
+++ b/brian2/tests/test_subgroup.py
@@ -158,13 +158,11 @@ def test_state_variables_string_group():
     G = NeuronGroup(10, 'v : 1')
     G.v = 'i'
     c = 3
-    SG1 = G['i > 5']
-    SG2 = G['v > c']
+    SG1 = G['i > 5']  # indexing with constant expressions should even work in standalone
     SG1.v = 'v * 2'
     run(0*ms)  # for standalone
     assert_equal(G.v[:], [0, 1, 2, 3, 4, 5, 12, 14, 16, 18])
     assert_equal(SG1.v[:], [12, 14, 16, 18])
-    assert_equal(SG2.v[:], [4, 5, 12, 14, 16, 18])
 
 
 @pytest.mark.standalone_compatible

--- a/brian2/tests/test_subgroup.py
+++ b/brian2/tests/test_subgroup.py
@@ -683,7 +683,7 @@ def test_spike_monitor():
 @pytest.mark.codegen_independent
 @pytest.mark.parametrize('item', [slice(10, None), slice(3, 2),
                                   [9, 10], [10, 11], [2.5, 3.5, 4.5],
-                                  [5, 5, 5], []])
+                                  [5, 5, 5], [], [5, 4, 3]])
 def test_wrong_indexing(item):
     G = NeuronGroup(10, 'v:1')
     with pytest.raises((TypeError, IndexError)):
@@ -696,7 +696,6 @@ def test_wrong_indexing(item):
                                            (3, np.array([3])),
                                            ([3, 4, 5], np.array([3, 4, 5])),
                                            ([3, 5, 7], np.array([3, 5, 7])),
-                                           ([7, 5, 3], np.array([3, 5, 7])),
                                            ([3, -1], np.array([3, 9]))])
 def test_alternative_indexing(item, expected):
     G = NeuronGroup(10, 'v : integer')

--- a/brian2/tests/test_subgroup.py
+++ b/brian2/tests/test_subgroup.py
@@ -154,6 +154,20 @@ def test_state_variables_group_as_index_problematic():
                         for entry in l])
 
 @pytest.mark.standalone_compatible
+def test_state_variables_string_group():
+    G = NeuronGroup(10, 'v : 1')
+    G.v = 'i'
+    c = 3
+    SG1 = G['i > 5']
+    SG2 = G['v > c']
+    SG1.v = 'v * 2'
+    run(0*ms)  # for standalone
+    assert_equal(G.v[:], [0, 1, 2, 3, 4, 5, 12, 14, 16, 18])
+    assert_equal(SG1.v[:], [12, 14, 16, 18])
+    assert_equal(SG2.v[:], [4, 5, 12, 14, 16, 18])
+
+
+@pytest.mark.standalone_compatible
 def test_state_monitor():
     G = NeuronGroup(10, 'v : volt')
     G.v = np.arange(10) * volt
@@ -669,7 +683,7 @@ def test_spike_monitor():
 
 
 @pytest.mark.codegen_independent
-@pytest.mark.parametrize('item', ['string', slice(10, None), slice(3, 2),
+@pytest.mark.parametrize('item', [slice(10, None), slice(3, 2),
                                   [9, 10], [10, 11], [2.5, 3.5, 4.5],
                                   [5, 5, 5], []])
 def test_wrong_indexing(item):

--- a/brian2/tests/test_subgroup.py
+++ b/brian2/tests/test_subgroup.py
@@ -639,15 +639,16 @@ def test_run_regularly():
 
 @pytest.mark.standalone_compatible
 def test_spike_monitor():
+    set_device('cpp_standalone', directory='/tmp/testsubgroup')
     G = NeuronGroup(10, 'v:1', threshold='v>1', reset='v=0')
-    G.v[0] = 1.1
-    G.v[2] = 1.1
-    G.v[5] = 1.1
+    G.v[[0, 2, 5]] = 1.1
     SG = G[3:]
     SG2 = G[:3]
+    SGi = G[[3, 5, 7]]
     s_mon = SpikeMonitor(G)
     sub_s_mon = SpikeMonitor(SG)
     sub_s_mon2 = SpikeMonitor(SG2)
+    sub_s_moni = SpikeMonitor(SGi)
     run(defaultclock.dt)
     assert_equal(s_mon.i, np.array([0, 2, 5]))
     assert_equal(s_mon.t_, np.zeros(3))
@@ -655,6 +656,8 @@ def test_spike_monitor():
     assert_equal(sub_s_mon.t_, np.zeros(1))
     assert_equal(sub_s_mon2.i, np.array([0, 2]))
     assert_equal(sub_s_mon2.t_, np.zeros(2))
+    assert_equal(sub_s_moni.i, np.array([1]))
+    assert_equal(sub_s_moni.t, np.zeros(1))
     expected = np.zeros(10, dtype=int)
     expected[[0, 2, 5]] = 1
     assert_equal(s_mon.count, expected)
@@ -662,6 +665,7 @@ def test_spike_monitor():
     expected[[2]] = 1
     assert_equal(sub_s_mon.count, expected)
     assert_equal(sub_s_mon2.count, np.array([1, 0, 1]))
+    assert_equal(sub_s_moni.count, np.array([0, 1, 0]))
 
 
 @pytest.mark.codegen_independent

--- a/brian2/tests/test_subgroup.py
+++ b/brian2/tests/test_subgroup.py
@@ -684,7 +684,7 @@ def test_wrong_indexing(item):
                                            (3, np.array([3])),
                                            ([3, 4, 5], np.array([3, 4, 5])),
                                            ([3, 5, 7], np.array([3, 5, 7])),
-                                           ([7, 5, 3], np.array([7, 5, 3])),
+                                           ([7, 5, 3], np.array([3, 5, 7])),
                                            ([3, -1], np.array([3, 9]))])
 def test_alternative_indexing(item, expected):
     G = NeuronGroup(10, 'v : integer')

--- a/brian2/tests/test_synapses.py
+++ b/brian2/tests/test_synapses.py
@@ -75,9 +75,16 @@ def test_creation_errors():
     # Check that using pre and on_pre (resp. post/on_post) at the same time
     # raises an error
     with pytest.raises(TypeError):
-        Synapses(G, G, 'w:1', pre='v+=w', on_pre='v+=w', connect=True)
+        Synapses(G, G, 'w:1', pre='v+=w', on_pre='v+=w')
     with pytest.raises(TypeError):
-        Synapses(G, G, 'w:1', post='v+=w', on_post='v+=w', connect=True)
+        Synapses(G, G, 'w:1', post='v+=w', on_post='v+=w')
+    # We do not allow non-contiguous subgroups as source/target groups at the
+    # moment
+    with pytest.raises(TypeError):
+        Synapses(G[::2], G, '')
+    with pytest.raises(TypeError):
+        Synapses(G, G[::2], '')
+
 
 
 @pytest.mark.codegen_independent

--- a/dev/tools/run_tests.py
+++ b/dev/tools/run_tests.py
@@ -6,5 +6,5 @@ import sys
 import brian2
 
 if __name__ == '__main__':
-    if not brian2.test():  # If the test fails, exit with a non-zero error code
+    if not brian2.test(additional_args=['-x']):  # If the test fails, exit with a non-zero error code
         sys.exit(1)


### PR DESCRIPTION
Brian has always allowed subgroups, but these needed to use slicing syntax. While working on the `SpatialNeuronGroup` (see e.g. #1008) I found that quite limiting, e.g. it would not be possible to have a subgroup representing the somata of several neurons in the group. To a lesser extent, the same problem already exists for `SpatialNeuron`, e.g. you could not have a subgroup for all distal dendrite compartments.
In the current version, you can work around this limitation by using indices directly. For example, this would work:
```Python
distal = neuron.indices['distance>100*um']
neuron.g_na[distal] = ...
neuron.g_kd[distal] = ...
neuron.g_Ca[distal] = ...
```
This is ok, but it has the disadvantage of being quite redundant, and in general we try to avoid that the user needs to know about indices in the first place. With this PR, you can write instead:
```Python
distal = neuron['distance > 100*um']
distal.g_na = ...
distal.g_kd = ...
distal.g_Ca = ...
```
There's also an argument to make for consistency. Currently:
```pycon
>>> neurons = NeuronGroup(10, 'v : volt')
>>> neurons.v[:5] = -70*mV
>>> neurons[:5].v = -70*mV  # same effect
>>> neurons.v['i>=5'] = -60*mV
>>> neurons['i>=5'].v = -60*mV
Traceback (most recent call last):
...
TypeError: Subgroups can only be constructed using slicing syntax, a single index, or an array of contiguous indices.
```
With the new support, the last line would work as well.

Finally, another use case is to record a non-contiguous subset of neurons with a `SpikeMonitor`. For example to record a random subset of neurons in a non-random network (i.e. where you cannot simply take any subset).

Now, the main arguments against supporting this feature are performance and code complexity. It is true that for `SpikeMonitor` and `PopulationRateMonitor` the code is now a bit more complex to also support non-contiguous subgroups, but performance-wise it should still be ok by requiring that subgroup indices are ordered. Of course, if you want to record the first and the last neuron of a large group, this will be quite inefficient.

For now, you cannot create `Synapses` based on a non-contiguous subgroup, because this complicates the indexing quite a bit. It's perfectly doable, but I wanted to get the basics working first.

Oh, while thinking about the consistency of the different syntaxes of indexing things, I also made two diagrams (the same thing with and without units). I guess it can be useful to explain the difference between `neurons[:5].v` and `neurons.v[:5]`, but not sure whether it is too detailed for the documentation. Might also go into a blog post one day.

Here they are for reference: https://gist.github.com/mstimberg/25b5058bc85a1f1fbaff958741629ee8
