### PR TITLE
Synapses is not resolving dt correctly.

### DIFF
--- a/brian2/synapses/synapses.py
+++ b/brian2/synapses/synapses.py
@@ -1057,8 +1057,7 @@ class Synapses(Group):
         self.variables.add_dynamic_array('_synaptic_post', size=0,
                                          dtype=np.int32, constant=True,
                                          read_only=True)
-        self.variables.create_clock_variables(self._clock,
-                                              prefix='_clock_')
+        self.variables.create_clock_variables(self._clock)
         if '_offset' in self.target.variables:
             self.variables.add_reference('_target_offset', self.target,
                                          '_offset')

--- a/brian2/tests/test_synapses.py
+++ b/brian2/tests/test_synapses.py
@@ -1135,6 +1135,19 @@ def test_clocks():
     assert synapse.post._clock.dt == target_dt
     assert synapse._clock.dt == synapse_dt
 
+def test_equations_with_clocks():
+    '''
+    Make sure that dt of a `Synapse` object is correctly resolved.
+    '''
+    source_dt = 0.1*ms
+    synapse_dt = 1*ms
+    source_target = NeuronGroup(1, 'v:1', dt=source_dt, threshold='False')
+    synapse = Synapses(source_target, source_target, 'dw/dt = 1/ms : 1 (clock-driven)', dt=synapse_dt, method='euler')
+    synapse.connect()
+    synapse.w = 0
+    run(1*ms)
+
+    assert synapse.w[0] == 1
 
 def test_changed_dt_spikes_in_queue():
     defaultclock.dt = .5*ms


### PR DESCRIPTION
I've committed a test case that demonstrates the issue:
```python
source_dt = 0.1*ms
synapse_dt = 1*ms
source_target = NeuronGroup(1, 'v:1', dt=source_dt, threshold='False')
synapse = Synapses(source_target, source_target, 'dw/dt = 1/ms : 1 (clock-driven)', 
                   dt=synapse_dt, method='euler')
synapse.connect()
synapse.w = 0
run(1*ms)

assert synapse.w[0] == 1
```

The issue is that `synapse.w[0]` will be `0.1` because `Synapses` uses the `NeuronGroup`'s `dt` for scaling the constant `1` in the equation, but `Synapses` uses its own `dt` for the actual timestep.

I have found the source of the issue, the `SynapseGroup`'s `dt` variable is being prefixed with `_clock_`, why that is I am not sure of.
Removing the prefix fixes my issue and still all tests in `test_synapse.py` pass, but I do not understand the code well enough to be sure that this is the correct fix.