### PR TITLE
Dimension objects should stay singletons even when pickled

### DIFF
--- a/brian2/tests/test_units.py
+++ b/brian2/tests/test_units.py
@@ -203,6 +203,18 @@ def test_pickling():
 
 
 @pytest.mark.codegen_independent
+def test_dimension_singletons():
+    # Make sure that Dimension objects are singletons, even when pickled
+    volt_dim = get_or_create_dimension((2, 1, -3, -1, 0, 0, 0))
+    assert volt.dim is volt_dim
+    import pickle
+    pickled_dim = pickle.dumps(volt_dim)
+    unpickled_dim = pickle.loads(pickled_dim)
+    assert unpickled_dim is volt_dim
+    assert unpickled_dim is volt.dim
+
+
+@pytest.mark.codegen_independent
 def test_str_repr():
     """
     Test that str representations do not raise any errors and that repr

--- a/brian2/units/fundamentalunits.py
+++ b/brian2/units/fundamentalunits.py
@@ -485,6 +485,10 @@ class Dimension(object):
     def __setstate__(self, state):
         self._dims = state
 
+    def __reduce__(self):
+        # Make sure that unpickling Dimension objects does not bypass the singleton system
+        return (get_or_create_dimension, (self._dims, ))
+
     ### Dimension objects are singletons and deepcopy is therefore not necessary
     def __deepcopy__(self, memodict):
         return self


### PR DESCRIPTION
Fixes the issue reported by @appukuttan-shailesh in #1431: for efficiency reasons, we compare `Dimension` objects with `is`, which generally works since they are singletons. They are never created directly, but always via `get_or_create_Dimension` which will return a reference to a previously existing `Dimension` object if they are the same.
This was broken during pickling, since the unpickled object was no longer identical to the previous singleton. As described by @appukuttan-shailesh in #1431, this can lead to weird error messages like 

    Expression 'v - vr' uses inconsistent units ('v' has unit V; 'vr' has unit V).
 
with both variables referring to separate instances of a `Dimension` object for volt. The fix is quite straightforward with Python's `__reduce__` mechanism; `Dimension` objects will call `get_or_create_dimension` during unpickling so that they will simply turn into a reference to existing singletons.