### PR TITLE
Update wheel building infrastructure

### DIFF
--- a/.github/workflows/publish_to_pypi.yml
+++ b/.github/workflows/publish_to_pypi.yml
@@ -31,6 +31,7 @@ jobs:
           CIBW_BEFORE_BUILD: pip install --only-binary numpy "cython>=0.29" numpy>=1.17 setuptools
           CIBW_PROJECT_REQUIRES_PYTHON: ">=3.7"
           CIBW_ARCHS: auto64
+          CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
           CIBW_ARCHS_MACOS: x86_64 universal2
           CIBW_TEST_SKIP: '*_arm64 *_universal2:arm64'
           CIBW_SKIP: pp*

--- a/.github/workflows/publish_to_pypi.yml
+++ b/.github/workflows/publish_to_pypi.yml
@@ -23,7 +23,7 @@ jobs:
           python setup.py sdist --formats=gztar --with-cython --fail-on-error
         if: ${{ startsWith(matrix.os, 'ubuntu-') }}
       - name: Build wheels
-        uses: joerick/cibuildwheel@v1.9.0
+        uses: pypa/cibuildwheel@v2.2.2
         with:
           output-dir: dist
         env:

--- a/.github/workflows/publish_to_pypi.yml
+++ b/.github/workflows/publish_to_pypi.yml
@@ -6,6 +6,7 @@ jobs:
     name: Build wheels on ${{ matrix.os }} and publish to (Test)PyPI
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [ ubuntu-20.04, windows-2019, macOS-10.15 ]
     steps:

--- a/.github/workflows/publish_to_pypi.yml
+++ b/.github/workflows/publish_to_pypi.yml
@@ -34,7 +34,7 @@ jobs:
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
           CIBW_ARCHS_MACOS: x86_64 universal2
           CIBW_TEST_SKIP: '*_arm64 *_universal2:arm64'
-          CIBW_SKIP: pp*
+          CIBW_SKIP: 'pp* *-musllinux_*'
           CIBW_TEST_COMMAND: python {project}/dev/continuous-integration/run_simple_test.py
           CIBW_TEST_REQUIRES: pytest
       - name: Publish distribution 📦 to Test PyPI

--- a/docs_sphinx/introduction/release_notes.rst
+++ b/docs_sphinx/introduction/release_notes.rst
@@ -1,6 +1,12 @@
 Release notes
 =============
 
+Brian 2.5.0.1
+-------------
+A new build to provide binary
+`wheels <https://packaging.python.org/guides/distributing-packages-using-setuptools/#wheels>`_
+for Python 3.10.
+
 .. _brian2.5:
 Brian 2.5
 ---------


### PR DESCRIPTION
Make sure that we can build wheels for Python 3.10