### PR TITLE
Build binary wheels

### DIFF
--- a/.github/workflows/publish_to_pypi.yml
+++ b/.github/workflows/publish_to_pypi.yml
@@ -19,12 +19,15 @@ jobs:
       - name: Install cibuildwheel & dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install cibuildwheel==1.9.0 "cython>=0.29" numpy>=1.15 setuptools
+          python -m pip install cibuildwheel==1.9.0
       - name: Build source tarball (only on Linux)
         run: python setup.py sdist --formats=gztar --with-cython --fail-on-error
         if: ${{ startsWith(matrix.os, 'ubuntu-') }}
       - name: Build wheels
         run: python -m cibuildwheel --output-dir dist
+        env:
+          CIBW_BEFORE_BUILD: pip install "cython>=0.29" numpy>=1.15 setuptools
+          CIBW_BUILD_VERBOSITY: 1
       - name: Publish distribution 📦 to Test PyPI
         if: ${{ ! startsWith(github.ref, 'refs/tags') }}
         uses: pypa/gh-action-pypi-publish@master

--- a/.github/workflows/publish_to_pypi.yml
+++ b/.github/workflows/publish_to_pypi.yml
@@ -28,6 +28,7 @@ jobs:
           output-dir: dist
         env:
           CIBW_BEFORE_BUILD: pip install "cython>=0.29" numpy>=1.15 setuptools
+          CIBW_PROJECT_REQUIRES_PYTHON: ">=3.7"
           CIBW_BUILD_VERBOSITY: 1
       - name: Publish distribution 📦 to Test PyPI
         if: ${{ ! startsWith(github.ref, 'refs/tags') }}

--- a/.github/workflows/publish_to_pypi.yml
+++ b/.github/workflows/publish_to_pypi.yml
@@ -33,6 +33,7 @@ jobs:
           CIBW_ARCHS_MACOS: x86_64 universal2
           CIBW_SKIP: pp*
           CIBW_TEST_COMMAND: python {project}/dev/continuous-integration/run_simple_test.py
+          CIBW_TEST_REQUIRES: pytest
       - name: Publish distribution 📦 to Test PyPI
         if: ${{ ! startsWith(github.ref, 'refs/tags') }}
         run: |

--- a/.github/workflows/publish_to_pypi.yml
+++ b/.github/workflows/publish_to_pypi.yml
@@ -27,7 +27,7 @@ jobs:
         with:
           output-dir: dist
         env:
-          CIBW_BEFORE_BUILD: pip install "cython>=0.29" numpy>=1.15 setuptools
+          CIBW_BEFORE_BUILD: pip install --only-binary numpy "cython>=0.29" numpy>=1.15 setuptools
           CIBW_PROJECT_REQUIRES_PYTHON: ">=3.7"
           CIBW_ARCHS_MACOS: x86_64 universal2
           CIBW_BUILD_VERBOSITY: 1

--- a/.github/workflows/publish_to_pypi.yml
+++ b/.github/workflows/publish_to_pypi.yml
@@ -42,12 +42,17 @@ jobs:
           CIBW_BUILD_VERBOSITY: 1
       - name: Publish distribution 📦 to Test PyPI
         if: ${{ ! startsWith(github.ref, 'refs/tags') }}
