### PR TITLE
Helpful compile error on Unix

### DIFF
--- a/brian2/codegen/runtime/cython_rt/cython_rt.py
+++ b/brian2/codegen/runtime/cython_rt/cython_rt.py
@@ -1,6 +1,4 @@
-
-import os
-import sys
+import platform
 
 import numpy
 
@@ -123,12 +121,15 @@ class CythonCodeObject(NumpyCodeObject):
             compiled.main()
             return True
         except Exception as ex:
-            logger.warn(
-                f"Cannot use Cython, a test compilation failed: {str(ex)} ({ex.__class__.__name__})\n"
-                f"Certain compiler configurations (e.g. clang in a conda environment on OS X) are "
-                f"known to be problematic. Note that you can switch the compiler by setting the "
-                f"'CC' and 'CXX' environment variables. For example, you may want to try 'CC=gcc' "
-                f"and 'CXX=g++'.", 'failed_compile_test')
+            msg = (f"Cannot use Cython, a test compilation failed: {str(ex)} " 
+                   f"({ex.__class__.__name__})")
+            if platform.system() != 'Windows':
+                msg += ("\nCertain compiler configurations (e.g. clang in a conda "
+                        "environment on OS X) are known to be problematic. Note that "
+                        "you can switch the compiler by setting the 'CC' and 'CXX' "
+                        "environment variables. For example, you may want to try "
+                        "'CC=gcc' and 'CXX=g++'.")
+            logger.warn(msg, 'failed_compile_test')
             return False
 
     def compile_block(self, block):

--- a/brian2/codegen/runtime/cython_rt/cython_rt.py
+++ b/brian2/codegen/runtime/cython_rt/cython_rt.py
@@ -123,8 +123,12 @@ class CythonCodeObject(NumpyCodeObject):
             compiled.main()
             return True
         except Exception as ex:
-            logger.warn(f'Cannot use Cython, a test compilation failed: {str(ex)} ({ex.__class__.__name__})',
-                        'failed_compile_test')
+            logger.warn(
+                f"Cannot use Cython, a test compilation failed: {str(ex)} ({ex.__class__.__name__})\n"
+                f"Certain compiler configurations (e.g. clang in a conda environment on OS X) are "
+                f"known to be problematic. Note that you can switch the compiler by setting the "
+                f"'CC' and 'CXX' environment variables. For example, you may want to try 'CC=gcc' "
+                f"and 'CXX=g++'.", 'failed_compile_test')
             return False
 
     def compile_block(self, block):

--- a/brian2/codegen/runtime/cython_rt/extension_manager.py
+++ b/brian2/codegen/runtime/cython_rt/extension_manager.py
@@ -81,16 +81,21 @@ class CythonExtensionManager(object):
             os.makedirs(lib_dir)
         except OSError:
             if not os.path.exists(lib_dir):
-                raise IOError("Couldn't create Cython cache directory '%s', try setting the "
-                              "cache directly with prefs.codegen.runtime.cython.cache_dir." % lib_dir)
+                raise IOError(
+                    f"Couldn't create Cython cache directory '{lib_dir}', try setting the "
+                    f"cache directly with prefs.codegen.runtime.cython.cache_dir.")
 
         numpy_version = '.'.join(numpy.__version__.split('.')[:2])  # Only use major.minor version
-        key = code, sys.version_info, sys.executable, Cython.__version__, numpy_version
+        # avoid some issues when manually switching compilers
+        CC = os.environ.get('CC', None)
+        CXX = os.environ.get('CXX', None)
+        key = (code, sys.version_info, sys.executable, Cython.__version__,
+               numpy_version, CC, CXX)
             
         if force:
             # Force a new module name by adding the current time to the
             # key which is hashed to determine the module name.
-            key += time.time(),            
+            key += time.time(),  # Note the trailing comma (this is a tuple)
 
         if key in self._code_cache:
             return self._code_cache[key]


### PR DESCRIPTION
Mentions the `CC` and `CXX` environment variables if the Cython test compilation fails. See this discussion in the [discussion forum](https://brian.discourse.group/t/problem-with-cython) for some context.