### PR TITLE
Fixed size synapses

### DIFF
--- a/brian2/codegen/runtime/cython_rt/templates/common_group.pyx
+++ b/brian2/codegen/runtime/cython_rt/templates/common_group.pyx
@@ -17,6 +17,9 @@ from libc.stdlib cimport abs  # For integers
 from libc.math cimport abs  # For floating point values
 from libc.limits cimport INT_MIN, INT_MAX
 from libcpp cimport bool
+from libcpp.set cimport set
+from cython.operator cimport dereference as _deref, preincrement as _preinc
+cimport cython as _cython
 
 _numpy.import_array()
 cdef extern from "numpy/ndarraytypes.h":

--- a/brian2/codegen/runtime/cython_rt/templates/synapses_create_generator.pyx
+++ b/brian2/codegen/runtime/cython_rt/templates/synapses_create_generator.pyx
@@ -88,14 +88,14 @@ cdef void _flush_buffer(buf, dynarr, int buf_len):
         if _iter_size > _n_total:
             _iter_size = _n_total
         if _selection_algo:
-            {{iteration_variable}} = _iter_low
+            {{iteration_variable}} = _iter_low - _iter_step
         else:
             # For the tracking algorithm, we have to first create all values
             # to make sure they will be iterated in sorted order
             _selected_set.clear()
             while _n_selected < _iter_size:
                 _r = <int> (_rand(_vectorisation_idx) * _n_total)
-                while not _selected_set.insert(_r).second:
+                while not _selected_set.insert(_r).second:  # .second will be False if duplicate
                     _r = <int> (_rand(_vectorisation_idx) * _n_total)
                 _n_selected += 1
             _n_selected = 0
@@ -103,13 +103,13 @@ cdef void _flush_buffer(buf, dynarr, int buf_len):
 
         while _n_selected < _iter_size:
             if _selection_algo:
+                {{iteration_variable}} += _iter_step
                 # Selection sampling technique
                 # See section 3.4.2 of Donald E. Knuth, AOCP, Vol 2,
                 # Seminumerical Algorithms
                 _n_dealt_with += 1
                 _U = _rand(_vectorisation_idx)
                 if (_n_total - _n_dealt_with) * _U >= _iter_size - _n_selected:
-                    {{iteration_variable}} += _iter_step
                     continue
             else:
                 {{iteration_variable}} = _iter_low + _deref(_selected_it)*_iter_step

--- a/brian2/codegen/runtime/cython_rt/templates/synapses_create_generator.pyx
+++ b/brian2/codegen/runtime/cython_rt/templates/synapses_create_generator.pyx
@@ -84,7 +84,7 @@ cdef void _flush_buffer(buf, dynarr, int buf_len):
                 _n_total = (_iter_high - _iter_low - 1) // _iter_step + 1
             else:
                 _n_total = (_iter_low - _iter_high - 1) // -_iter_step + 1
-            _selection_algo = _iter_size / _n_total > {{algo_cutoff}}
+            _selection_algo = 1.0*_iter_size / _n_total > {{algo_cutoff}}
         if _iter_size > _n_total:
             _iter_size = _n_total
         if _selection_algo:

--- a/brian2/codegen/runtime/cython_rt/templates/synapses_create_generator.pyx
+++ b/brian2/codegen/runtime/cython_rt/templates/synapses_create_generator.pyx
@@ -86,7 +86,18 @@ cdef void _flush_buffer(buf, dynarr, int buf_len):
                 _n_total = (_iter_low - _iter_high - 1) // -_iter_step + 1
             _selection_algo = 1.0*_iter_size / _n_total > {{algo_cutoff}}
         if _iter_size > _n_total:
+            {% if skip_if_invalid %}
             _iter_size = _n_total
