### PR TITLE
Fix for exc.errisinstance with pytest.raises

### DIFF
--- a/brian2/parsing/bast.py
+++ b/brian2/parsing/bast.py
@@ -57,7 +57,7 @@ def brian_dtype_from_value(value):
 # so we don't use numpy.issubdtype but instead a precalculated list of all
 # standard types
 
-bool_dtype =numpy.dtype(numpy.bool)
+bool_dtype = numpy.dtype(bool)
 def is_boolean_dtype(obj):
     return numpy.dtype(obj) is bool_dtype
 

--- a/brian2/tests/test_GSL.py
+++ b/brian2/tests/test_GSL.py
@@ -8,6 +8,8 @@ from brian2.core.preferences import PreferenceError
 from brian2.codegen.runtime.GSLcython_rt import IntegrationError
 from brian2.stateupdaters.base import UnsupportedEquationsException
 
+from .utils import exc_isinstance
+
 max_difference = .1*mV
 
 pytestmark = pytest.mark.gsl
@@ -185,7 +187,8 @@ def test_GSL_stochastic():
     with pytest.raises(BrianObjectException) as exc:
         net.run(0*ms, namespace={'tau': tau,
                                  'sigma': sigma})
-        assert exc.errisinstance(UnsupportedEquationsException)
+    assert exc_isinstance(exc, UnsupportedEquationsException)
+
 
 @pytest.mark.standalone_compatible
 @skip_if_not_implemented
@@ -200,7 +203,7 @@ def test_GSL_error_dimension_mismatch_unit():
     net = Network(neuron)
     with pytest.raises(BrianObjectException) as exc:
         net.run(0*ms, namespace={})
-        assert exc.errisinstance(DimensionMismatchError)
+    assert exc_isinstance(exc, DimensionMismatchError)
 
 
 @pytest.mark.standalone_compatible
@@ -216,7 +219,7 @@ def test_GSL_error_dimension_mismatch_dimensionless1():
     net = Network(neuron)
     with pytest.raises(BrianObjectException) as exc:
         net.run(0*ms, namespace={})
-        assert exc.errisinstance(DimensionMismatchError)
+    assert exc_isinstance(exc, DimensionMismatchError)
 
 
 @pytest.mark.standalone_compatible
@@ -232,7 +235,7 @@ def test_GSL_error_dimension_mismatch_dimensionless2():
     net = Network(neuron)
     with pytest.raises(BrianObjectException) as exc:
         net.run(0*ms, namespace={})
-        assert exc.errisinstance(DimensionMismatchError)
+    assert exc_isinstance(exc, DimensionMismatchError)
 
 
 @pytest.mark.standalone_compatible
@@ -248,7 +251,7 @@ def test_GSL_error_nonexisting_variable():
     net = Network(neuron)
     with pytest.raises(BrianObjectException) as exc:
         net.run(0*ms, namespace={})
-        assert exc.errisinstance(KeyError)
+    assert exc_isinstance(exc, KeyError)
 
 
 @pytest.mark.standalone_compatible
@@ -268,10 +271,10 @@ def test_GSL_error_incorrect_error_format():
     net2 = Network(neuron2)
     with pytest.raises(BrianObjectException) as exc:
         net.run(0*ms, namespace={})
-        assert exc.errisinstance(TypeError)
+    assert exc_isinstance(exc, TypeError)
     with pytest.raises(BrianObjectException) as exc:
         net2.run(0*ms, namespace={})
-        assert exc.errisinstance(TypeError)
+    assert exc_isinstance(exc, TypeError)
 
 
 @pytest.mark.standalone_compatible
@@ -287,7 +290,7 @@ def test_GSL_error_nonODE_variable():
     net = Network(neuron)
     with pytest.raises(BrianObjectException) as exc:
         net.run(0*ms, namespace={})
-        assert exc.errisinstance(KeyError)
+    assert exc_isinstance(exc, KeyError)
 
 
 @pytest.mark.standalone_compatible

--- a/brian2/tests/test_GSL.py
+++ b/brian2/tests/test_GSL.py
@@ -187,7 +187,8 @@ def test_GSL_stochastic():
     with pytest.raises(BrianObjectException) as exc:
         net.run(0*ms, namespace={'tau': tau,
                                  'sigma': sigma})
-    assert exc_isinstance(exc, UnsupportedEquationsException)
+    assert exc_isinstance(exc, UnsupportedEquationsException,
+                          raise_not_implemented=True)
 
 
 @pytest.mark.standalone_compatible
@@ -203,7 +204,8 @@ def test_GSL_error_dimension_mismatch_unit():
     net = Network(neuron)
     with pytest.raises(BrianObjectException) as exc:
         net.run(0*ms, namespace={})
