### PR TITLE
Fix unit string representation

### DIFF
--- a/brian2/tests/test_units.py
+++ b/brian2/tests/test_units.py
@@ -234,13 +234,16 @@ def test_str_repr():
                      Unit(1, dim=get_or_create_dimension(length=5, time=2)),
                      8000*umetre**3, [0.0001, 10000] * umetre**3,
                      1/metre, 1/(coulomb*metre**2), Unit(1)/second,
-                     3.*mM, 5*mole/liter, 7*liter/meter3]
+                     3.*mM, 5*mole/liter, 7*liter/meter3,
+                     1/second**2, volt**-2, (volt**2)**-1,
+                     (1/second)/meter, 1/(1/second)]
     
     unitless = [second/second, 5 * second/second, Unit(1)]
     
     for u in itertools.chain(units_which_should_exist, some_scaled_units,
                               powered_units, complex_units, unitless):
         assert(len(str(u)) > 0)
+        assert get_dimensions(eval(repr(u))) == get_dimensions(u)
         assert_allclose(eval(repr(u)), u)
 
     # test the `DIMENSIONLESS` object

--- a/brian2/units/fundamentalunits.py
+++ b/brian2/units/fundamentalunits.py
@@ -1719,6 +1719,7 @@ class Quantity(np.ndarray, object):
     cumprod.__doc__ = np.ndarray.cumprod.__doc__
     cumprod._do_not_run_doctests = True
 
+
 class Unit(Quantity):
     r'''
     A physical unit.
@@ -2062,7 +2063,8 @@ class Unit(Quantity):
             latexname += '^{%s}' % latex(other)
             scale = self.scale * other
             u = Unit(10.0**scale, dim=self.dim ** other, name=name,
-                     dispname=dispname, latexname=latexname, scale=scale)
+                     dispname=dispname, latexname=latexname, scale=scale,
+                     iscompound=True)  # To avoid issues with units like (second ** -1) ** -1
             return u
         else:
             return super(Unit, self).__pow__(other)

--- a/brian2/units/fundamentalunits.py
+++ b/brian2/units/fundamentalunits.py
@@ -623,7 +623,7 @@ def is_scalar_type(obj):
         dimensionless `Quantity`.
     """
     try:
-        return obj.ndim == 0
+        return obj.ndim == 0 and is_dimensionless(obj)
     except AttributeError:
         return np.isscalar(obj) and not isinstance(obj, str)
 

--- a/brian2/units/fundamentalunits.py
+++ b/brian2/units/fundamentalunits.py
@@ -734,7 +734,7 @@ def in_unit(x, u, precision=None):
     >>> in_unit(123123 * msecond, second, 2)
     '123.12 s'
     >>> in_unit(10 * uA/cm**2, nA/um**2)
-    '1.00000000e-04 nA/um^2'
+    '1.00000000e-04 nA/(um^2)'
     >>> in_unit(10 * mV, ohm * amp)
     '0.01 ohm A'
     >>> in_unit(10 * nS, ohm) # doctest: +NORMALIZE_WHITESPACE
@@ -1798,9 +1798,9 @@ class Unit(Quantity):
     used for display when appropriate:
 
     >>> usiemens/cm**2
-    usiemens / cmetre ** 2
-    >>> conductance/area  # same as before, but now Brian nows about uS/cm^2
-    50. * usiemens / cmetre ** 2
+    usiemens / (cmetre ** 2)
+    >>> conductance/area  # same as before, but now Brian knows about uS/cm^2
+    50. * usiemens / (cmetre ** 2)
 
     Note that user-defined units cannot override the standard units (`volt`,
     `second`, etc.) that are predefined by Brian. For example, the unit
@@ -2013,7 +2013,7 @@ class Unit(Quantity):
 
     def __div__(self, other):
         if isinstance(other, Unit):
-            if other.iscompound:
+            if self.iscompound:
                 dispname = '(' + self.dispname + ')'
                 name = '(' + self.name + ')'
             else:
@@ -2198,7 +2198,7 @@ def register_new_unit(u):
     2. * metre ** -4 * kilogram ** -1 * second ** 4 * amp ** 2
     >>> register_new_unit(pfarad / mmetre**2)
     >>> 2.0*farad/metre**2
-    2000000. * pfarad / mmetre ** 2
+    2000000. * pfarad / (mmetre ** 2)
     """
     user_unit_register.add(u)
 


### PR DESCRIPTION
As @romainbrette noticed, the string representation of some units were not correct in the sense that evaluating them in Python did not result in the same unit – this is obviously bad, in particular when storing units/equations in text and importing them later (as Romain did). The problem concerned units raised to powers more than once, e.g.:
```pycon
>>> (second ** 2) ** -1  # or 1/second**2 which will be interpreted in the same way
second ** 2 ** -1
```
Due to Python's operator precedence, this will be interpreted as `second ** (2 ** -1)`, i.e. `second ** 0.5` instead of `second ** -2` as it should be. The simple fix in this PR is to consider units raised to powers as "compound units", which will lead to the use of parentheses:
```pycon
>>> (second ** 2) ** -1
(second ** 2) ** -1
```
Note that this changes the output also in situations that do not need correction, e.g. `amp / cm ** 2` will now be represented as `amp / (cm ** 2)`. I'd rather keep the fix as simple as it is though, the new output might even be helpful to avoid confusion.

While fixing this I came across another minor issue which is now fixed as well: the function `is_scalar_type` was supposed to return `True ` for a scalar that "can be interpreted as a *dimensionless* `Quantity`", but it actually only checked if it was a scalar, not whether it was dimensionless. Since this function was used to check whether an exponent of a unit was useable, it did give a somewhat confusing error message for nonsensical operations like `second**second`:
```pytb
...
brian2.units.fundamentalunits.DimensionMismatchError: Cannot calculate 10.0 ** 0. s, the exponent has to be dimensionless (unit is s).
```
With the fix, the error message is more meaningful
```pytb
brian2.units.fundamentalunits.DimensionMismatchError: Cannot calculate s ** s, the exponent has to be dimensionless (unit is s).
```