### PR TITLE
"contained objects" should be accessible via Network.get_states/set_states

### DIFF
--- a/brian2/core/network.py
+++ b/brian2/core/network.py
@@ -426,7 +426,8 @@ class Network(Nameable):
         if not isinstance(item, str):
             raise TypeError(('Need a name to access objects in a Network, '
                              'got {type} instead').format(type=type(item)))
-        for obj in self.objects:
+        all_objects = _get_all_objects(self.objects)
+        for obj in all_objects:
             if obj.name == item:
                 return obj
 
@@ -444,16 +445,19 @@ class Network(Nameable):
         raise KeyError('No object with name "%s" found' % key)
 
     def __contains__(self, item):
-        for obj in self.objects:
+        all_objects = _get_all_objects(self.objects)
+        for obj in all_objects:
             if obj.name == item:
                 return True
         return False
 
     def __len__(self):
-        return len(self.objects)
+        all_objects = _get_all_objects(self.objects)
+        return len(all_objects)
 
     def __iter__(self):
-        return iter(self.objects)
+        all_objects = _get_all_objects(self.objects)
+        return iter(all_objects)
 
     def add(self, *objs):
         """
@@ -694,7 +698,7 @@ class Network(Nameable):
         VariableOwner.get_states
         '''
         states = dict()
-        for obj in self.objects:
+        for obj in self.sorted_objects:
             if hasattr(obj, 'get_states'):
                 states[obj.name] = obj.get_states(vars=None, units=units,
                                                   format=format,
@@ -731,7 +735,7 @@ class Network(Nameable):
                 raise KeyError(("Network does not include a network with "
                                 "name '%s'.") % obj_name)
             self[obj_name].set_states(obj_values, units=units, format=format,
-                                     level=level+1)
+                                      level=level+1)
 
 
     def _get_schedule(self):


### PR DESCRIPTION
As @bdevans noticed on the [Brian forum](https://brian.discourse.group/t/delays-as-variables/365/5), setting delays is not possible via `Network.set_states`, because the `SynapticPathway` is not included in the `Network` (it is a "contained object" of the `Synapses`). This has changed with  #1069, in order to avoid issues when `run_regularly` functions (another type of "contained objects") were created after an object had been added to the `Network`.
The fix is fairly simple: `Network.objects` still only contains the main objects, but in cases where we try to access objects from the `Network` object by treating it as a dictionary, we create a full list of objects on the fly (as we already do in a few other places). This indirectly also applies to the `get_states`/`set_states` mechanism.
Apparently this does not break anything, but potentially it should be documented a bit better...