### PR TITLE
No longer use deprecated numpy type aliases

### DIFF
--- a/brian2/core/clocks.py
+++ b/brian2/core/clocks.py
@@ -90,9 +90,9 @@ class Clock(VariableOwner):
         self.variables.add_array('timestep', size=1, dtype=np.int64,
                                  read_only=True, scalar=True)
         self.variables.add_array('t', dimensions=second.dim, size=1,
-                                 dtype=np.double, read_only=True, scalar=True)
+                                 dtype=np.float64, read_only=True, scalar=True)
         self.variables.add_array('dt', dimensions=second.dim, size=1, values=float(dt),
-                                 dtype=np.float, read_only=True, constant=True,
+                                 dtype=np.float64, read_only=True, constant=True,
                                  scalar=True)
         self.variables.add_constant('N', value=1)
         self._enable_group_attributes()

--- a/brian2/core/variables.py
+++ b/brian2/core/variables.py
@@ -320,7 +320,7 @@ class Constant(Variable):
                    value is np.False_)
 
         if is_bool:
-            dtype = np.bool
+            dtype = bool
         else:
             dtype = get_dtype(value)
 
@@ -1023,7 +1023,7 @@ class VariableView(object):
         abstract_code_cond = '_cond = '+cond
         abstract_code = self.name + ' = ' + code
         variables = Variables(None)
-        variables.add_auxiliary_variable('_cond', dtype=np.bool)
+        variables.add_auxiliary_variable('_cond', dtype=bool)
         from brian2.codegen.codeobject import create_runner_codeobj
         # TODO: Have an additional argument to avoid going through the index
         # array for situations where iterate_all could be used
@@ -1069,7 +1069,7 @@ class VariableView(object):
         variables.add_auxiliary_variable('_variable', dimensions=variable.dim,
                                          dtype=variable.dtype,
                                          scalar=variable.scalar)
-        variables.add_auxiliary_variable('_cond', dtype=np.bool)
+        variables.add_auxiliary_variable('_cond', dtype=bool)
 
         abstract_code = '_variable = ' + self.name + '\n'
         abstract_code += '_cond = ' + code

--- a/brian2/groups/group.py
+++ b/brian2/groups/group.py
@@ -144,7 +144,7 @@ def get_dtype(equation, dtype=None):
 
     # Use default dtypes (or a provided standard dtype for floats)
     if equation.var_type == BOOLEAN:
-        return np.bool
+        return bool
     elif equation.var_type == INTEGER:
         return prefs['core.default_integer_dtype']
     elif equation.var_type == FLOAT:
@@ -253,7 +253,7 @@ class Indexing(object):
                 index_array = np.arange(start, stop, step, dtype=np.int32)
             else:
                 index_array = np.asarray(item)
