### PR TITLE
Cython: Include support code in before_run block

### DIFF
--- a/brian2/codegen/runtime/cython_rt/templates/common_group.pyx
+++ b/brian2/codegen/runtime/cython_rt/templates/common_group.pyx
@@ -51,6 +51,9 @@ cdef extern from "stdint_compat.h":
 {{ cython_directives() }}
 {{ imports() }}
 
+# support code
+{{ support_code_lines | autoindent }}
+
 def main(_namespace):
     {{ load_namespace | autoindent }}
     if '_owner' in _namespace:

--- a/brian2/tests/test_spatialneuron.py
+++ b/brian2/tests/test_spatialneuron.py
@@ -868,6 +868,18 @@ def test_spatialneuron_threshold_location():
         assert_allclose(mon.t, [0*ms, 2*defaultclock.dt])
 
 
+@pytest.mark.standalone_compatible
+def test_spatialneuron_timedarray():
+    # See GitHub issue 1427
+    ta = TimedArray([0, 1]*nA, dt=1*ms)
+    morpho = Soma(diameter=10*um)
+    neuron = SpatialNeuron(morpho, 'Im = ta(t)/area : amp/meter**2', method='euler')
+    mon = StateMonitor(neuron, 'v', record=0, when='after_groups')
+    run(2*ms)
+    assert_allclose(np.diff(mon.v_[0]), np.r_[np.zeros(9),
+                                              np.array(np.ones(10)*1*nA/neuron.area[0]/neuron.Cm*defaultclock.dt)])
+
+
 if __name__ == '__main__':
     test_custom_events()
     test_construction()
@@ -885,3 +897,4 @@ if __name__ == '__main__':
     test_spatialneuron_subtree_assignment()
     test_spatialneuron_morphology_assignment()
     test_spatialneuron_capacitive_currents()
+    test_spatialneuron_timedarray()


### PR DESCRIPTION
Support code has to be included for `before_run` blocks, otherwise variables needed for functions that refer to namespaces (e.g. `TimedArray`) will not be correctly defined. This is a simple fix, in the longer run we should think about custom functions, namespaces etc. in `before_run` block. Currently, these blocks do not actually need any of all this, since they don't run user-defined code (but potentially that might change in the future?).

Fixes #1427, see https://brian.discourse.group/t/time-dependend-input-in-equation-vs-parameter/753/5 for example code that failed previously.