### PR TITLE
Remove duplicated profiling code in codegen.

### DIFF
--- a/brian2/devices/cpp_standalone/templates/synapses_push_spikes.cpp
+++ b/brian2/devices/cpp_standalone/templates/synapses_push_spikes.cpp
@@ -26,14 +26,4 @@
         {{owner.name}}.advance();
         {{owner.name}}.push({{_eventspace}}, {{_eventspace}}[_num{{eventspace_variable.name}}-1]);
     }
-
-    {% if profiled %}
-    // Profiling
-    {% if openmp_pragma('with_openmp') %}
-    const double _run_time = omp_get_wtime() -_start_time;
-    {% else %}
-    const double _run_time = (double)(std::clock() -_start_time)/CLOCKS_PER_SEC;
-    {% endif %}
-    {{codeobj_name}}_profiling_info += _run_time;
-    {% endif %}
 {% endblock %}

--- a/brian2/tests/test_cpp_standalone.py
+++ b/brian2/tests/test_cpp_standalone.py
@@ -344,6 +344,18 @@ def test_run_with_debug():
     mon = SpikeMonitor(group)
     run(defaultclock.dt)
 
+
+@pytest.mark.cpp_standalone
+@pytest.mark.standalone_only
+def test_run_with_synapses_and_profile():
+    set_device('cpp_standalone', build_on_run=True, directory=None)
+    group = NeuronGroup(1, 'v: 1', threshold='False', reset='')
+    syn = Synapses(group, group, on_pre='v += 1')
+    syn.connect()
+    mon = SpikeMonitor(group)
+    run(defaultclock.dt, profile=True)
+
+
 @pytest.mark.cpp_standalone
 @pytest.mark.standalone_only
 def test_changing_profile_arg():
@@ -395,6 +407,7 @@ def test_changing_profile_arg():
             profiling_dict['op2_codeobject_2'] > 0*second)
     assert ('op3_codeobject_1' in profiling_dict and
             profiling_dict['op3_codeobject_1'] > 0*second)
+
 
 @pytest.mark.cpp_standalone
 @pytest.mark.standalone_only


### PR DESCRIPTION
Hello,

I've encountered an issue with `profile=True` in standalone mode where the generated code would fail to compile. It turned out, that the code generator duplicated the profiling lines for `synapses_push_spikes` which led to a duplicated variable definition. Removing them once fixed the issue for me.

The same code is already included at the end of templates/common_group.cpp,
and currently prevents compiling code involving synapses with profile=True.

The unittest failed before, but should be passing now.