### PR TITLE
Update python support

### DIFF
--- a/.github/workflows/publish_to_pypi.yml
+++ b/.github/workflows/publish_to_pypi.yml
@@ -27,7 +27,7 @@ jobs:
         with:
           output-dir: dist
         env:
-          CIBW_BEFORE_BUILD: pip install --only-binary numpy "cython>=0.29" numpy>=1.15 setuptools
+          CIBW_BEFORE_BUILD: pip install --only-binary numpy "cython>=0.29" numpy>=1.17 setuptools
           CIBW_PROJECT_REQUIRES_PYTHON: ">=3.7"
           CIBW_ARCHS: auto64
           CIBW_ARCHS_MACOS: x86_64 universal2

--- a/README.rst
+++ b/README.rst
@@ -48,8 +48,8 @@ Dependencies
 ------------
 The following packages need to be installed to use Brian 2:
 
-* Python >= 3.5
-* NumPy >=1.10
+* Python >= 3.7
+* NumPy >=1.17
 * SymPy >= 1.2
 * Cython >= 0.29
 * PyParsing

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -11,8 +11,8 @@ stages:
         vmImage: 'ubuntu-20.04'
       strategy:
         matrix:
-          Python36_runtime_1:
-            python.version: '3.6'
+          Python37_runtime_1:
+            python.version: '3.7'
             script_name: dev/continuous-integration/run_test_suite.py
             standalone: false
             split_run: 1
@@ -21,6 +21,16 @@ stages:
             script_name: dev/continuous-integration/run_test_suite.py
             standalone: false
             split_run: 1
+          Python37_runtime_2:
+            python.version: '3.7'
+            script_name: dev/continuous-integration/run_test_suite.py
+            standalone: false
+            split_run: 2
+          Python39_runtime_2:
+            python.version: '3.9'
+            script_name: dev/continuous-integration/run_test_suite.py
+            standalone: false
+            split_run: 2
           Python38_runtime_1:
             python.version: '3.8'
             script_name: dev/continuous-integration/run_test_suite.py
@@ -64,6 +74,21 @@ stages:
         vmImage: 'macOS-10.15'
       strategy:
         matrix:
+          Python37_runtime_1:
+            python.version: '3.7'
+            script_name: dev/continuous-integration/run_test_suite.py
+            standalone: false
+            split_run: 1
+          Python37_runtime_2:
+            python.version: '3.7'
+            script_name: dev/continuous-integration/run_test_suite.py
+            standalone: false
+            split_run: 2
+          Python39_runtime_2:
+            python.version: '3.9'
+            script_name: dev/continuous-integration/run_test_suite.py
+            standalone: false
+            split_run: 2
           Python38_runtime_1:
             python.version: '3.8'
             script_name: dev/continuous-integration/run_test_suite.py
@@ -87,6 +112,26 @@ stages:
         vmImage: 'vs2017-win2016'
       strategy:
         matrix:
+          Python37_runtime_1:
+            python.version: '3.7'
+            script_name: dev/continuous-integration/run_test_suite.py
+            standalone: false
+            split_run: 1
+          Python37_runtime_2:
+            python.version: '3.7'
+            script_name: dev/continuous-integration/run_test_suite.py
+            standalone: false
+            split_run: 2
+          Python39_runtime_1:
+            python.version: '3.9'
+            script_name: dev/continuous-integration/run_test_suite.py
+            standalone: false
+            split_run: 1
+          Python39_runtime_2:
+            python.version: '3.9'
+            script_name: dev/continuous-integration/run_test_suite.py
+            standalone: false
+            split_run: 2
           Python38_runtime_1:
             python.version: '3.8'
             script_name: dev/continuous-integration/run_test_suite.py

--- a/brian2/codegen/cpp_prefs.py
+++ b/brian2/codegen/cpp_prefs.py
@@ -20,6 +20,7 @@ import sys
 import tempfile
 
 from brian2.core.preferences import prefs, BrianPreference
+from brian2.utils.filetools import ensure_directory
 from brian2.utils.logger import get_logger, std_silent
 
 __all__ = ['get_compiler_and_args', 'get_msvc_env', 'compiler_supports_c99',
@@ -40,6 +41,7 @@ if platform.system() == 'Windows':
 
     # Check whether we've already stored the CPU flags previously
     user_dir = os.path.join(os.path.expanduser('~'), '.brian')
+    ensure_directory(user_dir)
     flag_file = os.path.join(user_dir, 'cpu_flags.txt')
     hostname = socket.gethostname()
     if os.path.isfile(flag_file):

--- a/brian2/codegen/cpp_prefs.py
+++ b/brian2/codegen/cpp_prefs.py
@@ -61,7 +61,8 @@ if platform.system() == 'Windows':
         try:
             output = subprocess.check_output([sys.executable,
                                               get_cpu_flags_script],
-                                             universal_newlines=True)
+                                             universal_newlines=True,
+                                             encoding='utf-8')
             flags = json.loads(output)
             # Store flags to a file so we don't have to call cpuinfo next time
             try:

--- a/dev/conda-recipe/meta.yaml
+++ b/dev/conda-recipe/meta.yaml
@@ -10,13 +10,13 @@ requirements:
   build:
     - {{ compiler('cxx') }}
   host:
-    - python
+    - python >=3.7
     - cython >=0.29
     - setuptools >=24
     # we build against the oldest supported numpy version
-    - numpy 1.15
+    - numpy 1.17
   run:
-    - python
+    - python >=3.7
     # we don't need the same version as during the build, newer versions are
     # still ABI-compatible
     - {{ pin_compatible('numpy') }}

--- a/setup.py
+++ b/setup.py
@@ -156,7 +156,7 @@ setup(name='Brian2',
                     # include default_preferences file
                     'brian2': ['default_preferences']
                     },
-      install_requires=['numpy>=1.15',
+      install_requires=['numpy>=1.17',
                         'cython>=0.29',
                         'sympy>=1.2',
                         'pyparsing',
@@ -193,5 +193,5 @@ setup(name='Brian2',
           'Programming Language :: Python :: 3',
           'Topic :: Scientific/Engineering :: Bio-Informatics'
       ],
-      python_requires='>=3.6'
+      python_requires='>=3.7'
       )


### PR DESCRIPTION
This updates the requirements to numpy >=1.17 and Python >= 3.7 in line with the [NEP 29](https://numpy.org/neps/nep-0029-deprecation_policy.html) guidelines. It also updates the testing to do more thorough testing on the oldest and newest supported Python version (i.e. 3.7 and 3.9) and it adds a test for issue #1284. 