### PR TITLE
Fix flag_file load encoding error for Python 3.9

### DIFF
--- a/brian2/codegen/cpp_prefs.py
+++ b/brian2/codegen/cpp_prefs.py
@@ -44,8 +44,8 @@ if platform.system() == 'Windows':
     hostname = socket.gethostname()
     if os.path.isfile(flag_file):
         try:
-            with open(flag_file, 'r') as f:
-                previously_stored_flags = json.load(f, encoding='utf-8')
+            with open(flag_file, 'r', encoding='utf-8') as f:
+                previously_stored_flags = json.load(f)
             if hostname not in previously_stored_flags:
                 logger.debug('Ignoring stored CPU flags for a different host')
             else:

--- a/brian2/codegen/cpp_prefs.py
+++ b/brian2/codegen/cpp_prefs.py
@@ -70,7 +70,7 @@ if platform.system() == 'Windows':
                     to_store[hostname] = flags
                 else:
                     to_store = {hostname: flags}
-                with open(flag_file, 'w') as f:
+                with open(flag_file, 'w', encoding='utf-8') as f:
                     json.dump(to_store, f)
             except (IOError, OSError) as ex:
                 logger.debug('Writing file "{}" to store CPU flags failed with '


### PR DESCRIPTION
Try opening flag_file with encoding. As opposed to json.load. Was breaking for Python 3.9