-    assert exc_isinstance(exc, DimensionMismatchError)
+    assert exc_isinstance(exc, DimensionMismatchError,
+                          raise_not_implemented=True)
 
 
 @pytest.mark.standalone_compatible
@@ -219,7 +221,8 @@ def test_GSL_error_dimension_mismatch_dimensionless1():
     net = Network(neuron)
     with pytest.raises(BrianObjectException) as exc:
         net.run(0*ms, namespace={})
-    assert exc_isinstance(exc, DimensionMismatchError)
+    assert exc_isinstance(exc, DimensionMismatchError,
+                          raise_not_implemented=True)
 
 
 @pytest.mark.standalone_compatible
@@ -235,7 +238,8 @@ def test_GSL_error_dimension_mismatch_dimensionless2():
     net = Network(neuron)
     with pytest.raises(BrianObjectException) as exc:
         net.run(0*ms, namespace={})
-    assert exc_isinstance(exc, DimensionMismatchError)
+    assert exc_isinstance(exc, DimensionMismatchError,
+                          raise_not_implemented=True)
 
 
 @pytest.mark.standalone_compatible
@@ -251,7 +255,8 @@ def test_GSL_error_nonexisting_variable():
     net = Network(neuron)
     with pytest.raises(BrianObjectException) as exc:
         net.run(0*ms, namespace={})
-    assert exc_isinstance(exc, KeyError)
+    assert exc_isinstance(exc, KeyError,
+                          raise_not_implemented=True)
 
 
 @pytest.mark.standalone_compatible
@@ -271,10 +276,12 @@ def test_GSL_error_incorrect_error_format():
     net2 = Network(neuron2)
     with pytest.raises(BrianObjectException) as exc:
         net.run(0*ms, namespace={})
-    assert exc_isinstance(exc, TypeError)
+    assert exc_isinstance(exc, TypeError,
+                          raise_not_implemented=True)
     with pytest.raises(BrianObjectException) as exc:
         net2.run(0*ms, namespace={})
-    assert exc_isinstance(exc, TypeError)
+    assert exc_isinstance(exc, TypeError,
+                          raise_not_implemented=True)
 
 
 @pytest.mark.standalone_compatible
@@ -290,7 +297,8 @@ def test_GSL_error_nonODE_variable():
     net = Network(neuron)
     with pytest.raises(BrianObjectException) as exc:
         net.run(0*ms, namespace={})
-    assert exc_isinstance(exc, KeyError)
+    assert exc_isinstance(exc, KeyError,
+                          raise_not_implemented=True)
 
 
 @pytest.mark.standalone_compatible

--- a/brian2/tests/test_GSL.py
+++ b/brian2/tests/test_GSL.py
@@ -7,8 +7,7 @@ from brian2.core.preferences import PreferenceError
 
 from brian2.codegen.runtime.GSLcython_rt import IntegrationError
 from brian2.stateupdaters.base import UnsupportedEquationsException
-
-from .utils import exc_isinstance
+from brian2.tests.utils import exc_isinstance
 
 max_difference = .1*mV
 

--- a/brian2/tests/test_functions.py
+++ b/brian2/tests/test_functions.py
@@ -9,11 +9,9 @@ from brian2.core.functions import timestep
 from brian2.devices import RuntimeDevice
 from brian2.parsing.sympytools import str_to_sympy, sympy_to_str
 from brian2.utils.logger import catch_logs
-from brian2.tests.utils import assert_allclose
+from brian2.tests.utils import assert_allclose, exc_isinstance
 from brian2.codegen.generators import CodeGenerator
 from brian2.codegen.codeobject import CodeObject
-
-from .utils import exc_isinstance
 
 
 @pytest.mark.codegen_independent

--- a/brian2/tests/test_functions.py
+++ b/brian2/tests/test_functions.py
@@ -1,5 +1,3 @@
-
-
 import os
 
 import pytest
@@ -14,6 +12,9 @@ from brian2.utils.logger import catch_logs
 from brian2.tests.utils import assert_allclose
 from brian2.codegen.generators import CodeGenerator
 from brian2.codegen.codeobject import CodeObject
+
+from .utils import exc_isinstance
+
 
 @pytest.mark.codegen_independent
 def test_constants_sympy():
@@ -314,8 +315,8 @@ def test_manual_user_defined_function():
                        y : 1''')
     net = Network(group)
     with pytest.raises(BrianObjectException) as exc:
-        net.run(0*ms, namespace={ 'foo': foo})
-        assert exc.errisinstance(DimensionMismatchError)
+        net.run(0*ms, namespace={'foo': foo})
+    assert exc_isinstance(exc, DimensionMismatchError)
 
     # Incorrect output unit
     group = NeuronGroup(1, '''
@@ -325,7 +326,7 @@ def test_manual_user_defined_function():
     net = Network(group)
     with pytest.raises(BrianObjectException) as exc:
         net.run(0*ms, namespace={'foo': foo})
