### PR TITLE
Add `before_run` & `after_run` code slots for `insert_code` mechanism

### DIFF
--- a/brian2/devices/cpp_standalone/device.py
+++ b/brian2/devices/cpp_standalone/device.py
@@ -196,10 +196,10 @@ class CPPStandaloneDevice(Device):
         #: Note that the main slot is handled separately as part of `main_queue`
         self.code_lines = {'before_start': [],
                            'after_start': [],
+                           'before_network_run': [],
+                           'after_network_run': [],
                            'before_end': [],
-                           'after_end': [],
-                           'before_run': [],
-                           'after_run': []}
+                           'after_end': []}
 
         self.clocks = set([])
 
@@ -1481,9 +1481,9 @@ class CPPStandaloneDevice(Device):
             if clock not in all_clocks:
                 run_lines.append(f'{net.name}.add(&{clock.name}, NULL);')
 
-        run_lines.extend(self.code_lines['before_run'])
+        run_lines.extend(self.code_lines['before_network_run'])
         run_lines.append(f'{net.name}.run({float(duration)!r}, {report_call}, {float(report_period)!r});')
-        run_lines.extend(self.code_lines['after_run'])
+        run_lines.extend(self.code_lines['after_network_run'])
         self.main_queue.append(('run_network', (net, run_lines)))
 
         net.after_run()

--- a/brian2/devices/cpp_standalone/device.py
+++ b/brian2/devices/cpp_standalone/device.py
@@ -197,7 +197,9 @@ class CPPStandaloneDevice(Device):
         self.code_lines = {'before_start': [],
                            'after_start': [],
                            'before_end': [],
-                           'after_end': []}
+                           'after_end': [],
+                           'before_run': [],
+                           'after_run': []}
 
         self.clocks = set([])
 
@@ -1479,7 +1481,9 @@ class CPPStandaloneDevice(Device):
             if clock not in all_clocks:
                 run_lines.append(f'{net.name}.add(&{clock.name}, NULL);')
 
+        run_lines.extend(self.code_lines['before_run'])
         run_lines.append(f'{net.name}.run({float(duration)!r}, {report_call}, {float(report_period)!r});')
+        run_lines.extend(self.code_lines['after_run'])
         self.main_queue.append(('run_network', (net, run_lines)))
 
         net.after_run()

--- a/docs_sphinx/user/computation.rst
+++ b/docs_sphinx/user/computation.rst
@@ -172,8 +172,6 @@ of the number of threads. However, this is working fine for networks with not
 too small timestep (dt > 0.1ms), and results do not depend on the number of
 threads used in the simulation.
 
-.. _standalone_custom_build:
-
 Custom code injection
 ~~~~~~~~~~~~~~~~~~~~~
 It is possible to insert custom code directly into the generated code of a
@@ -225,6 +223,7 @@ The code injection mechanism has been used for benchmarking experiments, see
 e.g. `here for Brian2CUDA benchmarks <https://github.com/brian-team/brian2cuda/blob/835c978ad758bc0621e34344c1fb7b811ef8a118/brian2cuda/tests/features/cuda_configuration.py#L148-L156>`_ or `here for Brian2GeNN benchmarks <https://github.com/brian-team/brian2genn_benchmarks/blob/6d1a6d9d97c05653cec2e413c9fd312cfe13e15c/benchmark_utils.py#L78-L136>`_.
 
 
+.. _standalone_custom_build:
 
 Customizing the build process
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
I used these for my benchmarks, would like to get this out of the patch file, also for future benchmarking. Any objections? :)