+            {% else %}
+            raise IndexError('Requested sample size %d is bigger than the '
+                             'population size %d.' % (_iter_size, _n_total))
+            {% endif %}
+        elif _iter_size < 0:
+            {% if skip_if_invalid %}
+            continue
+            {% else %}
+            raise IndexError('Requested sample size %d is negative.' % _iter_size)
+            {% endif %}
         if _selection_algo:
             {{iteration_variable}} = _iter_low - _iter_step
         else:

--- a/brian2/codegen/runtime/cython_rt/templates/synapses_create_generator.pyx
+++ b/brian2/codegen/runtime/cython_rt/templates/synapses_create_generator.pyx
@@ -84,7 +84,8 @@ cdef void _flush_buffer(buf, dynarr, int buf_len):
                 _n_total = (_iter_high - _iter_low - 1) // _iter_step + 1
             else:
                 _n_total = (_iter_low - _iter_high - 1) // -_iter_step + 1
-            _selection_algo = 1.0*_iter_size / _n_total > {{algo_cutoff}}
+            # Value determined by benchmarking, see github PR #1280
+            _selection_algo = 1.0*_iter_size / _n_total > 0.06
         if _iter_size > _n_total:
             {% if skip_if_invalid %}
             _iter_size = _n_total

--- a/brian2/codegen/runtime/numpy_rt/templates/synapses_create_generator.py_
+++ b/brian2/codegen/runtime/numpy_rt/templates/synapses_create_generator.py_
@@ -30,8 +30,21 @@ except:
             n = (high-low-1)//step+1
         else:
             n = (low-high-1)//-step+1
-        if n <= 0 or (size is not None and size <= 0):
+        if n <= 0 or (size is not None and size == 0):
             return _numpy.array([], dtype=_numpy.int32)
+        elif size is not None and size < 0:
+            {% if skip_if_invalid %}
+            return _numpy.array([], dtype=_numpy.int32)
+            {% else %}
+            raise IndexError('Requested sample size %d is negative.' % size)
+            {% endif %}
+        elif size is not None and size > n:
+            {% if skip_if_invalid %}
+            size = n
+            {% else %}
+            raise IndexError('Requested sample size %d is bigger than the '
+                             'population size %d.' % (size, n))
+            {% endif %}
         if n == size:
             return _numpy.arange(low, high, step)
         if p is None:

--- a/brian2/codegen/runtime/numpy_rt/templates/synapses_create_generator.py_
+++ b/brian2/codegen/runtime/numpy_rt/templates/synapses_create_generator.py_
@@ -21,7 +21,7 @@ except:
 
     from numpy.random import binomial as _binomial
     import bisect as _bisect
-    def _sample_without_replacement(low, high, step, p):
+    def _sample_without_replacement(low, high, step, p=None, size=None):
         if p == 0:
             return _numpy.array([], dtype=_numpy.int32)
         if p == 1:
@@ -30,8 +30,17 @@ except:
             n = (high-low-1)//step+1
         else:
             n = (low-high-1)//-step+1
-        if n <= 0:
+        if n <= 0 or (size is not None and size <= 0):
             return _numpy.array([], dtype=_numpy.int32)
+        if n == size:
+            return _numpy.arange(low, high, step)
+        if p is None:
+            if step == 0:
+                _choice = _numpy.random.choice(n,  size=size, replace=False) + low
+            else:
+                _chose_from = _numpy.arange(low, high, step)
+                _choice = _numpy.random.choice(_chose_from, size=size, replace=False)
+            return _numpy.sort(_choice)
         if n <= 1000 or p > 0.25: # based on rough profiling
             samples, = (_np_rand(n)<p).nonzero()
         else:
@@ -89,7 +98,11 @@ for _i in range(N_pre):
     {% if iterator_func=='range' %}
     {{iteration_variable}} = _numpy.arange(_iter_low, _iter_high, _iter_step)
     {% elif iterator_func=='sample' %}