-                if index_array.dtype == np.bool:
+                if index_array.dtype == bool:
                     index_array = np.nonzero(index_array)[0]
                 elif not np.issubdtype(index_array.dtype, np.signedinteger):
                     raise TypeError(('Indexing is only supported for integer '
@@ -290,7 +290,7 @@ class IndexWrapper(object):
         if isinstance(item, str):
             variables = Variables(None)
             variables.add_auxiliary_variable('_indices', dtype=np.int32)
-            variables.add_auxiliary_variable('_cond', dtype=np.bool)
+            variables.add_auxiliary_variable('_cond', dtype=bool)
 
             abstract_code = '_cond = ' + item
             namespace = get_local_namespace(level=1)

--- a/brian2/groups/neurongroup.py
+++ b/brian2/groups/neurongroup.py
@@ -308,7 +308,7 @@ class Thresholder(CodeRunner):
         template_kwds['eventspace_variable'] = group.variables[eventspace_name]
         needed_variables.append(eventspace_name)
         self.variables = Variables(self)
-        self.variables.add_auxiliary_variable('_cond', dtype=np.bool)
+        self.variables.add_auxiliary_variable('_cond', dtype=bool)
         CodeRunner.__init__(self, group,
                             'threshold',
                             code='',  # will be set in update_abstract_code
@@ -736,7 +736,7 @@ class NeuronGroup(Group, SpikeSource):
             if value.index is not None:
                 try:
                     index_array = np.asarray(value.index)
-                    if not np.issubsctype(index_array.dtype, np.int):
+                    if not np.issubsctype(index_array.dtype, int):
                         raise TypeError()
                 except TypeError:
                     raise TypeError(('The index for a linked variable has '

--- a/brian2/input/timedarray.py
+++ b/brian2/input/timedarray.py
@@ -201,7 +201,7 @@ class TimedArray(Function, Nameable, CacheKey):
         Nameable.__init__(self, name)
         dimensions = get_dimensions(values)
         self.dim = dimensions
-        values = np.asarray(values, dtype=np.double)
+        values = np.asarray(values, dtype=np.float64)
         self.values = values
         dt = float(dt)
         self.dt = dt

--- a/brian2/synapses/spikequeue.py
+++ b/brian2/synapses/spikequeue.py
@@ -84,12 +84,12 @@ class SpikeQueue(object):
             # adapt the spikes to the new dt if it changed
             if self._dt != dt:
                 spiketimes = spikes[:, 0] * self._dt
-                spikes[:, 0] = np.round(spiketimes / dt).astype(np.int)
+                spikes[:, 0] = np.round(spiketimes / dt).astype(int)
         else:
             spikes = None
 
         if len(delays):
-            delays = np.array(np.round(delays / dt)).astype(np.int)
+            delays = np.array(np.round(delays / dt)).astype(int)
             max_delays = max(delays)
             min_delays = min(delays)
         else:

--- a/brian2/synapses/synapses.py
+++ b/brian2/synapses/synapses.py
@@ -1708,7 +1708,7 @@ class Synapses(Group):
         variables.add_auxiliary_variable('_pre_idx', dtype=np.int32)
         variables.add_auxiliary_variable('_post_idx', dtype=np.int32)
         if parsed['if_expression'] is not None:
-            variables.add_auxiliary_variable('_cond', dtype=np.bool)
+            variables.add_auxiliary_variable('_cond', dtype=bool)
         variables.add_auxiliary_variable('_n', dtype=np.int32)
 
         if '_offset' in self.source.variables:

--- a/brian2/tests/test_codegen.py
+++ b/brian2/tests/test_codegen.py
@@ -250,17 +250,17 @@ def test_apply_loop_invariant_optimisation_no_optimisation():
                  'rand': DEFAULT_FUNCTIONS['rand']
                  }
     statements = [
-        # This hould not be simplified to 0!
-        Statement('v1', '=', 'rand() - rand()', '', np.float),
-        Statement('v1', '=', '3*rand() - 3*rand()', '', np.float),
-        Statement('v1', '=', '3*rand() - ((1+2)*rand())', '', np.float),
+        # This should not be simplified to 0!
+        Statement('v1', '=', 'rand() - rand()', '', float),
+        Statement('v1', '=', '3*rand() - 3*rand()', '', float),
+        Statement('v1', '=', '3*rand() - ((1+2)*rand())', '', float),
         # This should not pull out rand()*N
-        Statement('v1', '=', 's1*rand()*N', '', np.float),
-        Statement('v1', '=', 's2*rand()*N', '', np.float),
+        Statement('v1', '=', 's1*rand()*N', '', float),
+        Statement('v1', '=', 's2*rand()*N', '', float),
         # This is not important mathematically, but it would change the numbers
         # that are generated
-        Statement('v1', '=', '0*rand()*N', '', np.float),
-        Statement('v1', '=', '0/rand()*N', '', np.float)
+        Statement('v1', '=', '0*rand()*N', '', float),
+        Statement('v1', '=', '0/rand()*N', '', float)
     ]
     scalar, vector = optimise_statements([], statements, variables)
     for vs in vector[:3]:
@@ -277,26 +277,26 @@ def test_apply_loop_invariant_optimisation_simplification():
                  }
     statements = [
         # Should be simplified to 0.0
-        Statement('v1', '=', 'v1 - v1', '', np.float),
-        Statement('v1', '=', 'N*v1 - N*v1', '', np.float),
-        Statement('v1', '=', 'v1*N * 0', '', np.float),
-        Statement('v1', '=', 'v1 * 0', '', np.float),
-        Statement('v1', '=', 'v1 * 0.0', '', np.float),
-        Statement('v1', '=', '0.0 / (v1*N)', '', np.float),
+        Statement('v1', '=', 'v1 - v1', '', float),
+        Statement('v1', '=', 'N*v1 - N*v1', '', float),
+        Statement('v1', '=', 'v1*N * 0', '', float),
+        Statement('v1', '=', 'v1 * 0', '', float),
+        Statement('v1', '=', 'v1 * 0.0', '', float),
+        Statement('v1', '=', '0.0 / (v1*N)', '', float),
         # Should be simplified to 0
-        Statement('i1', '=', 'i1*N * 0', '', np.int),
-        Statement('i1', '=', '0 * i1', '', np.int),
-        Statement('i1', '=', '0 * i1*N', '', np.int),
-        Statement('i1', '=', 'i1 * 0', '', np.int),
+        Statement('i1', '=', 'i1*N * 0', '', int),
+        Statement('i1', '=', '0 * i1', '', int),
+        Statement('i1', '=', '0 * i1*N', '', int),
+        Statement('i1', '=', 'i1 * 0', '', int),
         # Should be simplified to v1*N
-        Statement('v2', '=', '0 + v1*N', '', np.float),
-        Statement('v2', '=', 'v1*N + 0.0', '', np.float),
-        Statement('v2', '=', 'v1*N - 0', '', np.float),
-        Statement('v2', '=', 'v1*N - 0.0', '', np.float),
-        Statement('v2', '=', '1 * v1*N', '', np.float),
-        Statement('v2', '=', '1.0 * v1*N', '', np.float),
-        Statement('v2', '=', 'v1*N / 1.0', '', np.float),
-        Statement('v2', '=', 'v1*N / 1', '', np.float),
+        Statement('v2', '=', '0 + v1*N', '', float),
+        Statement('v2', '=', 'v1*N + 0.0', '', float),
+        Statement('v2', '=', 'v1*N - 0', '', float),
+        Statement('v2', '=', 'v1*N - 0.0', '', float),
+        Statement('v2', '=', '1 * v1*N', '', float),
+        Statement('v2', '=', '1.0 * v1*N', '', float),
+        Statement('v2', '=', 'v1*N / 1.0', '', float),
+        Statement('v2', '=', 'v1*N / 1', '', float),
         # Should be simplified to i1
         Statement('i1', '=', 'i1*1', '', int),
         Statement('i1', '=', 'i1//1', '', int),
@@ -353,9 +353,9 @@ def test_apply_loop_invariant_optimisation_constant_evaluation():
                  'exp': DEFAULT_FUNCTIONS['exp']
                  }
     statements = [
-        Statement('v1', '=', 'v1 * (1 + 2 + 3)', '', np.float),
-        Statement('v1', '=', 'exp(N)*v1', '', np.float),
-        Statement('v1', '=', 'exp(0)*v1', '', np.float),
+        Statement('v1', '=', 'v1 * (1 + 2 + 3)', '', float),
+        Statement('v1', '=', 'exp(N)*v1', '', float),
+        Statement('v1', '=', 'exp(0)*v1', '', float),
     ]
     scalar, vector = optimise_statements([], statements, variables)
     # exp(N) should be pulled out of the vector statements, the rest should be
@@ -382,7 +382,7 @@ def test_automatic_augmented_assignments():
         'z': ArrayVariable('y', owner=None, size=10,
                            device=device),
         'b': ArrayVariable('b', owner=None, size=10,
-                           dtype=np.bool, device=device),
+                           dtype=bool, device=device),
         'clip': DEFAULT_FUNCTIONS['clip'],
         'inf': DEFAULT_CONSTANTS['inf']
     }

--- a/brian2/tests/test_neurongroup.py
+++ b/brian2/tests/test_neurongroup.py
@@ -1449,14 +1449,14 @@ def test_get_dtype():
     assert get_dtype(eqs['v']) == prefs['core.default_float_dtype']
     assert get_dtype(eqs['x']) == prefs['core.default_float_dtype']
     assert get_dtype(eqs['n']) == prefs['core.default_integer_dtype']
-    assert get_dtype(eqs['b']) == np.bool
+    assert get_dtype(eqs['b']) == bool
 
     # Test a changed default (float) dtype
     assert get_dtype(eqs['v'], np.float32) == np.float32, get_dtype(eqs['v'], np.float32)
     assert get_dtype(eqs['x'], np.float32) == np.float32
     # integer and boolean variables should be unaffected
     assert get_dtype(eqs['n']) == prefs['core.default_integer_dtype']
-    assert get_dtype(eqs['b']) == np.bool
+    assert get_dtype(eqs['b']) == bool
 
     # Explicitly provide a dtype for some variables
     dtypes = {'v': np.float32, 'x': np.float64, 'n': np.int64}
@@ -1793,9 +1793,9 @@ def test_semantics_floor_division():
                            fvalue : 1
                            ivalue : integer''',
                     dtype={'a': np.int32, 'b': np.int64,
-                           'x': np.float, 'y': np.double})
+                           'x': float, 'y': float})
     int_values = np.arange(-5, 6)
-    float_values = np.arange(-5.0, 6.0, dtype=np.double)
+    float_values = np.arange(-5.0, 6.0, dtype=np.float64)
     G.ivalue = int_values
     G.fvalue = float_values
     with catch_logs() as l:
@@ -1823,9 +1823,9 @@ def test_semantics_floating_point_division():
                            fvalue : 1
                            ivalue : integer''',
                     dtype={'a': np.int32, 'b': np.int64,
-                           'x': np.float, 'y': np.double})
+                           'x': float, 'y': float})
     int_values = np.arange(-5, 6)
