### PR TITLE
Error/Warning for Summed Variable Pointing to Event Variable

### DIFF
--- a/brian2/synapses/synapses.py
+++ b/brian2/synapses/synapses.py
@@ -815,7 +815,7 @@ class Synapses(Group):
             """
             val = False
             for eq in eqs.values():
-                if var in eq.identifiers:
+                if var in eq.identifiers and eq.varname != var:
                     if val == True:
                         break
                     elif 'summed' in eq.flags:

--- a/brian2/synapses/synapses.py
+++ b/brian2/synapses/synapses.py
@@ -957,6 +957,13 @@ class Synapses(Group):
                 variable that is required for checking
             eqs : Equations Object
                 Equations object in which we need to check
+            orig_var : str
+                Carries the name of the original event-driven variable
+                Default Value - None
+            intermediate_vars : list
+                Carries the names of all the intermediate variables that have referred 
+                to the event-driven variable.
+                Default Value - []
 
             Returns
             ----------
@@ -976,10 +983,10 @@ class Synapses(Group):
                     raise EquationError(f"The clock-driven equation for variable {eq.varname} should "
                  f"not refer to a event-driven variable '{orig_var}' {via_str}")
                 else:
-                    temp = intermediate_vars.copy()
+                    temp_inter_vars = intermediate_vars.copy()
                     if orig_var != eq.varname and eq.varname not in intermediate_vars:
-                        temp.append(eq.varname)
-                    Synapses._recur_check_event_summed_clock(eq.varname,eqs,orig_var=orig_var,intermediate_vars=temp)
+                        temp_inter_vars.append(eq.varname)
+                    Synapses._recur_check_event_summed_clock(eq.varname,eqs,orig_var=orig_var,intermediate_vars=temp_inter_vars)
 
     N_outgoing_pre = property(fget= lambda self: self.variables['N_outgoing'].get_value(),
                               doc='The number of outgoing synapses for each neuron in the '

--- a/brian2/synapses/synapses.py
+++ b/brian2/synapses/synapses.py
@@ -795,7 +795,7 @@ class Synapses(Group):
         
         # Checking whether a summed variable or a clock-driven equation is referring to an event-driven variable
         for eq in event_driven:
-            Synapses._recur_check_event_summed_clock(eq.varname,model)
+            Synapses._recur_check_event_summed_clock(eq.varname, model)
 
         if len(event_driven):
             self.event_driven = Equations(event_driven)
@@ -945,7 +945,7 @@ class Synapses(Group):
         self._enable_group_attributes()
     
     @staticmethod
-    def _recur_check_event_summed_clock(var,eqs,orig_var = None,intermediate_vars = []):
+    def _recur_check_event_summed_clock(var, eqs, orig_var=None, intermediate_vars=None):
         """
             Recursive Function Used to identify whether a summed variable 
             or a clock driven equation is referring to an event-driven variable
