### PR TITLE
Fix `prefs.reset_to_defaults()` which is currently failing with `TypeError`

### DIFF
--- a/brian2/core/preferences.py
+++ b/brian2/core/preferences.py
@@ -6,7 +6,7 @@ object ``prefs``.
 import re
 import os
 from collections.abc import MutableMapping
-from io import BytesIO
+from io import StringIO
 
 from brian2.utils.stringtools import deindent, indent
 from brian2.units.fundamentalunits import have_same_dimensions, Quantity
@@ -457,7 +457,7 @@ class BrianGlobalPreferences(MutableMapping):
         '''
         Resets the parameters to their default values.
         '''
-        self.read_preference_file(BytesIO(self.defaults_as_file))
+        self.read_preference_file(StringIO(self.defaults_as_file))
 
     def register_preferences(self, prefbasename, prefbasedoc, **prefs):
         '''

--- a/brian2/tests/__init__.py
+++ b/brian2/tests/__init__.py
@@ -437,7 +437,7 @@ def run(codegen_targets=None, long_tests=False, test_codegen_independent=True,
 
         if reset_preferences:
             # Restore the user preferences
-            prefs.load_preferences(stored_prefs)
+            prefs.read_preference_file(StringIO(stored_prefs))
             prefs._backup()
 
         fundamentalunits.user_unit_register = old_unit_registry

--- a/brian2/tests/__init__.py
+++ b/brian2/tests/__init__.py
@@ -254,11 +254,8 @@ def run(codegen_targets=None, long_tests=False, test_codegen_independent=True,
 
     if reset_preferences:
         print('Resetting to default preferences')
-
-    if reset_preferences:
         stored_prefs = prefs.as_file
-        prefs.read_preference_file(StringIO(prefs.defaults_as_file))
-
+        prefs.reset_to_defaults()
 
     # Avoid failures in the tests for user-registered units
     import copy
@@ -440,7 +437,7 @@ def run(codegen_targets=None, long_tests=False, test_codegen_independent=True,
 
         if reset_preferences:
             # Restore the user preferences
-            prefs.read_preference_file(StringIO(stored_prefs))
+            prefs.load_preferences(stored_prefs)
             prefs._backup()
 
         fundamentalunits.user_unit_register = old_unit_registry

--- a/brian2/tests/test_preferences.py
+++ b/brian2/tests/test_preferences.py
@@ -169,6 +169,9 @@ def test_brianglobalpreferences():
     # check that load_preferences works, but nothing about its values
     gp = BrianGlobalPreferences()
     gp.load_preferences()
+    # Check that resetting to default preferences works
+    gp = BrianGlobalPreferences()
+    gp.reset_to_defaults()
 
 
 @pytest.mark.codegen_independent

--- a/brian2/tests/test_preferences.py
+++ b/brian2/tests/test_preferences.py
@@ -1,4 +1,3 @@
-
 from numpy import float64, float32
 from io import StringIO
 
@@ -169,9 +168,16 @@ def test_brianglobalpreferences():
     # check that load_preferences works, but nothing about its values
     gp = BrianGlobalPreferences()
     gp.load_preferences()
+
     # Check that resetting to default preferences works
     gp = BrianGlobalPreferences()
+    gp.register_preferences('a', 'docs for a',
+                            b=BrianPreference(5, 'docs for b'))
+    assert gp['a.b'] == 5
+    gp['a.b'] = 7
+    assert gp['a.b'] == 7
     gp.reset_to_defaults()
+    assert gp['a.b'] == 5
 
 
 @pytest.mark.codegen_independent


### PR DESCRIPTION
I modified the `test_globalprefences` test to test `prefs.reset_to_defaults()`.

The function call resulted in a `TypeError` due to using `BytesIO` (change introduced in 01050fc0c). Changed it back to `StringIO`, which fixes it.

Not sure if this is an issue specific to the Python version, but the test suite will show I guess. I was running with Python 3.9.6.

EDIT:
The `TypeError` was the following:
```
Traceback (most recent call last):
  File "<string>", line 13, in <module>
  File "/path/to/brian2cuda/tests/features/cuda_configuration.py", line 308, in before_run
    brian2.prefs.reset_to_defaults()
  File "/path/to/brian2/brian2/core/preferences.py", line 460, in reset_to_defaults
    self.read_preference_file(BytesIO(self.defaults_as_file))
TypeError: a bytes-like object is required, not 'str'
```