### PR TITLE
Fix wrong preference example in documentation

### DIFF
--- a/docs_sphinx/advanced/preferences.rst
+++ b/docs_sphinx/advanced/preferences.rst
@@ -11,13 +11,13 @@ Accessing and setting preferences
 Preferences can be accessed and set either keyword-based or attribute-based.
 The following are equivalent::
 
-    prefs['codegen.cpp.compiler'] = 'gcc'
-    prefs.codegen.cpp.compiler = 'gcc'
+    prefs['codegen.cpp.compiler'] = 'unix'
+    prefs.codegen.cpp.compiler = 'unix'
 
 Using the attribute-based form can be particulary useful for interactive
 work, e.g. in ipython, as it offers autocompletion and documentation.
-In ipython, ``prefs.codegen.c?`` would display a docstring with all
-the preferences available in the ``codegen.c`` category.
+In ipython, ``prefs.codegen.cpp?`` would display a docstring with all
+the preferences available in the ``codegen.cpp`` category.
 
 Preference files
 ----------------

--- a/docs_sphinx/advanced/preferences.rst
+++ b/docs_sphinx/advanced/preferences.rst
@@ -3,7 +3,7 @@ Preferences
 
 Brian has a system of global preferences that affect how certain objects
 behave. These can be set either in scripts by using the `prefs` object
-or in a file. Each preference looks like ``codegen.c.compiler``, i.e. dotted
+or in a file. Each preference looks like ``codegen.cpp.compiler``, i.e. dotted
 names.
 
 Accessing and setting preferences
@@ -11,8 +11,8 @@ Accessing and setting preferences
 Preferences can be accessed and set either keyword-based or attribute-based.
 The following are equivalent::
 
-    prefs['codegen.c.compiler'] = 'gcc'
-    prefs.codegen.c.compiler = 'gcc'
+    prefs['codegen.cpp.compiler'] = 'gcc'
+    prefs.codegen.cpp.compiler = 'gcc'
 
 Using the attribute-based form can be particulary useful for interactive
 work, e.g. in ipython, as it offers autocompletion and documentation.


### PR DESCRIPTION
The preference `codegen.c.compiler` does not exist, guess it was renamed to `codegen.cpp.compiler`?