### PR TITLE
Improve error message for multiple uses of `xi` and add link to docs

### DIFF
--- a/brian2/equations/equations.py
+++ b/brian2/equations/equations.py
@@ -579,10 +579,18 @@ class Equations(Hashable, Mapping):
                     raise EquationError(('The equation defining %s contains the '
                                          'symbol "xi" but is not a differential '
                                          'equation.') % eq.varname)
-                elif not uses_xi is None:
+                elif uses_xi is not None:
                     raise EquationError(('The equation defining %s contains the '
                                          'symbol "xi", but it is already used '
-                                         'in the equation defining %s.') %
+                                         'in the equation defining %s. Rename '
+                                         'the variables to "xi_..." to make '
+                                         'clear whether they are the same or '
+                                         'independent random variables. Using '
+                                         'the same name twice will lead to '
+                                         'identical noise realizations '
+                                         'whereas using different names will '
+                                         'lead to independent noise '
+                                         'realizations.') %
                                         (eq.varname, uses_xi))
                 else:
                     uses_xi = eq.varname

--- a/docs_sphinx/user/models.rst
+++ b/docs_sphinx/user/models.rst
@@ -74,6 +74,11 @@ You don't necessarily need to understand why this is, but it is
 possible to get a reasonably simple intuition for it by thinking
 about numerical integration: :ref:`see below <time_scaling_of_noise>`.
 
+.. note::
+    If you want to use noise in more than one equation of a
+    `NeuronGroup` or `Synapses`, you will have to use suffixed names (see
+    :ref:`equation_strings` for details).
+
 Threshold and reset
 -------------------
 To emit spikes, neurons need a *threshold*. Threshold and reset are given


### PR DESCRIPTION
As reported in the [discourse forum](https://brian.discourse.group/t/multiple-independent-sources-of-noise-in-single-neuron-model/212), the error message for multiple uses of `xi` is not very helpful, and the main documentation does not directly point to the solution either. This PR makes the error message quite verbose (but hopefully clear) and adds a link to the documentation pointing to the place where this issue is discussed.