### PR TITLE
Point unresolved error message to discourse forum [ci skip]

### DIFF
--- a/brian2/utils/logger.py
+++ b/brian2/utils/logger.py
@@ -170,7 +170,7 @@ def _encode(text):
 
 UNHANDLED_ERROR_MESSAGE = ('Brian 2 encountered an unexpected error. '
 'If you think this is a bug in Brian 2, please report this issue either to the '
-'mailing list at <http://groups.google.com/group/brian-development/>, '
+'discourse forum at <http://brian.discourse.group/>, '
 'or to the issue tracker at <https://github.com/brian-team/brian2/issues>.')
 
 


### PR DESCRIPTION
Given [@mstimberg's comment](https://groups.google.com/g/brian-development/c/N61MUSEfU64) on the brian-development list, I'm guessing error messages should also point to discourse.