### PR TITLE
Use the pre-processor only when checking for C99 compatibility

### DIFF
--- a/brian2/codegen/cpp_prefs.py
+++ b/brian2/codegen/cpp_prefs.py
@@ -327,7 +327,7 @@ def compiler_supports_c99():
             os.remove(tmp_file)
         else:
             cmd = ('echo "#if (__STDC_VERSION__ < 199901L)\n#error\n#endif" | '
-                  'cc -xc -c - > /dev/null 2>&1')
+                  'cc -xc -E - > /dev/null 2>&1')
             return_value = os.system(cmd)
             _compiler_supports_c99 = return_value == 0
     return _compiler_supports_c99

--- a/brian2/tests/test_codegen.py
+++ b/brian2/tests/test_codegen.py
@@ -449,7 +449,12 @@ def test_compiler_c99():
     # On a user's computer, we do not know whether the compiler actually
     # has C99 support, so we just check whether the test does not raise an
     # error
+
+    # The compiler check previously created spurious '-.o' files (see #1348)
+    if os.path.exists('-.o'):
+        os.remove('-.o')
     c99_support = compiler_supports_c99()
+    assert not os.path.exists('-.o')
     # On our Azure test server we know that the compilers support C99
     if os.environ.get('AGENT_OS', ''):
         assert c99_support


### PR DESCRIPTION
Actually compiling the file is not only unnecessary, it also creates a spurious `-.o` file
Fixes #1348