### PR TITLE
Allow to turn on profiling in `set_device`

### DIFF
--- a/brian2/devices/cpp_standalone/device.py
+++ b/brian2/devices/cpp_standalone/device.py
@@ -1362,6 +1362,14 @@ class CPPStandaloneDevice(Device):
         # We store this as an instance variable for later access by the
         # `code_object` method
         self.enable_profiling = profile
+
+        # Allow setting `profile` in the `set_device` call (used e.g. in brian2cuda
+        # SpeedTest configurations)
+        if 'profile' in self.build_options:
+            build_profile = self.build_options.pop('profile')
+            if build_profile:
+                self.enable_profiling = True
+
         all_objects = net.sorted_objects
         net._clocks = {obj.clock for obj in all_objects}
         t_end = net.t+duration


### PR DESCRIPTION
I've been using this for my benchmarks. I use the `Configuration` classes to setup different benchmark configurations, and being able to set `profile` in `set_device` allows to have configurations with profiling enabled.

The way this is implemented, one can use `set_device(..., profile=True)`, which would overrule the profiling set in `run(..., profile=...)`. I see a problem in this when someone sets `set_device(..., profile=True)` and explicitly `run(..., profile=False)`. This should usually raise a warning and state which option is being used I would say. Easy to implement: Change the default argument to `run(..., profile=None)`, which defaults to not profiling and enables catching an explicit `profile=False`. Happy to implement that if you want it.

I'm just trying to get all the changes that I typically store in a separate `brian2.diff` file into brian2 master to get rid of the diff file. This change is not strictly necessary for me. I have my own `run_speed_tests` function and could somehow pass a profile argument to the run call of the `SpeedTest`s. But if I don't have to, this solution is certainly cleaner for the configuration classes.