### PR TITLE
Fix using indexed morphology for threshold_location

### DIFF
--- a/brian2/spatialneuron/spatialneuron.py
+++ b/brian2/spatialneuron/spatialneuron.py
@@ -246,12 +246,12 @@ class SpatialNeuron(NeuronGroup):
             if hasattr(threshold_location,
                        '_indices'):  # assuming this is a method
                 threshold_location = threshold_location._indices()
-                # for now, only a single compartment allowed
-                if len(threshold_location) == 1:
-                    threshold_location = threshold_location[0]
-                else:
-                    raise AttributeError("Threshold can only be applied on a "
-                                         "single location")
+            # for now, only a single compartment allowed
+            try:
+                treshold_location = int(threshold_location)
+            except TypeError:
+                raise AttributeError("Threshold can only be applied on a "
+                                     "single location")
             threshold = f"({threshold}) and (i == {str(threshold_location)})"
 
         # Check flags (we have point currents)

--- a/brian2/tests/test_spatialneuron.py
+++ b/brian2/tests/test_spatialneuron.py
@@ -822,6 +822,51 @@ def test_point_current():
     assert 'I1/area' in neuron.equations['Im'].expr.code
     assert 'I2/area' in neuron.equations['Im'].expr.code  # see issue #1160
 
+@pytest.mark.standalone_compatible
+@pytest.mark.multiple_runs
+def test_spatialneuron_threshold_location():
+    morpho = Soma(10*um)
+    morpho.axon = Cylinder(1*um, n=2, length=20*um)
+    model = '''
+    Im = 0*nA/cm**2 : amp/meter**2
+    should_spike : boolean (constant)
+    '''
+    neuron = SpatialNeuron(morpho, model, threshold_location=morpho.axon[15*um],
+                           threshold='should_spike')
+    # Different variants that should do the same thing
+    neuron2 = SpatialNeuron(morpho, model, threshold_location=morpho.axon.indices[15*um],
+                           threshold='should_spike')
+    neuron3 = SpatialNeuron(morpho, model, threshold_location=2,
+                           threshold='should_spike')
+    # Cannot use multiple compartments
+    with pytest.raises(AttributeError):
+        SpatialNeuron(morpho, model, threshold_location=[2, 3],
+                           threshold='should_spike')
+    with pytest.raises(AttributeError):
+        SpatialNeuron(morpho, model, threshold_location=morpho.axon[5*um:15*um],
+                           threshold='should_spike')
+    neurons = [neuron, neuron2, neuron3]
+    monitors = [SpikeMonitor(n) for n in neurons]
+
+    net = Network(neurons, monitors)
+    for n in neurons:
+        n.should_spike = True  # all compartments want to spike
+    net.run(defaultclock.dt)
+    for n in neurons:
+        n.should_spike = False  # no compartment wants to spike
+    net.run(defaultclock.dt)
+    for n in neurons:
+        n.should_spike = [False, False, True]
+    net.run(defaultclock.dt)
+    for n in neurons:
+        n.should_spike = [True, True, False]
+    net.run(defaultclock.dt)
+    device.build(direct_call=False, **device.build_options)
+    for mon in monitors:
+        assert len(mon.i) == 2
+        assert all(mon.i == 2)
+        assert_allclose(mon.t, [0*ms, 2*defaultclock.dt])
+
 
 if __name__ == '__main__':
     test_custom_events()


### PR DESCRIPTION
As @romainbrette noticed, the `threshold_location` argument of `SpatialNeuron` did not accept a morphology, as in 
```Python
neuron = SpatialNeuron(..., threshold_location=morpho.axon[15*um])
```
We explicitly mention this syntax in the [documentation](https://brian2.readthedocs.io/en/stable/user/multicompartmental.html#detecting-spikes), so it should work.
The workaround was to either directly provide the compartment number or use `morpho.axon.indices[15*um]`.

This PR fixes the issue, and also adds a corresponding test to make sure this error does not come up again.