### PR TITLE
Ignore import errors when collecting doctests

### DIFF
--- a/brian2/tests/__init__.py
+++ b/brian2/tests/__init__.py
@@ -108,6 +108,7 @@ def make_argv(dirnames, markers=None, doctests=False, test_GSL=False):
             '--quiet',
             '--doctest-modules',
             '--doctest-glob=*.rst',
+            '--doctest-ignore-import-errors',
             '--confcutdir', os.path.abspath(os.path.join(os.path.dirname(__file__), '..')),
             '--pyargs', 'brian2'
         ]


### PR DESCRIPTION
This avoids scary error messages when running the test suite without having sphinx/docutils installed (required for the `brian2.sphinxext` package). See e.g. this [report on the discussion forum](https://brian.discourse.group/t/errors-with-conda-installation-of-brian2-on-a-mac-with-m1-processor/464/8).