### PR TITLE
Remove erroneous list operation

### DIFF
--- a/tutorials/1-intro-to-brian-neurons.ipynb
+++ b/tutorials/1-intro-to-brian-neurons.ipynb
@@ -788,7 +788,7 @@
     "\n",
     "run(duration)\n",
     "\n",
-    "_ = hist(spikemon.t/ms, 100, histtype='stepfilled', facecolor='k', weights=list(ones(len(spikemon))/(N*defaultclock.dt)))\n",
+    "_ = hist(spikemon.t/ms, 100, histtype='stepfilled', facecolor='k', weights=ones(len(spikemon))/(N*defaultclock.dt))\n",
     "xlabel('Time (ms)')\n",
     "ylabel('Instantaneous firing rate (sp/s)');"
    ]


### PR DESCRIPTION
With the current version "Brian2==2.4.2", the last cell doesn't properly execute, as weights now has to have the same shape as x, which it can only have if it's an np array.