@@ -971,14 +971,16 @@ class Synapses(Group):
 """
         if orig_var == None:
             orig_var = var
+        if intermediate_vars is None:
+            intermediate_vars = []
         via_str = ""
         if intermediate_vars:
-            via_str = "(via "+", ".join(f"'{v}'" for v in intermediate_vars) + ")"
+            via_str = "(via " + ", ".join(f"'{v}'" for v in intermediate_vars) + ")"
         for eq in eqs.values():
             if var in eq.identifiers and eq.varname != var:
                 if 'summed' in eq.flags:
-                    raise EquationError(f"The summed variable '{eq.varname}' should not refer a event-driven"
-                f" variable '{orig_var}' {via_str}")
+                    raise EquationError(f"The summed variable '{eq.varname}' should not refer a"
+                f" event-driven variable '{orig_var}' {via_str}")
                 elif eq.type == DIFFERENTIAL_EQUATION and 'event-driven' not in eq.flags:
                     raise EquationError(f"The clock-driven equation for variable {eq.varname} should "
                  f"not refer to a event-driven variable '{orig_var}' {via_str}")
@@ -986,7 +988,8 @@ class Synapses(Group):
                     temp_inter_vars = intermediate_vars.copy()
                     if orig_var != eq.varname and eq.varname not in intermediate_vars:
                         temp_inter_vars.append(eq.varname)
-                    Synapses._recur_check_event_summed_clock(eq.varname,eqs,orig_var=orig_var,intermediate_vars=temp_inter_vars)
+                    Synapses._recur_check_event_summed_clock(eq.varname, eqs, orig_var=orig_var,
+                    intermediate_vars=temp_inter_vars)
 
     N_outgoing_pre = property(fget= lambda self: self.variables['N_outgoing'].get_value(),
                               doc='The number of outgoing synapses for each neuron in the '

--- a/brian2/tests/test_synapses.py
+++ b/brian2/tests/test_synapses.py
@@ -1312,9 +1312,8 @@ def test_summed_variable_errors():
     
     #Summed variable referring to an event-driven variable
     with pytest.raises(EquationError):
-        Synapses(G,G,'''ds/dt = -s/(3*ms) : 1 (event-driven)
-                        a = s : 1 (summed)
-                        ''',on_pre='s += 1')
+        Synapses(G, G, '''ds/dt = -s/(3*ms) : 1 (event-driven)
+                        a = s : 1 (summed)''', on_pre='s += 1')
 
 @pytest.mark.codegen_independent
 def test_multiple_summed_variables():
@@ -1574,11 +1573,11 @@ def test_event_driven_dependency_error2():
 
 @pytest.mark.codegen_independent
 def test_event_driven_dependency_error3():
-    P = NeuronGroup(10,'dv/dt = -v/(10*ms) : volt')
+    P = NeuronGroup(10, 'dv/dt = -v/(10*ms) : volt')
     with pytest.raises(EquationError):
-        syn = Synapses(P,P,'''ds/dt = -s/(3*ms) : 1 (event-driven)
+        Synapses(P, P, '''ds/dt = -s/(3*ms) : 1 (event-driven)
                             df/dt = f*s : 1 (clock-driven)
-                            ''',on_pre='s += 1')
+                            ''', on_pre='s += 1')
 
 
 @pytest.mark.codegen_independent

--- a/brian2/tests/test_synapses.py
+++ b/brian2/tests/test_synapses.py
@@ -1573,6 +1573,15 @@ def test_event_driven_dependency_error2():
         assert exc.errisinstance(UnsupportedEquationsException)
 
 @pytest.mark.codegen_independent
+def test_event_driven_dependency_error3():
+    P = NeuronGroup(10,'dv/dt = -v/(10*ms) : volt')
+    with pytest.raises(EquationError):
+        syn = Synapses(P,P,'''ds/dt = -s/(3*ms) : 1 (event-driven)
+                            df/dt = f*s : 1 (clock-driven)
+                            ''',on_pre='s += 1')
+
+
+@pytest.mark.codegen_independent
 def test_repr():
     G = NeuronGroup(1, 'v: volt', threshold='False')
     S = Synapses(G, G,
@@ -2745,6 +2754,7 @@ if __name__ == '__main__':
     test_event_driven()
     test_event_driven_dependency_error()
     test_event_driven_dependency_error2()
+    test_event_driven_dependency_error3()
     test_repr()
     test_pre_post_variables()
     test_variables_by_owner()
@@ -2777,3 +2787,4 @@ if __name__ == '__main__':
     test_synaptic_subgroups()
     test_incorrect_connect_N_incoming_outgoing()
     print('Tests took', time.time()-start)
+    

--- a/brian2/tests/test_synapses.py
+++ b/brian2/tests/test_synapses.py
@@ -21,7 +21,7 @@ from brian2.devices.device import reinit_and_delete, all_devices, get_device
 from brian2.codegen.permutation_analysis import check_for_order_independence, OrderDependenceError
 from brian2.synapses.parse_synaptic_generator_syntax import parse_synapse_generator
 from brian2.tests.utils import assert_allclose
-
+from brian2.equations.equations import EquationError
 
 def _compare(synapses, expected):
     conn_matrix = np.zeros((len(synapses.source), len(synapses.target)),
@@ -1309,6 +1309,12 @@ def test_summed_variable_errors():
     with pytest.raises(ValueError):
         Synapses(G, G, '''p_post = 3*volt : volt (summed)
                           p_pre = 3*volt : volt (summed)''')
+    
+    #Summed variable referring to an event-driven variable
+    with pytest.raises(EquationError):
+        Synapses(G,G,'''ds/dt = -s/(3*ms) : 1 (event-driven)
+                        a = s : 1 (summed)
+                        ''',on_pre='s += 1')
 
 @pytest.mark.codegen_independent
 def test_multiple_summed_variables():


### PR DESCRIPTION
Hello @mstimberg,
As discussed in #1263, I have added the check for cases where the summed variables are referring to event-driven variables. Here I have used a recursive function to check for the additional cases that you pointed out instead of using the `get_substitued_expression()` function because the `get_substitued_expression()` function was not giving me the desired result. Also, I have defined the recursive function inside the `__init__` because this function will not be needed anywhere outside the `__init__` method. What are your thoughts?
Since we have not yet decided whether we need an error or a warning, I have placed a temporary print statement in its place for now. I will modify it as soon as we reach a decision.