### PR TITLE
Verify that namespace keys do not start with underscore

### DIFF
--- a/brian2/core/base.py
+++ b/brian2/core/base.py
@@ -40,17 +40,23 @@ class BrianObject(Nameable):
     order : int, optional
         The priority of this object for operations occurring at the same time
         step and in the same scheduling slot. Defaults to 0.
+    namespace: dict, optional
+        A dictionary mapping identifier names to objects. If not given, the
+        namespace will be filled in at the time of the call of `Network.run`,
+        with either the values from the ``namespace`` argument of the
+        `Network.run` method or from the local context, if no such argument is
+        given.
     name : str, optional
         A unique name for the object - one will be assigned automatically if
         not provided (of the form ``brianobject_1``, etc.).
-
     Notes
     -----
         
     The set of all `BrianObject` objects is stored in ``BrianObject.__instances__()``.
     '''    
     @check_units(dt=second)
-    def __init__(self, dt=None, clock=None, when='start', order=0, name='brianobject*'):
+    def __init__(self, dt=None, clock=None, when='start', order=0,
+                 namespace=None, name='brianobject*'):
         # Setup traceback information for this object
         creation_stack = []
         bases = []
@@ -125,7 +131,18 @@ class BrianObject(Nameable):
         
         #: The scope key is used to determine which objects are collected by magic
         self._scope_key = self._scope_current_key
-        
+
+        # Make sure that keys in the namespace are valid
+        if namespace is None:
+            namespace = {}
+        for key in namespace:
+            if key.startswith('_'):
+                raise ValueError("Names starting with underscores are "
+                                 "reserved for internal use an cannot be "
+                                 "defined in the namespace argument.")
+        #: The group-specific namespace
+        self.namespace = namespace
+
         logger.diagnostic("Created BrianObject with name {self.name}, "
                           "clock={self._clock}, "
                           "when={self.when}, order={self.order}".format(self=self))

--- a/brian2/groups/neurongroup.py
+++ b/brian2/groups/neurongroup.py
@@ -477,7 +477,7 @@ class NeuronGroup(Group, SpikeSource):
                  name='neurongroup*',
                  codeobj_class=None):
         Group.__init__(self, dt=dt, clock=clock, when='start', order=order,
-                       name=name)
+                       namespace=namespace, name=name)
         if dtype is None:
             dtype = {}
         if isinstance(dtype, MutableMapping):
@@ -530,11 +530,6 @@ class NeuronGroup(Group, SpikeSource):
         self._linked_variables = set()
         logger.diagnostic("Creating NeuronGroup of size {self._N}, "
                           "equations {self.equations}.".format(self=self))
-
-        if namespace is None:
-            namespace = {}
-        #: The group-specific namespace
-        self.namespace = namespace
 
         # All of the following will be created in before_run
 

--- a/brian2/input/poissongroup.py
+++ b/brian2/input/poissongroup.py
@@ -52,13 +52,8 @@ class PoissonGroup(Group, SpikeSource):
                  order=0, namespace=None, name='poissongroup*',
                  codeobj_class=None):
 
-        if namespace is None:
-            namespace = {}
-        #: The group-specific namespace
-        self.namespace = namespace
-
         Group.__init__(self, dt=dt, clock=clock, when=when, order=order,
-                       name=name)
+                       namespace=namespace, name=name)
 
         self.codeobj_class = codeobj_class
 

--- a/brian2/synapses/synapses.py
+++ b/brian2/synapses/synapses.py
@@ -725,7 +725,7 @@ class Synapses(Group):
             on_post = post
 
         Group.__init__(self, dt=dt, clock=clock, when='start', order=order,
-                       name=name)
+                       namespace=namespace, name=name)
 
         if dtype is None:
             dtype = {}
@@ -823,11 +823,6 @@ class Synapses(Group):
 
         self._create_variables(model, user_dtype=dtype)
         self.equations = Equations(continuous)
-
-        if namespace is None:
-            namespace = {}
-        #: The group-specific namespace
-        self.namespace = namespace
 
         #: Set of `Variable` objects that should be resized when the
         #: number of synapses changes

--- a/brian2/tests/test_namespaces.py
+++ b/brian2/tests/test_namespaces.py
@@ -18,10 +18,9 @@ from brian2.utils.logger import catch_logs
 class SimpleGroup(Group):
     def __init__(self, variables, namespace=None):
         self.variables = variables
-        self.namespace = namespace
         # We use a unique name to get repeated warnings
-        Group.__init__(self, name='simplegroup_' +
-                                  str(uuid.uuid4()).replace('-', '_'))
+        Group.__init__(self, namespace=namespace,
+                       name='simplegroup_' + str(uuid.uuid4()).replace('-', '_'))
 
 def _assert_one_warning(l):
     assert len(l) == 1, "expected one warning got %d" % len(l)
@@ -84,6 +83,9 @@ def test_errors():
     with pytest.raises(KeyError):
         group._resolve('nonexisting_variable', {})
 
+    # Illegal name
+    with pytest.raises(ValueError):
+        SimpleGroup(namespace={'_illegal': 3.0}, variables={})
 
 @pytest.mark.codegen_independent
 def test_resolution():


### PR DESCRIPTION
This fixes #1302. The example given in that issue was:
```Python
lam = 0.5
G = NeuronGroup(5, 'x : integer')
G.run_regularly('''x = poisson(lam)''')

G1 = NeuronGroup(5, 'x : integer', namespace={'lam': 0.1})
G1.run_regularly('''x = poisson(lam)''')

G2 = NeuronGroup(5, 'x : integer', namespace={'a': 0.1})
G2.run_regularly('''x = poisson(a)''')

G3 = NeuronGroup(5, 'x : integer', namespace={'_poisson': 0.1})
G3.run_regularly('''x = poisson(_poisson)''')
```
The first three examples work correctly (since #1276), and the fourth now raises a meaningful error instead of failing during compilation.