### PR TITLE
Consistent naming for contained objects

### DIFF
--- a/brian2/core/names.py
+++ b/brian2/core/names.py
@@ -10,7 +10,25 @@ __all__ = ['Nameable']
 logger = get_logger(__name__)
 
 
-def find_name(name):
+def find_name(name, names=None):
+    """
+    Determine a unique name. If the desired ``name`` is already taken, will try
+    to use a derived ``name_1``, ``name_2``, etc.
+
+    Parameters
+    ----------
+    name : str
+        The desired name.
+    names : Iterable, optional
+        A set of names that are already taken. If not provided, will use the names
+        of all Brian objects as stored in `Nameable`.
+    
+    Returns
+    -------
+    unique_name : str
+        A name based on ``name`` or ``name`` itself, unique with respect to the
+        names in ``names``.
+    """
     if not name.endswith('*'):
         # explicitly given names are used as given. Network.before_run (and
         # the device in case of standalone) will check for name clashes later
@@ -18,9 +36,12 @@ def find_name(name):
 
     name = name[:-1]
 
-    instances = set(Nameable.__instances__())
-    allnames = set(obj().name for obj in instances
-                   if hasattr(obj(), 'name'))
+    if names is None:
+        instances = set(Nameable.__instances__())
+        allnames = set(obj().name for obj in instances
+                    if hasattr(obj(), 'name'))
+    else:
+        allnames = names
 
     # Try the name without any additions first:
     if name not in allnames:

--- a/brian2/groups/group.py
+++ b/brian2/groups/group.py
@@ -15,7 +15,7 @@ import inspect
 import numpy as np
 
 from brian2.core.base import BrianObject, weakproxy_with_fallback
