### PR TITLE
Add standalone project directory path to pytest report

### DIFF
--- a/brian2/conftest.py
+++ b/brian2/conftest.py
@@ -6,7 +6,7 @@ import re
 import numpy as np
 import pytest
 
-from brian2.devices import reinit_devices
+from brian2.devices import reinit_devices, get_device
 from brian2.units import ms
 from brian2.core.clocks import defaultclock
 from brian2.core.functions import Function, DEFAULT_FUNCTIONS
@@ -99,6 +99,9 @@ def pytest_runtest_makereport(item, call):
     outcome = yield
     rep = outcome.get_result()
     if rep.outcome == 'failed':
+        project_dir = get_device().project_dir
+        if project_dir is not None:
+            rep.sections.append(('Standalone project directory', f'{project_dir}'))
         reinit_devices()
         if not fail_for_not_implemented:
             exc_cause = getattr(call.excinfo.value, '__cause__', None)

--- a/brian2/conftest.py
+++ b/brian2/conftest.py
@@ -99,7 +99,7 @@ def pytest_runtest_makereport(item, call):
     outcome = yield
     rep = outcome.get_result()
     if rep.outcome == 'failed':
-        project_dir = get_device().project_dir
+        project_dir = getattr(get_device(), 'project_dir', None)
         if project_dir is not None:
             rep.sections.append(('Standalone project directory', f'{project_dir}'))
         reinit_devices()


### PR DESCRIPTION
The standalone project directory is not deleted for failed tests. This commit adds a section to the pytest error report that prints this directory. Helps with debugging.

This checks first if the project directory is even set, which is not the case for RuntimeDevices and standalone tests that failed before code generation. I first considered checking the test markers to decide when to print this information, but I guess checking for `project_dir is not None` is the easiest?