### PR TITLE
change docstring of NeuronGroup so that model isn't a tuple

### DIFF
--- a/brian2/groups/neurongroup.py
+++ b/brian2/groups/neurongroup.py
@@ -404,7 +404,7 @@ class NeuronGroup(Group, SpikeSource):
     ----------
     N : int
         Number of neurons in the group.
-    model : (str, `Equations`)
+    model : str, `Equations`
         The differential equations defining the group
     method : (str, function), optional
         The numerical integration method. Either a string with the name of a


### PR DESCRIPTION
Issue:

Because of the parenthesis in the docstring, PyCharm was expecting model to be a Tuple(str, Equation).

![image](https://user-images.githubusercontent.com/22040952/111696133-4eeae700-880a-11eb-80a4-8113aa2cc41e.png)

Removal of the said parenthesis resolves the issue.