### PR TITLE
Provide fair defaults build flags to several archs

### DIFF
--- a/brian2/codegen/cpp_prefs.py
+++ b/brian2/codegen/cpp_prefs.py
@@ -96,11 +96,11 @@ else:
                              '-fno-finite-math-only', '-march=native',
                              '-std=c++11']
     elif re.match('^(alpha|ppc.*|sparc.*)$', machine):
-	default_buildopts = ['-w', '-O3', '-ffast-math',
-			     '-fno-finite-math-only', '-mcpu=native',
+        default_buildopts = ['-w', '-O3', '-ffast-math',
+                             '-fno-finite-math-only', '-mcpu=native',
                              '-mtune=native', '-std=c++11']
     elif re.match('^(parisc.*|riscv.*)$', machine):
-	default_buildopts = ['-w', '-O3', '-ffast-math',
+        default_buildopts = ['-w', '-O3', '-ffast-math',
                              '-fno-finite-math-only', '-std=c++11']
     else:
         default_buildopts = ['-w']

--- a/brian2/codegen/cpp_prefs.py
+++ b/brian2/codegen/cpp_prefs.py
@@ -88,19 +88,22 @@ if platform.system() == 'Windows':
         if 'avx2' in flags:
             msvc_arch_flag = '/arch:AVX2'
 
-# Optimized default build options for a range a CPU architectures
-machine = os.uname().machine
-if re.match('^(x86_64|aarch64|arm.*|s390.*|i.86.*|mips.*)$', machine):
-    default_buildopts = ['-w', '-O3', '-ffast-math', '-fno-finite-math-only',
-                         '-march=native', '-std=c++11']
-elif re.match('^(alpha|ppc.*|sparc.*)$', machine):
-    default_buildopts = ['-w', '-O3', '-ffast-math', '-fno-finite-math-only',
-                         '-mcpu=native', '-mtune=native', '-std=c++11']
-elif re.match('^(parisc.*|riscv.*)$', machine):
-    default_buildopts = ['-w', '-O3', '-ffast-math', '-fno-finite-math-only',
-                         '-std=c++11']
 else:
-    default_buildopts = ['-w']
+    # Optimized default build options for a range a CPU architectures
+    machine = os.uname().machine
+    if re.match('^(x86_64|aarch64|arm.*|s390.*|i.86.*|mips.*)$', machine):
+        default_buildopts = ['-w', '-O3', '-ffast-math',
+                             '-fno-finite-math-only', '-march=native',
+                             '-std=c++11']
+    elif re.match('^(alpha|ppc.*|sparc.*)$', machine):
+	default_buildopts = ['-w', '-O3', '-ffast-math',
+			     '-fno-finite-math-only', '-mcpu=native',
+                             '-mtune=native', '-std=c++11']
+    elif re.match('^(parisc.*|riscv.*)$', machine):
+	default_buildopts = ['-w', '-O3', '-ffast-math',
+                             '-fno-finite-math-only', '-std=c++11']
+    else:
+        default_buildopts = ['-w']
 
 # Preferences
 prefs.register_preferences(

--- a/brian2/codegen/cpp_prefs.py
+++ b/brian2/codegen/cpp_prefs.py
@@ -11,6 +11,7 @@ import distutils
 from distutils.ccompiler import get_default_compiler
 import json
 import os
+import re
 import platform
 import socket
 import struct
@@ -87,6 +88,20 @@ if platform.system() == 'Windows':
         if 'avx2' in flags:
             msvc_arch_flag = '/arch:AVX2'
 
+# Optimized default build options for a range a CPU architectures
+machine = os.uname().machine
+if re.match('^(x86_64|aarch64|arm.*|s390.*|i.86.*|mips.*)$', machine):
+    default_buildopts = ['-w', '-O3', '-ffast-math', '-fno-finite-math-only',
+                         '-march=native', '-std=c++11']
+elif re.match('^(alpha|ppc.*|sparc.*)$', machine):
+    default_buildopts = ['-w', '-O3', '-ffast-math', '-fno-finite-math-only',
+                         '-mcpu=native', '-mtune=native', '-std=c++11']
+elif re.match('^(parisc.*|riscv.*)$', machine):
+    default_buildopts = ['-w', '-O3', '-ffast-math', '-fno-finite-math-only',
+                         '-std=c++11']
+else:
+    default_buildopts = ['-w']
+
 # Preferences
 prefs.register_preferences(
     'codegen.cpp',
@@ -108,7 +123,7 @@ prefs.register_preferences(
         '''
         ),
     extra_compile_args_gcc=BrianPreference(
-        default=['-w', '-O3', '-ffast-math', '-fno-finite-math-only', '-march=native', '-std=c++11'],
+        default=default_buildopts,
         docs='''
         Extra compile arguments to pass to GCC compiler
         '''

--- a/brian2/codegen/cpp_prefs.py
+++ b/brian2/codegen/cpp_prefs.py
@@ -94,7 +94,7 @@ if platform.system() == 'Windows':
 else:
     # Optimized default build options for a range a CPU architectures
     machine = os.uname().machine
-    if re.match('^(x86_64|aarch64|arm.*|s390.*|i.86.*|mips.*)$', machine):
+    if re.match('^(x86_64|aarch64|arm.*|s390.*|i.86.*)$', machine):
         default_buildopts = ['-w', '-O3', '-ffast-math',
                              '-fno-finite-math-only', '-march=native',
                              '-std=c++11']
@@ -102,7 +102,7 @@ else:
         default_buildopts = ['-w', '-O3', '-ffast-math',
                              '-fno-finite-math-only', '-mcpu=native',
                              '-mtune=native', '-std=c++11']
-    elif re.match('^(parisc.*|riscv.*)$', machine):
+    elif re.match('^(parisc.*|riscv.*|mips.*)$', machine):
         default_buildopts = ['-w', '-O3', '-ffast-math',
                              '-fno-finite-math-only', '-std=c++11']
     else:

--- a/brian2/codegen/cpp_prefs.py
+++ b/brian2/codegen/cpp_prefs.py
@@ -28,6 +28,9 @@ __all__ = ['get_compiler_and_args', 'get_msvc_env', 'compiler_supports_c99',
 
 logger = get_logger(__name__)
 
+# default_buildopts stores default build options for Gcc compiler
+default_buildopts = []
+
 # Try to get architecture information to get the best compiler setting for
 # Windows
 msvc_arch_flag = ''


### PR DESCRIPTION
Greetings,

While integrating the package _brian_ in the Debian project with @mr-c, we tried to get the package to build and test seamlessly on all architectures possible supported by the project without the need for users to change the default build options in _brian2/codegen/cpp_prefs.py_.  You can see for instance a summary of the [latest _brian_ build and test results per architecture during the upload to _experimental_](https://buildd.debian.org/status/package.php?p=brian&suite=experimental) on the build servers status page.

Would you be interested to have such a default build options selector upstreamed?

The present version only matches the architectures on which I believe it might be possible to do some testing on real hardware; thus no SuperH, nor x32, due to missing build dependencies for instance.  Also, there are still some results missing due to the build queue depth on older CPU architectures at the moment, hence the draft status.

Kind Regards,
Étienne.

Edited to add: since upload to _sid_, build results for _experimental_ are not available anymore.  [Build results for _sid_ are available though.](https://buildd.debian.org/status/package.php?p=brian&suite=sid)