### PR TITLE
Fix Python system prefix appending in C++ Standalone

### DIFF
--- a/brian2/codegen/cpp_prefs.py
+++ b/brian2/codegen/cpp_prefs.py
@@ -172,6 +172,9 @@ prefs.register_preferences(
         default=[],
         docs='''
         List of directories to search for C/C++ libraries at run time.
+        Note that in on Linux platforms, ``$prefix/lib`` will be appended to the end
+        automatically, where ``$prefix`` is Python's site-specific directory prefix as
+        returned by `sys.prefix`.
         '''
     ),
     libraries=BrianPreference(

--- a/brian2/devices/cpp_standalone/device.py
+++ b/brian2/devices/cpp_standalone/device.py
@@ -1159,25 +1159,25 @@ class CPPStandaloneDevice(Device):
                                 self.code_objects.values()
                                 for include_dir in
                                 codeobj.compiler_kwds.get('include_dirs', [])]
-        include_dirs = (self.include_dirs +
-                        prefs['codegen.cpp.include_dirs'] +
-                        codeobj_include_dirs)
+        include_dirs = (prefs['codegen.cpp.include_dirs'] +
+                        codeobj_include_dirs +
+                        self.include_dirs)
 
         codeobj_library_dirs = [library_dir for codeobj in
                                 self.code_objects.values()
                                 for library_dir in
                                 codeobj.compiler_kwds.get('library_dirs', [])]
-        library_dirs = (self.library_dirs +
-                        prefs['codegen.cpp.library_dirs'] +
-                        codeobj_library_dirs)
+        library_dirs = (prefs['codegen.cpp.library_dirs'] +
+                        codeobj_library_dirs +
+                        self.library_dirs)
 
         codeobj_runtime_dirs = [runtime_dir for codeobj in
                                 self.code_objects.values()
                                 for runtime_dir in
                                 codeobj.compiler_kwds.get('runtime_library_dirs', [])]
-        runtime_library_dirs = (self.runtime_library_dirs +
-                                prefs['codegen.cpp.runtime_library_dirs'] +
-                                codeobj_runtime_dirs)
+        runtime_library_dirs = (prefs['codegen.cpp.runtime_library_dirs'] +
+                                codeobj_runtime_dirs +
+                                self.runtime_library_dirs)
 
         codeobj_libraries = [library for codeobj in
                              self.code_objects.values()


### PR DESCRIPTION
The `sys.prefix` was previously prepended to the `include_dirs`, `libraries` and `runtime_library_dirs`. But I think it should be appended instead, right? Otherwise setting `prefs.codegen.cpp.include_dirs/libraries/runtime_library_dirs` would have no effect if a library with the same name exists in the `lib/include` folder of the `sys.prefix` path.

I also updated the docs for `runtime_library_dirs`. But the `sys.prefix` is only added for linux systems, right? Not sure if you want that in the docs.