### PR TITLE
Add constant definitions instead of replacing them in the code for standalone mode

### DIFF
--- a/brian2/tests/test_cpp_standalone.py
+++ b/brian2/tests/test_cpp_standalone.py
@@ -494,6 +494,18 @@ def test_continued_standalone_runs():
     assert target.v[0] == 1  # Make sure the spike got delivered
 
 
+@pytest.mark.cpp_standalone
+@pytest.mark.standalone_only
+def test_constant_replacement():
+    # see github issue #1276
+    set_device('cpp_standalone')
+    x = 42
+    G = NeuronGroup(1, 'y : 1')
+    G.y = 'x'
+    run(0*ms)
+    assert G.y[0] == 42.
+
+
 if __name__=='__main__':
     for t in [
              test_cpp_standalone,


### PR DESCRIPTION
This fixes #1276, the problem that external constants were unconditionally search&replaced in the final generated code which could lead to unexpected results for external constants named `x` for example (which we use in several places as function arguments).

At first, I thought this would be easy to fix by just replacing constants in the abstract code instead of in the final code which includes all the function definitions. But I then realized that we use the `freeze` mechanism also to replace constants outside of user code, e.g. templates might refer to `N` as the number of neurons which is represented as an "external constant" as well. The easiest way to fix it that I found was to use the mechanism that we already use for constants such as `_num_arrayname` that we add to give the code access to the length of arrays, i.e. the `%CONSTANTS%` block. This means, instead of replacing the constant with its value in the code, we add something like `const int N = 10` to this block. Potentially this could mean slower code if the compiler does not optimize code based on `const` definitions as much as numerical literals, but I doubt that this would make any measurable difference.

A minor point: the change means we can remove the `CPPStandaloneDevice.freeze` function, but I leave it in for now as it would break `Brian2CUDA` and potentially other projects that we don't know of (`Brian2GeNN` copied the code instead, so it won't be affected). I added a warning for now, we can remove the code at a later point.

To make the difference between the old and the new approach clear, consider the stateupdater code for this example:
```Python
tau = 10*ms
eqs = '''
dv/dt = (1-v)/tau : 1
'''
```

Before, we generated the following code where `N` and `tau` were replaced directly:
```C++
    ///// CONSTANTS ///////////
    //...
    //// MAIN CODE ////////////
    //...
    const double _lio_1 = 1.0 - exp(1.0f*(- dt)/0.01);
    const double _lio_2 = exp(1.0f*(- dt)/0.01);

    const int _N = 10;
    
    for(int _idx=0; _idx<_N; _idx++)
    {
       // ...
    }
```
With the new approach, we have them as constants in the code:
```C++
    ///// CONSTANTS ///////////
    const double tau = 0.01;
    const int64_t N = 10;
    //...

    //// MAIN CODE ////////////
    //...
    const double _lio_1 = 1.0 - exp(1.0f*(- dt)/tau);
    const double _lio_2 = exp(1.0f*(- dt)/tau);

    const int _N = N;
    
    for(int _idx=0; _idx<_N; _idx++)
    {
        //...
    }
```