-        assert exc.errisinstance(DimensionMismatchError)
+    assert exc_isinstance(exc, DimensionMismatchError)
 
     G = NeuronGroup(1, '''
                        func = foo(x, y) : volt
@@ -407,7 +408,7 @@ def test_manual_user_defined_function_cpp_standalone_wrong_compiler_args1():
     net = Network(G, mon)
     with pytest.raises(BrianObjectException) as exc:
         net.run(defaultclock.dt, namespace={'foo': foo})
-        assert exc.errisinstance(ValueError)
+    assert exc_isinstance(exc, ValueError)
 
 
 @pytest.mark.cpp_standalone
@@ -432,7 +433,7 @@ def test_manual_user_defined_function_cpp_standalone_wrong_compiler_args2():
     net = Network(G, mon)
     with pytest.raises(BrianObjectException) as exc:
         net.run(defaultclock.dt, namespace={'foo': foo})
-        assert exc.errisinstance(TypeError)
+    assert exc_isinstance(exc, TypeError)
 
 
 def test_manual_user_defined_function_cython_compiler_args():
@@ -480,7 +481,7 @@ def test_manual_user_defined_function_cython_wrong_compiler_args1():
     net = Network(G, mon)
     with pytest.raises(BrianObjectException) as exc:
         net.run(defaultclock.dt, namespace={'foo': foo})
-        assert exc.errisinstance(ValueError)
+    assert exc_isinstance(exc, ValueError)
 
 
 def test_manual_user_defined_function_cython_wrong_compiler_args2():
@@ -503,7 +504,7 @@ def test_manual_user_defined_function_cython_wrong_compiler_args2():
     net = Network(G, mon)
     with pytest.raises(BrianObjectException) as exc:
         net.run(defaultclock.dt, namespace={'foo': foo})
-        assert exc.errisinstance(TypeError)
+    assert exc_isinstance(exc, TypeError)
 
 
 def test_external_function_cython():
@@ -851,7 +852,7 @@ def test_declare_types():
         Network(G).run(1*ms)
     with pytest.raises(BrianObjectException) as exc:
         bad_units()
-        assert exc.errisinstance(TypeError)
+    assert exc_isinstance(exc, TypeError)
 
     def bad_type():
         @implementation('numpy', discard_units=True)
@@ -867,7 +868,7 @@ def test_declare_types():
         Network(G).run(1*ms)
     with pytest.raises(BrianObjectException) as exc:
         bad_type()
-        assert exc.errisinstance(TypeError)
+    assert exc_isinstance(exc, TypeError)
 
 
 def test_multiple_stateless_function_calls():
@@ -877,18 +878,18 @@ def test_multiple_stateless_function_calls():
     net = Network(G)
     with pytest.raises(BrianObjectException) as exc:
         net.run(0*ms)
-        assert exc.errisinstance(NotImplementedError)
+    assert exc_isinstance(exc, NotImplementedError)
     G2 = NeuronGroup(1, 'v:1', threshold='v>1', reset='v=rand() - rand()')
     net2 = Network(G2)
     with pytest.raises(BrianObjectException) as exc:
         net2.run(0*ms)
-        assert exc.errisinstance(NotImplementedError)
+    assert exc_isinstance(exc, NotImplementedError)
     G3 = NeuronGroup(1, 'v:1')
     G3.run_regularly('v = rand() - rand()')
     net3 = Network(G3)
     with pytest.raises(BrianObjectException) as exc:
         net3.run(0*ms)
-        assert exc.errisinstance(NotImplementedError)
+    assert exc_isinstance(exc, NotImplementedError)
     G4 = NeuronGroup(1, 'x : 1')
     # Verify that synaptic equations are checked as well, see #1146
     S = Synapses(G4, G4, 'dy/dt = (rand() - rand())/second : 1 (clock-driven)')
@@ -896,7 +897,7 @@ def test_multiple_stateless_function_calls():
     net = Network(G4, S)
     with pytest.raises(BrianObjectException) as exc:
         net.run(0*ms)
-        assert exc.errisinstance(NotImplementedError)
+    assert exc_isinstance(exc, NotImplementedError)
 
 
 if __name__ == '__main__':

--- a/brian2/tests/test_neurongroup.py
+++ b/brian2/tests/test_neurongroup.py
@@ -24,8 +24,7 @@ from brian2.units.fundamentalunits import (DimensionMismatchError,
 from brian2.units.stdunits import ms, mV, Hz
 from brian2.units.unitsafefunctions import linspace
 from brian2.utils.logger import catch_logs
-
-from .utils import exc_isinstance
+from brian2.tests.utils import exc_isinstance
 
 
 @pytest.mark.codegen_independent

--- a/brian2/tests/test_neurongroup.py
+++ b/brian2/tests/test_neurongroup.py
@@ -25,6 +25,8 @@ from brian2.units.stdunits import ms, mV, Hz
 from brian2.units.unitsafefunctions import linspace
 from brian2.utils.logger import catch_logs
 
+from .utils import exc_isinstance
+
 
 @pytest.mark.codegen_independent
 def test_creation():
@@ -644,7 +646,7 @@ def test_linked_var_in_reset_incorrect():
     # (as for any other shared variable)
     with pytest.raises(BrianObjectException) as exc:
         net.run(0*ms)
-        assert exc.errisinstance(SyntaxError)
+    assert exc_isinstance(exc, SyntaxError)
 
 @pytest.mark.codegen_independent
 def test_incomplete_namespace():
@@ -671,21 +673,21 @@ def test_namespace_errors():
     net = Network(G)
     with pytest.raises(BrianObjectException) as exc:
         net.run(1*ms)
-        assert exc.errisinstance(KeyError)
+    assert exc_isinstance(exc, KeyError)
 
     # reset uses unknown identifier
     G = NeuronGroup(1, 'dv/dt = -v/tau : 1', threshold='False', reset='v = v_r')
     net = Network(G)
     with pytest.raises(BrianObjectException) as exc:
         net.run(1*ms)
-        assert exc.errisinstance(KeyError)
+    assert exc_isinstance(exc, KeyError)
 
     # threshold uses unknown identifier
     G = NeuronGroup(1, 'dv/dt = -v/tau : 1', threshold='v > v_th')
     net = Network(G)
     with pytest.raises(BrianObjectException) as exc:
         net.run(1*ms)
-        assert exc.errisinstance(KeyError)
+    assert exc_isinstance(exc, KeyError)
 
 
 @pytest.mark.codegen_independent
@@ -788,7 +790,7 @@ def test_unit_errors_threshold_reset():
     group = NeuronGroup(1, 'dv/dt = -v/(10*ms) : 1', threshold='v > -20*mV')
     with pytest.raises(BrianObjectException) as exc:
         Network(group).run(0*ms)
-        assert exc.errisinstance(DimensionMismatchError)
+    assert exc_isinstance(exc, DimensionMismatchError)
 
     # Unit error in reset
     group = NeuronGroup(1, 'dv/dt = -v/(10*ms) : 1',
@@ -796,7 +798,7 @@ def test_unit_errors_threshold_reset():
                         reset='v = -65*mV')
     with pytest.raises(BrianObjectException) as exc:
         Network(group).run(0*ms)
-        assert exc.errisinstance(DimensionMismatchError)
+    assert exc_isinstance(exc, DimensionMismatchError)
 
     # More complicated unit reset with an intermediate variable
     # This should pass
@@ -819,7 +821,7 @@ def test_unit_errors_threshold_reset():
                                  v = temp_var''')
     with pytest.raises(BrianObjectException) as exc:
         Network(group).run(0*ms)
