### PR TITLE
Manually limit builds to 3.9

### DIFF
--- a/.github/workflows/testsuite.yml
+++ b/.github/workflows/testsuite.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       min-python: ${{ steps.nep29.outputs.min-python }}
-      max-python: ${{ steps.nep29.outputs.max-python }}
+      max-python: "3.9"
     steps:
       - name: "calculate versions according to NEP29"
         id: nep29


### PR DESCRIPTION
Python 3.10 is not yet supported by conda, etc.