### PR TITLE
include user headers in before/after blocks

### DIFF
--- a/brian2/devices/cpp_standalone/templates/common_group.cpp
+++ b/brian2/devices/cpp_standalone/templates/common_group.cpp
@@ -8,6 +8,9 @@
 #include<iostream>
 #include<fstream>
 #include<climits>
+{% for name in user_headers | sort %}
+#include {{name}}
+{% endfor %}
 
 ////// SUPPORT CODE ///////
 namespace {
@@ -120,6 +123,9 @@ void _run_{{codeobj_name}}();
 #include<iostream>
 #include<fstream>
 #include<climits>
+{% for name in user_headers | sort %}
+#include {{name}}
+{% endfor %}
 
 ////// SUPPORT CODE ///////
 namespace {

--- a/brian2/tests/test_cpp_standalone.py
+++ b/brian2/tests/test_cpp_standalone.py
@@ -618,7 +618,7 @@ def test_header_file_inclusion():
             ''')
         @implementation('cpp',
         '''
-        double function(int index) {
+        double brian_function(int index) {
             using namespace brian_test_namespace;
             return test_variable * index;
         }
@@ -627,11 +627,11 @@ def test_header_file_inclusion():
         sources=[os.path.join(tmpdir, 'foo.cpp')],
         include_dirs=[tmpdir])
         @check_units(index=1, result=1)
-        def function(index):
+        def brian_function(index):
             raise NotImplementedError()
         # Use the function in a somewhat convoluted way that exposes errors in the
         # code generation process
-        G = PoissonGroup(5, rates='function(i)*Hz')
+        G = PoissonGroup(5, rates='brian_function(i)*Hz')
         S = Synapses(G, G, 'rate_copy : Hz')
         S.connect(j='i')
         S.run_regularly('rate_copy = rates_pre')

--- a/brian2/tests/test_cpp_standalone.py
+++ b/brian2/tests/test_cpp_standalone.py
@@ -1,5 +1,6 @@
 
 import os
+import tempfile
 
 import pytest
 from numpy.testing import assert_equal
@@ -598,6 +599,46 @@ def test_constant_replacement():
     assert G.y[0] == 42.
 
 
+@pytest.mark.cpp_standalone
+@pytest.mark.standalone_only
+def test_header_file_inclusion():
+    set_device('cpp_standalone', directory=None, debug=True)
+    with tempfile.TemporaryDirectory() as tmpdir:
+        with open(os.path.join(tmpdir, 'foo.h'), 'wt') as f:
+            f.write('''
+            namespace brian_test_namespace {
+                extern double test_variable;
+            }
+            ''')
+        with open(os.path.join(tmpdir, 'foo.cpp'), 'wt') as f:
+            f.write('''
+            namespace brian_test_namespace {
+                double test_variable = 42;
+            }
+            ''')
+        @implementation('cpp',
+        '''
+        double function(int index) {
+            using namespace brian_test_namespace;
+            return test_variable * index;
+        }
+        ''',
+        headers=['"foo.h"'],
+        sources=[os.path.join(tmpdir, 'foo.cpp')],
+        include_dirs=[tmpdir])
+        @check_units(index=1, result=1)
+        def function(index):
+            raise NotImplementedError()
+        # Use the function in a somewhat convoluted way that exposes errors in the
+        # code generation process
+        G = PoissonGroup(5, rates='function(i)*Hz')
+        S = Synapses(G, G, 'rate_copy : Hz')
+        S.connect(j='i')
+        S.run_regularly('rate_copy = rates_pre')
+        run(defaultclock.dt)
+    assert_allclose(S.rate_copy[:], np.arange(len(G))*42*Hz)
+
+
 if __name__=='__main__':
     for t in [
              test_cpp_standalone,
@@ -613,7 +654,8 @@ if __name__=='__main__':
              test_profile_via_set_device_arg,
              test_delete_code_data,
              test_delete_directory,
-             test_multiple_standalone_runs
+             test_multiple_standalone_runs,
+             test_header_file_inclusion
              ]:
         t()
         reinit_and_delete()


### PR DESCRIPTION
The `after_run` and `before_run` code blocks (only used in a few templates) were including support code, but not user-provided header files. This means that user-defined functions that relied on external header files were not compiling correctly. The fix is rather trivial and has considerably fewer lines of code than the new test :blush: 

See https://brian.discourse.group/t/how-to-use-prefs-devices-cpp-standalone-extra-make-args-unix/783 for the discussion that triggered this PR (and thanks to @wxie2013 for reporting it!).