+    {% if iterator_kwds['sample_size'] == 'fixed' %}
+    {{iteration_variable}} = _sample_without_replacement(_iter_low, _iter_high, _iter_step, None, size=_iter_size)
+    {% else %}
     {{iteration_variable}} = _sample_without_replacement(_iter_low, _iter_high, _iter_step, _iter_p)
+    {% endif %}
     {% endif %}
 
     _vectorisation_idx = {{iteration_variable}}

--- a/brian2/codegen/runtime/numpy_rt/templates/synapses_create_generator.py_
+++ b/brian2/codegen/runtime/numpy_rt/templates/synapses_create_generator.py_
@@ -48,7 +48,7 @@ except:
         if n == size:
             return _numpy.arange(low, high, step)
         if p is None:
-            if step == 0:
+            if step == 1:
                 _choice = _numpy.random.choice(n,  size=size, replace=False) + low
             else:
                 _chose_from = _numpy.arange(low, high, step)

--- a/brian2/core/base.py
+++ b/brian2/core/base.py
@@ -1,6 +1,7 @@
 '''
 All Brian objects should derive from `BrianObject`.
 '''
+import functools
 import weakref
 import traceback
 import os
@@ -277,8 +278,8 @@ def device_override(name):
             else:
                 return func(*args, **kwds)
 
-        device_override_decorated_function.__doc__ = func.__doc__
         device_override_decorated_function.original_function = func
+        functools.update_wrapper(device_override_decorated_function, func)
 
         return device_override_decorated_function
 

