### PR TITLE
Compiler dirs prefix

### DIFF
--- a/brian2/codegen/cpp_prefs.py
+++ b/brian2/codegen/cpp_prefs.py
@@ -111,6 +111,11 @@ else:
     else:
         default_buildopts = ['-w']
 
+if sys.platform == 'win32':
+    prefix_dir = os.path.join(sys.prefix, 'Library')
+else:
+    prefix_dir = sys.prefix
+
 # Preferences
 prefs.register_preferences(
     'codegen.cpp',
@@ -154,26 +159,33 @@ prefs.register_preferences(
         '''
     ),
     include_dirs=BrianPreference(
-        default=[],
+        default=[os.path.join(prefix_dir, 'include')],
         docs='''
-        Include directories to use. Note that ``$prefix/include`` will be
-        appended to the end automatically, where ``$prefix`` is Python's
-        site-specific directory prefix as returned by `sys.prefix`.
+        Include directories to use.
+        The default value is ``$prefix/include`` (or ``$prefix/Library/include``
+        on Windows), where ``$prefix`` is Python's site-specific directory
+        prefix as returned by `sys.prefix`. This will make compilation use
+        library files installed into a conda environment.
         '''
         ),
     library_dirs=BrianPreference(
-        default=[],
+        default=[os.path.join(prefix_dir, 'lib')],
         docs='''
         List of directories to search for C/C++ libraries at link time.
-        Note that ``$prefix/lib`` will be appended to the end automatically,
-        where ``$prefix`` is Python's site-specific directory prefix as returned
-        by `sys.prefix`.
+        The default value is ``$prefix/lib`` (or ``$prefix/Library/lib``
+        on Windows), where ``$prefix`` is Python's site-specific directory
+        prefix as returned by `sys.prefix`. This will make compilation use
+        library files installed into a conda environment.
         '''
     ),
     runtime_library_dirs=BrianPreference(
-        default=[],
+        default=[os.path.join(prefix_dir, 'lib')],
         docs='''
         List of directories to search for C/C++ libraries at run time.
+        The default value is ``$prefix/lib`` (or ``$prefix/Library/lib``
+        on Windows), where ``$prefix`` is Python's site-specific directory
+        prefix as returned by `sys.prefix`. This will make compilation use
+        library files installed into a conda environment.
         '''
     ),
     libraries=BrianPreference(

--- a/brian2/codegen/cpp_prefs.py
+++ b/brian2/codegen/cpp_prefs.py
@@ -179,13 +179,14 @@ prefs.register_preferences(
         '''
     ),
     runtime_library_dirs=BrianPreference(
-        default=[os.path.join(prefix_dir, 'lib')],
+        default=[os.path.join(prefix_dir, 'lib')]
+                    if sys.platform != 'win32' else [],
         docs='''
         List of directories to search for C/C++ libraries at run time.
-        The default value is ``$prefix/lib`` (or ``$prefix/Library/lib``
-        on Windows), where ``$prefix`` is Python's site-specific directory
-        prefix as returned by `sys.prefix`. This will make compilation use
-        library files installed into a conda environment.
+        The default value is ``$prefix/lib`` (not used on Windows), where
+        ``$prefix`` is Python's site-specific directory prefix as returned by
+        `sys.prefix`. This will make compilation use library files installed
+        into a conda environment.
         '''
     ),
     libraries=BrianPreference(

--- a/brian2/codegen/runtime/cython_rt/cython_rt.py
+++ b/brian2/codegen/runtime/cython_rt/cython_rt.py
@@ -97,7 +97,7 @@ class CythonCodeObject(NumpyCodeObject):
         self.library_dirs = (list(prefs['codegen.cpp.library_dirs']) +
                              compiler_kwds.get('library_dirs', []))
 
-        self.runtime_library_dirs = (list(prefs['codegen.cpp.runtime_library_dirs']),
+        self.runtime_library_dirs = (list(prefs['codegen.cpp.runtime_library_dirs']) +
                                      compiler_kwds.get('runtime_library_dirs', []))
 
         self.libraries = (list(prefs['codegen.cpp.libraries']) +
@@ -118,7 +118,8 @@ class CythonCodeObject(NumpyCodeObject):
                                                                  extra_compile_args=extra_compile_args,
                                                                  extra_link_args=prefs['codegen.cpp.extra_link_args'],
                                                                  include_dirs=prefs['codegen.cpp.include_dirs'],
-                                                                 library_dirs=prefs['codegen.cpp.library_dirs'])
+                                                                 library_dirs=prefs['codegen.cpp.library_dirs'],
+                                                                 runtime_library_dirs=prefs['codegen.cpp.runtime_library_dirs'])
             compiled.main()
             return True
         except Exception as ex:
@@ -140,6 +141,7 @@ class CythonCodeObject(NumpyCodeObject):
             extra_link_args=self.extra_link_args,
             include_dirs=self.include_dirs,
             library_dirs=self.library_dirs,
+            runtime_library_dirs=self.runtime_library_dirs,
             compiler=self.compiler,
             owner_name=self.owner.name+'_'+self.template_name,
             sources=self.sources

--- a/brian2/codegen/runtime/cython_rt/cython_rt.py
+++ b/brian2/codegen/runtime/cython_rt/cython_rt.py
@@ -93,17 +93,9 @@ class CythonCodeObject(NumpyCodeObject):
         self.include_dirs = (list(prefs['codegen.cpp.include_dirs']) +
                              compiler_kwds.get('include_dirs', []))
         self.include_dirs = list(prefs['codegen.cpp.include_dirs'])
-        if sys.platform == 'win32':
-            self.include_dirs += [os.path.join(sys.prefix, 'Library', 'include')]
-        else:
-            self.include_dirs += [os.path.join(sys.prefix, 'include')]
 
         self.library_dirs = (list(prefs['codegen.cpp.library_dirs']) +
                              compiler_kwds.get('library_dirs', []))
-        if sys.platform == 'win32':
-            self.library_dirs += [os.path.join(sys.prefix, 'Library', 'lib')]
-        else:
-            self.library_dirs += [os.path.join(sys.prefix, 'lib')]
 
         self.runtime_library_dirs = (list(prefs['codegen.cpp.runtime_library_dirs']),
                                      compiler_kwds.get('runtime_library_dirs', []))

--- a/brian2/codegen/runtime/cython_rt/extension_manager.py
+++ b/brian2/codegen/runtime/cython_rt/extension_manager.py
@@ -191,6 +191,8 @@ class CythonExtensionManager(object):
                 include_dirs = []
             if library_dirs is None:
                 library_dirs = []
+            if runtime_library_dirs is None:
+                runtime_library_dirs = []
             if extra_compile_args is None:
                 extra_compile_args = []
             if extra_link_args is None:

--- a/brian2/devices/cpp_standalone/device.py
+++ b/brian2/devices/cpp_standalone/device.py
@@ -205,18 +205,8 @@ class CPPStandaloneDevice(Device):
         self.define_macros = []
         self.headers = []
         self.include_dirs = ['brianlib/randomkit']
-        if sys.platform == 'win32':
-            self.include_dirs += [os.path.join(sys.prefix, 'Library', 'include')]
-        else:
-            self.include_dirs += [os.path.join(sys.prefix, 'include')]
         self.library_dirs = ['brianlib/randomkit']
-        if sys.platform == 'win32':
-            self.library_dirs += [os.path.join(sys.prefix, 'Library', 'Lib')]
-        else:
-            self.library_dirs += [os.path.join(sys.prefix, 'lib')]
         self.runtime_library_dirs = []
-        if sys.platform.startswith('linux'):
-            self.runtime_library_dirs += [os.path.join(sys.prefix, 'lib')]
         self.run_environment_variables = {}
         if sys.platform.startswith('darwin'):
             if 'DYLD_LIBRARY_PATH' in os.environ:


### PR DESCRIPTION
See discussion in #1333. The `sys.prefix` setting was prepended to the preferences for `include_dirs`/`library_dirs`/`runtime_library_dirs` in standalone mode, but appended in Cython (and `runtime_library_dirs` was completely ignored in Cython).

This is now uniform, the `sys,prefix` setting is simply the default for the respective preference, so the user can overwrite it completely if they prefer.