### PR TITLE
Fix LaTeX output for newer sympy versions

### DIFF
--- a/brian2/equations/equations.py
+++ b/brian2/equations/equations.py
@@ -458,13 +458,13 @@ class SingleEquation(Hashable, CacheKey):
 
     def _latex(self, *args):
         if self.type == DIFFERENTIAL_EQUATION:
-            return (r'\frac{\mathrm{d}' + sympy.latex(self.varname) + r'}{\mathrm{d}t} = ' +
+            return (r'\frac{\mathrm{d}' + sympy.latex(sympy.Symbol(self.varname)) + r'}{\mathrm{d}t} = ' +
                     sympy.latex(str_to_sympy(self.expr.code)))
         elif self.type == SUBEXPRESSION:
-            return (sympy.latex(self.varname) + ' = ' +
+            return (sympy.latex(sympy.Symbol(self.varname)) + ' = ' +
                     sympy.latex(str_to_sympy(self.expr.code)))
         elif self.type == PARAMETER:
-            return sympy.latex(self.varname)
+            return sympy.latex(sympy.Symbol(self.varname))
 
     def __str__(self):
         if self.type == DIFFERENTIAL_EQUATION:
@@ -1065,7 +1065,7 @@ class Equations(Hashable, Mapping):
                                                               sympy.latex(get_unit(eq.dim)),
                                                               flag_str)
             else:
-                eq_latex = r'%s &= %s && \text{(unit of $%s$: $%s$%s)}' % (sympy.latex(lhs),
+                eq_latex = r'%s &= %s && \text{(unit of $%s$: $%s$%s)}' % (lhs,  # already a string
                                                                            sympy.latex(rhs),
                                                                            sympy.latex(varname),
                                                                            sympy.latex(get_unit(eq.dim)),

--- a/brian2/tests/test_neurongroup.py
+++ b/brian2/tests/test_neurongroup.py
@@ -1401,9 +1401,12 @@ def test_repr():
     # Test that string/LaTeX representations do not raise errors
     for func in [str, repr, sympy.latex]:
         assert len(func(G))
+        assert 'textbackslash' not in func(G)  # for LaTeX, see #1296
         assert len(func(G.equations))
+        assert 'textbackslash' not in func(G.equations)
         for eq in G.equations.values():
             assert len(func(eq))
+
 
 @pytest.mark.codegen_independent
 def test_ipython_html():


### PR DESCRIPTION
Fixes #1296 (see issue for an example of what goes wrong)

Since sympy 1.7, `sympy.latex('...')` will no longer consider a string as "already LaTeX" but rather replace backslashes in it by `\textbackslash` to make it appear as written. With this change, we now only call `sympy.latex` on sympy objects (e.g. Symbol) or our own objects implementing `_latex`.