### PR TITLE
Change 'is not' to '!=' expressions.py

### DIFF
--- a/brian2/parsing/expressions.py
+++ b/brian2/parsing/expressions.py
@@ -360,7 +360,7 @@ def parse_expression_dimensions(expr, variables, orig_expr=None):
         right_dim = parse_expression_dimensions(expr.right, variables, orig_expr=orig_expr)
         if op in ['Add', 'Sub', 'Mod']:
             # dimensions should be the same
-            if left_dim != right_dim:
+            left_dim is not right_dim and left_dim != right_dim:
                 op_symbol = {'Add': '+', 'Sub': '-', 'Mod': '%'}.get(op)
                 left_str = NodeRenderer().render_node(expr.left)
                 right_str = NodeRenderer().render_node(expr.right)

--- a/brian2/parsing/expressions.py
+++ b/brian2/parsing/expressions.py
@@ -360,7 +360,7 @@ def parse_expression_dimensions(expr, variables, orig_expr=None):
         right_dim = parse_expression_dimensions(expr.right, variables, orig_expr=orig_expr)
         if op in ['Add', 'Sub', 'Mod']:
             # dimensions should be the same
-            if left_dim is not right_dim:
+            if left_dim != right_dim:
                 op_symbol = {'Add': '+', 'Sub': '-', 'Mod': '%'}.get(op)
                 left_str = NodeRenderer().render_node(expr.left)
                 right_str = NodeRenderer().render_node(expr.right)


### PR DESCRIPTION
For a script that I have been running, I am getting the error:
> Expression 'v - vr' uses inconsistent units ('v' has unit V; 'vr' has unit V).

I was certain that the units had been correctly assigned, and therefore examined the source code, and found them to be idential when printed. Changing it to `!=` worked for me (and still did the expected checking of units). If there are no strong motivations for using `is not` for the comparison, I propose using `!=` here.

**==** determines if the values of two objects are equal, 
while **is** determines if they are the exact same object.

I would have liked to provide a dummy script that could reproduce this, but my current one is quite bulky and in a bit of a hurry. I could try to develop a simpler demo later if required.