-        uses: pypa/gh-action-pypi-publish@master
-        with:
-          password: ${{ secrets.test_pypi_password }}
-          repository_url: https://test.pypi.org/legacy/
+        run: |
+          pip install twine
+          twine upload -r testpypi dist/*
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.test_pypi_password }}
       - name: Publish distribution release 📦 to PyPI
-        if: startsWith(github.ref, 'refs/tags')
-        uses: pypa/gh-action-pypi-publish@master
-        with:
-          password: ${{ secrets.pypi_password }}
+        if: ${{ startsWith(github.ref, 'refs/tags') }}
+        run: |
+          pip install twine
+          twine upload dist/*
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.pypi_password }}

--- a/.github/workflows/publish_to_pypi.yml
+++ b/.github/workflows/publish_to_pypi.yml
@@ -16,15 +16,16 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: '3.x'
-      - name: Install cibuildwheel & dependencies
+      - name: Build source tarball (only on Linux)
         run: |
           python -m pip install --upgrade pip
-          python -m pip install cibuildwheel==1.9.0
-      - name: Build source tarball (only on Linux)
-        run: python setup.py sdist --formats=gztar --with-cython --fail-on-error
+          python -m pip install "cython>=0.29" numpy>=1.15 setuptools
+          python setup.py sdist --formats=gztar --with-cython --fail-on-error
         if: ${{ startsWith(matrix.os, 'ubuntu-') }}
       - name: Build wheels
-        run: python -m cibuildwheel --output-dir dist
+        uses: joerick/cibuildwheel@v1.9.0
+        with:
+          output-dir: dist
         env:
           CIBW_BEFORE_BUILD: pip install "cython>=0.29" numpy>=1.15 setuptools
           CIBW_BUILD_VERBOSITY: 1

--- a/.github/workflows/publish_to_pypi.yml
+++ b/.github/workflows/publish_to_pypi.yml
@@ -22,6 +22,13 @@ jobs:
           python -m pip install "cython>=0.29" numpy>=1.15 setuptools
           python setup.py sdist --formats=gztar --with-cython --fail-on-error
         if: ${{ startsWith(matrix.os, 'ubuntu-') }}
+      - name: Debug disk space on OS X
+        run: |
+          df -h /
+          df -h .
+          sudo du -hs /usr/local/*
+          sudo du -hs /opt/*
+        if: ${{ startsWith(matrix.os, 'macOS-') }}
       - name: Build wheels
         uses: joerick/cibuildwheel@v1.9.0
         with:

--- a/.github/workflows/publish_to_pypi.yml
+++ b/.github/workflows/publish_to_pypi.yml
@@ -36,7 +36,7 @@ jobs:
           CIBW_TEST_COMMAND: python {project}/dev/continuous-integration/run_simple_test.py
           CIBW_TEST_REQUIRES: pytest
       - name: Publish distribution 📦 to Test PyPI
-        if: ${{ ! startsWith(github.ref, 'refs/tags') }}
+        if: github.ref == 'refs/heads/master'
         run: |
           pip install twine
           twine upload -r testpypi dist/*

--- a/.github/workflows/publish_to_pypi.yml
+++ b/.github/workflows/publish_to_pypi.yml
@@ -31,6 +31,7 @@ jobs:
           CIBW_PROJECT_REQUIRES_PYTHON: ">=3.7"
           CIBW_ARCHS: auto64
           CIBW_ARCHS_MACOS: x86_64 universal2
+          CIBW_TEST_SKIP: '*_arm64 *_universal2:arm64'
           CIBW_SKIP: pp*
           CIBW_TEST_COMMAND: python {project}/dev/continuous-integration/run_simple_test.py
           CIBW_TEST_REQUIRES: pytest

--- a/.github/workflows/publish_to_pypi.yml
+++ b/.github/workflows/publish_to_pypi.yml
@@ -19,6 +19,13 @@ jobs:
           pip install setuptools cython
       - name: Build source tarball
         run: python setup.py sdist --formats=gztar --with-cython --fail-on-error
+      - name: Build manylinux wheel
+        uses: RalfG/python-wheels-manylinux-build@v0.3.3-manylinux2010_x86_64
+        with:
+          python-versions: 'cp37-cp37m cp38-cp38 cp39-cp39'
+          build-requirements: 'cython>=0.29 numpy>=1.15'
+      - name: Remove unused wheels
+        run: rm dist/*-linux*.whl
       - name: Publish distribution 📦 to Test PyPI
         if: ${{ ! startsWith(github.ref, 'refs/tags') }}
         uses: pypa/gh-action-pypi-publish@master

--- a/.github/workflows/publish_to_pypi.yml
+++ b/.github/workflows/publish_to_pypi.yml
@@ -29,6 +29,7 @@ jobs:
         env:
           CIBW_BEFORE_BUILD: pip install "cython>=0.29" numpy>=1.15 setuptools
           CIBW_PROJECT_REQUIRES_PYTHON: ">=3.7"
+          CIBW_ARCHS_MACOS: x86_64 universal2
           CIBW_BUILD_VERBOSITY: 1
       - name: Publish distribution 📦 to Test PyPI
         if: ${{ ! startsWith(github.ref, 'refs/tags') }}

--- a/.github/workflows/publish_to_pypi.yml
+++ b/.github/workflows/publish_to_pypi.yml
@@ -22,13 +22,6 @@ jobs:
           python -m pip install "cython>=0.29" numpy>=1.15 setuptools
           python setup.py sdist --formats=gztar --with-cython --fail-on-error
         if: ${{ startsWith(matrix.os, 'ubuntu-') }}
-      - name: Debug disk space on OS X
-        run: |
-          df -h /
-          df -h .
-          sudo du -hs /usr/local/*
-          sudo du -hs /opt/*
-        if: ${{ startsWith(matrix.os, 'macOS-') }}
       - name: Build wheels
         uses: joerick/cibuildwheel@v1.9.0
         with:
@@ -39,7 +32,7 @@ jobs:
           CIBW_ARCHS: auto64
           CIBW_ARCHS_MACOS: x86_64 universal2
           CIBW_SKIP: pp*
-          CIBW_BUILD_VERBOSITY: 1
+          CIBW_TEST_COMMAND: python {project}/dev/continuous-integration/run_simple_test.py
       - name: Publish distribution 📦 to Test PyPI
         if: ${{ ! startsWith(github.ref, 'refs/tags') }}
         run: |

--- a/.github/workflows/publish_to_pypi.yml
+++ b/.github/workflows/publish_to_pypi.yml
@@ -31,6 +31,7 @@ jobs:
           CIBW_PROJECT_REQUIRES_PYTHON: ">=3.7"
           CIBW_ARCHS: auto64
           CIBW_ARCHS_MACOS: x86_64 universal2
+          CIBW_SKIP: pp*
           CIBW_BUILD_VERBOSITY: 1
       - name: Publish distribution 📦 to Test PyPI
         if: ${{ ! startsWith(github.ref, 'refs/tags') }}

--- a/.github/workflows/publish_to_pypi.yml
+++ b/.github/workflows/publish_to_pypi.yml
@@ -1,10 +1,13 @@
-name: Publish source package to TestPyPI
-on: [push]
+name: Build and publish to TestPyPI or PyPI
+on: [push, pull_request]
 
 jobs:
   build-n-publish:
-    name: Build and publish source package to TestPyPI and PyPI
-    runs-on: ubuntu-latest
+    name: Build wheels on ${{ matrix.os }} and publish to (Test)PyPI
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ ubuntu-20.04, windows-2019, macOS-10.15 ]
     steps:
       - uses: actions/checkout@v2
         with:
@@ -13,19 +16,15 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: '3.x'
-      - name: Install dependencies
+      - name: Install cibuildwheel & dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install setuptools cython
-      - name: Build source tarball
+          python -m pip install cibuildwheel==1.9.0 "cython>=0.29" numpy>=1.15 setuptools
+      - name: Build source tarball (only on Linux)
         run: python setup.py sdist --formats=gztar --with-cython --fail-on-error
-      - name: Build manylinux wheel
-        uses: RalfG/python-wheels-manylinux-build@v0.3.3-manylinux2010_x86_64
-        with:
-          python-versions: 'cp37-cp37m cp38-cp38 cp39-cp39'
-          build-requirements: 'cython>=0.29 numpy>=1.15'
-      - name: Remove unused wheels
-        run: rm dist/*-linux*.whl
+        if: ${{ Eq(matrix.os, 'ubuntu-20.04') }}
+      - name: Build wheels
+        run: python -m cibuildwheel --output-dir dist
       - name: Publish distribution 📦 to Test PyPI
         if: ${{ ! startsWith(github.ref, 'refs/tags') }}
         uses: pypa/gh-action-pypi-publish@master

--- a/.github/workflows/publish_to_pypi.yml
+++ b/.github/workflows/publish_to_pypi.yml
@@ -29,6 +29,7 @@ jobs:
         env:
           CIBW_BEFORE_BUILD: pip install --only-binary numpy "cython>=0.29" numpy>=1.15 setuptools
           CIBW_PROJECT_REQUIRES_PYTHON: ">=3.7"
+          CIBW_ARCHS: auto64
           CIBW_ARCHS_MACOS: x86_64 universal2
           CIBW_BUILD_VERBOSITY: 1
       - name: Publish distribution 📦 to Test PyPI

--- a/.github/workflows/publish_to_pypi.yml
+++ b/.github/workflows/publish_to_pypi.yml
@@ -22,7 +22,7 @@ jobs:
           python -m pip install cibuildwheel==1.9.0 "cython>=0.29" numpy>=1.15 setuptools
       - name: Build source tarball (only on Linux)
         run: python setup.py sdist --formats=gztar --with-cython --fail-on-error
-        if: ${{ Eq(matrix.os, 'ubuntu-20.04') }}
+        if: ${{ startsWith(matrix.os, 'ubuntu-') }}
       - name: Build wheels
         run: python -m cibuildwheel --output-dir dist
       - name: Publish distribution 📦 to Test PyPI

--- a/brian2/codegen/cpp_prefs.py
+++ b/brian2/codegen/cpp_prefs.py
@@ -9,7 +9,6 @@ Preferences
 from setuptools import msvc
 import distutils
 from distutils.ccompiler import get_default_compiler
-from distutils.msvccompiler import MSVCCompiler
 import json
 import os
 import platform
@@ -206,7 +205,7 @@ def _determine_flag_compatibility(compiler, flagname):
 
 _compiler_flag_compatibility = {}
 def has_flag(compiler, flagname):
-    if isinstance(compiler, MSVCCompiler):
+    if compiler.compiler_type == 'msvc':
         compiler_exe = 'msvc'
     else:
         compiler_exe = ' '.join(compiler.executables['compiler_cxx'])

--- a/brian2/codegen/cpp_prefs.py
+++ b/brian2/codegen/cpp_prefs.py
@@ -224,15 +224,18 @@ def get_compiler_and_args():
     extra_compile_args = prefs['codegen.cpp.extra_compile_args']
     if extra_compile_args is None:
         if compiler in ('gcc', 'unix'):
-            from distutils.ccompiler import new_compiler
-            from distutils.sysconfig import customize_compiler
-            compiler_obj = new_compiler(compiler=compiler, verbose=0)
-            customize_compiler(compiler_obj)
-            extra_compile_args = [flag
-                                  for flag in prefs['codegen.cpp.extra_compile_args_gcc']
-                                  if has_flag(compiler_obj, flag)]
+            extra_compile_args = prefs['codegen.cpp.extra_compile_args_gcc']
         if compiler == 'msvc':
             extra_compile_args = prefs['codegen.cpp.extra_compile_args_msvc']
+
+    from distutils.ccompiler import new_compiler
+    from distutils.sysconfig import customize_compiler
+    compiler_obj = new_compiler(compiler=compiler, verbose=0)
+    customize_compiler(compiler_obj)
+    extra_compile_args = [flag
+                          for flag in extra_compile_args
+                          if has_flag(compiler_obj, flag)]
+
     return compiler, extra_compile_args
 
 
@@ -253,7 +256,7 @@ def get_msvc_env():
                                                          arch_name=arch_name)
         return None, vcvars_cmd
 
-    # Search for MSVC environemtn if not already cached
+    # Search for MSVC environment if not already cached
     if _msvc_env is None:
         try:
             _msvc_env = msvc.msvc14_get_vc_env(arch_name)

--- a/brian2/codegen/cpp_prefs.py
+++ b/brian2/codegen/cpp_prefs.py
@@ -225,8 +225,11 @@ def get_compiler_and_args():
     if extra_compile_args is None:
         if compiler in ('gcc', 'unix'):
             extra_compile_args = prefs['codegen.cpp.extra_compile_args_gcc']
-        if compiler == 'msvc':
+        elif compiler == 'msvc':
             extra_compile_args = prefs['codegen.cpp.extra_compile_args_msvc']
+        else:
+            extra_compile_args = []
+            logger.warn(f'Unsupported compiler \'{compiler}\'.')
 
     from distutils.ccompiler import new_compiler
     from distutils.sysconfig import customize_compiler

--- a/brian2/codegen/cpp_prefs.py
+++ b/brian2/codegen/cpp_prefs.py
@@ -206,7 +206,11 @@ def _determine_flag_compatibility(compiler, flagname):
 _compiler_flag_compatibility = {}
 def has_flag(compiler, flagname):
     if compiler.compiler_type == 'msvc':
-        compiler_exe = 'msvc'
+        # MSVC does not raise an error for illegal flags, so determining
+        # whether it accepts a flag would mean parsing the output for warnings
+        # This is non-trivial so we don't do it (the main reason to check
+        # flags in the first place are differences between gcc and clang)
+        return True
     else:
         compiler_exe = ' '.join(compiler.executables['compiler_cxx'])
 

--- a/brian2/codegen/cpp_prefs.py
+++ b/brian2/codegen/cpp_prefs.py
@@ -9,6 +9,7 @@ Preferences
 from setuptools import msvc
 import distutils
 from distutils.ccompiler import get_default_compiler
+from distutils.msvccompiler import MSVCCompiler
 import json
 import os
 import platform
@@ -205,7 +206,10 @@ def _determine_flag_compatibility(compiler, flagname):
 
 _compiler_flag_compatibility = {}
 def has_flag(compiler, flagname):
-    compiler_exe = ' '.join(compiler.executables['compiler_cxx'])
+    if isinstance(compiler, MSVCCompiler):
+        compiler_exe = 'msvc'
+    else:
+        compiler_exe = ' '.join(compiler.executables['compiler_cxx'])
 
     if (compiler_exe, flagname) not in _compiler_flag_compatibility:
         compatibility = _determine_flag_compatibility(compiler, flagname)

--- a/brian2/tests/test_codegen.py
+++ b/brian2/tests/test_codegen.py
@@ -6,7 +6,7 @@ import numpy as np
 import pytest
 
 from brian2 import prefs, clear_cache, _cache_dirs_and_extensions
-from brian2.codegen.cpp_prefs import compiler_supports_c99
+from brian2.codegen.cpp_prefs import compiler_supports_c99, get_compiler_and_args
 from brian2.codegen.optimisation import optimise_statements
 from brian2.codegen.translation import (analyse_identifiers,
                                         get_identifiers_recursively,
@@ -21,6 +21,7 @@ from brian2.core.functions import Function, DEFAULT_FUNCTIONS, DEFAULT_CONSTANTS
 from brian2.devices.device import auto_target, device
 from brian2.units.fundamentalunits import Unit
 from brian2.units import second, ms
+from brian2.utils.logger import catch_logs
 
 FakeGroup = namedtuple('FakeGroup', ['variables'])
 
@@ -450,6 +451,32 @@ def test_compiler_c99():
     # On our Azure test server we know that the compilers support C99
     if os.environ.get('AGENT_OS', ''):
         assert c99_support
+
+
+def test_cpp_flags_support():
+    from distutils.ccompiler import get_default_compiler
+    compiler = get_default_compiler()
+    old_prefs = prefs['codegen.cpp.extra_compile_args']
+
+    # Should always be supported
+    if compiler in ('gcc', 'unix'):
+        prefs['codegen.cpp.extra_compile_args'] = ['-w']
+    else:
+        prefs['codegen.cpp.extra_compile_args'] = ['/w']
+    _, compile_args = get_compiler_and_args()
+    assert compile_args == prefs['codegen.cpp.extra_compile_args']
+
+    # Should never be supported and raise a warning
+    if compiler in ('gcc', 'unix'):
+        prefs['codegen.cpp.extra_compile_args'] = ['-invalidxyz']
+    else:
+        prefs['codegen.cpp.extra_compile_args'] = ['/invalidxyz']
+    with catch_logs() as l:
+        _, compile_args = get_compiler_and_args()
+    assert len(l) == 1 and l[0][0] == 'WARNING'
+    assert compile_args == []
+
+    prefs['codegen.cpp.extra_compile_args'] = old_prefs
 
 
 if __name__ == '__main__':

--- a/brian2/tests/test_codegen.py
+++ b/brian2/tests/test_codegen.py
@@ -456,21 +456,17 @@ def test_compiler_c99():
 def test_cpp_flags_support():
     from distutils.ccompiler import get_default_compiler
     compiler = get_default_compiler()
+    if compiler == 'msvc':
+        pytest.skip('No flag support check for msvc')
     old_prefs = prefs['codegen.cpp.extra_compile_args']
 
     # Should always be supported
-    if compiler in ('gcc', 'unix'):
-        prefs['codegen.cpp.extra_compile_args'] = ['-w']
-    else:
-        prefs['codegen.cpp.extra_compile_args'] = ['/w']
+    prefs['codegen.cpp.extra_compile_args'] = ['-w']
     _, compile_args = get_compiler_and_args()
     assert compile_args == prefs['codegen.cpp.extra_compile_args']
 
     # Should never be supported and raise a warning
-    if compiler in ('gcc', 'unix'):
-        prefs['codegen.cpp.extra_compile_args'] = ['-invalidxyz']
-    else:
-        prefs['codegen.cpp.extra_compile_args'] = ['/invalidxyz']
+    prefs['codegen.cpp.extra_compile_args'] = ['-invalidxyz']
     with catch_logs() as l:
         _, compile_args = get_compiler_and_args()
     assert len(l) == 1 and l[0][0] == 'WARNING'

--- a/dev/continuous-integration/run_simple_test.py
+++ b/dev/continuous-integration/run_simple_test.py
@@ -1,0 +1,8 @@
+# Run a simple test that uses the main simulation elements and force code
+# generation to use Cython
+from brian2 import prefs
+from brian2.tests.test_synapses import test_transmission_simple
+
+prefs.codegen.target = 'cython'
+
+test_transmission_simple()


### PR DESCRIPTION
This PR makes github action build binary wheels for all platforms and uploads them to PyPI for tagged releases (and to TestPyPI for all commits). This makes for a rather impressive list of files, including wheels for the brand-new Apple machines with an ARM chip :), see https://test.pypi.org/project/Brian2/2.4.2.post0.dev90/#files

This seems to work well, and will installation much better/quicker for users that install with `pip` (actually, we might even reconsider our recommendation to use `conda`). There's one thing that is left to do which is only tangentially related to building the wheels: on some OS X installations, `/usr/bin/gcc` is actually a symlink to the `clang` compiler. This is fine in general, as both are mostly compatible. However, this fails with our default `gcc` arguments which include `-march=native` which is not supported by `clang`. In the current PR, I work around this by trying all the flags and check whether compilation works for them, and then filtering the list of flags accordingly. This does quite a bit of unnecessary compilation, but seems to be fast enough to not be really noticeable. We could of course speed this up by caching the results, but we might also consider having different defaults for `gcc` and `clang` and treating them separately in general. All this is a bit complicated by the fact that I don't have access to an OS X machine for testing, I can only observe the results on the CI server... But maybe just using `clang` on a Linux machine would be enough.