### PR TITLE
Make evaluate_expr more robust

### DIFF
--- a/brian2/codegen/optimisation.py
+++ b/brian2/codegen/optimisation.py
@@ -31,11 +31,24 @@ def evaluate_expr(expr, ns):
     Try to evaluate the expression in the given namespace
 
     Returns either (value, True) if successful, or (expr, False) otherwise.
+
+    Example
+    -------
+    >>> assumptions = {'sin': DEFAULT_FUNCTIONS['sin'].pyfunc,
+    ...                'pi': DEFAULT_CONSTANTS['pi'].value}
+    >>> evaluate_expr('1/2', assumptions)
+    (0.5, True)
+    >>> evaluate_expr('sin(pi/2)', assumptions)
+    (1.0, True)
+    >>> evaluate_expr('sin(2*pi*freq*t)', assumptions)
+    ('sin(2*pi*freq*t)', False)
+    >>> evaluate_expr('1/0', assumptions)
+    ('1/0', False)
     """
     try:
         val = eval(expr, ns)
         return val, True
-    except NameError:
+    except (NameError, ArithmeticError):
         return expr, False
 
 


### PR DESCRIPTION
This function is used during code optimization to replace constant expressions. It previously failed for expressions like 1/0.

This has been reported on the [discussion forum](https://brian.discourse.group/t/model-fitting-with-refractory-period/615) in the context of a model with refractoriness. With the `(unless refractory)` flag, a differential equation will be multiplied with `int(not_refractory)` and our optimization procedure recognizes this pattern and transforms it into an `if not_refractory:... else: ...` structure with 1 or 0 substituted for `int(not_refractory)`. For the refractory block, it can happen that the 0 values appears in multiple places, including the denominator of divisions – in the end this won't matter since everything gets multiplied by 0 anyway, but intermediate steps might try to evaluate these terms that divide by 0.

The fix in this PR is really simple, it simply does not optimize terms that raise an `ArithmeticError` such as a division by 0.