-    float_values = np.arange(-5.0, 6.0, dtype=np.double)
+    float_values = np.arange(-5.0, 6.0, dtype=np.float64)
     G.ivalue = int_values
     G.fvalue = float_values
     with catch_logs() as l:
@@ -1857,9 +1857,9 @@ def test_semantics_mod():
                            fvalue : 1
                            ivalue : integer''',
                     dtype={'a': np.int32, 'b': np.int64,
-                           'x': np.float, 'y': np.double})
+                           'x': float, 'y': float})
     int_values = np.arange(-5, 6)
-    float_values = np.arange(-5.0, 6.0, dtype=np.double)
+    float_values = np.arange(-5.0, 6.0, dtype=np.float64)
     G.ivalue = int_values
     G.fvalue = float_values
     with catch_logs() as l:

--- a/brian2/tests/test_poissoninput.py
+++ b/brian2/tests/test_poissoninput.py
@@ -82,7 +82,7 @@ def test_poissoninput_refractory():
     P = PoissonInput(G, 'v', 1, 1/defaultclock.dt, weight=1.0)
     mon = StateMonitor(G, 'v', record=5)
     run(10*defaultclock.dt)
-    expected = np.arange(10, dtype=np.float)
+    expected = np.arange(10, dtype=float)
     expected[6-int(schedule_propagation_offset()/defaultclock.dt):] = 0
     assert_allclose(mon[5].v[:], expected)
 

--- a/brian2/tests/test_units.py
+++ b/brian2/tests/test_units.py
@@ -123,13 +123,13 @@ def test_get_dimensions():
     
     assert get_dimensions(5) is DIMENSIONLESS
     assert get_dimensions(5.0) is DIMENSIONLESS
-    assert get_dimensions(np.array(5, dtype=np.int)) is DIMENSIONLESS
+    assert get_dimensions(np.array(5, dtype=np.int32)) is DIMENSIONLESS
     assert get_dimensions(np.array(5.0)) is DIMENSIONLESS
     assert get_dimensions(np.float32(5.0)) is DIMENSIONLESS
     assert get_dimensions(np.float64(5.0)) is DIMENSIONLESS
     assert is_scalar_type(5)
     assert is_scalar_type(5.0)
-    assert is_scalar_type(np.array(5, dtype=np.int))
+    assert is_scalar_type(np.array(5, dtype=np.int32))
     assert is_scalar_type(np.array(5.0))
     assert is_scalar_type(np.float32(5.0))
     assert is_scalar_type(np.float64(5.0))

--- a/brian2/tests/test_variables.py
+++ b/brian2/tests/test_variables.py
@@ -17,7 +17,7 @@ from brian2.units.allunits import second
 def test_construction_errors():
     # Boolean variable that isn't dimensionless
     with pytest.raises(ValueError):
-        Variable(name='name', dimensions=second.dim, dtype=np.bool)
+        Variable(name='name', dimensions=second.dim, dtype=bool)
 
     # Dynamic array variable that is constant but not constant in size
     with pytest.raises(ValueError):


### PR DESCRIPTION
Numpy type aliases are deprecated since numpy 1.20 and using e.g. `np.bool` over `bool` does not add anything. This PR therefore removes all unnecessary type aliases. Note that types like `np.int32` or `np.float32` are still useful (and not deprecated), since Python does not have any builtin equivalents.

See https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations