### PR TITLE
Deterministic code generation

### DIFF
--- a/brian2/codegen/codeobject.py
+++ b/brian2/codegen/codeobject.py
@@ -349,7 +349,7 @@ def create_runner_codeobj(group, code, template_name,
         needed_variables = []
     # Resolve all variables (variables used in the code and variables needed by
     # the template)
-    variables = group.resolve_all(identifiers | set(needed_variables) | set(template_variables),
+    variables = group.resolve_all(sorted(identifiers | set(needed_variables) | set(template_variables)),
                                   # template variables are not known to the user:
                                   user_identifiers=user_identifiers,
                                   additional_variables=additional_variables,

--- a/brian2/codegen/generators/cpp_generator.py
+++ b/brian2/codegen/generators/cpp_generator.py
@@ -240,7 +240,7 @@ class CPPCodeGenerator(CodeGenerator):
     def translate_to_read_arrays(self, read, write, indices):
         lines = []
         # index and read arrays (index arrays first)
-        for varname in itertools.chain(indices, read):
+        for varname in itertools.chain(sorted(indices), sorted(read)):
             index_var = self.variable_indices[varname]
             var = self.variables[varname]
             if varname not in write:
@@ -255,7 +255,7 @@ class CPPCodeGenerator(CodeGenerator):
     def translate_to_declarations(self, read, write, indices):
         lines = []
         # simply declare variables that will be written but not read
-        for varname in write:
+        for varname in sorted(write):
             if varname not in read and varname not in indices:
                 var = self.variables[varname]
                 line = f"{self.c_data_type(var.dtype)} {varname};"
@@ -278,7 +278,7 @@ class CPPCodeGenerator(CodeGenerator):
     def translate_to_write_arrays(self, write):
         lines = []
         # write arrays
-        for varname in write:
+        for varname in sorted(write):
             index_var = self.variable_indices[varname]
             var = self.variables[varname]
             line = f"{self.get_array_name(var)}[{index_var}] = {varname};"

--- a/brian2/codegen/generators/cython_generator.py
+++ b/brian2/codegen/generators/cython_generator.py
@@ -132,7 +132,7 @@ class CythonCodeGenerator(CodeGenerator):
 
     def translate_to_read_arrays(self, read, indices):
         lines = []
-        for varname in itertools.chain(indices, read):
+        for varname in itertools.chain(sorted(indices), sorted(read)):
             var = self.variables[varname]
             index = self.variable_indices[varname]
             arrayname = self.get_array_name(var)
@@ -157,7 +157,7 @@ class CythonCodeGenerator(CodeGenerator):
 
     def translate_to_write_arrays(self, write):
         lines = []
-        for varname in write:
+        for varname in sorted(write):
             index_var = self.variable_indices[varname]
             var = self.variables[varname]
             line = f"{self.get_array_name(var, self.variables)}[{index_var}] = {varname}"

--- a/brian2/devices/cpp_standalone/device.py
+++ b/brian2/devices/cpp_standalone/device.py
@@ -13,6 +13,7 @@ import itertools
 import numbers
 import tempfile
 from distutils import ccompiler
+import zlib
 
 import numpy as np
 
@@ -325,8 +326,8 @@ class CPPStandaloneDevice(Device):
         -------
         filename : str
             A filename of the form
-            ``'results/'+varname+'_'+str(hash(varname))``, where varname is the
-            name returned by `get_array_name`.
+            ``'results/'+varname+'_'+str(zlib.crc32(varname))``, where varname
+            is the name returned by `get_array_name`.
 
         Notes
         -----
@@ -335,7 +336,7 @@ class CPPStandaloneDevice(Device):
         that are not case sensitive (e.g. on Windows).
         """
         varname = self.get_array_name(var, access_data=False)
-        return os.path.join(basedir, f"{varname}_{str(hash(varname))}")
+        return os.path.join(basedir, f"{varname}_{str(zlib.crc32(varname.encode('utf-8')))}")
 
     def add_array(self, var):
         # Note that a dynamic array variable is added to both the arrays and

--- a/brian2/monitors/spikemonitor.py
+++ b/brian2/monitors/spikemonitor.py
@@ -111,7 +111,7 @@ class EventMonitor(Group, CodeRunner):
         # Some dummy code so that code generation takes care of the indexing
         # and subexpressions
         code = [f'_to_record_{v} = _source_{v}'
-                for v in self.record_variables]
+                for v in sorted(self.record_variables)]
         code = '\n'.join(code)
 
         self.codeobj_class = codeobj_class


### PR DESCRIPTION
Two main issues led to code files changing for identical models (i.e., even when running a model again in a new process where the problems with regard to names as discussed in #680 do not play a role):
1. Variable declarations and other "unordered" code was generated in a different order for every run, and
2. The file names written to the result directory used `hash()` to deal with the problem of case-insensitivity on Windows (otherwise `i` and `I` would be stored to the same file). For security reasons, the `hash()` function changes its output for every run.

The fix in this PR is to:
1. Use `sorted()` whenever iterating over variables that are stored in sets, and 
2. Use `zlib.crc32` instead of `hash` to calculate the hash value for the filenames. Strictly speaking, `crc32` is a checksum and not a hash value and is more prone to lead to collisions, but this should not matter for us since we only need to disambiguate in very specific circumstances (names that are identical except for case).

I did not set up a formal test for this, but I verified with fairly complex examples (e.g. `frompapers/Kremer_et_al_2011_barrel_cortex.py`) that the generated is identical over runs.