### PR TITLE
Update documentation for C++ compiler prefs

### DIFF
--- a/brian2/codegen/cpp_prefs.py
+++ b/brian2/codegen/cpp_prefs.py
@@ -118,9 +118,11 @@ prefs.register_preferences(
     compiler = BrianPreference(
         default='',
         docs='''
-        Compiler to use (uses default if empty)
-        
-        Should be gcc or msvc.
+        Compiler to use (uses default if empty).
+        Should be ``'unix'`` or ``'msvc'``.
+
+        To specify a specific compiler binary on unix systems, set the `CXX` environment
+        variable instead.
         '''
         ),
     extra_compile_args=BrianPreference(


### PR DESCRIPTION
See #1322

I expected to be able to set the actual compiler binary with this preferences (which is not the case). So I added a sentence on how to set a specific compiler binary (using environment variable `CXX`). But if you think this doesn't belong here, feel free to remove it again.

And I never used Windows makefiles so I couldn't tell from the win_makefile template if there was a Windows equivalent?