### PR TITLE
Fix deactivation of spiking objects

### DIFF
--- a/brian2/codegen/runtime/cython_rt/templates/common_group.pyx
+++ b/brian2/codegen/runtime/cython_rt/templates/common_group.pyx
@@ -86,6 +86,9 @@ def main(_namespace):
 {{ cython_directives() }}
 {{ imports() }}
 
+# support code
+{{support_code_lines | autoindent}}
+
 def main(_namespace):
     {{ load_namespace | autoindent }}
     if '_owner' in _namespace:

--- a/brian2/codegen/runtime/cython_rt/templates/threshold.pyx
+++ b/brian2/codegen/runtime/cython_rt/templates/threshold.pyx
@@ -32,3 +32,8 @@
     {{_eventspace}}[N] = _cpp_numevents
     
 {% endblock %}
+
+{% block after_code %}
+    {% set _eventspace = get_array_name(eventspace_variable) %}
+    {{_eventspace}}[N] = 0  # Note that this is not an off-by-1-error: the array has N+1 elements
+{% endblock %}

--- a/brian2/codegen/runtime/numpy_rt/templates/threshold.py_
+++ b/brian2/codegen/runtime/numpy_rt/templates/threshold.py_
@@ -40,3 +40,8 @@ else:
 {{lastspike}}[_events] = {{t}}
 {% endif %}
 {% endblock %}
+
+{% block after_code %}
+{% set _eventspace = get_array_name(eventspace_variable) %}
+{{_eventspace}}[-1] = 0
+{% endblock %}

--- a/brian2/core/magic.py
+++ b/brian2/core/magic.py
@@ -222,6 +222,7 @@ class MagicNetwork(Network):
                     break
 
     def after_run(self):
+        super(MagicNetwork, self).after_run()
         self.objects.clear()
         gc.collect()  # Make sure that all unused objects are cleared
 

--- a/brian2/devices/cpp_standalone/device.py
+++ b/brian2/devices/cpp_standalone/device.py
@@ -1504,6 +1504,8 @@ class CPPStandaloneDevice(Device):
                                                                                               report_period=float(report_period)))
         self.main_queue.append(('run_network', (net, run_lines)))
 
+        net.after_run()
+
         # Manually set the cache for the clocks, simulation scripts might
         # want to access the time (which has been set in code and is therefore
         # not accessible by the normal means until the code has been built and

--- a/brian2/devices/cpp_standalone/device.py
+++ b/brian2/devices/cpp_standalone/device.py
@@ -144,8 +144,8 @@ class CPPStandaloneDevice(Device):
         #: List of all arrays to be filled with numbers (list of
         #: (var, varname, start) tuples
         self.arange_arrays = []
-        #: List of all existing synapses
-        self.synapses = []
+        #: Set of all existing synapses
+        self.synapses = set()
         #: Whether the simulation has been run
         self.has_been_run = False
 
@@ -175,7 +175,6 @@ class CPPStandaloneDevice(Device):
         self.networks = set()
         self.static_array_specs = []
         self.report_func = ''
-        self.synapses = []
 
         #: Code lines that have been manually added with `device.insert_code`
         #: Dictionary mapping slot names to lists of lines.
@@ -1374,8 +1373,8 @@ class CPPStandaloneDevice(Device):
             namespace = get_local_namespace(level=level+2)
 
         net.before_run(namespace)
-        self.synapses.extend([s for s in net.objects
-                              if isinstance(s, Synapses)])
+        self.synapses |= {s for s in net.objects
+                          if isinstance(s, Synapses)}
         self.clocks.update(net._clocks)
         net.t_ = float(t_end)
 

--- a/brian2/devices/cpp_standalone/templates/common_group.cpp
+++ b/brian2/devices/cpp_standalone/templates/common_group.cpp
@@ -9,6 +9,11 @@
 #include<fstream>
 #include<climits>
 
+////// SUPPORT CODE ///////
+namespace {
+    {{support_code_lines|autoindent}}
+}
+
 void _before_run_{{codeobj_name}}()
 {
     using namespace brian;
@@ -115,6 +120,11 @@ void _run_{{codeobj_name}}();
 #include<iostream>
 #include<fstream>
 #include<climits>
+
+////// SUPPORT CODE ///////
+namespace {
+    {{support_code_lines|autoindent}}
+}
 
 void _after_run_{{codeobj_name}}()
 {

--- a/brian2/devices/cpp_standalone/templates/threshold.cpp
+++ b/brian2/devices/cpp_standalone/templates/threshold.cpp
@@ -30,3 +30,8 @@
     }
     {{_eventspace}}[N] = _count;
 {% endblock %}
+
+{% block after_code %}
+{% set _eventspace = get_array_name(eventspace_variable) %}
+{{_eventspace}}[N] = 0;  // Note that this is not an off-by-1-error: the array has N+1 elements
+{% endblock %}

--- a/brian2/tests/test_network.py
+++ b/brian2/tests/test_network.py
@@ -537,6 +537,19 @@ def test_network_active_flag():
     assert_equal(y.count, 0)
 
 
+@pytest.mark.standalone_compatible
+@pytest.mark.multiple_runs
+def test_spikes_after_deactivating():
+    # Make sure that a spike in the last time step gets cleared. See #1319
+    always_spike = NeuronGroup(1, '', threshold='True', reset='')
+    spike_mon = SpikeMonitor(always_spike)
+    run(defaultclock.dt)
+    always_spike.active = False
+    run(defaultclock.dt)
+    device.build(direct_call=False, **device.build_options)
+    assert_equal(spike_mon.t[:], [0]*second)
+
+
 @pytest.mark.codegen_independent
 def test_network_t():
     # test that Network.t works as expected


### PR DESCRIPTION
This fixes #1319 (a group continues to spike after it is deactivated with `active=False`). The reason was quite easy to identify: the threshold notes the spikes in the `spikespace` data structure at every time step, but it never clears it up. So if it has spiked in the last time step of a previous run, deactivating it will simply mean that the `spikespace` never gets cleared, and the object therefore repeats the spikes every time step. 
The fix is relatively straightforward: I added a cleanup step (setting the number of spikes to 0) to the `after_run` part of the thresholder template. Unfortunately, this did not work quite flawlessly, which maybe shouldn't come as a complete surprise since we've never actually used the `after_run` slots (we only needed `before_run` so far)... In particular, `MagicNetwork` (which uses its `after_run` method to clean its internal list of objects to avoid memory leaks), did not call `Network.after_run`, and another issue prevented standalone mode from working correctly.
But well, tests pass now, all looks good :)