### PR TITLE
Avoid that formatted strings discard units of quantities

### DIFF
--- a/brian2/tests/test_units.py
+++ b/brian2/tests/test_units.py
@@ -258,6 +258,15 @@ def test_str_repr():
 
 
 @pytest.mark.codegen_independent
+def test_format_quantity():
+    # Avoid that the default f-string (or .format call) discards units when used without
+    # a format spec
+    q = 0.5*ms
+    assert f"{q}" == f"{q!s}" == str(q)
+    assert f"{q:g}" == f"{float(q)}"
+
+
+@pytest.mark.codegen_independent
 def test_slicing():
     # Slicing and indexing, setting items
     quantity = np.reshape(np.arange(6), (2, 3)) * mV

--- a/brian2/units/fundamentalunits.py
+++ b/brian2/units/fundamentalunits.py
@@ -1597,6 +1597,13 @@ class Quantity(np.ndarray, object):
     def __str__(self):
         return self.in_best_unit()
 
+    def __format__(self, format_spec):
+        # Avoid that formatted strings like f"{q}" use floating point formatting for the
+        # quantity, i.e. discard the unit
+        if format_spec == "":
+            return str(self)
+        else:
+            return super(Quantity, self).__format__(format_spec)
     #### Mathematic methods ####
 
     cumsum = wrap_function_keep_dimensions(np.ndarray.cumsum)


### PR DESCRIPTION
The big string formatting unification in d3ae59251c753ae introduced a regression in a few places, because the default formatting for quantities used in f-strings or `.format` is to display it as a floating point number, discarding its units:
```pycon
>>> start = 0*second
>>> duration = 1 * second
>>> print("Starting simulation at t=%s for a duration of %s" % (start, duration))
Starting simulation at t=0. s for a duration of 1. s
>>> print(f"Starting simulation at t={start} for a duration of {duration}")
Starting simulation at t=0.0 for a duration of 1.0
```
In most places, I worked around this by using something like `"... t={start!s}"` to manually force a conversion to a string, but I think it would be better if we changed quantities' default for "formatting without format spec" (which would also be more consistent with a simple `print(start)`). Luckily, we can do this easily using the `__format__` function. With this PR, both print statements above give the same output.