### PR TITLE
Fix automatic g++ compiler detection on linux

### DIFF
--- a/brian2/devices/cpp_standalone/templates/makefile
+++ b/brian2/devices/cpp_standalone/templates/makefile
@@ -4,9 +4,8 @@ SRCS = {{source_files}}
 H_SRCS = {{header_files}}
 OBJS = ${SRCS:.cpp=.o}
 OBJS := ${OBJS:.c=.o}
-CC = @g++
 OPTIMISATIONS = {{ compiler_flags }}
-CFLAGS = -c -Wno-write-strings $(OPTIMISATIONS) -I. {{ openmp_pragma('compilation') }} {{ compiler_debug_flags }}
+CXXFLAGS = -c -Wno-write-strings $(OPTIMISATIONS) -I. {{ openmp_pragma('compilation') }} {{ compiler_debug_flags }}
 LFLAGS = {{ openmp_pragma('compilation') }} {{ linker_flags }} {{ linker_debug_flags }}
 DEPS = make.deps
 
@@ -15,17 +14,17 @@ all: $(PROGRAM)
 .PHONY: all clean
 
 $(PROGRAM): $(OBJS) $(DEPS) makefile
-	$(CC) $(OBJS) -o $(PROGRAM) $(LFLAGS)
+	$(CXX) $(OBJS) -o $(PROGRAM) $(LFLAGS)
 
 clean:
 	{{ rm_cmd }}
 
 make.deps: $(SRCS) $(H_SRCS)
-	$(CC) $(CFLAGS) -MM $(SRCS) > make.deps
+	$(CXX) $(CXXFLAGS) -MM $(SRCS) > make.deps
 	
 ifneq ($(wildcard $(DEPS)), )
 include $(DEPS)
 endif
 
 %.o : %.cpp makefile
-	$(CC) $(CFLAGS) $< -o $@
+	$(CXX) $(CXXFLAGS) $< -o $@


### PR DESCRIPTION
Disclaimer 1: I'm no expert on make, I just had to fix a local linking error because my system compiler was mixed with the conda environment's standard library and want to contribute this.
Disclaimer 2: I haven't tested this particular change, but I made the same edits to a makefile of an already generated standalone build and it worked there. Relying on continuous integration here :)

From the commit message:

(Ana)conda environments allow to install gcc/g++ compilers and standard libraries.
The compilers are not linked to `gcc` or `g++` but rather preserve their platform dependent naming.
For automatic compiler detection by tools conda sets environment variables.
Details: https://docs.conda.io/projects/conda-build/en/latest/resources/compiler-tools.html#using-the-compiler-packages

The Linux makefile of brian's standalone mode ignores these environment variables because of two reasons:
- CC is overwritten to `@g++`
- CC is used instead of CXX (which is for the C compiler)

Instead, remove the default on CC and use CXX everywhere.
This automatically detects the right C++ compiler in anaconda environments.

For added benefit, use .SILENT instead of the @ prefix.