### PR TITLE
Remove incorrect space in LaTeX representation of units

### DIFF
--- a/brian2/units/fundamentalunits.py
+++ b/brian2/units/fundamentalunits.py
@@ -1938,7 +1938,7 @@ class Unit(Quantity):
         scale = _siprefixes[scalefactor] + baseunit.scale
         if scalefactor == 'u':
             scalefactor = r'\mu'
-        latexname = r'\mathrm{' + scalefactor + '}' + r'\,' + baseunit.latexname
+        latexname = r'\mathrm{' + scalefactor + '}' + baseunit.latexname
 
         u = Unit(10.0**scale, dim=baseunit.dim,  name=name, dispname=dispname,
                  latexname=latexname, scale=scale)


### PR DESCRIPTION
This is a micro-fix: I noticed that our LaTeX export for `Quantity` objects was slightly off, it added a space between the scale and the unit symbol which is wrong and makes for confusing compound units. This removes the space, so a space is now only added between the separate units. A fairly non-controversial change, I think :)

LaTeX output for `print(sympy.latex(ms*pA))`

Before:
![image](https://user-images.githubusercontent.com/1381982/97680974-d4f2d500-1a97-11eb-84ad-7363ba750e1b.png)

After:
![image](https://user-images.githubusercontent.com/1381982/97680880-ae349e80-1a97-11eb-8893-e68c1f2aa9f0.png)