-from brian2.core.names import Nameable
+from brian2.core.names import Nameable, find_name
 from brian2.core.preferences import prefs
 from brian2.core.variables import (Variables, Constant, Variable,
                                    ArrayVariable, DynamicArrayVariable,
@@ -943,7 +943,8 @@ class Group(VariableOwner, BrianObject):
             A reference to the object that will be run.
         """
         if name is None:
-            name = f"{self.name}_run_regularly*"
+            names = [o.name for o in self.contained_objects]
+            name = find_name(f"{self.name}_run_regularly*", names)
 
         if dt is None and clock is None:
             clock = self._clock

--- a/brian2/groups/neurongroup.py
+++ b/brian2/groups/neurongroup.py
@@ -179,7 +179,7 @@ class StateUpdater(CodeRunner):
                             clock=group.clock,
                             when='groups',
                             order=group.order,
-                            name=f"{group.name}_stateupdater*",
+                            name=f"{group.name}_stateupdater",
                             check_units=False,
                             generate_empty_code=False)
 
@@ -312,7 +312,7 @@ class Thresholder(CodeRunner):
                             clock=group.clock,
                             when=when,
                             order=group.order,
-                            name=f"{group.name}_thresholder*",
+                            name=f"{group.name}_{event}_thresholder",
                             needed_variables=needed_variables,
                             template_kwds=template_kwds)
 
@@ -369,7 +369,7 @@ class Resetter(CodeRunner):
                             clock=group.clock,
                             when=when,
                             order=order,
-                            name=f"{group.name}_resetter*",
+                            name=f"{group.name}_{event}_resetter",
                             override_conditional_write=['not_refractory'],
                             needed_variables=needed_variables,
                             template_kwds=template_kwds)

--- a/brian2/tests/test_network.py
+++ b/brian2/tests/test_network.py
@@ -297,10 +297,11 @@ def test_scheduling_summary_magic():
                                       name=f"{basename}_sm_ia", when='after_end')
     inactive_state_mon.active = False
     summary_before = scheduling_summary()
+
     assert [entry.name for entry in summary_before.entries] == [f"{basename}_sm",
                                                                 f"{basename}_stateupdater",
-                                                                f"{basename}_thresholder",
-                                                                f"{basename}_resetter",
+                                                                f"{basename}_spike_thresholder",
+                                                                f"{basename}_spike_resetter",
                                                                 f"{basename}_run_regularly",
                                                                 f"{basename}_sm_ia"]
     assert [entry.when for entry in summary_before.entries] == ['start',
@@ -347,8 +348,8 @@ def test_scheduling_summary():
     summary_before = scheduling_summary(net)
     assert [entry.name for entry in summary_before.entries] == [f"{basename}_sm",
                                                                 f"{basename}_stateupdater",
-                                                                f"{basename}_thresholder",
-                                                                f"{basename}_resetter",
+                                                                f"{basename}_spike_thresholder",
+                                                                f"{basename}_spike_resetter",
                                                                 f"{basename}_net_op",
                                                                 f"{basename}_run_regularly",
                                                                 f"{basename}_sm_ia"]
@@ -1436,7 +1437,7 @@ def test_profile():
     # does
     assert 3 <= len(info) <= 4
     assert len(info) == 3 or 'profile_test' in info_dict
-    for obj in ['stateupdater', 'thresholder', 'resetter']:
+    for obj in ['stateupdater', 'spike_thresholder', 'spike_resetter']:
         name = f"profile_test_{obj}"
         assert name in info_dict or f"{name}_codeobject" in info_dict
     assert all([t>=0*second for _, t in info])


### PR DESCRIPTION
We've been discussing the issue of auto-generated names (`neurongroup_1`, etc.) in code for a while, see e.g. #680. This is a big issue without an easy fix, but when discussing a related issue in Brian2GeNN with @kernfel (brian-team/brian2genn#141) I realized that we should at least make an intermediate solution work: if the user specifies names, then the network should have consistent names for all objects. This sounds trivial, but did actually not work correctly before. E.g. when you do:
```Python
for _ in range(2):
  group = NeuronGroup(10, 'dv/dt = 100*Hz : 1',
          threshold='v > 1', reset='v = 0', name='group')
  from brian2.core.network import _get_all_objects
  print(sorted([o.name for o in _get_all_objects(collect())]))
```
You'll get:
```
['group', 'group_resetter', 'group_stateupdater', 'group_thresholder']
['group', 'group_resetter_1', 'group_stateupdater_1', 'group_thresholder_1']
```
Brian uses the automatic naming system for `resetter`, etc., but at that point, the previous objects still exist. With this PR, objects get a consistent name derived from the parent name. We can only have one `stateupdater`, so there's nothing else we need to do, and for `resetter` and `thresholder` we can add the name of the event to make the names unique in case of custom events. The new output is then:
```
['group', 'group_spike_resetter', 'group_spike_thresholder', 'group_stateupdater']
['group', 'group_spike_resetter', 'group_spike_thresholder', 'group_stateupdater']
```

For `run_regularly` operations, we keep the previous naming scheme but only restrict the names to existing `run_regularly` objects within the same containing object. This means that
```Python
for _ in range(2):
  group = NeuronGroup(10, 'x : 1', name='group')
  group.run_regularly('x -= 1')
  group.run_regularly('x += 1')
  from brian2.core.network import _get_all_objects
  print(sorted([o.name for o in _get_all_objects(collect())]))
```
no longer cycles through the names like it does on `master`: 
```
['group', 'group_run_regularly', 'group_run_regularly_1', 'group_stateupdater_2']
['group', 'group_run_regularly_2', 'group_run_regularly_3', 'group_stateupdater_1']
```
but instead reuses the same names:
```
['group', 'group_run_regularly', 'group_run_regularly_1', 'group_stateupdater']
['group', 'group_run_regularly', 'group_run_regularly_1', 'group_stateupdater']
```
In principle, this could change simulation results in some corner cases (regenerated objects, results rely on the ordering imposed by the names), but if this is the case, then the results were "fragile" before, since running the garbage collector could make a difference. I'm not sure whether this is really something to worry about. To me the behaviour before was "undefined" and now it becomes well-defined (while almost always giving the same results).
