### PR TITLE
Fix python 2 exception syntax in code string

### DIFF
--- a/brian2/tests/features/base.py
+++ b/brian2/tests/features/base.py
@@ -255,7 +255,7 @@ try:
     f = open(r'{tempfname}', 'wb')
     pickle.dump((None, results, run_time, new_prof_info), f, -1)
     f.close()
-except Exception, ex:
+except Exception as ex:
     #traceback.print_exc(file=sys.stdout)
     tb = traceback.format_exc()
     f = open(r'{tempfname}', 'wb')


### PR DESCRIPTION
I came across this trying to run brian2genn feature tests, which failed immediately with a cryptic
```
felix@mouse:~/projects/lib/brian2genn/scripts$ python run_correctness_testing.py
Running feature tests
Configurations: Default, GeNN
Input: SpikeGeneratorGroup: [ ERROR      Brian 2 encountered an unexpected error. If you think this is a bug in Brian 2, please report this issue either to the discourse forum at <http://brian.discourse.group/>, or to the issue tracker at <https://github.com/brian-team/brian2/issues>. Please include this file with debug information in your report: /tmp/brian_debug_labacji8.log  Additionally, you can also include a copy of the script that was run, available at: /tmp/brian_script_2id5zh1j.py Thanks! [brian2]
Traceback (most recent call last):
  File "/home/felix/projects/lib/brian2genn/scripts/run_correctness_testing.py", line 32, in <module>
    print(run_feature_tests(configurations=[DefaultConfiguration,GeNNConfiguration],
  File "/home/felix/projects/lib/brian2/brian2/tests/features/base.py", line 328, in run_feature_tests
    tb, res, runtime, prof_info = results(configuration, ft, maximum_run_time=maximum_run_time)
  File "/home/felix/projects/lib/brian2/brian2/tests/features/base.py", line 282, in results
    with open(tempfilename, 'rb') as f:
FileNotFoundError: [Errno 2] No such file or directory: '/tmp/tmpjnngagj1exception'
```
Turns out that the subprocess launched just prior to the raising line failed with 
```
File "<string>", line 32
    except Exception, ex:
                    ^
SyntaxError: invalid syntax
```
Replacing the offending line with `except Exception as ex:` fixes this.