### PR TITLE
Add timers for compilation and binary execution

### DIFF
--- a/brian2/devices/cpp_standalone/device.py
+++ b/brian2/devices/cpp_standalone/device.py
@@ -1265,6 +1265,13 @@ class CPPStandaloneDevice(Device):
             self.compile_source(directory, compiler, debug, clean)
             if run:
                 self.run(directory, with_output, run_args)
+        time_measurements = {"'make clean'": self.timers['compile']['clean'],
+                             "'make'": self.timers['compile']['make'],
+                             "running 'main'": self.timers['run_binary']}
+        logged_times = [f"{task}: {measurement:.2f}s"
+                        for task, measurement in time_measurements.items()
+                        if measurement is not None]
+        logger.debug(f"Time measurements: {', '.join(logged_times)}")
 
     def delete(self, code=True, data=True, directory=True, force=False):
         if self.project_dir is None:

--- a/brian2/devices/cpp_standalone/device.py
+++ b/brian2/devices/cpp_standalone/device.py
@@ -1,4 +1,3 @@
-
 """
 Module implementing the C++ "standalone" device.
 """
@@ -201,9 +200,8 @@ class CPPStandaloneDevice(Device):
 
         #: Dictionary storing compile and binary execution times
         self.timers = {'run_binary': None,
-                       'compile': {'clean':None,
-                                   'make': None,
-                                   'all': None}}
+                       'compile': {'clean': None,
+                                   'make': None}}
 
         self.clocks = set([])
 
@@ -975,9 +973,7 @@ class CPPStandaloneDevice(Device):
                         start_time = time.time()
                         x = os.system(f'{make_cmd} {make_args}>>winmake.log 2>&1')
                         self.timers['compile']['make'] = time.time() - start_time
-                    self.timers['compile']['all'] = sum(
-                        t for t in self.timers['compile'].values() if t is not None
-                    )
+
                     if x != 0:
                         if os.path.exists('winmake.log'):
                             with open('winmake.log', 'r') as f:
@@ -992,10 +988,14 @@ class CPPStandaloneDevice(Device):
             else:
                 with std_silent(debug):
                     if clean:
+                        start_time = time.time()
                         os.system('make clean >/dev/null 2>&1')
+                        self.timers['compile']['clean'] = time.time() - start_time
                     make_cmd = prefs.devices.cpp_standalone.make_cmd_unix
                     make_args = ' '.join(prefs.devices.cpp_standalone.extra_make_args_unix)
+                    start_time = time.time()
                     x = os.system(f'{make_cmd} {make_args}')
+                    self.timers['compile']['make'] = time.time() - start_time
                     if x != 0:
                         error_message = ('Project compilation failed (error '
                                          'code: %u).') % x
@@ -1032,7 +1032,9 @@ class CPPStandaloneDevice(Device):
             else:
                 stdout = None
             if os.name == 'nt':
+                start_time = time.time()
                 x = subprocess.call(['main'] + run_args, stdout=stdout)
+                self.timers['run_binary'] = time.time() - start_time
             else:
                 run_cmd = prefs.devices.cpp_standalone.run_cmd_unix
                 if isinstance(run_cmd, str):


### PR DESCRIPTION
I used these for benchmarks as well. I find this information quite useful. I would even go as far as printing it out explicitly when running with `profile=True`. Or even when not running with it. At least for Brian2CUDA this could be quite important to evaluate the usefulness of using a GPU or not. Or to track down why things go slow.

I just copied what I used in the patch file. It adds a bit of noise to the code and it adds the overhead of 4 `time.time()` calls. If you want, I can make this optional, only when `profile == True` or anything like that? But I doubt this generates much simulation overhead, no?

Oh, and I only added it to the CPPStandaloneDevice I just realized. If you want this, I can also add it to the other devices of course?