### PR TITLE
Improve support for index-based synapses in standalone

### DIFF
--- a/brian2/devices/cpp_standalone/device.py
+++ b/brian2/devices/cpp_standalone/device.py
@@ -587,6 +587,36 @@ class CPPStandaloneDevice(Device):
                                          prefs['codegen.cpp.headers'] +
                                          codeobj_headers)
         template_kwds['profiled'] = self.enable_profiling
+
+        
+        do_not_invalidate = set()
+        if template_name == 'synapses_create_array':
+            cache = self.array_cache
+            if cache[variables['N']] is None:  # case 1: synapses have been created with code
+                pass  # Nothing we can do
+            elif cache[variables['N']][0] == 0:  # case 2: first time we are creating synapses
+                cache[variables['N']][0] = variables['sources'].size
+                do_not_invalidate.add(variables['N'])
+                for var, value in [(variables['_synaptic_pre'],
+                                    variables['sources'].get_value() +
+                                    variables['_source_offset'].get_value()),
+                                   (variables['_synaptic_post'],
+                                    variables['targets'].get_value() +
+                                    variables['_target_offset'].get_value())]:
+                    cache[var] = value
+                    do_not_invalidate.add(var)
+            elif cache[variables['N']][0] > 0:  # case 3: we created synapses with arrays before
+                cache[variables['N']][0] += variables['sources'].size
+                do_not_invalidate.add(variables['N'])
+                for var, value in [(variables['_synaptic_pre'],
+                                    variables['sources'].get_value() +
+                                    variables['_source_offset'].get_value()),
+                                   (variables['_synaptic_post'],
+                                    variables['targets'].get_value() +
+                                    variables['_target_offset'].get_value())]:
+                    cache[var] = np.append(cache[var], value)
+                    do_not_invalidate.add(var)
+
         codeobj = super(CPPStandaloneDevice, self).code_object(owner, name, abstract_code, variables,
                                                                template_name, variable_indices,
                                                                codeobj_class=codeobj_class,
@@ -620,7 +650,7 @@ class CPPStandaloneDevice(Device):
                                   for varname in template.writes_read_only} |
                                  getattr(owner, 'written_readonly_vars', set()))
         for var in codeobj.variables.values():
-            if (isinstance(var, ArrayVariable) and
+            if (isinstance(var, ArrayVariable) and not var in do_not_invalidate and
                     (not var.read_only or var in written_readonly_vars)):
                 self.array_cache[var] = None
 

--- a/brian2/monitors/statemonitor.py
+++ b/brian2/monitors/statemonitor.py
@@ -209,6 +209,20 @@ class StateMonitor(Group, CodeRunner):
         self.record = record
         self.n_indices = len(record)
 
+        if not self.record_all:
+            # Check whether the values in record make sense
+            error_message = ("The indices to record from contain values outside of the range "
+                             "[0, {max_value}] allowed for the group '{group_name}'")
+        try:
+            if len(record) and (np.max(record) >= len(source) or np.min(record) < 0):
+                raise IndexError(error_message.format(max_value=len(source)-1,
+                                                      group_name=source.name))
+        except NotImplementedError:
+            logger.warn("Cannot check whether the indices to record from are valid. This can happen "
+                        "in standalone mode when recording from synapses that have been created with "
+                        "a connection pattern. You can avoid this situation by using synaptic indices "
+                        "in the connect call.", name_suffix='cannot_check_statemonitor_indices')
+
         # Some dummy code so that code generation takes care of the indexing
         # and subexpressions
         code = [f'_to_record_{v} = _source_{v}'

--- a/brian2/synapses/synapses.py
+++ b/brian2/synapses/synapses.py
@@ -1588,12 +1588,20 @@ class Synapses(Group):
                          'values outside of the range [0, {max_value}] '
                          'allowed for the {source_or_target} group '
                          '"{group_name}"')
-        for indices, source_or_target, group in [(sources, 'source', self.source),
-                                                 (targets, 'target', self.target)]:
-            if np.max(indices) >= len(group) or np.min(indices) < 0:
-                raise IndexError(error_message.format(source_or_target=source_or_target,
-                                                      max_value=len(group)-1,
-                                                      group_name=group.name))
+        try:
+            for indices, source_or_target, group in [(sources, 'source', self.source),
+                                                    (targets, 'target', self.target)]:
+                if np.max(indices) >= len(group) or np.min(indices) < 0:
+                    raise IndexError(error_message.format(source_or_target=source_or_target,
+                                                        max_value=len(group)-1,
+                                                        group_name=group.name))
+        except NotImplementedError:
+            logger.warn("Cannot check whether the indices given for the connect call are "
+                        "valid. This can happen in standalone mode when using indices to connect "
+                        "to synapses that have been created with a connection pattern. You can "
+                        "avoid this situation by either using a connection pattern or synaptic "
+                        "indices in both connect calls.",
+                        name_suffix='cannot_check_synapse_indices')
         n = np.atleast_1d(n)
         p = np.atleast_1d(p)
 

--- a/brian2/synapses/synapses.py
+++ b/brian2/synapses/synapses.py
@@ -1614,9 +1614,9 @@ class Synapses(Group):
         targets = targets.repeat(n)
 
         variables.add_array('sources', len(sources), dtype=np.int32,
-                            values=sources)
+                            values=sources, read_only=True)
         variables.add_array('targets', len(targets), dtype=np.int32,
-                            values=targets)
+                            values=targets, read_only=True)
         # These definitions are important to get the types right in C++
         variables.add_auxiliary_variable('_real_sources', dtype=np.int32)
         variables.add_auxiliary_variable('_real_targets', dtype=np.int32)