-        assert exc.errisinstance(DimensionMismatchError)
+    assert exc_isinstance(exc, DimensionMismatchError)
 
     # Resets with an in-place modification
     # This should work
@@ -834,7 +836,7 @@ def test_unit_errors_threshold_reset():
                         reset='''v -= 60*mV''')
     with pytest.raises(BrianObjectException) as ecx:
         Network(group).run(0*ms)
-        assert exc.errisinstance(DimensionMismatchError)
+    assert exc_isinstance(exc, DimensionMismatchError)
 
 
 @pytest.mark.codegen_independent
@@ -901,7 +903,7 @@ def test_incorrect_custom_event_definition():
     G = NeuronGroup(1, '', events={'my_event': 10*mV})
     with pytest.raises(BrianObjectException) as exc:
         Network(G).run(0*ms)
-        assert exc.errisinstance(TypeError)
+    assert exc_isinstance(exc, TypeError)
     # schedule for a non-existing event
     G = NeuronGroup(1, '', threshold='False', events={'my_event': 'True'})
     with pytest.raises(ValueError):
@@ -1313,7 +1315,7 @@ def test_scalar_subexpression():
     net = Network(group)
     with pytest.raises(BrianObjectException) as exc:
         net.run(0*ms)
-        assert exc.errisinstance(SyntaxError)
+    assert exc_isinstance(exc, SyntaxError)
 
 
 @pytest.mark.standalone_compatible
@@ -1389,7 +1391,7 @@ def test_subexpression_checks():
     net = Network(group)
     with pytest.raises(BrianObjectException) as exc:
         net.run(0 * ms)
-        assert exc.errisinstance(SyntaxError)
+    assert exc_isinstance(exc, SyntaxError)
 
 
 @pytest.mark.codegen_independent

--- a/brian2/tests/test_poissongroup.py
+++ b/brian2/tests/test_poissongroup.py
@@ -7,8 +7,7 @@ from brian2 import *
 from brian2.core.network import schedule_propagation_offset
 from brian2.devices.device import reinit_and_delete
 from brian2.utils.logger import catch_logs
-
-from .utils import exc_isinstance
+from brian2.tests.utils import exc_isinstance
 
 
 @pytest.mark.standalone_compatible

--- a/brian2/tests/test_poissongroup.py
+++ b/brian2/tests/test_poissongroup.py
@@ -1,4 +1,3 @@
-
 import uuid
 
 from numpy.testing import assert_equal
@@ -8,6 +7,8 @@ from brian2 import *
 from brian2.core.network import schedule_propagation_offset
 from brian2.devices.device import reinit_and_delete
 from brian2.utils.logger import catch_logs
+
+from .utils import exc_isinstance
 
 
 @pytest.mark.standalone_compatible
@@ -43,13 +44,13 @@ def test_rate_unit_check():
     net = Network(P)
     with pytest.raises(BrianObjectException) as exc:
         net.run(0*ms)
-        assert exc.errisinstance(DimensionMismatchError)
+    assert exc_isinstance(exc, DimensionMismatchError)
 
     P = PoissonGroup(1, 'i')
     net = Network(P)
     with pytest.raises(BrianObjectException) as exc:
         net.run(0*ms)
-        assert exc.errisinstance(DimensionMismatchError)
+    assert exc_isinstance(exc, DimensionMismatchError)
 
 
 @pytest.mark.standalone_compatible

--- a/brian2/tests/test_poissoninput.py
+++ b/brian2/tests/test_poissoninput.py
@@ -1,4 +1,3 @@
-
 from numpy.testing import assert_equal
 import pytest
 
@@ -7,6 +6,7 @@ from brian2.devices.device import reinit_and_delete
 from brian2.core.network import schedule_propagation_offset
 from brian2.tests.utils import assert_allclose
 
+from .utils import exc_isinstance
 
 @pytest.mark.standalone_compatible
 def test_poissoninput():
@@ -68,7 +68,7 @@ def test_poissoninput_errors():
     net = Network(collect())
     with pytest.raises(BrianObjectException) as exc:
         net.run(0*ms)
-        assert exc.errisinstance(NotImplementedError)
+    assert exc_isinstance(exc, NotImplementedError)
     defaultclock.dt = old_dt
 
 

--- a/brian2/tests/test_poissoninput.py
+++ b/brian2/tests/test_poissoninput.py
@@ -4,9 +4,7 @@ import pytest
 from brian2 import *
 from brian2.devices.device import reinit_and_delete
 from brian2.core.network import schedule_propagation_offset
-from brian2.tests.utils import assert_allclose
-
-from .utils import exc_isinstance
+from brian2.tests.utils import assert_allclose, exc_isinstance
 
 @pytest.mark.standalone_compatible
 def test_poissoninput():

--- a/brian2/tests/test_refractory.py
+++ b/brian2/tests/test_refractory.py
@@ -1,4 +1,3 @@
-
 from collections import Counter
 
 import pytest
@@ -10,6 +9,9 @@ from brian2 import *
 from brian2.equations.refractory import add_refractoriness
 from brian2.devices.device import reinit_and_delete
 from brian2.tests.utils import assert_allclose
+
+from .utils import exc_isinstance
+
 
 @pytest.mark.codegen_independent
 def test_add_refractoriness():
@@ -187,19 +189,19 @@ def test_refractoriness_types():
     group = NeuronGroup(1, '', refractory='3*Hz')
     with pytest.raises(BrianObjectException) as exc:
         Network(group).run(0*ms)
-        assert exc.errisinstance(TypeError)
+    assert exc_isinstance(exc, TypeError)
     group = NeuronGroup(1, 'ref: Hz', refractory='ref')
     with pytest.raises(BrianObjectException) as exc:
         Network(group).run(0*ms)
-        assert exc.errisinstance(TypeError)
+    assert exc_isinstance(exc, TypeError)
     group = NeuronGroup(1, '', refractory='3')
     with pytest.raises(BrianObjectException) as exc:
         Network(group).run(0*ms)
-        assert exc.errisinstance(TypeError)
+    assert exc_isinstance(exc, TypeError)
     group = NeuronGroup(1, 'ref: 1', refractory='ref')
     with pytest.raises(BrianObjectException) as exc:
         Network(group).run(0*ms)
-        assert exc.errisinstance(TypeError)
+    assert exc_isinstance(exc, TypeError)
 
 @pytest.mark.codegen_independent
 def test_conditional_write_set():

--- a/brian2/tests/test_refractory.py
+++ b/brian2/tests/test_refractory.py
@@ -8,9 +8,7 @@ from brian2.utils.logger import catch_logs
 from brian2 import *
 from brian2.equations.refractory import add_refractoriness
 from brian2.devices.device import reinit_and_delete
-from brian2.tests.utils import assert_allclose
-
-from .utils import exc_isinstance
+from brian2.tests.utils import assert_allclose, exc_isinstance
 
 
 @pytest.mark.codegen_independent

--- a/brian2/tests/test_spikegenerator.py
+++ b/brian2/tests/test_spikegenerator.py
@@ -12,10 +12,8 @@ from numpy.testing import assert_equal, assert_array_equal
 from brian2 import *
 from brian2.core.network import schedule_propagation_offset
 from brian2.devices.device import reinit_and_delete
-from brian2.tests.utils import assert_allclose
+from brian2.tests.utils import assert_allclose, exc_isinstance
 from brian2.utils.logger import catch_logs
-
-from .utils import exc_isinstance
 
 
 @pytest.mark.standalone_compatible

--- a/brian2/tests/test_spikegenerator.py
+++ b/brian2/tests/test_spikegenerator.py
@@ -15,6 +15,8 @@ from brian2.devices.device import reinit_and_delete
 from brian2.tests.utils import assert_allclose
 from brian2.utils.logger import catch_logs
 
+from .utils import exc_isinstance
+
 
 @pytest.mark.standalone_compatible
 def test_spikegenerator_connected():
@@ -131,7 +133,7 @@ def test_spikegenerator_period_rounding():
     net = Network(s)
     with pytest.raises(BrianObjectException) as exc:
         net.run(0*ms)
-        assert exc.errisinstance(ValueError)
+    assert exc_isinstance(exc, ValueError)
 
 
 def test_spikegenerator_period_repeat():
@@ -246,19 +248,19 @@ def test_spikegenerator_incorrect_period():
     net = Network(SG)
     with pytest.raises(BrianObjectException) as exc:
         net.run(0*ms)
-        assert exc.errisinstance(NotImplementedError)
+    assert exc_isinstance(exc, NotImplementedError)
 
     SG = SpikeGeneratorGroup(1, [], [] * second, period=0.101 * ms, dt=0.1 * ms)
     net = Network(SG)
     with pytest.raises(BrianObjectException) as exc:
         net.run(0*ms)
-        assert exc.errisinstance(NotImplementedError)
+    assert exc_isinstance(exc, NotImplementedError)
 
     SG = SpikeGeneratorGroup(1, [], [] * second, period=3.333 * ms, dt=0.1 * ms)
     net = Network(SG)
     with pytest.raises(BrianObjectException) as exc:
         net.run(0*ms)
-        assert exc.errisinstance(NotImplementedError)
+    assert exc_isinstance(exc, NotImplementedError)
 
     # This should not raise an error (see #1041)
     SG = SpikeGeneratorGroup(1, [], []*ms, period=150*ms, dt=0.1*ms)
@@ -270,7 +272,7 @@ def test_spikegenerator_incorrect_period():
     net = Network(SG)
     with pytest.raises(BrianObjectException) as exc:
         net.run(0*ms)
-        assert exc.errisinstance(ValueError)
+    assert exc_isinstance(exc, ValueError)
 
 
 def test_spikegenerator_rounding():
@@ -353,7 +355,8 @@ def test_spikegenerator_multiple_spikes_per_bin():
     net = Network(SG)
     with pytest.raises(BrianObjectException) as exc:
         net.run(0*ms)
-        assert exc.errisinstance(NotImplementedError)
+    print(exc.value.__cause__)
+    assert exc_isinstance(exc, ValueError)
 
     # More complicated scenario where dt changes between runs
     defaultclock.dt = 0.1*ms
@@ -363,7 +366,7 @@ def test_spikegenerator_multiple_spikes_per_bin():
     defaultclock.dt = 0.2*ms  # Now the two spikes fall into the same bin
     with pytest.raises(BrianObjectException) as exc:
         net.run(0*ms)
-        assert exc.errisinstance(NotImplementedError)
+    assert exc_isinstance(exc, ValueError)
 
 
 @pytest.mark.standalone_compatible

--- a/brian2/tests/test_stateupdaters.py
+++ b/brian2/tests/test_stateupdaters.py
@@ -1,5 +1,3 @@
-
-
 import re
 import logging
 
@@ -12,6 +10,7 @@ from brian2.core.variables import ArrayVariable, Variable, Constant
 from brian2.stateupdaters.base import UnsupportedEquationsException
 from brian2.tests.utils import assert_allclose
 
+from .utils import exc_isinstance
 
 @pytest.mark.codegen_independent
 def test_explicit_stateupdater_parsing():
@@ -172,7 +171,7 @@ def test_multiplicative_noise():
     net1 = Network(group1)
     with pytest.raises(BrianObjectException) as exc:
         net1.run(0*ms)
