### PR TITLE
Synapse generator expressions i='...'

### DIFF
--- a/brian2/codegen/runtime/numpy_rt/templates/synapses_create_generator.py_
+++ b/brian2/codegen/runtime/numpy_rt/templates/synapses_create_generator.py_
@@ -96,13 +96,18 @@ _cur_num_synapses = _old_num_synapses
 # scalar code
 _vectorisation_idx = 1
 {{scalar_code['setup_iterator']|autoindent}}
-{{scalar_code['create_j']|autoindent}}
+{{scalar_code['generator_expr']|autoindent}}
 {{scalar_code['create_cond']|autoindent}}
-{{scalar_code['update_post']|autoindent}}
+{{scalar_code['update']|autoindent}}
 
-for _i in range(N_pre):
-    _raw_pre_idx = _i + _source_offset
-    {% if not postsynaptic_condition %}
+{# For a connect call j='k+i for k in range(0, N_post, 2) if k+i < N_post'
+"j" is called the "target variable" (and "_post_idx" the "target array", etc.)
+"i" is called the "base variable" (and "_pre_idx" the "base array", etc.)
+"k" is called the iteration variable #}
+
+for _{{base_var}} in range({{base_var_size}}):
+    _raw{{base_array}} = _{{base_var}} + {{base_offset}}
+    {% if not target_condition %}
     {{vector_code['create_cond']|autoindent}}
     if not _cond:
         continue
@@ -119,76 +124,76 @@ for _i in range(N_pre):
     {% endif %}
 
     _vectorisation_idx = {{iteration_variable}}
-    {{vector_code['create_j']|autoindent}}
-    _vectorisation_idx = _j
-    _raw_post_idx = _j + _target_offset
-    {% if postsynaptic_condition %}
-    {% if postsynaptic_variable_used %}
+    {{vector_code['generator_expr']|autoindent}}
+    _vectorisation_idx = _{{target_var}}
+    _raw{{target_array}} = _{{target_var}} + {{target_offset}}
+    {% if target_condition %}
+    {% if target_variable_used %}
     {# The condition could index outside of array range #}
     {% if skip_if_invalid %}
-    if _numpy.isscalar(_j):
-        if _j<0 or _j>=N_post:
+    if _numpy.isscalar(_{{target_var}}):
+        if _{{target_var}}<0 or _{{target_var}}>={{target_var_size}}:
             continue
     else:
-        _in_range = _numpy.logical_and(_j>=0, _j<N_post)
-        _j = _j[_in_range]
+        _in_range = _numpy.logical_and(_{{target_var}}>=0, _{{target_var}}<{{target_var_size}})
+        _{{target_var}} = _{{target_var}}[_in_range]
     {% else %}
-    if _numpy.isscalar(_j):
-        _min_j = _max_j = _j
-    elif _j.shape == (0, ):
+    if _numpy.isscalar(_{{target_var}}):
+        _min_val = _max_val = _{{target_var}}
+    elif _{{target_var}}.shape == (0, ):
         continue
     else:
-        _min_j = _numpy.min(_j)
-        _max_j = _numpy.max(_j)
-    if _min_j < 0:
-        raise IndexError("index j=%d outside allowed range from 0 to %d, and the condition refers to a post-synaptic variable" % (_min_j, N_post-1))
-    elif _max_j >= N_post:
-        raise IndexError("index j=%d outside allowed range from 0 to %d, and the condition refers to a post-synaptic variable" % (_max_j, N_post-1))
+        _min_val = _numpy.min(_{{target_var}})
+        _max_val = _numpy.max(_{{target_var}})
+    if _min_val < 0:
+        raise IndexError("index {{target_var}}=%d outside allowed range from 0 to %d, and the condition refers to a post-synaptic variable" % (_min_val, {{target_var_size}}-1))
+    elif _max_val >= {{target_var_size}}:
+        raise IndexError("index {{target_var}}=%d outside allowed range from 0 to %d, and the condition refers to a post-synaptic variable" % (_max_val, {{target_var_size}}-1))
     {% endif %}
     {% endif %}
     {{vector_code['create_cond']|autoindent}}
     {% endif %}
-    {% if if_expression!='True' and postsynaptic_condition %}
-    _j, _cond = _numpy.broadcast_arrays(_j, _cond)
-    _j = _j[_cond]
+    {% if if_expression!='True' and target_condition %}
+    _{{target_var}}, _cond = _numpy.broadcast_arrays(_{{target_var}}, _cond)
+    _{{target_var}} = _{{target_var}}[_cond]
     {% else %}
-    _j, {{iteration_variable}} = _numpy.broadcast_arrays(_j, {{iteration_variable}})
+    _{{target_var}}, {{iteration_variable}} = _numpy.broadcast_arrays(_{{target_var}}, {{iteration_variable}})
     {% endif %}
 
     {% if skip_if_invalid %}
-    if _numpy.isscalar(_j):
-        if _j<0 or _j>=N_post:
+    if _numpy.isscalar(_{{target_var}}):
+        if _{{target_var}}<0 or _{{target_var}}>={{target_var_size}}:
             continue
     else:
-        _in_range = _numpy.logical_and(_j>=0, _j<N_post)
-        _j = _j[_in_range]
-    {% elif not postsynaptic_variable_used %}
+        _in_range = _numpy.logical_and(_{{target_var}}>=0, _{{target_var}}<{{target_var_size}})
+        _{{target_var}} = _{{target_var}}[_in_range]
+    {% elif not target_variable_used %}
     {# Otherwise, we already checked before #}
-    if _numpy.isscalar(_j):
-        _min_j = _max_j = _j
-    elif _j.shape == (0, ):
+    if _numpy.isscalar(_{{target_var}}):
+        _min_val = _max_val = _{{target_var}}
+    elif _{{target_var}}.shape == (0, ):
         continue
     else:
-        _min_j = _numpy.min(_j)
-        _max_j = _numpy.max(_j)
-    if _min_j < 0:
-        raise IndexError("index j=%d outside allowed range from 0 to %d" % (_min_j, N_post-1))
-    elif _max_j >= N_post:
-        raise IndexError("index j=%d outside allowed range from 0 to %d" % (_max_j, N_post-1))
+        _min_val = _numpy.min(_{{target_var}})
+        _max_val = _numpy.max(_{{target_var}})
+    if _min_val < 0:
+        raise IndexError("index _{{target_var}}=%d outside allowed range from 0 to %d" % (_min_val, {{target_var_size}}-1))
+    elif _max_val >= {{target_var_size}}:
+        raise IndexError("index _{{target_var}}=%d outside allowed range from 0 to %d" % (_max_val, {{target_var_size}}-1))
     {% endif %}
 
-    _vectorisation_idx = _j
-    _raw_post_idx = _j + _target_offset
-    {{vector_code['update_post']|autoindent}}
+    _vectorisation_idx = _{{target_var}}
+    _raw{{target_array}} = _{{target_var}} + {{target_offset}}
+    {{vector_code['update']|autoindent}}
 
     if not _numpy.isscalar(_n):
-        # The "n" expression involved j
-        _post_idx = _post_idx.repeat(_n[_j])
+        # The "n" expression involved the target variable
+        {{target_array}} = {{target_array}}.repeat(_n[_j])
     elif _n != 1:
-        # We have a j-independent number
-        _post_idx = _post_idx.repeat(_n)
+        # We have a target-independent number
+        {{target_array}} = {{target_array}}.repeat(_n)
+    _numnew = len({{target_array}})
 
-    _numnew = len(_post_idx)
     _new_num_synapses = _cur_num_synapses + _numnew
     {{_dynamic__synaptic_pre}}.resize(_new_num_synapses)
     {{_dynamic__synaptic_post}}.resize(_new_num_synapses)

--- a/brian2/codegen/runtime/numpy_rt/templates/synapses_create_generator.py_
+++ b/brian2/codegen/runtime/numpy_rt/templates/synapses_create_generator.py_
@@ -101,98 +101,98 @@ _vectorisation_idx = 1
 {{scalar_code['update']|autoindent}}
 
 {# For a connect call j='k+i for k in range(0, N_post, 2) if k+i < N_post'
-"j" is called the "target variable" (and "_post_idx" the "target array", etc.)
-"i" is called the "base variable" (and "_pre_idx" the "base array", etc.)
-"k" is called the iteration variable #}
+"j" is called the "result index" (and "_post_idx" the "result index array", etc.)
+"i" is called the "outer index" (and "_pre_idx" the "outer index array", etc.)
+"k" is called the inner variable #}
 
-for _{{base_var}} in range({{base_var_size}}):
-    _raw{{base_array}} = _{{base_var}} + {{base_offset}}
-    {% if not target_condition %}
+for _{{outer_index}} in range({{outer_index_size}}):
+    _raw{{outer_index_array}} = _{{outer_index}} + {{outer_index_offset}}
+    {% if not result_index_condition %}
     {{vector_code['create_cond']|autoindent}}
     if not _cond:
         continue
     {% endif %}
     {{vector_code['setup_iterator']|autoindent}}
     {% if iterator_func=='range' %}
-    {{iteration_variable}} = _numpy.arange(_iter_low, _iter_high, _iter_step)
+    {{inner_variable}} = _numpy.arange(_iter_low, _iter_high, _iter_step)
     {% elif iterator_func=='sample' %}
     {% if iterator_kwds['sample_size'] == 'fixed' %}
-    {{iteration_variable}} = _sample_without_replacement(_iter_low, _iter_high, _iter_step, None, size=_iter_size)
+    {{inner_variable}} = _sample_without_replacement(_iter_low, _iter_high, _iter_step, None, size=_iter_size)
     {% else %}
-    {{iteration_variable}} = _sample_without_replacement(_iter_low, _iter_high, _iter_step, _iter_p)
+    {{inner_variable}} = _sample_without_replacement(_iter_low, _iter_high, _iter_step, _iter_p)
     {% endif %}
     {% endif %}
 
-    _vectorisation_idx = {{iteration_variable}}
+    _vectorisation_idx = {{inner_variable}}
     {{vector_code['generator_expr']|autoindent}}
-    _vectorisation_idx = _{{target_var}}
-    _raw{{target_array}} = _{{target_var}} + {{target_offset}}
-    {% if target_condition %}
-    {% if target_variable_used %}
+    _vectorisation_idx = _{{result_index}}
+    _raw{{result_index_array}} = _{{result_index}} + {{result_index_offset}}
+    {% if result_index_condition %}
+    {% if result_index_used %}
     {# The condition could index outside of array range #}
     {% if skip_if_invalid %}
-    if _numpy.isscalar(_{{target_var}}):
-        if _{{target_var}}<0 or _{{target_var}}>={{target_var_size}}:
+    if _numpy.isscalar(_{{result_index}}):
+        if _{{result_index}}<0 or _{{result_index}}>={{result_index_size}}:
             continue
     else:
-        _in_range = _numpy.logical_and(_{{target_var}}>=0, _{{target_var}}<{{target_var_size}})
-        _{{target_var}} = _{{target_var}}[_in_range]
+        _in_range = _numpy.logical_and(_{{result_index}}>=0, _{{result_index}}<{{result_index_size}})
+        _{{result_index}} = _{{result_index}}[_in_range]
     {% else %}
-    if _numpy.isscalar(_{{target_var}}):
-        _min_val = _max_val = _{{target_var}}
-    elif _{{target_var}}.shape == (0, ):
+    if _numpy.isscalar(_{{result_index}}):
+        _min_val = _max_val = _{{result_index}}
+    elif _{{result_index}}.shape == (0, ):
         continue
     else:
-        _min_val = _numpy.min(_{{target_var}})
-        _max_val = _numpy.max(_{{target_var}})
+        _min_val = _numpy.min(_{{result_index}})
+        _max_val = _numpy.max(_{{result_index}})
     if _min_val < 0:
-        raise IndexError("index {{target_var}}=%d outside allowed range from 0 to %d, and the condition refers to a post-synaptic variable" % (_min_val, {{target_var_size}}-1))
-    elif _max_val >= {{target_var_size}}:
-        raise IndexError("index {{target_var}}=%d outside allowed range from 0 to %d, and the condition refers to a post-synaptic variable" % (_max_val, {{target_var_size}}-1))
+        raise IndexError("index {{result_index}}=%d outside allowed range from 0 to %d, and the condition refers to a post-synaptic variable" % (_min_val, {{result_index_size}}-1))
+    elif _max_val >= {{result_index_size}}:
+        raise IndexError("index {{result_index}}=%d outside allowed range from 0 to %d, and the condition refers to a post-synaptic variable" % (_max_val, {{result_index_size}}-1))
     {% endif %}
     {% endif %}
     {{vector_code['create_cond']|autoindent}}
     {% endif %}
-    {% if if_expression!='True' and target_condition %}
-    _{{target_var}}, _cond = _numpy.broadcast_arrays(_{{target_var}}, _cond)
-    _{{target_var}} = _{{target_var}}[_cond]
+    {% if if_expression!='True' and result_index_condition %}
+    _{{result_index}}, _cond = _numpy.broadcast_arrays(_{{result_index}}, _cond)
+    _{{result_index}} = _{{result_index}}[_cond]
     {% else %}
-    _{{target_var}}, {{iteration_variable}} = _numpy.broadcast_arrays(_{{target_var}}, {{iteration_variable}})
+    _{{result_index}}, {{inner_variable}} = _numpy.broadcast_arrays(_{{result_index}}, {{inner_variable}})
     {% endif %}
 
     {% if skip_if_invalid %}
-    if _numpy.isscalar(_{{target_var}}):
-        if _{{target_var}}<0 or _{{target_var}}>={{target_var_size}}:
+    if _numpy.isscalar(_{{result_index}}):
+        if _{{result_index}}<0 or _{{result_index}}>={{result_index_size}}:
             continue
     else:
-        _in_range = _numpy.logical_and(_{{target_var}}>=0, _{{target_var}}<{{target_var_size}})
-        _{{target_var}} = _{{target_var}}[_in_range]
-    {% elif not target_variable_used %}
+        _in_range = _numpy.logical_and(_{{result_index}}>=0, _{{result_index}}<{{result_index_size}})
+        _{{result_index}} = _{{result_index}}[_in_range]
+    {% elif not result_index_used %}
     {# Otherwise, we already checked before #}
-    if _numpy.isscalar(_{{target_var}}):
-        _min_val = _max_val = _{{target_var}}
-    elif _{{target_var}}.shape == (0, ):
+    if _numpy.isscalar(_{{result_index}}):
+        _min_val = _max_val = _{{result_index}}
+    elif _{{result_index}}.shape == (0, ):
         continue
     else:
-        _min_val = _numpy.min(_{{target_var}})
-        _max_val = _numpy.max(_{{target_var}})
+        _min_val = _numpy.min(_{{result_index}})
+        _max_val = _numpy.max(_{{result_index}})
     if _min_val < 0:
-        raise IndexError("index _{{target_var}}=%d outside allowed range from 0 to %d" % (_min_val, {{target_var_size}}-1))
-    elif _max_val >= {{target_var_size}}:
-        raise IndexError("index _{{target_var}}=%d outside allowed range from 0 to %d" % (_max_val, {{target_var_size}}-1))
+        raise IndexError("index _{{result_index}}=%d outside allowed range from 0 to %d" % (_min_val, {{result_index_size}}-1))
+    elif _max_val >= {{result_index_size}}:
+        raise IndexError("index _{{result_index}}=%d outside allowed range from 0 to %d" % (_max_val, {{result_index_size}}-1))
     {% endif %}
 
-    _vectorisation_idx = _{{target_var}}
-    _raw{{target_array}} = _{{target_var}} + {{target_offset}}
+    _vectorisation_idx = _{{result_index}}
+    _raw{{result_index_array}} = _{{result_index}} + {{result_index_offset}}
     {{vector_code['update']|autoindent}}
 
     if not _numpy.isscalar(_n):
         # The "n" expression involved the target variable
-        {{target_array}} = {{target_array}}.repeat(_n[_j])
+        {{result_index_array}} = {{result_index_array}}.repeat(_n[_j])
     elif _n != 1:
         # We have a target-independent number
-        {{target_array}} = {{target_array}}.repeat(_n)
-    _numnew = len({{target_array}})
+        {{result_index_array}} = {{result_index_array}}.repeat(_n)
+    _numnew = len({{result_index_array}})
 
     _new_num_synapses = _cur_num_synapses + _numnew
     {{_dynamic__synaptic_pre}}.resize(_new_num_synapses)

--- a/brian2/synapses/parse_synaptic_generator_syntax.py
+++ b/brian2/synapses/parse_synaptic_generator_syntax.py
@@ -86,11 +86,11 @@ def parse_synapse_generator(expr):
 
     The general form is:
 
-    ``element for iteration_variable in iterator_func(...)``
+    ``element for inner_variable in iterator_func(...)``
 
     or
 
-    ``element for iteration_variable in iterator_func(...) if if_expression``
+    ``element for inner_variable in iterator_func(...) if if_expression``
 
     Returns a dictionary with keys:
 
@@ -98,7 +98,7 @@ def parse_synapse_generator(expr):
         The original expression as a string.
     ``element``
         As above, a string expression.
-    ``iteration_variable``
+    ``inner_variable``
         A variable name, as above.
     ``iterator_func``
         String. Either ``range`` or ``sample``.
@@ -128,7 +128,7 @@ def parse_synapse_generator(expr):
     if _cname(target) != 'Name':
         raise SyntaxError(parse_error + " Generator must iterate over a single "
                                         "variable (not tuple, etc.).")
-    iteration_variable = target.id
+    inner_variable = target.id
     iterator = generator.iter
     if _cname(iterator) != 'Call' or _cname(iterator.func) !=  'Name':
         raise SyntaxError(parse_error + " Iterator expression must be one of "
@@ -163,7 +163,7 @@ def parse_synapse_generator(expr):
     parsed = {
         'original_expression': expr,
         'element': nr.render_node(element),
-        'iteration_variable': iteration_variable,
+        'inner_variable': inner_variable,
         'iterator_func': iterator_funcname,
         'iterator_kwds': iterator_kwds,
         'if_expression': nr.render_node(condition),

--- a/brian2/tests/test_subgroup.py
+++ b/brian2/tests/test_subgroup.py
@@ -156,13 +156,13 @@ def test_shared_variable():
 
 @pytest.mark.standalone_compatible
 def test_synapse_creation():
-    G1 = NeuronGroup(10, '', threshold='False')
-    G2 = NeuronGroup(20, '', threshold='False')
+    G1 = NeuronGroup(10, '')
+    G2 = NeuronGroup(20, '')
     SG1 = G1[:5]
     SG2 = G2[10:]
-    S = Synapses(SG1, SG2, 'w:1')
+    S = Synapses(SG1, SG2)
     S.connect(i=2, j=2)  # Should correspond to (2, 12)
-    S.connect('i==2 and j==5') # Should correspond to (2, 15)
+    S.connect('i==2 and j==5')  # Should correspond to (2, 15)
 
     run(0*ms)  # for standalone
 
@@ -177,26 +177,27 @@ def test_synapse_creation():
     assert all(S.N_incoming[:, 2] == 1)
     assert all(S.N_incoming[:, 5] == 1)
 
+
 @pytest.mark.standalone_compatible
 def test_synapse_creation_state_vars():
-    G1 = NeuronGroup(10, 'v : 1', threshold='False')
-    G2 = NeuronGroup(20, 'v : 1', threshold='False')
+    G1 = NeuronGroup(10, 'v : 1')
+    G2 = NeuronGroup(20, 'v : 1')
     G1.v = 'i'
     G2.v = '10 + i'
     SG1 = G1[:5]
     SG2 = G2[10:]
 
     # connect based on pre-/postsynaptic state variables
-    S2 = Synapses(SG1, SG2, 'w:1', on_pre='v+=w')
+    S2 = Synapses(SG1, SG2, 'w:1')
     S2.connect('v_pre > 2')
 
-    S3 = Synapses(SG1, SG2, 'w:1', on_pre='v+=w')
+    S3 = Synapses(SG1, SG2, 'w:1')
     S3.connect('v_post < 25')
 
-    S4 = Synapses(SG2, SG1, 'w:1', on_pre='v+=w')
+    S4 = Synapses(SG2, SG1, 'w:1')
     S4.connect('v_post > 2')
 
-    S5 = Synapses(SG2, SG1, 'w:1', on_pre='v+=w')
+    S5 = Synapses(SG2, SG1, 'w:1')
     S5.connect('v_pre < 25')
 
     run(0*ms)  # for standalone
@@ -214,26 +215,26 @@ def test_synapse_creation_state_vars():
 
 @pytest.mark.standalone_compatible
 def test_synapse_creation_generator():
-    G1 = NeuronGroup(10, 'v:1', threshold='False')
-    G2 = NeuronGroup(20, 'v:1', threshold='False')
+    G1 = NeuronGroup(10, 'v:1')
+    G2 = NeuronGroup(20, 'v:1')
     G1.v = 'i'
     G2.v = '10 + i'
     SG1 = G1[:5]
     SG2 = G2[10:]
-    S = Synapses(SG1, SG2, 'w:1', on_pre='v+=w')
+    S = Synapses(SG1, SG2, 'w:1')
     S.connect(j='i*2 + k for k in range(2)')  # diverging connections
 
     # connect based on pre-/postsynaptic state variables
-    S2 = Synapses(SG1, SG2, 'w:1', on_pre='v+=w')
+    S2 = Synapses(SG1, SG2, 'w:1')
     S2.connect(j='k for k in range(N_post) if v_pre > 2')
 
-    S3 = Synapses(SG1, SG2, 'w:1', on_pre='v+=w')
+    S3 = Synapses(SG1, SG2, 'w:1')
     S3.connect(j='k for k in range(N_post) if v_post < 25')
 
-    S4 = Synapses(SG2, SG1, 'w:1', on_pre='v+=w')
+    S4 = Synapses(SG2, SG1, 'w:1')
     S4.connect(j='k for k in range(N_post) if v_post > 2')
 
-    S5 = Synapses(SG2, SG1, 'w:1', on_pre='v+=w')
+    S5 = Synapses(SG2, SG1, 'w:1')
     S5.connect(j='k for k in range(N_post) if v_pre < 25')
 
     run(0*ms)  # for standalone
@@ -262,40 +263,40 @@ def test_synapse_creation_generator():
 
 @pytest.mark.standalone_compatible
 def test_synapse_creation_generator_multiple_synapses():
-    G1 = NeuronGroup(10, 'v:1', threshold='False')
-    G2 = NeuronGroup(20, 'v:1', threshold='False')
+    G1 = NeuronGroup(10, 'v:1')
+    G2 = NeuronGroup(20, 'v:1')
     G1.v = 'i'
     G2.v = '10 + i'
     SG1 = G1[:5]
     SG2 = G2[10:]
-    S1 = Synapses(SG1, SG2, 'w:1', on_pre='v+=w')
+    S1 = Synapses(SG1, SG2)
     S1.connect(j='k for k in range(N_post)', n='i')
 
-    S2 = Synapses(SG1, SG2, 'w:1', on_pre='v+=w')
+    S2 = Synapses(SG1, SG2)
     S2.connect(j='k for k in range(N_post)', n='j')
 
-    S3 = Synapses(SG2, SG1, 'w:1', on_pre='v+=w')
+    S3 = Synapses(SG2, SG1)
     S3.connect(j='k for k in range(N_post)', n='i')
 
-    S4 = Synapses(SG2, SG1, 'w:1', on_pre='v+=w')
+    S4 = Synapses(SG2, SG1)
     S4.connect(j='k for k in range(N_post)', n='j')
 
-    S5 = Synapses(SG1, SG2, 'w:1', on_pre='v+=w')
+    S5 = Synapses(SG1, SG2)
     S5.connect(j='k for k in range(N_post)', n='i+j')
 
-    S6 = Synapses(SG2, SG1, 'w:1', on_pre='v+=w')
+    S6 = Synapses(SG2, SG1)
     S6.connect(j='k for k in range(N_post)', n='i+j')
 
-    S7 = Synapses(SG1, SG2, 'w:1', on_pre='v+=w')
+    S7 = Synapses(SG1, SG2)
     S7.connect(j='k for k in range(N_post)', n='int(v_pre>2)*2')
 
-    S8 = Synapses(SG2, SG1, 'w:1', on_pre='v+=w')
+    S8 = Synapses(SG2, SG1)
     S8.connect(j='k for k in range(N_post)', n='int(v_post>2)*2')
 
-    S9 = Synapses(SG1, SG2, 'w:1', on_pre='v+=w')
+    S9 = Synapses(SG1, SG2)
     S9.connect(j='k for k in range(N_post)', n='int(v_post>22)*2')
 
-    S10 = Synapses(SG2, SG1, 'w:1', on_pre='v+=w')
+    S10 = Synapses(SG2, SG1)
     S10.connect(j='k for k in range(N_post)', n='int(v_pre>22)*2')
 
     run(0*ms)  # for standalone
@@ -320,21 +321,21 @@ def test_synapse_creation_generator_multiple_synapses():
 
 @pytest.mark.standalone_compatible
 def test_synapse_creation_generator_complex_ranges():
-    G1 = NeuronGroup(10, 'v:1', threshold='False')
-    G2 = NeuronGroup(20, 'v:1', threshold='False')
+    G1 = NeuronGroup(10, 'v:1')
+    G2 = NeuronGroup(20, 'v:1')
     G1.v = 'i'
     G2.v = '10 + i'
     SG1 = G1[:5]
     SG2 = G2[10:]
-    S = Synapses(SG1, SG2, 'w:1', on_pre='v+=w')
+    S = Synapses(SG1, SG2)
     S.connect(j='i+k for k in range(N_post-i)')  # Connect to all j>i
 
     # connect based on pre-/postsynaptic state variables
-    S2 = Synapses(SG1, SG2, 'w:1', on_pre='v+=w')
+    S2 = Synapses(SG1, SG2)
     S2.connect(j='k for k in range(N_post * int(v_pre > 2))')
 
     # connect based on pre-/postsynaptic state variables
-    S3 = Synapses(SG2, SG1, 'w:1', on_pre='v+=w')
+    S3 = Synapses(SG2, SG1)
     S3.connect(j='k for k in range(N_post * int(v_pre > 22))')
 
     run(0*ms)  # for standalone
@@ -354,18 +355,18 @@ def test_synapse_creation_generator_complex_ranges():
 
 @pytest.mark.standalone_compatible
 def test_synapse_creation_generator_random():
-    G1 = NeuronGroup(10, 'v:1', threshold='False')
-    G2 = NeuronGroup(20, 'v:1', threshold='False')
+    G1 = NeuronGroup(10, 'v:1')
+    G2 = NeuronGroup(20, 'v:1')
     G1.v = 'i'
     G2.v = '10 + i'
     SG1 = G1[:5]
     SG2 = G2[10:]
 
     # connect based on pre-/postsynaptic state variables
-    S2 = Synapses(SG1, SG2, 'w:1', on_pre='v+=w')
+    S2 = Synapses(SG1, SG2)
     S2.connect(j='k for k in sample(N_post, p=1.0*int(v_pre > 2))')
 
-    S3 = Synapses(SG2, SG1, 'w:1', on_pre='v+=w')
+    S3 = Synapses(SG2, SG1)
     S3.connect(j='k for k in sample(N_post, p=1.0*int(v_pre > 22))')
 
     run(0*ms)  # for standalone
@@ -377,13 +378,13 @@ def test_synapse_creation_generator_random():
 
 
 def test_synapse_access():
-    G1 = NeuronGroup(10, 'v:1', threshold='False')
+    G1 = NeuronGroup(10, 'v:1')
     G1.v = 'i'
-    G2 = NeuronGroup(20, 'v:1', threshold='False')
+    G2 = NeuronGroup(20, 'v:1')
     G2.v = 'i'
     SG1 = G1[:5]
     SG2 = G2[10:]
-    S = Synapses(SG1, SG2, 'w:1', on_pre='v+=w')
+    S = Synapses(SG1, SG2, 'w:1')
     S.connect(True)
     S.w['j == 0'] = 5
     assert all(S.w['j==0'] == 5)
@@ -466,6 +467,7 @@ def test_synapses_access_subgroups_problematic():
             assert len(l) == n_warnings, 'expected %d, got %d warnings' % (n_warnings, len(l))
             assert all([entry[1].endswith('ambiguous_string_expression')
                         for entry in l])
+
 
 @pytest.mark.standalone_compatible
 def test_subgroup_summed_variable():

--- a/brian2/tests/test_synapses.py
+++ b/brian2/tests/test_synapses.py
@@ -2670,7 +2670,6 @@ def test_synapse_generator_fixed_random_negative_steps():
 
 @pytest.mark.standalone_compatible
 def test_synapse_generator_fixed_random_error1():
-    set_device('cpp_standalone')
     G = NeuronGroup(5, '')
     G2 = NeuronGroup(7, '')
     S = Synapses(G, G2)

--- a/brian2/tests/test_synapses.py
+++ b/brian2/tests/test_synapses.py
@@ -397,7 +397,7 @@ def test_connection_random_with_condition():
 @pytest.mark.standalone_compatible
 @pytest.mark.long
 def test_connection_random_with_condition_2():
-    G = NeuronGroup(4)
+    G = NeuronGroup(4, '')
 
     # Just checking that everything works in principle (we can't check the
     # actual connections)
@@ -2404,8 +2404,8 @@ def test_synapse_generator_deterministic_over_postsynaptic():
 def test_synapse_generator_deterministic_2():
     # Same as "test_connection_string_deterministic" but using the generator
     # syntax
-    G = NeuronGroup(16)
-    G2 = NeuronGroup(4)
+    G = NeuronGroup(16, '')
+    G2 = NeuronGroup(4, '')
     # A few more tests of deterministic connections where the generator syntax
     # is particularly useful
 

--- a/brian2/tests/test_synapses.py
+++ b/brian2/tests/test_synapses.py
@@ -141,6 +141,7 @@ def test_name_clashes():
     Synapses(G1, G2, 'a_syn : 1')
     Synapses(G1, G2, 'b_syn : 1')
 
+
 @pytest.mark.standalone_compatible
 def test_incoming_outgoing():
     '''
@@ -148,9 +149,9 @@ def test_incoming_outgoing():
     (It will be also automatically tested for all connection patterns that
     use the above _compare function for testing)
     '''
-    G1 = NeuronGroup(5, 'v: 1', threshold='False')
-    G2 = NeuronGroup(5, 'v: 1', threshold='False')
-    S = Synapses(G1, G2, 'w:1', on_pre='v+=w')
+    G1 = NeuronGroup(5, '')
+    G2 = NeuronGroup(5, '')
+    S = Synapses(G1, G2, '')
     S.connect(i=[0, 0, 0, 1, 1, 2],
               j=[0, 1, 2, 1, 2, 3])
     run(0*ms)  # to make this work for standalone
@@ -174,8 +175,8 @@ def test_connection_arrays():
     '''
     Test connecting synapses with explictly given arrays
     '''
-    G = NeuronGroup(42, 'v : 1')
-    G2 = NeuronGroup(17, 'v : 1')
+    G = NeuronGroup(42, '')
+    G2 = NeuronGroup(17, '')
 
     # one-to-one
     expected1 = np.eye(len(G2))
@@ -232,20 +233,19 @@ def test_connection_arrays():
     with pytest.raises(TypeError):
         S.connect(object())
 
+
 @pytest.mark.standalone_compatible
 def test_connection_string_deterministic_full():
-    G = NeuronGroup(17, 'v : 1', threshold='False')
-    G.v = 'i'
-    G2 = NeuronGroup(4, 'v : 1', threshold='False')
-    G2.v = '17 + i'
+    G = NeuronGroup(17, '')
+    G2 = NeuronGroup(4, '')
 
     # Full connection
     expected_full = np.ones((len(G), len(G2)))
 
-    S1 = Synapses(G, G2, 'w:1', 'v+=w')
+    S1 = Synapses(G, G2, '')
     S1.connect(True)
 
-    S2 = Synapses(G, G2, 'w:1', 'v+=w')
+    S2 = Synapses(G, G2, '')
     S2.connect('True')
 
     run(0 * ms)  # for standalone
@@ -253,23 +253,24 @@ def test_connection_string_deterministic_full():
     _compare(S1, expected_full)
     _compare(S2, expected_full)
 
+
 @pytest.mark.standalone_compatible
 def test_connection_string_deterministic_full_no_self():
-    G = NeuronGroup(17, 'v : 1', threshold='False')
+    G = NeuronGroup(17, 'v : 1')
     G.v = 'i'
-    G2 = NeuronGroup(4, 'v : 1', threshold='False')
+    G2 = NeuronGroup(4, 'v : 1')
     G2.v = '17 + i'
 
     # Full connection without self-connections
     expected_no_self = np.ones((len(G), len(G))) - np.eye(len(G))
 
-    S1 = Synapses(G, G, 'w:1', 'v+=w')
+    S1 = Synapses(G, G)
     S1.connect('i != j')
 
-    S2 = Synapses(G, G, 'w:1', 'v+=w')
+    S2 = Synapses(G, G)
     S2.connect('v_pre != v_post')
 
-    S3 = Synapses(G, G, 'w:1', 'v+=w')
+    S3 = Synapses(G, G)
     S3.connect(condition='i != j')
 
     run(0*ms)  # for standalone
@@ -278,29 +279,30 @@ def test_connection_string_deterministic_full_no_self():
     _compare(S2, expected_no_self)
     _compare(S3, expected_no_self)
 
+
 @pytest.mark.standalone_compatible
 def test_connection_string_deterministic_full_one_to_one():
-    G = NeuronGroup(17, 'v : 1', threshold='False')
+    G = NeuronGroup(17, 'v : 1')
     G.v = 'i'
-    G2 = NeuronGroup(4, 'v : 1', threshold='False')
+    G2 = NeuronGroup(4, 'v : 1')
     G2.v = '17 + i'
 
     # One-to-one connectivity
     expected_one_to_one = np.eye(len(G))
 
-    S1 = Synapses(G, G, 'w:1', 'v+=w')
+    S1 = Synapses(G, G)
     S1.connect('i == j')
 
-    S2 = Synapses(G, G, 'w:1', 'v+=w')
+    S2 = Synapses(G, G)
     S2.connect('v_pre == v_post')
 
     S3 = Synapses(G, G, '''
                          sub_1 = v_pre : 1
                          sub_2 = v_post : 1
-                         w:1''', 'v+=w')
+                         w:1''')
     S3.connect('sub_1 == sub_2')
 
-    S4 = Synapses(G, G, 'w:1', 'v+=w')
+    S4 = Synapses(G, G)
     S4.connect(j='i')
 
     run(0*ms)  # for standalone
@@ -310,20 +312,21 @@ def test_connection_string_deterministic_full_one_to_one():
     _compare(S3, expected_one_to_one)
     _compare(S4, expected_one_to_one)
 
+
 @pytest.mark.standalone_compatible
 def test_connection_string_deterministic_full_custom():
-    G = NeuronGroup(17, 'v : 1', threshold='False')
-    G2 = NeuronGroup(4, 'v : 1', threshold='False')
+    G = NeuronGroup(17, '')
+    G2 = NeuronGroup(4, '')
     # Everything except for the upper [2, 2] quadrant
     number = 2
     expected_custom = np.ones((len(G), len(G)))
     expected_custom[:number, :number] = 0
-    S1 = Synapses(G, G, 'w:1', 'v+=w')
+    S1 = Synapses(G, G)
     S1.connect('(i >= number) or (j >= number)')
 
-    S2 = Synapses(G, G, 'w:1', 'v+=w')
+    S2 = Synapses(G, G)
     S2.connect('(i >= explicit_number) or (j >= explicit_number)',
-                namespace={'explicit_number': number})
+               namespace={'explicit_number': number})
 
     # check that this mistaken syntax raises an error
     with pytest.raises(ValueError):
@@ -340,6 +343,7 @@ def test_connection_string_deterministic_full_custom():
     _compare(S1, expected_custom)
     _compare(S2, expected_custom)
 
+
 @pytest.mark.standalone_compatible
 def test_connection_string_deterministic_multiple_and():
     # In Brian versions 2.1.0-2.1.2, this fails on the numpy target
@@ -353,27 +357,27 @@ def test_connection_string_deterministic_multiple_and():
 
 @pytest.mark.standalone_compatible
 def test_connection_random_with_condition():
-    G = NeuronGroup(4, 'v: 1', threshold='False')
+    G = NeuronGroup(4, '')
 
-    S1 = Synapses(G, G, 'w:1', 'v+=w')
+    S1 = Synapses(G, G)
     S1.connect('i!=j', p=0.0)
 
-    S2 = Synapses(G, G, 'w:1', 'v+=w')
+    S2 = Synapses(G, G)
     S2.connect('i!=j', p=1.0)
     expected2 = np.ones((len(G), len(G))) - np.eye(len(G))
 
-    S3 = Synapses(G, G, 'w:1', 'v+=w')
+    S3 = Synapses(G, G)
     S3.connect('i>=2', p=0.0)
 
-    S4 = Synapses(G, G, 'w:1', 'v+=w')
+    S4 = Synapses(G, G)
     S4.connect('i>=2', p=1.0)
     expected4 = np.zeros((len(G), len(G)))
     expected4[2, :] = 1
     expected4[3, :] = 1
 
-    S5 = Synapses(G, G, 'w:1', 'v+=w')
+    S5 = Synapses(G, G)
     S5.connect('j<2', p=0.0)
-    S6 = Synapses(G, G, 'w:1', 'v+=w')
+    S6 = Synapses(G, G)
     S6.connect('j<2', p=1.0)
     expected6 = np.zeros((len(G), len(G)))
     expected6[:, 0] = 1
@@ -389,55 +393,55 @@ def test_connection_random_with_condition():
     assert len(S5) == 0
     _compare(S6, expected6)
 
+
 @pytest.mark.standalone_compatible
 @pytest.mark.long
 def test_connection_random_with_condition_2():
-    G = NeuronGroup(4, 'v: 1', threshold='False')
+    G = NeuronGroup(4)
 
     # Just checking that everything works in principle (we can't check the
     # actual connections)
-    S7 = Synapses(G, G, 'w:1', 'v+=w')
+    S7 = Synapses(G, G)
     S7.connect('i!=j', p=0.01)
 
-    S8 = Synapses(G, G, 'w:1', 'v+=w')
+    S8 = Synapses(G, G)
     S8.connect('i!=j', p=0.03)
 
-    S9 = Synapses(G, G, 'w:1', 'v+=w')
+    S9 = Synapses(G, G)
     S9.connect('i!=j', p=0.3)
 
-    S10 = Synapses(G, G, 'w:1', 'v+=w')
+    S10 = Synapses(G, G)
     S10.connect('i>=2', p=0.01)
 
-    S11 = Synapses(G, G, 'w:1', 'v+=w')
+    S11 = Synapses(G, G)
     S11.connect('i>=2', p=0.03)
 
-    S12 = Synapses(G, G, 'w:1', 'v+=w')
+    S12 = Synapses(G, G)
     S12.connect('i>=2', p=0.3)
 
-    S13 = Synapses(G, G, 'w:1', 'v+=w')
+    S13 = Synapses(G, G)
     S13.connect('j>=2', p=0.01)
 
-    S14 = Synapses(G, G, 'w:1', 'v+=w')
+    S14 = Synapses(G, G)
     S14.connect('j>=2', p=0.03)
 
-    S15 = Synapses(G, G, 'w:1', 'v+=w')
+    S15 = Synapses(G, G)
     S15.connect('j>=2', p=0.3)
 
-    S16 = Synapses(G, G, 'w:1', 'v+=w')
+    S16 = Synapses(G, G)
     S16.connect('i!=j', p='i*0.1')
 
-    S17 = Synapses(G, G, 'w:1', 'v+=w')
+    S17 = Synapses(G, G)
     S17.connect('i!=j', p='j*0.1')
 
     # Forces the use of the "jump algorithm"
-    big_group = NeuronGroup(10000, 'v: 1', threshold='False')
-    S18 = Synapses(big_group, big_group, 'w:1', 'v+=w')
+    big_group = NeuronGroup(10000, '')
+    S18 = Synapses(big_group, big_group)
     S18.connect('i != j', p=0.001)
 
     # See github issue #835 -- this failed when using numpy
-    S19 = Synapses(big_group, big_group, 'w:1', 'v+=w')
+    S19 = Synapses(big_group, big_group)
     S19.connect('i < int(N_post*0.5)', p=0.001)
-
 
     with catch_logs() as _:  # Ignore warnings about empty synapses
         run(0*ms)  # for standalone
@@ -460,40 +464,40 @@ def test_connection_random_with_indices():
     '''
     Test random connections.
     '''
-    G = NeuronGroup(4, 'v: 1', threshold='False')
-    G2 = NeuronGroup(7, 'v: 1', threshold='False')
+    G = NeuronGroup(4, '')
+    G2 = NeuronGroup(7, '')
 
-    S1 = Synapses(G, G2, 'w:1', 'v+=w')
+    S1 = Synapses(G, G2)
     S1.connect(i=0, j=0, p=0.)
     expected1 = np.zeros((len(G), len(G2)))
 
-    S2 = Synapses(G, G2, 'w:1', 'v+=w')
+    S2 = Synapses(G, G2)
     S2.connect(i=0, j=0, p=1.)
     expected2 = np.zeros((len(G), len(G2)))
     expected2[0, 0] = 1
 
-    S3 = Synapses(G, G2, 'w:1', 'v+=w')
+    S3 = Synapses(G, G2)
     S3.connect(i=[0, 1], j=[0, 2], p=1.)
     expected3 = np.zeros((len(G), len(G2)))
     expected3[0, 0] = 1
     expected3[1, 2] = 1
 
     # Just checking that it works in principle
-    S4 = Synapses(G, G, 'w:1', 'v+=w')
+    S4 = Synapses(G, G)
     S4.connect(i=0, j=0, p=0.01)
-    S5 = Synapses(G, G, 'w:1', 'v+=w')
+    S5 = Synapses(G, G)
     S5.connect(i=[0, 1], j=[0, 2], p=0.01)
 
-    S6 = Synapses(G, G, 'w:1', 'v+=w')
+    S6 = Synapses(G, G)
     S6.connect(i=0, j=0, p=0.03)
 
-    S7 = Synapses(G, G, 'w:1', 'v+=w')
+    S7 = Synapses(G, G)
     S7.connect(i=[0, 1], j=[0, 2], p=0.03)
 
-    S8 = Synapses(G, G, 'w:1', 'v+=w')
+    S8 = Synapses(G, G)
     S8.connect(i=0, j=0, p=0.3)
 
-    S9 = Synapses(G, G, 'w:1', 'v+=w')
+    S9 = Synapses(G, G)
     S9.connect(i=[0, 1], j=[0, 2], p=0.3)
 
     with catch_logs() as _:  # Ignore warnings about empty synapses
@@ -509,33 +513,34 @@ def test_connection_random_with_indices():
     assert 0 <= len(S8) <= 1
     assert 0 <= len(S9) <= 2
 
+
 @pytest.mark.standalone_compatible
 def test_connection_random_without_condition():
     G = NeuronGroup(4, '''v: 1
-                          x : integer''', threshold='False')
+                          x : integer''')
     G.x = 'i'
     G2 = NeuronGroup(7, '''v: 1
-                           y : 1''', threshold='False')
+                           y : 1''')
     G2.y = '1.0*i/N'
 
-    S1 = Synapses(G, G2, 'w:1', 'v+=w')
+    S1 = Synapses(G, G2)
     S1.connect(True, p=0.0)
 
-    S2 = Synapses(G, G2, 'w:1', 'v+=w')
+    S2 = Synapses(G, G2)
     S2.connect(True, p=1.0)
 
     # Just make sure using values between 0 and 1 work in principle
-    S3 = Synapses(G, G2, 'w:1', 'v+=w')
+    S3 = Synapses(G, G2)
     S3.connect(True, p=0.3)
 
     # Use pre-/post-synaptic variables for "stochastic" connections that are
     # actually deterministic
-    S4 = Synapses(G, G2, 'w:1', on_pre='v+=w')
+    S4 = Synapses(G, G2)
     S4.connect(True, p='int(x_pre==2)*1.0')
 
     # Use pre-/post-synaptic variables for "stochastic" connections that are
     # actually deterministic
-    S5 = Synapses(G, G2, 'w:1', on_pre='v+=w')
+    S5 = Synapses(G, G2)
     S5.connect(True, p='int(x_pre==2 and y_post > 0.5)*1.0')
 
     with catch_logs() as _:  # Ignore warnings about empty synapses
@@ -557,27 +562,27 @@ def test_connection_multiple_synapses():
     '''
     Test multiple synapses per connection.
     '''
-    G = NeuronGroup(42, 'v: 1', threshold='False')
+    G = NeuronGroup(42, 'v: 1')
     G.v = 'i'
-    G2 = NeuronGroup(17, 'v: 1', threshold='False')
+    G2 = NeuronGroup(17, 'v: 1')
     G2.v = 'i'
 
-    S1 = Synapses(G, G2, 'w:1', 'v+=w')
+    S1 = Synapses(G, G2)
     S1.connect(True, n=0)
 
-    S2 = Synapses(G, G2, 'w:1', 'v+=w')
+    S2 = Synapses(G, G2)
     S2.connect(True, n=2)
 
-    S3 = Synapses(G, G2, 'w:1', 'v+=w')
+    S3 = Synapses(G, G2)
     S3.connect(True, n='j')
 
-    S4 = Synapses(G, G2, 'w:1', 'v+=w')
+    S4 = Synapses(G, G2)
     S4.connect(True, n='i')
 
-    S5 = Synapses(G, G2, 'w:1', 'v+=w')
+    S5 = Synapses(G, G2)
     S5.connect(True, n='int(i>j)*2')
 
-    S6 = Synapses(G, G2, 'w:1', 'v+=w')
+    S6 = Synapses(G, G2)
     S6.connect(True, n='int(v_pre>v_post)*2')
 
     with catch_logs() as _:  # Ignore warnings about empty synapses
@@ -602,7 +607,7 @@ def test_state_variable_assignment():
     Assign values to state variables in various ways
     '''
 
-    G = NeuronGroup(10, 'v: volt', threshold='False')
+    G = NeuronGroup(10, 'v: volt')
     G.v = 'i*mV'
     S = Synapses(G, G, 'w:volt')
     S.connect(True)
@@ -889,8 +894,9 @@ def test_delays_pathways_subgroups():
     G = NeuronGroup(10, 'x: meter', threshold='False')
     G.x = 'i*mmeter'
     # Array delay
-    S = Synapses(G[:5], G[5:], 'w:1', on_pre={'pre1': 'v+=w',
-                                      'pre2': 'v+=w'},
+    S = Synapses(G[:5], G[5:], 'w:1',
+                 on_pre={'pre1': 'v+=w',
+                         'pre2': 'v+=w'},
                  on_post='v-=w')
     S.connect(j='i')
     assert len(S.pre1.delay[:]) == 5
@@ -909,6 +915,7 @@ def test_delays_pathways_subgroups():
     assert_allclose(S.pre1.delay[:], np.ones(5) * 5*ms)
     assert_allclose(S.pre2.delay[:], np.ones(5) * 10*ms)
     assert_allclose(S.post.delay[:], np.ones(5) * 1*ms)
+
 
 @pytest.mark.codegen_independent
 def test_pre_before_post():
@@ -959,6 +966,7 @@ def test_transmission_simple():
     assert_allclose(mon[1].v[mon.t<1*ms+offset], 0.)
     assert_allclose(mon[1].v[mon.t>=1*ms+offset], 1.)
 
+
 @pytest.mark.standalone_compatible
 def test_transmission_custom_event():
     source = NeuronGroup(2, '',
@@ -974,6 +982,7 @@ def test_transmission_custom_event():
     assert_allclose(mon[0].v[mon.t>=2*ms], 1.)
     assert_allclose(mon[1].v[mon.t<1*ms], 0.)
     assert_allclose(mon[1].v[mon.t>=1*ms], 1.)
+
 
 @pytest.mark.codegen_independent
 def test_invalid_custom_event():
@@ -1097,6 +1106,7 @@ def test_transmission_scalar_delay_different_clocks():
     assert_allclose(mon[1].v[mon.t<1.5*ms], 0)
     assert_allclose(mon[1].v[mon.t>=1.5*ms], 1)
 
+
 @pytest.mark.standalone_compatible
 def test_transmission_boolean_variable():
     source = SpikeGeneratorGroup(4, [0, 1, 2, 3], [2, 1, 2, 1] * ms)
@@ -1135,6 +1145,7 @@ def test_clocks():
     assert synapse.post._clock.dt == target_dt
     assert synapse._clock.dt == synapse_dt
 
+
 def test_equations_with_clocks():
     '''
     Make sure that dt of a `Synapse` object is correctly resolved.
@@ -1148,6 +1159,7 @@ def test_equations_with_clocks():
     run(1*ms)
 
     assert synapse.w[0] == 1
+
 
 def test_changed_dt_spikes_in_queue():
     defaultclock.dt = .5*ms
@@ -1339,6 +1351,7 @@ def test_multiple_summed_variables():
     with pytest.raises(NotImplementedError):
         net.run(0*ms)
 
+
 @pytest.mark.standalone_compatible
 def test_summed_variables_subgroups():
     source = NeuronGroup(1, '')
@@ -1352,6 +1365,7 @@ def test_summed_variables_subgroups():
     run(defaultclock.dt)
     assert_allclose(target.v[:6], 2*np.ones(6))
     assert_allclose(target.v[6:], 1 * np.ones(4))
+
 
 @pytest.mark.codegen_independent
 def test_summed_variables_overlapping_subgroups():
@@ -1368,6 +1382,7 @@ def test_summed_variables_overlapping_subgroups():
     net = Network(collect())
     with pytest.raises(NotImplementedError):
         net.run(0*ms)
+
 
 @pytest.mark.codegen_independent
 def test_summed_variables_linked_variables():
@@ -1449,6 +1464,7 @@ def test_scalar_subexpression():
                           sub = v_post + s : 1 (shared)''',
                  on_pre='v+=s')
 
+
 @pytest.mark.standalone_compatible
 def test_sim_with_scalar_variable():
     inp = SpikeGeneratorGroup(2, [0, 1], [0, 0]*ms)
@@ -1462,6 +1478,7 @@ def test_sim_with_scalar_variable():
     run(2*defaultclock.dt)
     assert_allclose(out.v[:], [6, 7])
 
+
 @pytest.mark.standalone_compatible
 def test_sim_with_scalar_subexpression():
     inp = SpikeGeneratorGroup(2, [0, 1], [0, 0]*ms)
@@ -1473,6 +1490,7 @@ def test_sim_with_scalar_subexpression():
     syn.w = [1, 2]
     run(2*defaultclock.dt)
     assert_allclose(out.v[:], [6, 7])
+
 
 @pytest.mark.standalone_compatible
 def test_sim_with_constant_subexpression():
@@ -2138,6 +2156,7 @@ def test_ufunc_at_vectorisation():
         finally:
             NumpyCodeGenerator._use_ufunc_at_vectorisation = True # restore it
 
+
 def test_fallback_loop_and_stateless_func():
     # See github issue #1024
     if prefs.codegen.target != 'numpy':
@@ -2154,7 +2173,7 @@ def test_fallback_loop_and_stateless_func():
 
 @pytest.mark.standalone_compatible
 def test_synapses_to_synapses_summed_variable():
-    source = NeuronGroup(5, '', threshold='False')
+    source = NeuronGroup(5, '')
     target = NeuronGroup(5, '')
     conn = Synapses(source, target, 'w : integer')
     conn.connect(j='i')
@@ -2224,9 +2243,8 @@ def test_synapse_generator_syntax():
 
 
 def test_synapse_generator_out_of_range():
-    G = NeuronGroup(16, 'v : 1', threshold='False')
-    G.v = 'i'
-    G2 = NeuronGroup(4, 'v : 1', threshold='False')
+    G = NeuronGroup(16, '')
+    G2 = NeuronGroup(4, 'v : 1')
     G2.v = '16 + i'
 
     S1 = Synapses(G, G2, '')
@@ -2263,47 +2281,47 @@ def test_synapse_generator_out_of_range():
 def test_synapse_generator_deterministic():
     # Same as "test_connection_string_deterministic" but using the generator
     # syntax
-    G = NeuronGroup(16, 'v : 1', threshold='False')
+    G = NeuronGroup(16, 'v : 1')
     G.v = 'i'
-    G2 = NeuronGroup(4, 'v : 1', threshold='False')
+    G2 = NeuronGroup(4, 'v : 1')
     G2.v = '16 + i'
 
     # Full connection
     expected_full = np.ones((len(G), len(G2)))
 
-    S1 = Synapses(G, G2, 'w:1', 'v+=w')
+    S1 = Synapses(G, G2)
     S1.connect(j='k for k in range(N_post)')
 
     # Full connection without self-connections
     expected_no_self = np.ones((len(G), len(G))) - np.eye(len(G))
 
-    S2 = Synapses(G, G, 'w:1', 'v+=w')
+    S2 = Synapses(G, G)
     S2.connect(j='k for k in range(N_post) if k != i')
 
-    S3 = Synapses(G, G, 'w:1', 'v+=w')
+    S3 = Synapses(G, G)
     # slightly confusing with j on the RHS, but it should work...
     S3.connect(j='k for k in range(N_post) if j != i')
 
-    S4 = Synapses(G, G, 'w:1', 'v+=w')
+    S4 = Synapses(G, G)
     S4.connect(j='k for k in range(N_post) if v_post != v_pre')
 
     # One-to-one connectivity
     expected_one_to_one = np.eye(len(G))
 
-    S5 = Synapses(G, G, 'w:1', 'v+=w')
+    S5 = Synapses(G, G)
     S5.connect(j='k for k in range(N_post) if k == i')  # inefficient
 
-    S6 = Synapses(G, G, 'w:1', 'v+=w')
+    S6 = Synapses(G, G)
     # slightly confusing with j on the RHS, but it should work...
     S6.connect(j='k for k in range(N_post) if j == i')  # inefficient
 
-    S7 = Synapses(G, G, 'w:1', 'v+=w')
+    S7 = Synapses(G, G)
     S7.connect(j='k for k in range(N_post) if v_pre == v_post')  # inefficient
 
-    S8 = Synapses(G, G, 'w:1', 'v+=w')
+    S8 = Synapses(G, G)
     S8.connect(j='i for _ in range(1)')  # efficient
 
-    S9 = Synapses(G, G, 'w:1', 'v+=w')
+    S9 = Synapses(G, G)
     S9.connect(j='i')  # short form of the above
 
     with catch_logs() as _:  # Ignore warnings about empty synapses
@@ -2324,47 +2342,47 @@ def test_synapse_generator_deterministic():
 def test_synapse_generator_deterministic_over_postsynaptic():
     # Same as "test_connection_string_deterministic" but using the generator
     # syntax and iterating over post-synaptic variables
-    G = NeuronGroup(16, 'v : 1', threshold='False', reset='')
+    G = NeuronGroup(16, 'v : 1')
     G.v = 'i'
-    G2 = NeuronGroup(4, 'v : 1', threshold='False', reset='')
+    G2 = NeuronGroup(4, 'v : 1')
     G2.v = '16 + i'
 
     # Full connection
     expected_full = np.ones((len(G), len(G2)))
 
-    S1 = Synapses(G, G2, 'w:1', 'v+=w')
+    S1 = Synapses(G, G2)
     S1.connect(i='k for k in range(N_pre)')
 
     # Full connection without self-connections
     expected_no_self = np.ones((len(G), len(G))) - np.eye(len(G))
 
-    S2 = Synapses(G, G, 'w:1', 'v+=w')
+    S2 = Synapses(G, G)
     S2.connect(i='k for k in range(N_pre) if k != j')
 
-    S3 = Synapses(G, G, 'w:1', 'v+=w')
+    S3 = Synapses(G, G)
     # slightly confusing with i on the RHS, but it should work...
     S3.connect(i='k for k in range(N_pre) if i != j')
 
-    S4 = Synapses(G, G, 'w:1', 'v+=w')
+    S4 = Synapses(G, G)
     S4.connect(j='k for k in range(N_pre) if v_pre != v_post')
 
     # One-to-one connectivity
     expected_one_to_one = np.eye(len(G))
 
-    S5 = Synapses(G, G, 'w:1', 'v+=w')
+    S5 = Synapses(G, G)
     S5.connect(i='k for k in range(N_pre) if k == j')  # inefficient
 
-    S6 = Synapses(G, G, 'w:1', 'v+=w')
+    S6 = Synapses(G, G)
     # slightly confusing with j on the RHS, but it should work...
     S6.connect(i='k for k in range(N_pre) if i == j')  # inefficient
 
-    S7 = Synapses(G, G, 'w:1', 'v+=w')
+    S7 = Synapses(G, G)
     S7.connect(i='k for k in range(N_pre) if v_pre == v_post')  # inefficient
 
-    S8 = Synapses(G, G, 'w:1', 'v+=w')
+    S8 = Synapses(G, G)
     S8.connect(i='j for _ in range(1)')  # efficient
 
-    S9 = Synapses(G, G, 'w:1', 'v+=w')
+    S9 = Synapses(G, G)
     S9.connect(i='j')  # short form of the above
 
     with catch_logs() as _:  # Ignore warnings about empty synapses
@@ -2386,16 +2404,13 @@ def test_synapse_generator_deterministic_over_postsynaptic():
 def test_synapse_generator_deterministic_2():
     # Same as "test_connection_string_deterministic" but using the generator
     # syntax
-    G = NeuronGroup(16, 'v : 1', threshold='False')
-    G.v = 'i'
-    G2 = NeuronGroup(4, 'v : 1', threshold='False')
-    G2.v = '16 + i'
-
+    G = NeuronGroup(16)
+    G2 = NeuronGroup(4)
     # A few more tests of deterministic connections where the generator syntax
     # is particularly useful
 
     # Ring structure
-    S10 = Synapses(G, G, 'w:1', 'v+=w')
+    S10 = Synapses(G, G)
     S10.connect(j='(i + (-1)**k) % N_post for k in range(2)')
     expected_ring = np.zeros((len(G), len(G)), dtype=np.int32)
     expected_ring[np.arange(15), np.arange(15)+1] = 1  # Next cell
@@ -2403,14 +2418,14 @@ def test_synapse_generator_deterministic_2():
     expected_ring[[0, 15], [15, 0]] = 1  # wrap around the ring
 
     # Diverging connection pattern
-    S11 = Synapses(G2, G, 'w:1', 'v+=w')
+    S11 = Synapses(G2, G)
     S11.connect(j='i*4 + k for k in range(4)')
     expected_diverging = np.zeros((len(G2), len(G)), dtype=np.int32)
     for source in range(4):
         expected_diverging[source, np.arange(4) + source*4] = 1
 
     # Diverging connection pattern within population (no self-connections)
-    S11b = Synapses(G2, G2, 'w:1', 'v+=w')
+    S11b = Synapses(G2, G2)
     S11b.connect(j='k for k in range(i-3, i+4) if i!=k', skip_if_invalid=True)
     expected_diverging_b = np.zeros((len(G2), len(G2)), dtype=np.int32)
     for source in range(len(G2)):
@@ -2418,21 +2433,21 @@ def test_synapse_generator_deterministic_2():
         expected_diverging_b[source, source] = 0
 
     # Converging connection pattern
-    S12 = Synapses(G, G2, 'w:1', 'v+=w')
+    S12 = Synapses(G, G2)
     S12.connect(j='int(i/4)')
     expected_converging = np.zeros((len(G), len(G2)), dtype=np.int32)
     for target in range(4):
         expected_converging[np.arange(4) + target*4, target] = 1
 
     # skip if invalid
-    S13 = Synapses(G2, G2, 'w:1', 'v+=w')
+    S13 = Synapses(G2, G2)
     S13.connect(j='i+(-1)**k for k in range(2)', skip_if_invalid=True)
     expected_offdiagonal = np.zeros((len(G2), len(G2)), dtype=np.int32)
     expected_offdiagonal[np.arange(len(G2)-1), np.arange(len(G2)-1)+1] = 1
     expected_offdiagonal[np.arange(len(G2)-1)+1, np.arange(len(G2)-1)] = 1
 
     # Converging connection pattern with restriction
-    S14 = Synapses(G, G2, 'w:1', 'v+=w')
+    S14 = Synapses(G, G2)
     S14.connect(j='int(i/4) if i % 2 == 0')
     expected_converging_restricted = np.zeros((len(G), len(G2)), dtype=np.int32)
     for target in range(4):
@@ -2472,26 +2487,23 @@ def test_synapse_generator_deterministic_2():
 def test_synapse_generator_random():
     # The same tests as test_connection_random_without_condition, but using
     # the generator syntax
-    G = NeuronGroup(4, '''v: 1
-                          x : integer''', threshold='False')
+    G = NeuronGroup(4, 'x : integer')
     G.x = 'i'
-    G2 = NeuronGroup(7, '''v: 1
-                           y : 1''', threshold='False')
-    G2.y = '1.0*i/N'
+    G2 = NeuronGroup(7, '')
 
-    S1 = Synapses(G, G2, 'w:1', 'v+=w')
+    S1 = Synapses(G, G2)
     S1.connect(j='k for k in sample(N_post, p=0)')
 
-    S2 = Synapses(G, G2, 'w:1', 'v+=w')
+    S2 = Synapses(G, G2)
     S2.connect(j='k for k in sample(N_post, p=1)')
 
     # Just make sure using values between 0 and 1 work in principle
-    S3 = Synapses(G, G2, 'w:1', 'v+=w')
+    S3 = Synapses(G, G2)
     S3.connect(j='k for k in sample(N_post, p=0.3)')
 
     # Use pre-/post-synaptic variables for "stochastic" connections that are
     # actually deterministic
-    S4 = Synapses(G, G2, 'w:1', on_pre='v+=w')
+    S4 = Synapses(G, G2)
     S4.connect(j='k for k in sample(N_post, p=int(x_pre==2)*1.0)')
 
     with catch_logs() as _:  # Ignore warnings about empty synapses
@@ -2509,26 +2521,23 @@ def test_synapse_generator_random():
 def test_synapse_generator_random_over_postsynaptic():
     # The same tests as test_connection_random_without_condition, but using
     # the generator syntax and iterating over post-synaptic neurons
-    G = NeuronGroup(4, '''v: 1
-                          x : integer''', threshold='False', reset='')
-    G.x = 'i'
-    G2 = NeuronGroup(7, '''v: 1
-                           y : 1''', threshold='False', reset='')
+    G = NeuronGroup(4, '')
+    G2 = NeuronGroup(7, 'y : 1')
     G2.y = 'i'
 
-    S1 = Synapses(G, G2, 'w:1', 'v+=w')
+    S1 = Synapses(G, G2)
     S1.connect(i='k for k in sample(N_pre, p=0)')
 
-    S2 = Synapses(G, G2, 'w:1', 'v+=w')
+    S2 = Synapses(G, G2)
     S2.connect(i='k for k in sample(N_pre, p=1)')
 
     # Just make sure using values between 0 and 1 work in principle
-    S3 = Synapses(G, G2, 'w:1', 'v+=w')
+    S3 = Synapses(G, G2)
     S3.connect(i='k for k in sample(N_pre, p=0.3)')
 
     # Use pre-/post-synaptic variables for "stochastic" connections that are
     # actually deterministic
-    S4 = Synapses(G, G2, 'w:1', on_pre='v+=w')
+    S4 = Synapses(G, G2)
     S4.connect(i='k for k in sample(N_pre, p=int(y_post==2)*1.0)')
 
     with catch_logs() as _:  # Ignore warnings about empty synapses
@@ -2545,31 +2554,28 @@ def test_synapse_generator_random_over_postsynaptic():
 @pytest.mark.standalone_compatible
 def test_synapse_generator_random_positive_steps():
     # Test generator with sampling from stepped ranges (e.g. all even numbers)
-    G = NeuronGroup(4, '''v: 1
-                          x : integer''', threshold='False')
+    G = NeuronGroup(4, 'x : integer')
     G.x = 'i'
-    G2 = NeuronGroup(7, '''v: 1
-                           y : 1''', threshold='False')
-    G2.y = '1.0*i/N'
+    G2 = NeuronGroup(7, '')
 
-    S1 = Synapses(G, G2, 'w:1', 'v+=w')
+    S1 = Synapses(G, G2)
     S1.connect(j='k for k in sample(2, N_post, 2, p=0)')
 
-    S2 = Synapses(G, G2, 'w:1', 'v+=w')
+    S2 = Synapses(G, G2)
     S2.connect(j='k for k in sample(2, N_post, 2, p=1)')
 
     # Just make sure using values between 0 and 1 work in principle (note that
     # 0.25 is the cutoff between the general method and the "jump method", so
     # we test a value above and below
-    S3 = Synapses(G, G2, 'w:1', 'v+=w')
+    S3 = Synapses(G, G2)
     S3.connect(j='k for k in sample(2, N_post, 2, p=0.2)')
 
-    S3b = Synapses(G, G2, 'w:1', 'v+=w')
+    S3b = Synapses(G, G2)
     S3b.connect(j='k for k in sample(2, N_post, 2, p=0.3)')
 
     # Use pre-/post-synaptic variables for "stochastic" connections that are
     # actually deterministic
-    S4 = Synapses(G, G2, 'w:1', on_pre='v+=w')
+    S4 = Synapses(G, G2)
     S4.connect(j='k for k in sample(2, N_post, 2, p=int(x_pre==2)*1.0)')
 
     with catch_logs() as _:  # Ignore warnings about empty synapses
@@ -2594,31 +2600,28 @@ def test_synapse_generator_random_positive_steps():
 def test_synapse_generator_random_negative_steps():
     # Test generator with sampling from stepped ranges (e.g. all even numbers)
     # going backwards
-    G = NeuronGroup(4, '''v: 1
-                          x : integer''', threshold='False')
+    G = NeuronGroup(4, 'x : integer')
     G.x = 'i'
-    G2 = NeuronGroup(7, '''v: 1
-                           y : 1''', threshold='False')
-    G2.y = '1.0*i/N'
+    G2 = NeuronGroup(7, '')
 
-    S1 = Synapses(G, G2, 'w:1', 'v+=w')
+    S1 = Synapses(G, G2)
     S1.connect(j='k for k in sample(N_post-1, 0, -2, p=0)')
 
-    S2 = Synapses(G, G2, 'w:1', 'v+=w')
+    S2 = Synapses(G, G2)
     S2.connect(j='k for k in sample(N_post-1, 0, -2, p=1)')
 
     # Just make sure using values between 0 and 1 work in principle (note that
     # 0.25 is the cutoff between the general method and the "jump method", so
     # we test a value above and below
-    S3 = Synapses(G, G2, 'w:1', 'v+=w')
+    S3 = Synapses(G, G2)
     S3.connect(j='k for k in sample(N_post-1, 0, -2, p=0.2)')
 
-    S3b = Synapses(G, G2, 'w:1', 'v+=w')
+    S3b = Synapses(G, G2)
     S3b.connect(j='k for k in sample(N_post-1, 0, -2, p=0.3)')
 
     # Use pre-/post-synaptic variables for "stochastic" connections that are
     # actually deterministic
-    S4 = Synapses(G, G2, 'w:1', on_pre='v+=w')
+    S4 = Synapses(G, G2)
     S4.connect(j='k for k in sample(N_post-1, 0, -2, p=int(x_pre==2)*1.0)')
 
     with catch_logs() as _:  # Ignore warnings about empty synapses
@@ -2642,25 +2645,22 @@ def test_synapse_generator_random_negative_steps():
 @pytest.mark.standalone_compatible
 def test_synapse_generator_fixed_random():
     # Random samples with fixed size
-    G = NeuronGroup(4, '''v: 1
-                          x : integer''', threshold='False')
+    G = NeuronGroup(4, 'x : integer')
     G.x = 'i'
-    G2 = NeuronGroup(7, '''v: 1
-                           y : 1''', threshold='False')
-    G2.y = '1.0*i/N'
+    G2 = NeuronGroup(7, '')
 
-    S1 = Synapses(G, G2, 'w:1', 'v+=w')
+    S1 = Synapses(G, G2)
     S1.connect(j='k for k in sample(N_post, size=0)')
 
-    S2 = Synapses(G, G2, 'w:1', 'v+=w')
+    S2 = Synapses(G, G2)
     S2.connect(j='k for k in sample(N_post, size=N_post)')
 
-    S3 = Synapses(G, G2, 'w:1', 'v+=w')
+    S3 = Synapses(G, G2)
     S3.connect(j='k for k in sample(N_post, size=3)')
 
     # Use pre-/post-synaptic variables for "stochastic" connections that are
     # actually deterministic
-    S4 = Synapses(G, G2, 'w:1', on_pre='v+=w')
+    S4 = Synapses(G, G2)
     S4.connect(j='k for k in sample(N_post, size=int(x_pre==2)*N_post)')
 
     with catch_logs() as _:  # Ignore warnings about empty synapses
@@ -2683,26 +2683,23 @@ def test_synapse_generator_fixed_random():
 def test_synapse_generator_fixed_random_positive_steps():
     # Test generator with fixed-size sampling from stepped ranges (e.g. all
     # even numbers)
-    G = NeuronGroup(4, '''v: 1
-                          x : integer''', threshold='False')
+    G = NeuronGroup(4, 'x : integer')
     G.x = 'i'
-    G2 = NeuronGroup(7, '''v: 1
-                           y : 1''', threshold='False')
-    G2.y = '1.0*i/N'
+    G2 = NeuronGroup(7, '')
 
-    S1 = Synapses(G, G2, 'w:1', 'v+=w')
+    S1 = Synapses(G, G2)
     S1.connect(j='k for k in sample(2, N_post, 2, size=0)')
 
-    S2 = Synapses(G, G2, 'w:1', 'v+=w')
+    S2 = Synapses(G, G2)
     S2.connect(j='k for k in sample(2, N_post, 2, size=3)')
 
     # Just make sure using values between 0 and 1 work in principle
-    S3 = Synapses(G, G2, 'w:1', 'v+=w')
+    S3 = Synapses(G, G2)
     S3.connect(j='k for k in sample(2, N_post, 2, size=2)')
 
     # Use pre-/post-synaptic variables for "stochastic" connections that are
     # actually deterministic
-    S4 = Synapses(G, G2, 'w:1', on_pre='v+=w')
+    S4 = Synapses(G, G2)
     S4.connect(j='k for k in sample(2, N_post, 2, size=int(x_pre==2)*3)')
 
     with catch_logs() as _:  # Ignore warnings about empty synapses
@@ -2727,26 +2724,23 @@ def test_synapse_generator_fixed_random_positive_steps():
 def test_synapse_generator_fixed_random_negative_steps():
     # Test generator with fixed-size sampling from stepped ranges (e.g. all
     # even numbers) going backwards
-    G = NeuronGroup(4, '''v: 1
-                          x : integer''', threshold='False')
+    G = NeuronGroup(4, 'x : integer')
     G.x = 'i'
-    G2 = NeuronGroup(7, '''v: 1
-                           y : 1''', threshold='False')
-    G2.y = '1.0*i/N'
+    G2 = NeuronGroup(7, '')
 
-    S1 = Synapses(G, G2, 'w:1', 'v+=w')
+    S1 = Synapses(G, G2)
     S1.connect(j='k for k in sample(N_post-1, 0, -2, size=0)')
 
-    S2 = Synapses(G, G2, 'w:1', 'v+=w')
+    S2 = Synapses(G, G2)
     S2.connect(j='k for k in sample(N_post-1, 0, -2, size=3)')
 
     # Just make sure using intermediate values between 0 and 1 work in principle
-    S3 = Synapses(G, G2, 'w:1', 'v+=w')
+    S3 = Synapses(G, G2)
     S3.connect(j='k for k in sample(N_post-1, 0, -2, size=2)')
 
     # Use pre-/post-synaptic variables for "stochastic" connections that are
     # actually deterministic
-    S4 = Synapses(G, G2, 'w:1', on_pre='v+=w')
+    S4 = Synapses(G, G2, 'w:1')
     S4.connect(j='k for k in sample(N_post-1, 0, -2, size=int(x_pre==2)*3)')
 
     with catch_logs() as _:  # Ignore warnings about empty synapses
@@ -2765,6 +2759,7 @@ def test_synapse_generator_fixed_random_negative_steps():
     assert len(S4) == 3
     assert_equal(S4.i, np.ones(3) * 2)
     assert_equal(S4.j, np.arange(6, 0, -2))
+
 
 @pytest.mark.standalone_compatible
 def test_synapse_generator_fixed_random_error1():
@@ -2805,37 +2800,37 @@ def test_synapse_generator_fixed_random_skip_if_invalid():
 
 @pytest.mark.standalone_compatible
 def test_synapse_generator_random_with_condition():
-    G = NeuronGroup(4, 'v: 1', threshold='False')
+    G = NeuronGroup(4, '')
 
-    S1 = Synapses(G, G, 'w:1', 'v+=w')
+    S1 = Synapses(G, G)
     S1.connect(j='k for k in sample(N_post, p=0) if i != k')
 
-    S2 = Synapses(G, G, 'w:1', 'v+=w')
+    S2 = Synapses(G, G)
     S2.connect(j='k for k in sample(N_post, p=1) if i != k')
     expected2 = np.ones((len(G), len(G))) - np.eye(len(G))
 
-    S3 = Synapses(G, G, 'w:1', 'v+=w')
+    S3 = Synapses(G, G)
     S3.connect(j='k for k in sample(N_post, p=0) if i >= 2')
 
-    S4 = Synapses(G, G, 'w:1', 'v+=w')
+    S4 = Synapses(G, G)
     S4.connect(j='k for k in sample(N_post, p=1.0) if i >= 2')
     expected4 = np.zeros((len(G), len(G)))
     expected4[2, :] = 1
     expected4[3, :] = 1
 
-    S5 = Synapses(G, G, 'w:1', 'v+=w')
+    S5 = Synapses(G, G)
     S5.connect(j='k for k in sample(N_post, p=0) if j < 2')  # inefficient
 
-    S6 = Synapses(G, G, 'w:1', 'v+=w')
+    S6 = Synapses(G, G)
     S6.connect(j='k for k in sample(2, p=0)')  # better
 
-    S7 = Synapses(G, G, 'w:1', 'v+=w')
+    S7 = Synapses(G, G)
     expected7 = np.zeros((len(G), len(G)))
     expected7[:, 0] = 1
     expected7[:, 1] = 1
     S7.connect(j='k for k in sample(N_post, p=1.0) if j < 2')  # inefficient
 
-    S8 = Synapses(G, G, 'w:1', 'v+=w')
+    S8 = Synapses(G, G)
     S8.connect(j='k for k in sample(2, p=1.0)')  # better
 
     with catch_logs() as _:  # Ignore warnings about empty synapses
@@ -2854,65 +2849,64 @@ def test_synapse_generator_random_with_condition():
 @pytest.mark.standalone_compatible
 @pytest.mark.long
 def test_synapse_generator_random_with_condition_2():
-    G = NeuronGroup(4, 'v: 1', threshold='False')
+    G = NeuronGroup(4, '')
 
     # Just checking that everything works in principle (we can't check the
     # actual connections)
-    S9 = Synapses(G, G, 'w:1', 'v+=w')
+    S9 = Synapses(G, G)
     S9.connect(j='k for k in sample(N_post, p=0.001) if i != k')
 
-    S10 = Synapses(G, G, 'w:1', 'v+=w')
+    S10 = Synapses(G, G)
     S10.connect(j='k for k in sample(N_post, p=0.03) if i != k')
 
-    S11 = Synapses(G, G, 'w:1', 'v+=w')
+    S11 = Synapses(G, G)
     S11.connect(j='k for k in sample(N_post, p=0.1) if i != k')
 
-    S12 = Synapses(G, G, 'w:1', 'v+=w')
+    S12 = Synapses(G, G)
     S12.connect(j='k for k in sample(N_post, p=0.9) if i != k')
 
-    S13 = Synapses(G, G, 'w:1', 'v+=w')
+    S13 = Synapses(G, G)
     S13.connect(j='k for k in sample(N_post, p=0.001) if i >= 2')
 
-    S14 = Synapses(G, G, 'w:1', 'v+=w')
+    S14 = Synapses(G, G)
     S14.connect(j='k for k in sample(N_post, p=0.03) if i >= 2')
 
-    S15 = Synapses(G, G, 'w:1', 'v+=w')
+    S15 = Synapses(G, G)
     S15.connect(j='k for k in sample(N_post, p=0.1) if i >= 2')
 
-    S16 = Synapses(G, G, 'w:1', 'v+=w')
+    S16 = Synapses(G, G)
     S16.connect(j='k for k in sample(N_post, p=0.9) if i >= 2')
 
-    S17 = Synapses(G, G, 'w:1', 'v+=w')
+    S17 = Synapses(G, G)
     S17.connect(j='k for k in sample(N_post, p=0.001) if j < 2')
 
-    S18 = Synapses(G, G, 'w:1', 'v+=w')
+    S18 = Synapses(G, G)
     S18.connect(j='k for k in sample(N_post, p=0.03) if j < 2')
 
-    S19 = Synapses(G, G, 'w:1', 'v+=w')
+    S19 = Synapses(G, G)
     S19.connect(j='k for k in sample(N_post, p=0.1) if j < 2')
 
-    S20 = Synapses(G, G, 'w:1', 'v+=w')
+    S20 = Synapses(G, G)
     S20.connect(j='k for k in sample(N_post, p=0.9) if j < 2')
 
-    S21 = Synapses(G, G, 'w:1', 'v+=w')
+    S21 = Synapses(G, G)
     S21.connect(j='k for k in sample(2, p=0.001)')
 
-    S22 = Synapses(G, G, 'w:1', 'v+=w')
+    S22 = Synapses(G, G)
     S22.connect(j='k for k in sample(2, p=0.03)')
 
-    S23 = Synapses(G, G, 'w:1', 'v+=w')
+    S23 = Synapses(G, G)
     S23.connect(j='k for k in sample(2, p=0.1)')
 
-    S24 = Synapses(G, G, 'w:1', 'v+=w')
+    S24 = Synapses(G, G)
     S24.connect(j='k for k in sample(2, p=0.9)')
 
     # Some more tests specific to the generator syntax
-    S25 = Synapses(G, G, 'w:1', on_pre='v+=w')
+    S25 = Synapses(G, G)
     S25.connect(j='i+1 for _ in sample(1, p=0.5) if i < N_post-1')
 
-    S26 = Synapses(G, G, 'w:1', on_pre='v+=w')
+    S26 = Synapses(G, G)
     S26.connect(j='i+k for k in sample(N_post-i, p=0.5)')
-
 
     with catch_logs() as _:  # Ignore warnings about empty synapses
         run(0 * ms)  # for standalone
@@ -2966,6 +2960,7 @@ def test_synapses_refractory():
     assert_allclose(target.v[:5], 1)
     assert_allclose(target.v[5:], 0)
 
+
 @pytest.mark.standalone_compatible
 def test_synapses_refractory_rand():
     source = NeuronGroup(10, '', threshold='True')
@@ -2986,8 +2981,8 @@ def test_synapses_refractory_rand():
 @pytest.mark.codegen_independent
 def test_synapse_generator_range_noint():
     # arguments to `range` should only be integers (issue #781)
-    G = NeuronGroup(42, 'v: 1', threshold='False')
-    S = Synapses(G, G, 'w:1', 'v+=w')
+    G = NeuronGroup(42, '')
+    S = Synapses(G, G)
     msg = r'The "{}" argument of the range function was .+, but it needs to be an integer\.'
     with pytest.raises(TypeError, match=msg.format('high')):
         S.connect(j='k for k in range(42.0)')
@@ -3004,6 +2999,7 @@ def test_synapse_generator_range_noint():
     with pytest.raises(TypeError, match=msg.format('step')):
         S.connect(j='k for k in range(0, 42, True)')
 
+
 @pytest.mark.codegen_independent
 def test_missing_lastupdate_error_syn_pathway():
     G = NeuronGroup(1, 'v : 1', threshold='False')
@@ -3018,7 +3014,7 @@ def test_missing_lastupdate_error_syn_pathway():
 
 @pytest.mark.codegen_independent
 def test_missing_lastupdate_error_run_regularly():
-    G = NeuronGroup(1, 'v : 1', threshold='False')
+    G = NeuronGroup(1, 'v : 1')
     S = Synapses(G, G)
     S.connect()
     S.run_regularly('v += exp(-lastupdate/dt')

--- a/brian2/tests/test_synapses.py
+++ b/brian2/tests/test_synapses.py
@@ -2190,7 +2190,7 @@ def test_synapses_to_synapses_summed_variable():
 def test_synapse_generator_syntax():
     parsed = parse_synapse_generator('k for k in sample(1, N, p=p) if abs(i-k)<10')
     assert parsed['element'] == 'k'
-    assert parsed['iteration_variable'] == 'k'
+    assert parsed['inner_variable'] == 'k'
     assert parsed['iterator_func'] == 'sample'
     assert parsed['iterator_kwds']['low'] == '1'
     assert parsed['iterator_kwds']['high'] == 'N'
@@ -2201,7 +2201,7 @@ def test_synapse_generator_syntax():
     assert parsed['if_expression'] == 'abs(i - k) < 10'
     parsed = parse_synapse_generator('k for k in sample(N, size=5) if abs(i-k)<10')
     assert parsed['element'] == 'k'
-    assert parsed['iteration_variable'] == 'k'
+    assert parsed['inner_variable'] == 'k'
     assert parsed['iterator_func'] == 'sample'
     assert parsed['iterator_kwds']['low'] == '0'
     assert parsed['iterator_kwds']['high'] == 'N'
@@ -2212,7 +2212,7 @@ def test_synapse_generator_syntax():
     assert parsed['if_expression'] == 'abs(i - k) < 10'
     parsed = parse_synapse_generator('k+1 for k in range(i-100, i+100, 2)')
     assert parsed['element'] == 'k + 1'
-    assert parsed['iteration_variable'] == 'k'
+    assert parsed['inner_variable'] == 'k'
     assert parsed['iterator_func'] == 'range'
     assert parsed['iterator_kwds']['low'] == 'i - 100'
     assert parsed['iterator_kwds']['high'] == 'i + 100'

--- a/brian2/tests/test_synapses.py
+++ b/brian2/tests/test_synapses.py
@@ -2243,7 +2243,7 @@ def test_synapse_generator_syntax():
 
 
 def test_synapse_generator_out_of_range():
-    G = NeuronGroup(16, '')
+    G = NeuronGroup(16, 'v : 1')
     G2 = NeuronGroup(4, 'v : 1')
     G2.v = '16 + i'
 

--- a/docs_sphinx/user/synapses.rst
+++ b/docs_sphinx/user/synapses.rst
@@ -203,6 +203,21 @@ neurons 0, 2, 4, 6, ... to neurons 0, 1, 2, 3, ... you could write::
 
     S.connect(j='int(i/2) if i % 2 == 0')
 
+The connections above describe the target indices ``j`` as a function of the source indices ``i``.
+You can also apply the syntax in the other direction, i.e. describe source indices ``i`` as a function
+of target indices ``j``. For a 1-to-1 connection, this does not change anything in most cases::
+
+    S.connect(i='j')
+
+Note that there is a subtle difference between the two descriptions if the two groups do not have the same size:
+if the source group has fewer neurons than the target group, then using `j='i'` is possible (there is a target
+neuron for each source neuron), but `i='j'` would raise an error; the opposite is true if the source group is
+bigger than the target group.
+
+The second example from above (neurons 0, 2, 4, ... to neurons 0, 1, 2, ...) can be adapted for the other
+direction, as well, and is possibly more intuitive in this case::
+
+    S.connect(i='j*2')
 
 .. _accessing_synaptic_variables:
 
@@ -367,6 +382,10 @@ generator syntax, e.g. to connect neuron i to all neurons j with
 There are several parts to this syntax. The general form is::
 
     j='EXPR for VAR in RANGE if COND'
+
+or::
+
+    i='EXPR for VAR in RANGE if COND'
 
 Here ``EXPR`` can be any integer-valued expression. VAR is the name
 of the iteration variable (any name you like can be specified
@@ -592,12 +611,30 @@ presynaptic variables. Similarly, the expression for ``j``, ``EXPR`` can depend
 on ``i``, presynaptic variables, and on the iteration variable ``VAR``. The
 condition ``COND`` can depend on anything (presynaptic and postsynaptic variables).
 
+The generator syntax expressing ``i`` as a function of ``j`` is interpreted
+in the same way:
+
+    | For every j:
+    |     for every VAR in RANGE:
+    |         i = EXPR
+    |         if COND:
+    |             Create n(i, j) synapses for (i, j)
+
+Here, ``RANGE`` can only depend on ``j`` and postsynaptic variables, and ``EXPR``
+can only depend on ``j``, postsynaptic variables, and on the iteration variable
+``VAR``.
+
 With the 1-to-1 mapping syntax ``j='EXPR'`` the interpretation is:
 
     | For every i:
     |     j = EXPR
     |     Create n(i, j) synapses for (i, j)
 
+And finally, ``i='EXPR'`` is interpreted as:
+
+    | For every j:
+    |     i = EXPR
+    |     Create n(i, j) synapses for (i, j)
 
 Efficiency considerations
 ~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
As briefly discussed in #1280 , the main interest of "random fixed size sampling" is typically used to have a fixed number of *inputs* per target neuron. In contrast, our current code only allows its use in `j='...'` expressions, i.e. sampling a post-synaptic neurons for each pre-synaptic neurons.

This PR adds the missing feature of also using `i='...'` generator expressions, which together with the previous changes finally makes a fixed number of incoming connections possible. The implementation is rather straightforward: it replaces hardcoded names like `j` and `post_idx` in the templates by placeholders that get filled in depending on the way we iterate. Still, everything gets a bit more complicated... I tried to at least refactor `Synapses.connect` a bit which had a really hard-to-follow logic before.

Everything seems to basically work, but I'm still considering this a draft since testing is incomplete, and I did not document the new feature at all.