### PR TITLE
Remove false warning for SpatialNeuron when using Cython

### DIFF
--- a/brian2/spatialneuron/spatialneuron.py
+++ b/brian2/spatialneuron/spatialneuron.py
@@ -605,7 +605,7 @@ class SpatialStateUpdater(CodeRunner, Group):
         super(SpatialStateUpdater, self).before_run(run_namespace)
         # Raise a warning if the slow pure numpy version is used
         from brian2.codegen.runtime.numpy_rt.numpy_rt import NumpyCodeObject
-        if isinstance(self.code_objects[0], NumpyCodeObject):
+        if type(self.code_objects[0]) == NumpyCodeObject:
             # If numpy is used, raise a warning if scipy is not present
             try:
                 import scipy


### PR DESCRIPTION
If you install Brian2 via pip, it is possible that you don't install scipy (since it is not strictly necessary). For `SpatialNeuron`, this means that simulation will be very slow when run with `numpy`. We therefore raise a warning, but the warning tested whether the `CodeObject` is an instance of `NumpyCodeObject`. This is of course true for `numpy`, but it is unfortunately also true for `CythonCodeObject` which inherits from it. This trivial fix checks for the exact type instead.