-        assert exc.errisinstance(UnsupportedEquationsException)
+    assert exc_isinstance(exc, UnsupportedEquationsException)
 
     # Noise is multiplicative (multiplied with time)
     Eq2 = Equations('dv/dt = (t/ms)*xi*(5*ms)**-0.5 :1')
@@ -180,7 +179,7 @@ def test_multiplicative_noise():
     net2 = Network(group2)
     with pytest.raises(BrianObjectException) as exc:
         net2.run(0*ms)
-        assert exc.errisinstance(UnsupportedEquationsException)
+    assert exc_isinstance(exc, UnsupportedEquationsException)
 
     # Noise is multiplicative (multiplied with time-varying variable)
     Eq3 = Equations('''dv/dt = w*xi*(5*ms)**-0.5 :1
@@ -189,7 +188,7 @@ def test_multiplicative_noise():
     net3 = Network(group3)
     with pytest.raises(BrianObjectException) as exc:
         net3.run(0*ms)
-        assert exc.errisinstance(UnsupportedEquationsException)
+    assert exc_isinstance(exc, UnsupportedEquationsException)
 
     # One of the equations has multiplicative noise
     Eq4 = Equations('''dv/dt = xi_1*(5*ms)**-0.5 : 1
@@ -198,7 +197,7 @@ def test_multiplicative_noise():
     net4 = Network(group4)
     with pytest.raises(BrianObjectException) as exc:
         net4.run(0*ms)
-        assert exc.errisinstance(UnsupportedEquationsException)
+    assert exc_isinstance(exc, UnsupportedEquationsException)
 
     # One of the equations has multiplicative noise
     Eq5 = Equations('''dv/dt = xi_1*(5*ms)**-0.5 : 1
@@ -207,7 +206,7 @@ def test_multiplicative_noise():
     net5 = Network(group4)
     with pytest.raises(BrianObjectException) as exc:
         net5.run(0*ms)
-        assert exc.errisinstance(UnsupportedEquationsException)
+    assert exc_isinstance(exc, UnsupportedEquationsException)
 
 
 def test_pure_noise_deterministic(fake_randn_randn_fixture):
@@ -673,7 +672,7 @@ def test_locally_constant_check():
     net = Network(G)
     with pytest.raises(BrianObjectException) as exc:
         net.run(0*ms)
-        assert exc.errisinstance(UnsupportedEquationsException)
+    assert exc_isinstance(exc, UnsupportedEquationsException)
 
     # Arbitrary functions are not constant over a time step
     G = NeuronGroup(1, 'dv/dt = -v/(10*ms) + sin(2*pi*100*Hz*t)*Hz : 1',
@@ -681,7 +680,7 @@ def test_locally_constant_check():
     net = Network(G)
     with pytest.raises(BrianObjectException) as exc:
         net.run(0*ms)
-        assert exc.errisinstance(UnsupportedEquationsException)
+    assert exc_isinstance(exc, UnsupportedEquationsException)
 
     # Stateful functions aren't either
     G = NeuronGroup(1, 'dv/dt = -v/(10*ms) + rand()*Hz : 1',
@@ -689,14 +688,14 @@ def test_locally_constant_check():
     net = Network(G)
     with pytest.raises(BrianObjectException) as exc:
         net.run(0*ms)
-        assert exc.errisinstance(UnsupportedEquationsException)
+    assert exc_isinstance(exc, UnsupportedEquationsException)
 
     # Neither is "t" itself
     G = NeuronGroup(1, 'dv/dt = -v/(10*ms) + t/second**2 : 1', method='exact')
     net = Network(G)
     with pytest.raises(BrianObjectException) as exc:
         net.run(0*ms)
-        assert exc.errisinstance(UnsupportedEquationsException)
+    assert exc_isinstance(exc, UnsupportedEquationsException)
 
     # But if the argument is not referring to t, all should be well
     G = NeuronGroup(1, 'dv/dt = -v/(10*ms) + sin(2*pi*100*Hz*5*second)*Hz : 1',

--- a/brian2/tests/test_stateupdaters.py
+++ b/brian2/tests/test_stateupdaters.py
@@ -8,9 +8,7 @@ from brian2 import *
 from brian2.utils.logger import catch_logs
 from brian2.core.variables import ArrayVariable, Variable, Constant
 from brian2.stateupdaters.base import UnsupportedEquationsException
-from brian2.tests.utils import assert_allclose
-
-from .utils import exc_isinstance
+from brian2.tests.utils import assert_allclose, exc_isinstance
 
 @pytest.mark.codegen_independent
 def test_explicit_stateupdater_parsing():

--- a/brian2/tests/test_synapses.py
+++ b/brian2/tests/test_synapses.py
@@ -17,10 +17,8 @@ from brian2.utils.stringtools import get_identifiers, word_substitute, indent, d
 from brian2.devices.device import reinit_and_delete, all_devices, get_device
 from brian2.codegen.permutation_analysis import check_for_order_independence, OrderDependenceError
 from brian2.synapses.parse_synaptic_generator_syntax import parse_synapse_generator
-from brian2.tests.utils import assert_allclose
+from brian2.tests.utils import assert_allclose, exc_isinstance
 from brian2.equations.equations import EquationError
-
-from .utils import exc_isinstance
 
 
 def _compare(synapses, expected):

--- a/brian2/tests/utils.py
+++ b/brian2/tests/utils.py
@@ -1,4 +1,3 @@
-
 import numpy as np
 from numpy.testing import assert_allclose as numpy_allclose
 
@@ -27,3 +26,31 @@ def assert_allclose(actual, desired, rtol=4.5e8, atol=0, **kwds):
     eps = np.finfo(prefs['core.default_float_dtype']).eps
     rtol = eps*rtol
     numpy_allclose(np.asarray(actual), np.asarray(desired), rtol=rtol, atol=atol, **kwds)
+
+def exc_isinstance(exc_info, expected_exception):
+    """
+    Simple helper function as an alternative to calling
+    `~.pytest.ExceptionInfo.errisinstance` which will take into account all
+    the "causing" exceptions in an exception chain.
+
+    Parameters
+    ----------
+    exc_info : `pytest.ExceptionInfo` or `Exception`
+        The exception info as returned by `pytest.raises`.
+    expected_exception : `type`
+        The expected exception class
+
+    Returns
+    -------
+    correct_exception : bool
+        Whether the exception itself or one of the causing exceptions is of the
+        expected type.
+    """
+    if exc_info is None:
+        return False
+    if hasattr(exc_info, 'value'):
+        exc_info = exc_info.value
+    if isinstance(exc_info, expected_exception):
+        return True
+
+    return exc_isinstance(exc_info.__cause__, expected_exception)

--- a/brian2/tests/utils.py
+++ b/brian2/tests/utils.py
@@ -27,7 +27,7 @@ def assert_allclose(actual, desired, rtol=4.5e8, atol=0, **kwds):
     rtol = eps*rtol
     numpy_allclose(np.asarray(actual), np.asarray(desired), rtol=rtol, atol=atol, **kwds)
 
-def exc_isinstance(exc_info, expected_exception):
+def exc_isinstance(exc_info, expected_exception, raise_not_implemented=False):
     """
     Simple helper function as an alternative to calling
     `~.pytest.ExceptionInfo.errisinstance` which will take into account all
@@ -39,6 +39,10 @@ def exc_isinstance(exc_info, expected_exception):
         The exception info as returned by `pytest.raises`.
     expected_exception : `type`
         The expected exception class
+    raise_not_implemented : bool, optional
+        Whether to re-raise a `NotImplementedError` – necessary for tests that
+        should be skipped with ``@skip_if_not_implemented``. Defaults to
+        ``False``.
 
     Returns
     -------
@@ -50,7 +54,10 @@ def exc_isinstance(exc_info, expected_exception):
         return False
     if hasattr(exc_info, 'value'):
         exc_info = exc_info.value
+
     if isinstance(exc_info, expected_exception):
         return True
+    elif raise_not_implemented and isinstance(exc_info, NotImplementedError):
+        raise exc_info
 
     return exc_isinstance(exc_info.__cause__, expected_exception)

--- a/brian2/tests/utils.py
+++ b/brian2/tests/utils.py
@@ -60,4 +60,5 @@ def exc_isinstance(exc_info, expected_exception, raise_not_implemented=False):
     elif raise_not_implemented and isinstance(exc_info, NotImplementedError):
         raise exc_info
 
-    return exc_isinstance(exc_info.__cause__, expected_exception)
+    return exc_isinstance(exc_info.__cause__, expected_exception,
+                          raise_not_implemented=raise_not_implemented)


### PR DESCRIPTION
In contrast to what I claimed in #1196, the `ExceptionInfo.errisinstance` check does not actually work with chained exceptions.
Something like
```Python
assert exc_info.errisinstance(exc, KeyError)
```
will fail if exc_info is a `BrianObjectException` caused by a `KeyError`.

We have plenty of tests written like this
```Python
with pytest.raises(BrianObjectException) as exc:
    net.run(0*ms)
    assert exc.errisinstance(UnsupportedEquationsException)
```
These tests run just fine, but only because the test leaves the `pytest.raises` context as soon as an exception is raised, i.e. the `assert` is never triggered. This is mentioned in the [pytest documentation](https://docs.pytest.org/en/6.2.x/reference.html#pytest.raises)...

This PR fixes this by introducing our own testing function which recurses into the causing exceptions. This is not quite as elegant as I'd like (e.g. the error message if the assertion fails is not great), but it should do for now. It is certainly better than assertions that are never evaluated :)