### PR TITLE
Fix docstrings of `event_trains` and `spike_trains`

### DIFF
--- a/brian2/monitors/spikemonitor.py
+++ b/brian2/monitors/spikemonitor.py
@@ -326,7 +326,7 @@ class EventMonitor(Group, CodeRunner):
 
     def event_trains(self):
         """
-        Return a dictionary mapping event indices to arrays of event times.
+        Return a dictionary mapping neuron indices to arrays of event times.
         Equivalent to calling ``values('t')``.
 
         Returns
@@ -441,7 +441,7 @@ class SpikeMonitor(EventMonitor):
 
     def spike_trains(self):
         """
-        Return a dictionary mapping spike indices to arrays of spike times.
+        Return a dictionary mapping neuron indices to arrays of spike times.
 
         Returns
         -------


### PR DESCRIPTION
The descriptive part of the docstrings of the `EventMonitor.event_trains` and `SpikeMonitor.spike_trains` methods wrongly indicated that a dictionary mapping _event_/_spike_ indices to event/spike times is returned. What is actually returned instead is a dictionary mapping _neuron_ indices to event/spike times. This commit fixes these mistakes by changing "_event_/_spike_ indices" to "_neuron_ indices".