### PR TITLE
Remove warning that dividing integers leads to floating point values

### DIFF
--- a/brian2/parsing/bast.py
+++ b/brian2/parsing/bast.py
@@ -222,30 +222,6 @@ class BrianASTRenderer(object):
         if node.op.__class__.__name__ == 'Div':
             # Division turns integers into floating point values
             newdtype = 'float'
-            # Give a warning if the code uses floating point division where it
-            # previously might have used floor division
-            if node.left.dtype == node.right.dtype == 'integer':
-                # This would have led to floor division in earlier versions of
-                # Brian (except for the numpy target on Python 3)
-                # Ignore cases where the user already took care of this by
-                # wrapping the result of the division in int(...) or
-                # floor(...)
-                if not (hasattr(node, 'parent') and
-                        node.parent.__class__.__name__ == 'Call' and
-                        node.parent.func.id in ['int', 'floor']):
-                    rendered_expr = NodeRenderer().render_node(node)
-                    msg = ('The expression "{}" divides two integer values. '
-                           'In previous versions of Brian, this would have '
-                           'used either an integer ("flooring") or a floating '
-                           'point division, depending on the Python version '
-                           'and the code generation target. In the current '
-                           'version, it always uses a floating point '
-                           'division. Explicitly ask for an  integer division '
-                           '("//"), or turn one of the operands into a '
-                           'floating point value (e.g. replace "1/2" by '
-                           '"1.0/2") to no longer receive this '
-                           'warning.'.format(rendered_expr))
-                    logger.warn(msg, 'floating_point_division', once=True)
         node.dtype = newdtype
         node.scalar = node.left.scalar and node.right.scalar
         node.complexity = 1+node.left.complexity+node.right.complexity

--- a/brian2/tests/test_neurongroup.py
+++ b/brian2/tests/test_neurongroup.py
@@ -1840,11 +1840,7 @@ def test_semantics_floating_point_division():
         y2 = fvalue/3
         ''')
         run(defaultclock.dt)
-    # Some devices (e.g. Brian2GeNN) might not raise a warning
-    assert (len(l) == 0 or
-            (len(l) == 1 and
-             l[0][1].endswith('floating_point_division') and
-             'ivalue / 3' in l[0][2]))
+
     assert_allclose(G.x1[:], int_values / 3)
     assert_allclose(G.y1[:], int_values / 3)
     assert_allclose(G.x2[:], float_values / 3)


### PR DESCRIPTION
Note that we actually originally planned to remove this warning when going Python2-only :)
https://github.com/brian-team/brian2/pull/984#issuecomment-409170575

Fixes #1339