### PR TITLE
Avoid creating temp files in current dir

### DIFF
--- a/brian2/codegen/cpp_prefs.py
+++ b/brian2/codegen/cpp_prefs.py
@@ -239,7 +239,11 @@ def _determine_flag_compatibility(compiler, flagname):
     with tempfile.NamedTemporaryFile('w', suffix='.cpp') as f, std_silent():
         f.write('int main (int argc, char **argv) { return 0; }')
         try:
-            compiler.compile([f.name], extra_postargs=[flagname])
+            object_files = compiler.compile([f.name],
+                                            output_dir=os.path.dirname(f.name),
+                                            extra_postargs=[flagname])
+            for object_file in object_files:
+                os.unlink(object_file)
         except CompileError:
             logger.warn(f"Removing unsupported flag '{flagname}' from "
                         f'compiler flags.')

--- a/brian2/codegen/cpp_prefs.py
+++ b/brian2/codegen/cpp_prefs.py
@@ -236,14 +236,13 @@ prefs.register_preferences(
 def _determine_flag_compatibility(compiler, flagname):
     import tempfile
     from distutils.errors import CompileError
-    with tempfile.NamedTemporaryFile('w', suffix='.cpp') as f, std_silent():
-        f.write('int main (int argc, char **argv) { return 0; }')
+    with tempfile.TemporaryDirectory(prefix='brian_flag_test_') as temp_dir, std_silent():
+        fname = os.path.join(temp_dir, 'flag_test.cpp')
+        with open(fname, 'wt') as f:
+            f.write('int main (int argc, char **argv) { return 0; }')
         try:
-            object_files = compiler.compile([f.name],
-                                            output_dir=os.path.dirname(f.name),
-                                            extra_postargs=[flagname])
-            for object_file in object_files:
-                os.unlink(object_file)
+            compiler.compile([fname], output_dir=temp_dir,
+                             extra_postargs=[flagname])
         except CompileError:
             logger.warn(f"Removing unsupported flag '{flagname}' from "
                         f'compiler flags.')


### PR DESCRIPTION
Somewhat similar to #1348, our check whether the compiler supports certain flags created the compiled object files in a `tmp` directory in the current directory. This PR:
1. Creates these files in the temporary directory instead, and
2. Removes them after compilation