### PR TITLE
Avoid casting timesteps to 32bit in C++ standalone

### DIFF
--- a/brian2/devices/cpp_standalone/brianlib/clocks.h
+++ b/brian2/devices/cpp_standalone/brianlib/clocks.h
@@ -6,9 +6,9 @@
 #include<math.h>
 
 namespace {
-	inline int fround(double x)
+	inline int64_t fround(double x)
 	{
-		return (int)(x+0.5);
+		return (int64_t)(x+0.5);
 	};
 };
 
@@ -28,20 +28,20 @@ public:
 	inline bool running() { return timestep[0]<i_end; };
 	void set_interval(double start, double end)
 	{
-        int i_start = fround(start/dt[0]);
+        int64_t i_start = fround(start/dt[0]);
         double t_start = i_start*dt[0];
         if(t_start==start || fabs(t_start-start)<=epsilon*fabs(t_start))
         {
             timestep[0] = i_start;
         } else
         {
-            timestep[0] = (int)ceil(start/dt[0]);
+            timestep[0] = (int64_t)ceil(start/dt[0]);
         }
         i_end = fround(end/dt[0]);
         double t_end = i_end*dt[0];
         if(!(t_end==end || fabs(t_end-end)<=epsilon*fabs(t_end)))
         {
-            i_end = (int)ceil(end/dt[0]);
+            i_end = (int64_t)ceil(end/dt[0]);
         }
 	}
 private:

--- a/brian2/tests/test_network.py
+++ b/brian2/tests/test_network.py
@@ -1535,6 +1535,23 @@ def test_both_equal():
 
     assert (M1.v == M2.v).all()
 
+@pytest.mark.standalone_compatible
+def test_long_run():
+    defaultclock.dt = 0.1 * ms
+    group = NeuronGroup(1, 'x : 1')
+    group.run_regularly('x += 1')
+    # Timesteps are internally stored as 64bit integers, but previous versions
+    # converted them into 32bit integers along the way. We'll make sure that
+    # this is not the case and everything runs fine. To not actually run such a
+    # long simulation we manually advance the clock.
+    net = Network(group, name='network')
+    start_step = 2**31-5
+    start_time = start_step*defaultclock.dt_
+    with catch_logs() as l:
+        net.t_ = start_time  # for runtime
+        device.insert_code('main', 'network.t = {};'.format(start_time))  # for standalone
+        net.run(6 * defaultclock.dt)
+    assert group.x == 6
 
 @pytest.mark.codegen_independent
 def test_long_run_dt_change():
@@ -1570,6 +1587,7 @@ def test_multiple_runs_function_change():
     run(2*defaultclock.dt)
     device.build(direct_call=False, **device.build_options)
     assert_equal(mon.v[0], [1, 2, 3, 4])
+
 
 if __name__ == '__main__':
     BrianLogger.log_level_warn()
@@ -1635,6 +1653,7 @@ if __name__ == '__main__':
             test_runtime_rounding,
             test_small_runs,
             test_both_equal,
+            test_long_run,
             test_long_run_dt_change,
             test_multiple_runs_constant_change,
             test_multiple_runs_function_change


### PR DESCRIPTION
Before, long runs with more than 2e9 timesteps failed to run.
Note that the issue was also fixed as part of the open PR #1057, but progress on that PR has stalled.

Fixes #1394