### PR TITLE
Correcting units on Kremer et al 2011

### DIFF
--- a/examples/frompapers/Kremer_et_al_2011_barrel_cortex.py
+++ b/examples/frompapers/Kremer_et_al_2011_barrel_cortex.py
@@ -108,10 +108,10 @@ feedforward = Synapses(layer4, layer23exc,
                                 dA_target/dt = -A_target/taud : volt (event-driven)''',
                        on_pre='''ge+=w
                               A_source += Ap
-                              w = clip(w+A_target, 0, EPSC)''',
+                              w = clip(w+A_target, 0*volt, EPSC)''',
                        on_post='''
                               A_target += Ad
-                              w = clip(w+A_source, 0, EPSC)''',
+                              w = clip(w+A_source, 0*volt, EPSC)''',
                        name='feedforward')
 # Connect neurons in the same barrel with 50% probability
 feedforward.connect('(barrel_x_pre + barrelarraysize*barrel_y_pre) == barrel_idx_post',


### PR DESCRIPTION
prior version used:
```python
 w = clip(w+A_target, 0, EPSC)''',
```
on lines 111 and 114. This threw dimension mismatch errors since `w+A_target` is of unit `volt`

simply multiplying `0*volt` was sufficient to correct the script, and I have verified this runs on my machine and in binder:
```python
 w = clip(w+A_target, 0*volt, EPSC)''',
```