--- a/brian2/tests/test_cpp_standalone.py
+++ b/brian2/tests/test_cpp_standalone.py
@@ -61,6 +61,35 @@ def test_multiple_connects():
 
 @pytest.mark.cpp_standalone
 @pytest.mark.standalone_only
+def test_device_cache_synapses():
+    # Check that we can ask for known synaptic information at runtime
+    set_device('cpp_standalone', build_on_run=False)
+    G = NeuronGroup(10, 'v:1')
+    S = Synapses(G, G, 'w:1')
+    S.connect(i=[0], j=[0])
+    assert len(S) == 1
+    assert_equal(S.i[:], [0])
+    assert_equal(S.j[:], [0])
+    
+    S.connect(i=[1], j=[1])
+    assert len(S) == 2
+    assert_equal(S.i[:], [0, 1])
+    assert_equal(S.j[:], [0, 1])
+
+    S.connect(p=0.1)  # We can't know anything about synapses anymore
+
+    with pytest.raises(NotImplementedError):
+        len(S)
+    
+    with pytest.raises(NotImplementedError):
+        S.i[:]
+
+    with pytest.raises(NotImplementedError):
+        S.j[:]
+
+
+@pytest.mark.cpp_standalone
+@pytest.mark.standalone_only
 def test_storing_loading():
     set_device('cpp_standalone', build_on_run=False)
     G = NeuronGroup(10, """v : volt

--- a/brian2/tests/test_synapses.py
+++ b/brian2/tests/test_synapses.py
@@ -2077,6 +2077,20 @@ def test_synapses_to_synapses():
     # Third group has its weight increased to 2 after the second spike
     assert_array_equal(target.v, [5, 3, 4])
 
+@pytest.mark.standalone_compatible
+def test_synapses_to_synapses_connection_array():
+    source = SpikeGeneratorGroup(3, [0, 1, 2], [0, 0, 0]*ms, period=2*ms)
+    modulator = SpikeGeneratorGroup(3, [0, 2], [1, 3]*ms)
+    target = NeuronGroup(3, 'v : integer')
+    conn = Synapses(source, target, 'w : integer', on_pre='v += w')
+    conn.connect(i=[0, 1, 2], j=[0, 1, 2])
+    conn.w = 1
+    modulatory_conn = Synapses(modulator, conn, on_pre='w += 1')
+    modulatory_conn.connect(i=[0, 1, 2], j=[0, 1, 2])
+    run(5*ms)
+    # First group has its weight increased to 2 after the first spike
+    # Third group has its weight increased to 2 after the second spike
+    assert_array_equal(target.v, [5, 3, 4])
 
 @pytest.mark.standalone_compatible
 def test_synapses_to_synapses_statevar_access():

--- a/brian2/tests/test_synapses.py
+++ b/brian2/tests/test_synapses.py
@@ -15,6 +15,7 @@ from brian2.stateupdaters.base import UnsupportedEquationsException
 from brian2.utils.logger import catch_logs
 from brian2.utils.stringtools import get_identifiers, word_substitute, indent, deindent
 from brian2.devices.device import reinit_and_delete, all_devices, get_device
+from brian2.devices.cpp_standalone.device import CPPStandaloneDevice
 from brian2.codegen.permutation_analysis import check_for_order_independence, OrderDependenceError
 from brian2.synapses.parse_synaptic_generator_syntax import parse_synapse_generator
 from brian2.tests.utils import assert_allclose, exc_isinstance
@@ -2087,6 +2088,32 @@ def test_synapses_to_synapses_connection_array():
     conn.w = 1
     modulatory_conn = Synapses(modulator, conn, on_pre='w += 1')
     modulatory_conn.connect(i=[0, 1, 2], j=[0, 1, 2])
+    run(5*ms)
+    # First group has its weight increased to 2 after the first spike
+    # Third group has its weight increased to 2 after the second spike
+    assert_array_equal(target.v, [5, 3, 4])
+
+@pytest.mark.standalone_compatible
+def test_synapses_to_synapses_rule_and_array():
+    set_device('cpp_standalone')
+    source = SpikeGeneratorGroup(3, [0, 1, 2], [0, 0, 0]*ms, period=2*ms)
+    modulator = SpikeGeneratorGroup(3, [0, 2], [1, 3]*ms)
+    target = NeuronGroup(3, 'v : integer')
+    conn = Synapses(source, target, 'w : integer', on_pre='v += w')
+    conn.connect(j='i')
+    conn.w = 1
+    modulatory_conn = Synapses(modulator, conn, on_pre='w += 1')
+    # This will raise a warning in standalone mode, since we cannot check
+    # whether the 'j' indices actually correspond to existing synapses
+    # (the j='i' connection from above has not been executed yet)
+    with catch_logs() as l:
+        modulatory_conn.connect(i=[0, 1, 2], j=[0, 1, 2])
+    if isinstance(get_device(), CPPStandaloneDevice):
+        assert len(l) == 1
+        assert l[0][0] == 'WARNING'
+        assert l[0][1] == 'brian2.synapses.synapses.cannot_check_synapse_indices'
+    else:
+        assert len(l) == 0
     run(5*ms)
     # First group has its weight increased to 2 after the first spike
     # Third group has its weight increased to 2 after the second spike


### PR DESCRIPTION
Currently, Brian cannot check the indices of synapses before a run, even if they were connected with explicitly given index arrays. This leads to errors when connecting with modulating synapses to these synapses (as e.g. in the [Izhikevich 2007 example](https://brian2.readthedocs.io/en/stable/examples/frompapers.Izhikevich_2007.html)), since Brian tries to check whether the targeted synapses exist.
This PR fixes this by storing the indices of synapses (if connected with index arrays) in the "array cache", meaning that it knows them (and in particular the total number of synapses) before building/running the standalone simulation. When synapses are generated via an expression, the check mechanism will now raise a warning instead of an error (we cannot check, but we are also not sure it is wrong). This fixes #1383 and fixes #1028 and allows the above mentioned example to run in standalone mode.

This PR also adds support to check the indices provided to the `record` argument of a `StateMonitor` – in the same way as above, this will work for recording from synapses if the total number of synapses is known, and will raise a warning in standalone for an unknown number of synapses. This fixes  #961.

The fixes here apply to C++ standalone mode, but since `brian2cuda` and `brian2genn` call the same function, they should benefit from the fix as well.
@davideschiavone, @mdepitta, @denisalevi : I verified the examples given in the issues referenced above, but if you have other code that did not work before, I'd be happy if you could run it against this PR.