--- a/brian2/core/core_preferences.py
+++ b/brian2/core/core_preferences.py
@@ -40,7 +40,10 @@ prefs.register_preferences('core', 'Core Brian preferences',
         Whether to raise an error for outdated dependencies (``True``) or just
         a warning (``False``).
         '''
-        )
+        ),
+    algo_cutoff=BrianPreference(default=0.1,
+                                docs='Cutoff value to chose between selection '
+                                     'and tracking algorithm')
     )
 
 prefs.register_preferences('legacy', 'Preferences to enable legacy behaviour',

--- a/brian2/core/core_preferences.py
+++ b/brian2/core/core_preferences.py
@@ -40,10 +40,7 @@ prefs.register_preferences('core', 'Core Brian preferences',
         Whether to raise an error for outdated dependencies (``True``) or just
         a warning (``False``).
         '''
-        ),
-    algo_cutoff=BrianPreference(default=0.1,
-                                docs='Cutoff value to chose between selection '
-                                     'and tracking algorithm')
+        )
     )
 
 prefs.register_preferences('legacy', 'Preferences to enable legacy behaviour',

--- a/brian2/devices/cpp_standalone/templates/synapses_create_generator.cpp
+++ b/brian2/devices/cpp_standalone/templates/synapses_create_generator.cpp
@@ -73,6 +73,7 @@
         for(long {{iteration_variable}}=_uiter_low; {{iteration_variable}}<_uiter_high; {{iteration_variable}}+=_uiter_step)
         {
         {% elif iterator_func=='sample' %}
+        const int _iter_sign = _uiter_step > 0 ? 1 : -1;
         {% if iterator_kwds['sample_size'] == 'fixed' %}
         // Selection sampling technique
         // See section 3.4.2 of Donald E. Knuth, AOCP, Vol 2, Seminumerical Algorithms
@@ -83,7 +84,7 @@
             _n_total = (_uiter_high - _uiter_low - 1) / _uiter_step + 1;
         else
             _n_total = (_uiter_low - _uiter_high - 1) / -_uiter_step + 1;
-        for(long {{iteration_variable}}=_uiter_low; {{iteration_variable}}<_uiter_high; {{iteration_variable}}+=_uiter_step)
+        for(long {{iteration_variable}}=_uiter_low; _iter_sign*{{iteration_variable}}<_iter_sign*_uiter_high; {{iteration_variable}}+=_uiter_step)
         {
             const double _U = _rand(_vectorisation_idx);
             if ((_n_total - _n_dealt_with)*_U >= _uiter_size - _n_selected)
@@ -95,7 +96,6 @@
             _n_dealt_with += 1;
         {% else %}
         if(_uiter_p==0) continue;
-        const int _iter_sign = _uiter_step > 0 ? 1 : -1;
         const bool _jump_algo = _uiter_p<0.25;
         double _log1p;
         if(_jump_algo)

--- a/brian2/devices/cpp_standalone/templates/synapses_create_generator.cpp
+++ b/brian2/devices/cpp_standalone/templates/synapses_create_generator.cpp
@@ -84,7 +84,7 @@
             _n_total = (_uiter_high - _uiter_low - 1) / _uiter_step + 1;
         else
             _n_total = (_uiter_low - _uiter_high - 1) / -_uiter_step + 1;
-        const bool _selection_algo = _uiter_size / _n_total > {{algo_cutoff}};
+        const bool _selection_algo = 1.0*_uiter_size / _n_total > {{algo_cutoff}};
         if (_uiter_size > _n_total)
             _uiter_size = _n_total;
 

--- a/brian2/devices/cpp_standalone/templates/synapses_create_generator.cpp
+++ b/brian2/devices/cpp_standalone/templates/synapses_create_generator.cpp
@@ -84,7 +84,8 @@
             _n_total = (_uiter_high - _uiter_low - 1) / _uiter_step + 1;
         else
             _n_total = (_uiter_low - _uiter_high - 1) / -_uiter_step + 1;
-        const bool _selection_algo = 1.0*_uiter_size / _n_total > {{algo_cutoff}};
+        // Value determined by benchmarking, see github PR #1280
+        const bool _selection_algo = 1.0*_uiter_size / _n_total > 0.06;
         if (_uiter_size > _n_total)
         {
             {% if skip_if_invalid %}

--- a/brian2/devices/cpp_standalone/templates/synapses_create_generator.cpp
+++ b/brian2/devices/cpp_standalone/templates/synapses_create_generator.cpp
@@ -92,7 +92,7 @@
 
         if (_selection_algo)
         {
-            {{iteration_variable}} = _uiter_low;
+            {{iteration_variable}} = _uiter_low - _uiter_step;
         } else
         {
             // For the tracking algorithm, we have to first create all values
@@ -114,6 +114,7 @@
             {
                 // Selection sampling technique
                 // See section 3.4.2 of Donald E. Knuth, AOCP, Vol 2, Seminumerical Algorithms
+                {{iteration_variable}} += _uiter_step;
                 _n_dealt_with++;
                 const double _U = _rand(_vectorisation_idx);
                 if ((_n_total - _n_dealt_with) * _U >= _uiter_size - _n_selected)

--- a/brian2/devices/cpp_standalone/templates/synapses_create_generator.cpp
+++ b/brian2/devices/cpp_standalone/templates/synapses_create_generator.cpp
@@ -118,10 +118,7 @@
                 _n_dealt_with++;
                 const double _U = _rand(_vectorisation_idx);
                 if ((_n_total - _n_dealt_with) * _U >= _uiter_size - _n_selected)
-                {
-                    {{iteration_variable}} += _uiter_step;
                     continue;
-                }
             } else
             {
                 {{iteration_variable}} = _uiter_low + (*_selected_it)*_uiter_step;

--- a/brian2/devices/cpp_standalone/templates/synapses_create_generator.cpp
+++ b/brian2/devices/cpp_standalone/templates/synapses_create_generator.cpp
@@ -86,8 +86,24 @@
             _n_total = (_uiter_low - _uiter_high - 1) / -_uiter_step + 1;
         const bool _selection_algo = 1.0*_uiter_size / _n_total > {{algo_cutoff}};
         if (_uiter_size > _n_total)
+        {
+            {% if skip_if_invalid %}
             _uiter_size = _n_total;
-
+            {% else %}
+            cout << "Error: Requested sample size " << _uiter_size << " is bigger than the " <<
+                    "population size " << _n_total << "." << endl;
+            exit(1);
+            {% endif %}
+        } else if (_uiter_size < 0)
+        {
+            {% if skip_if_invalid %}
+            continue;
+            {% else %}
+            cout << "Error: Requested sample size " << _uiter_size << " is negative." << endl;
+            exit(1);
+            {% endif %}
+        } else if (_uiter_size == 0)
+            continue;
         long {{iteration_variable}};
 
         if (_selection_algo)

--- a/brian2/devices/cpp_standalone/templates/synapses_create_generator.cpp
+++ b/brian2/devices/cpp_standalone/templates/synapses_create_generator.cpp
@@ -95,6 +95,7 @@
             _n_dealt_with += 1;
         {% else %}
         if(_uiter_p==0) continue;
+        const int _iter_sign = _uiter_step > 0 ? 1 : -1;
         const bool _jump_algo = _uiter_p<0.25;
         double _log1p;
         if(_jump_algo)
@@ -102,16 +103,16 @@
         else
             _log1p = 1.0; // will be ignored
         const double _pconst = 1.0/log(1-_uiter_p);
-        for(long {{iteration_variable}}=_uiter_low; {{iteration_variable}}<_uiter_high; {{iteration_variable}}++)
+        for(long {{iteration_variable}}=_uiter_low; _iter_sign*{{iteration_variable}}<_iter_sign*_uiter_high; {{iteration_variable}} += _uiter_step)
         {
             if(_jump_algo) {
                 const double _r = _rand(_vectorisation_idx);
                 if(_r==0.0) break;
                 const int _jump = floor(log(_r)*_pconst)*_uiter_step;
                 {{iteration_variable}} += _jump;
-                if({{iteration_variable}}>=_uiter_high) continue;
+                if (_iter_sign*{{iteration_variable}} >= _iter_sign * _uiter_high) continue;
             } else {
-                if(_rand(_vectorisation_idx)>=_uiter_p) continue;
+                if (_rand(_vectorisation_idx)>=_uiter_p) continue;
             }
         {% endif %}
         {% endif %}

--- a/brian2/synapses/synapses.py
+++ b/brian2/synapses/synapses.py
@@ -1347,6 +1347,7 @@ class Synapses(Group):
         >>> S.connect(j='k for k in range(i+1)') # Connect neuron i to all j with 0<=j<=i
         >>> S.connect(j='i+(-1)**k for k in range(2) if i>0 and i<N_pre-1') # connect neuron i to its neighbours if it has both neighbours
         >>> S.connect(j='k for k in sample(N_post, p=i*1.0/(N_pre-1))') # neuron i connects to j with probability i/(N-1)
+        >>> S.connect(j='k for k in sample(N_post, size=i//2)') # Each neuron connects to i//2 other neurons (chosen randomly)
         '''
         # check types
         if condition is not None and not isinstance(condition, (bool,

--- a/brian2/synapses/synapses.py
+++ b/brian2/synapses/synapses.py
@@ -1795,9 +1795,6 @@ class Synapses(Group):
                       "using generator '%s'") % (self.source.name,
                                                  self.target.name,
                                                  parsed['original_expression']))
-        # FIXME: remove after benchmarking
-        from brian2 import prefs
-        template_kwds['algo_cutoff'] = prefs.core.algo_cutoff
         codeobj = create_runner_codeobj(self,
                                         abstract_code,
                                         'synapses_create_generator',

--- a/brian2/synapses/synapses.py
+++ b/brian2/synapses/synapses.py
@@ -1696,10 +1696,6 @@ class Synapses(Group):
         template_kwds.update(parsed)
         template_kwds['skip_if_invalid'] = skip_if_invalid
 
-        if (parsed['iterator_func'] == 'sample' and
-                    parsed['iterator_kwds']['sample_size']=='fixed'):
-            raise NotImplementedError("Fixed sample size not implemented yet.")
-
         abstract_code = {'setup_iterator': '',
                          'create_j': '',
                          'create_cond': '',

--- a/brian2/synapses/synapses.py
+++ b/brian2/synapses/synapses.py
@@ -1795,7 +1795,9 @@ class Synapses(Group):
                       "using generator '%s'") % (self.source.name,
                                                  self.target.name,
                                                  parsed['original_expression']))
-
+        # FIXME: remove after benchmarking
+        from brian2 import prefs
+        template_kwds['algo_cutoff'] = prefs.core.algo_cutoff
         codeobj = create_runner_codeobj(self,
                                         abstract_code,
                                         'synapses_create_generator',

--- a/brian2/tests/test_synapses.py
+++ b/brian2/tests/test_synapses.py
@@ -2618,6 +2618,8 @@ def test_synapse_generator_fixed_random_positive_steps():
     assert all(S3.N_outgoing_pre == 2)
     assert all(S3.j[:] % 2 == 0)
     assert all(S3.j >= 2)
+    assert all([len(S3.j[x, :]) == len(set(S3.j[x, :]))
+                for x in range(len(G))])
     assert len(S4) == 3
     assert_equal(S4.i, np.ones(3)*2)
     assert_equal(S4.j, np.arange(2, 7, 2))
@@ -2660,6 +2662,8 @@ def test_synapse_generator_fixed_random_negative_steps():
     assert all(S3.N_outgoing_pre == 2)
     assert all(S3.j[:] % 2 == 0)
     assert all(S3.j >= 2)
+    assert all([len(S3.j[x, :]) == len(set(S3.j[x, :]))
+                for x in range(len(G))])
     assert len(S4) == 3
     assert_equal(S4.i, np.ones(3) * 2)
     assert_equal(S4.j, np.arange(6, 0, -2))

--- a/brian2/tests/test_synapses.py
+++ b/brian2/tests/test_synapses.py
@@ -2668,6 +2668,43 @@ def test_synapse_generator_fixed_random_negative_steps():
     assert_equal(S4.i, np.ones(3) * 2)
     assert_equal(S4.j, np.arange(6, 0, -2))
 
+@pytest.mark.standalone_compatible
+def test_synapse_generator_fixed_random_error1():
+    set_device('cpp_standalone')
+    G = NeuronGroup(5, '')
+    G2 = NeuronGroup(7, '')
+    S = Synapses(G, G2)
+    with pytest.raises((BrianObjectException, IndexError, RuntimeError)):
+        # Won't work for i=4
+        S.connect(j='k for k in sample(N_post, size=i+4)')
+        run(0*ms)  # for standalone
+
+
+@pytest.mark.standalone_compatible
+def test_synapse_generator_fixed_random_error2():
+    G = NeuronGroup(5, '')
+    G2 = NeuronGroup(7, '')
+    S = Synapses(G, G2)
+    with pytest.raises((BrianObjectException, IndexError, RuntimeError)):
+        # Won't work for i=4
+        S.connect(j='k for k in sample(N_post, size=3-i)')
+        run(0*ms)  # for standalone
+
+
+@pytest.mark.standalone_compatible
+def test_synapse_generator_fixed_random_skip_if_invalid():
+    G = NeuronGroup(5, '')
+    G2 = NeuronGroup(7, '')
+    S1 = Synapses(G, G2)
+    S2 = Synapses(G, G2)
+    # > N_post for i=4
+    S1.connect(j='k for k in sample(N_post, size=i+4)', skip_if_invalid=True)
+    # < 0 for i=4
+    S2.connect(j='k for k in sample(N_post, size=3-i)', skip_if_invalid=True)
+    run(0*ms)  # for standalone
+    assert_array_equal(S1.N_outgoing_pre, [4, 5, 6, 7, 7])
+    assert_array_equal(S2.N_outgoing_pre, [3, 2, 1, 0, 0])
+
 
 @pytest.mark.standalone_compatible
 def test_synapse_generator_random_with_condition():

--- a/docs_sphinx/user/synapses.rst
+++ b/docs_sphinx/user/synapses.rst
@@ -377,13 +377,18 @@ created. Finally, ``RANGE`` can be either:
 1. a Python ``range``, e.g. ``range(N)`` is the integers from
    0 to N-1, ``range(A, B)`` is the integers from A to B-1,
    ``range(low, high, step)`` is the integers from ``low`` to
-   ``high-1`` with steps of size ``step``, or
-2. it can be a random sample ``sample(N, p=0.1)`` gives a
+   ``high-1`` with steps of size ``step``;
+2. a random sample ``sample(N, p=0.1)`` gives a
    random sample of integers from 0 to N-1 with 10% probability
    of each integer appearing in the sample. This can have extra
    arguments like range, e.g. ``sample(low, high, step, p=0.1)``
    will give each integer in ``range(low, high, step)`` with
-   probability 10%.
+   probability 10%;
+3. a random sample ``sample(N, size=10)`` with a fixed size,
+   in this example 10 values chosen (without replacement) from
+   the integers from 0 to N-1. As for the random sample based on
+   a probability, the ``sample`` expression can take additional
+   arguments to sample from a restricted range.
 
 If you try to create an invalid synapse (i.e. connecting
 neurons that are outside the correct range) then you will get
@@ -397,6 +402,11 @@ is invalid. There is an option to just skip any synapses
 that are outside the valid range::
 
     S.connect(j='i+(-1)**k for k in range(2)', skip_if_invalid=True)
+
+You can also use this argument to deal with random samples of
+incorrect size, i.e. a negative size or a size bigger than the
+total population size. With ``skip_if_invalid=True``, no error will
+be raised and a size of 0 or the population size will be used.
 
 Summed variables
 ----------------
@@ -567,7 +577,9 @@ interpreted in the following way:
     |        If uniform random number between 0 and 1 < p(i, j):
     |            Create n(i, j) synapses for (i, j)
 
-With the generator syntax ``j='EXPR for VAR in RANGE if COND'``, the interpretation is:
+With the generator syntax ``j='EXPR for VAR in RANGE if COND'`` (where the
+``RANGE`` can be a fukk range or a random sample as described above), the interpretation
+is:
 
     | For every i:
     |     for every VAR in RANGE:

--- a/docs_sphinx/user/synapses.rst
+++ b/docs_sphinx/user/synapses.rst
@@ -578,7 +578,7 @@ interpreted in the following way:
     |            Create n(i, j) synapses for (i, j)
 
 With the generator syntax ``j='EXPR for VAR in RANGE if COND'`` (where the
-``RANGE`` can be a fukk range or a random sample as described above), the interpretation
+``RANGE`` can be a full range or a random sample as described above), the interpretation
 is:
 
     | For every i:


### PR DESCRIPTION
This will fix #664 by finally implementing the `sample(..., size=...)` syntax in synapse generators.
This basically works already, but I'm still marking this as a draft because there are a couple of open questions:
1. how do we handle various types of errors? For example, if you ask for a bigger size than possible, should this raise an error? Or should we handle this via the `skip_if_invalid` option, i.e. silently generate fewer samples than the requested `size`?
2. The current algorithm is probably inefficient for small sizes (it scales with the total number of post-synaptic neurons) which are probably a quite common use case. Maybe it would make sense to use a simple "draw `size` random numbers and re-draw numbers for non-unique items" in these cases but we should probably run some benchmarking first.
3. I realized that our current syntax only allows to draw a fixed number of synapses per pre-synaptic neuron, i.e. to keep the "outgoing" synapses constant. A (more?) common use case would be to keep the number if *incoming* synapses constant. Maybe we could without too much work make our generator syntax work in the two directions, i.e. also support `connect(i='... for .... in ...')`?

Finally, we need more tests and documentation, but this should be straightforward.