### PR TITLE
Follow-up/fix to #1362 : do not overwrite inherited namespace

### DIFF
--- a/brian2/core/base.py
+++ b/brian2/core/base.py
@@ -132,7 +132,8 @@ class BrianObject(Nameable):
 
         # Make sure that keys in the namespace are valid
         if namespace is None:
-            namespace = {}
+            # Do not overwrite namespace if already set (e.g. in StateMonitor)
+            namespace = getattr(self, 'namespace', {})
         for key in namespace:
             if key.startswith('_'):
                 raise ValueError("Names starting with underscores are "

--- a/brian2/tests/test_monitor.py
+++ b/brian2/tests/test_monitor.py
@@ -432,6 +432,15 @@ def test_state_monitor_resize():
     # variable that is visible to the user
     assert mon.variables['v'].size == (10, 2)
 
+@pytest.mark.codegen_independent
+def test_statemonitor_namespace():
+    # Make sure that StateMonitor is correctly inheriting its source's namespace
+    G = NeuronGroup(2, 'x = i + y : integer', namespace={'y': 3})
+    mon = StateMonitor(G, 'x', record=True)
+    run(defaultclock.dt, namespace={})
+    assert_array_equal(mon.x, [[3], [4]])
+
+
 @pytest.mark.standalone_compatible
 def test_rate_monitor_1():
     G = NeuronGroup(5, 'v : 1', threshold='v>1') # no reset


### PR DESCRIPTION
Since the namespace handling moved to `BrianObject` (#1362), it enforced an empty dictionary as a namespace if no namespace was given during the object creation. This makes `StateMonitor`'s namespace handling break: `StateMonitor` inherits its source's namespace *before* calling `BrianObject.__init__`