### PR TITLE
flake8 precommit hook

### DIFF
--- a/.devcontainer/dev-requirements.txt
+++ b/.devcontainer/dev-requirements.txt
@@ -7,3 +7,5 @@ pre-commit == 2.20.*
 black == 22.10.0
 isort == 5.10.1
 pyupgrade == 3.2.3
+flake8 == 4.0.1
+flake8-bugbear == 21.11.29

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -19,13 +19,13 @@
 	"settings": {
 		"python.defaultInterpreterPath": "/usr/local/bin/python",
 		"python.linting.enabled": true,
-		"python.linting.pylintEnabled": true,
+		"python.linting.flake8Enabled": true,
 		"python.formatting.provider": "black",
 		"python.formatting.autopep8Path": "/usr/local/py-utils/bin/autopep8",
 		"python.formatting.blackPath": "black",
 		"python.formatting.yapfPath": "/usr/local/py-utils/bin/yapf",
 		"python.linting.banditPath": "/usr/local/py-utils/bin/bandit",
-		"python.linting.flake8Path": "/usr/local/py-utils/bin/flake8",
+		"python.linting.flake8Path": "flake8",
 		"python.linting.mypyPath": "/usr/local/py-utils/bin/mypy",
 		"python.linting.pycodestylePath": "/usr/local/py-utils/bin/pycodestyle",
 		"python.linting.pydocstylePath": "/usr/local/py-utils/bin/pydocstyle",
@@ -53,7 +53,7 @@
 
 	// Use 'postCreateCommand' to run commands after the container is created.
 	// "postCreateCommand": "pip3 install --user -r requirements.txt",
-	"postCreateCommand": "pre-commit install && pip3 install --user -e '.[test,doc]' && pip3 freeze > .devcontainer/frozen-requirements.txt",
+	"postCreateCommand": "pre-commit install && pip3 install --user -e '.[test,docs]' && pip3 freeze > .devcontainer/frozen-requirements.txt",
 
 	// Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
 	"remoteUser": "vscode",

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -12,3 +12,5 @@ d3ae59251c753ae0737d6ae6242b7e85b60908c4
 67bf6d3760fa3fb8b3aa121b1b972d6cf36ec048
 # Update syntax to Python 3.8 with pyupgrade
 28b02c51545298cb9a76d8295e64a5df391b9207
+# Fix a number of issues flagged by flake8
+0344b005e6ffd232f55e69621630ef01876bc0fb

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,6 +10,14 @@ repos:
         args: [--py38-plus]
         exclude: '^brian2/_version.py$'
         files: '^brian2/.*\.pyi?$'
+  - repo: https://github.com/pycqa/flake8
+    rev: 4.0.1
+    hooks:
+      - id: flake8
+        # We exclude all __init__.py files, since we use wildcard imports, etc.
+        exclude: '^brian2/_version[.]py$|^brian2/tests/.*$|^brian2/.*__init__[.]py$'
+        files: '^brian2/.*\.pyi?$'
+        additional_dependencies: ['flake8-bugbear==21.11.29']
   - repo: https://github.com/pycqa/isort
     rev: 5.10.1
     hooks:

--- a/brian2/codegen/_prefs.py
+++ b/brian2/codegen/_prefs.py
@@ -17,16 +17,16 @@ prefs.register_preferences(
         default="auto",
         docs="""
         Default target for code generation.
-        
+
         Can be a string, in which case it should be one of:
-        
+
         * ``'auto'`` the default, automatically chose the best code generation
           target available.
         * ``'cython'``, uses the Cython package to generate C++ code. Needs a
           working installation of Cython and a C++ compiler.
         * ``'numpy'`` works on all platforms and doesn't need a C compiler but
           is often less efficient.
-        
+
         Or it can be a ``CodeObject`` class.
         """,
         validator=lambda target: isinstance(target, str)

--- a/brian2/codegen/codeobject.py
+++ b/brian2/codegen/codeobject.py
@@ -164,7 +164,7 @@ def _error_msg(code, name):
     Little helper function for error messages.
     """
     error_msg = f"Error generating code for code object '{name}' "
-    code_lines = [l for l in code.split("\n") if len(l.strip())]
+    code_lines = [line for line in code.split("\n") if len(line.strip())]
     # If the abstract code is only one line, display it in full
     if len(code_lines) <= 1:
         error_msg += f"from this abstract code: '{code_lines[0]}'\n"
@@ -195,7 +195,7 @@ def check_compiler_kwds(compiler_kwds, accepted_kwds, target):
     ValueError
         If a compiler keyword is not understood
     """
-    for key, value in compiler_kwds.items():
+    for key in compiler_kwds:
         if key not in accepted_kwds:
             formatted_kwds = ", ".join(f"'{kw}'" for kw in accepted_kwds)
             raise ValueError(
@@ -465,7 +465,7 @@ def create_runner_codeobj(
     # Add the indices needed by the variables
     for varname in list(variables):
         var_index = all_variable_indices[varname]
-        if not var_index in ("_idx", "0"):
+        if var_index not in ("_idx", "0"):
             variables[var_index] = all_variables[var_index]
 
     return device.code_object(

--- a/brian2/codegen/cpp_prefs.py
+++ b/brian2/codegen/cpp_prefs.py
@@ -253,11 +253,12 @@ prefs.register_preferences(
         default="",
         docs="""
         MSVC architecture name (or use system architectue by default).
-        
+
         Could take values such as x86, amd64, etc.
         """,
     ),
 )
+
 
 # check whether compiler supports a flag
 # Adapted from https://github.com/pybind/pybind11/

--- a/brian2/codegen/generators/GSL_generator.py
+++ b/brian2/codegen/generators/GSL_generator.py
@@ -493,8 +493,8 @@ class GSLCodeGenerator:
             diff_scale = {}
             for var, error in list(abs_per_var.items()):
                 # first do some checks on input
-                if not var in diff_vars:
-                    if not var in self.variables:
+                if var not in diff_vars:
+                    if var not in self.variables:
                         raise KeyError(
                             "absolute_error specified for variable that "
                             f"does not exist: {var}"
@@ -554,19 +554,14 @@ class GSLCodeGenerator:
         variables = self.variables
         other_variables = {}
         for statement in statements:
-            var, op, expr, comment = (
-                statement.var,
-                statement.op,
-                statement.expr,
-                statement.comment,
-            )
+            var = statement.var
             if var not in variables:
                 other_variables[var] = AuxiliaryVariable(var, dtype=statement.dtype)
         return other_variables
 
     def find_used_variables(self, statements, other_variables):
         """
-        Find all the variables used in the right hand side of the given
+        Find all the variables used on the right hand side of the given
         expressions.
 
         Parameters
@@ -583,12 +578,7 @@ class GSLCodeGenerator:
         variables = self.variables
         used_variables = {}
         for statement in statements:
-            lhs, op, rhs, comment = (
-                statement.var,
-                statement.op,
-                statement.expr,
-                statement.comment,
-            )
+            rhs = statement.expr
             for var in get_identifiers(rhs):
                 if var in self.function_names:
                     continue
@@ -939,8 +929,7 @@ class GSLCodeGenerator:
                     "well-defined: the outcome may depend on the "
                     "order of execution. You can ignore this warning if "
                     "you are sure that the order of operations does not "
-                    "matter. "
-                    + error_msg
+                    "matter. " + error_msg
                 )
 
         # save function names because self.generator.translate_statement_sequence
@@ -993,9 +982,9 @@ class GSLCodeGenerator:
         # so that _dataholder holds diff_vars as well, even if they don't occur
         # in the actual statements
         for var in list(diff_vars.keys()):
-            if not var in variables_in_vector:
+            if var not in variables_in_vector:
                 variables_in_vector[var] = self.variables[var]
-        # lets keep track of the variables that eventually need to be added to
+        # let's keep track of the variables that eventually need to be added to
         # the _GSL_dataholder somehow
         self.variables_to_be_processed = list(variables_in_vector.keys())
 
@@ -1025,9 +1014,7 @@ class GSLCodeGenerator:
         )
         # rewrite scalar code, keep variables that are needed in scalar code normal
         # and add variables to _dataholder for vector_code
-        GSL_main_code += (
-            f"\n{self.translate_scalar_code(scalar_func_code, variables_in_scalar, variables_in_vector)}"
-        )
+        GSL_main_code += f"\n{self.translate_scalar_code(scalar_func_code, variables_in_scalar, variables_in_vector)}"
         if len(self.variables_to_be_processed) > 0:
             raise AssertionError(
                 "Not all variables that will be used in the vector "

--- a/brian2/codegen/generators/GSL_generator.py
+++ b/brian2/codegen/generators/GSL_generator.py
@@ -18,9 +18,13 @@ from brian2.core.preferences import BrianPreference, PreferenceError, prefs
 from brian2.core.variables import ArrayVariable, AuxiliaryVariable, Constant
 from brian2.parsing.statements import parse_statement
 from brian2.units.fundamentalunits import fail_for_dimension_mismatch
+from brian2.utils.logger import get_logger
 from brian2.utils.stringtools import get_identifiers, word_substitute
 
 __all__ = ["GSLCodeGenerator", "GSLCPPCodeGenerator", "GSLCythonCodeGenerator"]
+
+
+logger = get_logger(__name__)
 
 
 def valid_gsl_dir(val):
@@ -929,7 +933,8 @@ class GSLCodeGenerator:
                     "well-defined: the outcome may depend on the "
                     "order of execution. You can ignore this warning if "
                     "you are sure that the order of operations does not "
-                    "matter. " + error_msg
+                    "matter. "
+                    + error_msg
                 )
 
         # save function names because self.generator.translate_statement_sequence
@@ -1014,7 +1019,9 @@ class GSLCodeGenerator:
         )
         # rewrite scalar code, keep variables that are needed in scalar code normal
         # and add variables to _dataholder for vector_code
-        GSL_main_code += f"\n{self.translate_scalar_code(scalar_func_code, variables_in_scalar, variables_in_vector)}"
+        GSL_main_code += (
+            f"\n{self.translate_scalar_code(scalar_func_code, variables_in_scalar, variables_in_vector)}"
+        )
         if len(self.variables_to_be_processed) > 0:
             raise AssertionError(
                 "Not all variables that will be used in the vector "

--- a/brian2/codegen/generators/cpp_generator.py
+++ b/brian2/codegen/generators/cpp_generator.py
@@ -66,7 +66,7 @@ prefs.register_preferences(
         default="__restrict",
         docs="""
         The keyword used for the given compiler to declare pointers as restricted.
-        
+
         This keyword is different on different compilers, the default works for
         gcc and MSVS.
         """,
@@ -75,7 +75,7 @@ prefs.register_preferences(
         default=False,
         docs="""
         Adds code to flush denormals to zero.
-        
+
         The code is gcc and architecture specific, so may not compile on all
         platforms. The code, for reference is::
 
@@ -83,7 +83,7 @@ prefs.register_preferences(
             unsigned csr = __builtin_ia32_stmxcsr();
             csr |= CSR_FLUSH_TO_ZERO;
             __builtin_ia32_ldmxcsr(csr);
-            
+
         Found at `<http://stackoverflow.com/questions/2487653/avoiding-denormal-values-in-c>`_.
         """,
     ),
@@ -449,7 +449,7 @@ class CPPCodeGenerator(CodeGenerator):
         from brian2.devices.device import get_device
 
         device = get_device()
-        for varname, var in self.variables.items():
+        for var in self.variables.values():
             if isinstance(var, ArrayVariable):
                 # This is the "true" array name, not the restricted pointer.
                 array_name = device.get_array_name(var)
@@ -564,12 +564,12 @@ clip_code = """
         template <typename T>
         static inline T _clip(const T value, const double a_min, const double a_max)
         {
-	        if (value < a_min)
-	            return a_min;
-	        if (value > a_max)
-	            return a_max;
-	        return value;
-	    }
+            if (value < a_min)
+                return a_min;
+            if (value > a_max)
+                return a_max;
+            return value;
+        }
         """
 DEFAULT_FUNCTIONS["clip"].implementations.add_implementation(
     CPPCodeGenerator, code=clip_code, name="_clip"
@@ -587,7 +587,7 @@ DEFAULT_FUNCTIONS["sign"].implementations.add_implementation(
 timestep_code = """
 static inline int64_t _timestep(double t, double dt)
 {
-    return (int64_t)((t + 1e-3*dt)/dt); 
+    return (int64_t)((t + 1e-3*dt)/dt);
 }
 """
 DEFAULT_FUNCTIONS["timestep"].implementations.add_implementation(

--- a/brian2/codegen/generators/cython_generator.py
+++ b/brian2/codegen/generators/cython_generator.py
@@ -159,11 +159,10 @@ class CythonCodeGenerator(CodeGenerator):
     def translate_to_statements(self, statements, conditional_write_vars):
         lines = []
         for stmt in statements:
-            if stmt.op == ":=" and not stmt.var in self.variables:
+            if stmt.op == ":=" and stmt.var not in self.variables:
                 self.temporary_vars.add((stmt.var, stmt.dtype))
             line = self.translate_statement(stmt)
             if stmt.var in conditional_write_vars:
-                subs = {}
                 condvar = conditional_write_vars[stmt.var]
                 lines.append(f"if {condvar}:")
                 lines.append(indent(line))

--- a/brian2/codegen/generators/numpy_generator.py
+++ b/brian2/codegen/generators/numpy_generator.py
@@ -242,7 +242,7 @@ class NumpyCodeGenerator(CodeGenerator):
             #                line = '{varname} = {array_name}.take({index})'
             #            line = line.format(varname=varname, array_name=self.get_array_name(var), index=index)
             line = f"{varname} = {self.get_array_name(var)}"
-            if not index in self.iterate_all:
+            if index not in self.iterate_all:
                 line += f"[{index}]"
             elif varname in write:
                 # avoid potential issues with aliased variables, see github #259
@@ -365,6 +365,7 @@ for func_name, func in [
     DEFAULT_FUNCTIONS[func_name].implementations.add_implementation(
         NumpyCodeGenerator, code=func
     )
+
 
 # Functions that are implemented in a somewhat special way
 def randn_func(vectorisation_idx):

--- a/brian2/codegen/generators/numpy_generator.py
+++ b/brian2/codegen/generators/numpy_generator.py
@@ -332,7 +332,7 @@ class NumpyCodeGenerator(CodeGenerator):
 
     def determine_keywords(self):
         try:
-            import scipy
+            import scipy  # noqa: F401
 
             scipy_available = True
         except ImportError:

--- a/brian2/codegen/runtime/GSLcython_rt/GSLcython_rt.py
+++ b/brian2/codegen/runtime/GSLcython_rt/GSLcython_rt.py
@@ -56,4 +56,4 @@ class GSLCythonCodeObject(CythonCodeObject):
                 "\nIf GSL is installed but Python cannot find the correct files, it is "
                 "also possible to give the gsl directory manually by specifying "
                 "prefs.GSL.directory = ..."
-            )
+            ) from err

--- a/brian2/core/base.py
+++ b/brian2/core/base.py
@@ -81,7 +81,8 @@ class BrianObject(Nameable):
         #: A string indicating where this object was created (traceback with any parts of Brian code removed)
         self._creation_stack = (
             "Object was created here (most recent call only, full details in "
-            "debug log):\n" + creation_stack[-1]
+            "debug log):\n"
+            + creation_stack[-1]
         )
         self._full_creation_stack = "Object was created here:\n" + "\n".join(
             creation_stack

--- a/brian2/core/base.py
+++ b/brian2/core/base.py
@@ -81,8 +81,7 @@ class BrianObject(Nameable):
         #: A string indicating where this object was created (traceback with any parts of Brian code removed)
         self._creation_stack = (
             "Object was created here (most recent call only, full details in "
-            "debug log):\n"
-            + creation_stack[-1]
+            "debug log):\n" + creation_stack[-1]
         )
         self._full_creation_stack = "Object was created here:\n" + "\n".join(
             creation_stack
@@ -227,49 +226,49 @@ class BrianObject(Nameable):
     contained_objects = property(
         fget=lambda self: self._contained_objects,
         doc="""
-         The list of objects contained within the `BrianObject`.
-         
-         When a `BrianObject` is added to a `Network`, its contained objects will
-         be added as well. This allows for compound objects which contain
-         a mini-network structure.
-         
-         Note that this attribute cannot be set directly, you need to modify
-         the underlying list, e.g. ``obj.contained_objects.extend([A, B])``.
-         """,
+        The list of objects contained within the `BrianObject`.
+
+        When a `BrianObject` is added to a `Network`, its contained objects will
+        be added as well. This allows for compound objects which contain
+        a mini-network structure.
+
+        Note that this attribute cannot be set directly, you need to modify
+        the underlying list, e.g. ``obj.contained_objects.extend([A, B])``.
+        """,
     )
 
     code_objects = property(
         fget=lambda self: self._code_objects,
         doc="""
-         The list of `CodeObject` contained within the `BrianObject`.
-         
-         TODO: more details.
-                  
-         Note that this attribute cannot be set directly, you need to modify
-         the underlying list, e.g. ``obj.code_objects.extend([A, B])``.
-         """,
+        The list of `CodeObject` contained within the `BrianObject`.
+
+        TODO: more details.
+
+        Note that this attribute cannot be set directly, you need to modify
+        the underlying list, e.g. ``obj.code_objects.extend([A, B])``.
+        """,
     )
 
     updaters = property(
         fget=lambda self: self._updaters,
         doc="""
-         The list of `Updater` that define the runtime behaviour of this object.
-         
-         TODO: more details.
-                  
-         Note that this attribute cannot be set directly, you need to modify
-         the underlying list, e.g. ``obj.updaters.extend([A, B])``.
-         """,
+        The list of `Updater` that define the runtime behaviour of this object.
+
+        TODO: more details.
+
+        Note that this attribute cannot be set directly, you need to modify
+        the underlying list, e.g. ``obj.updaters.extend([A, B])``.
+        """,
     )
 
     clock = property(
         fget=lambda self: self._clock,
         doc="""
-                     The `Clock` determining when the object should be updated.
-                     
-                     Note that this cannot be changed after the object is
-                     created.
-                     """,
+        The `Clock` determining when the object should be updated.
+
+        Note that this cannot be changed after the object is
+        created.
+        """,
     )
 
     def _set_active(self, val):
@@ -282,13 +281,13 @@ class BrianObject(Nameable):
         fget=lambda self: self._active,
         fset=_set_active,
         doc="""
-                        Whether or not the object should be run.
-                        
-                        Inactive objects will not have their `update`
-                        method called in `Network.run`. Note that setting or
-                        unsetting the `active` attribute will set or unset
-                        it for all `contained_objects`. 
-                        """,
+        Whether or not the object should be run.
+
+        Inactive objects will not have their `update`
+        method called in `Network.run`. Note that setting or
+        unsetting the `active` attribute will set or unset
+        it for all `contained_objects`.
+        """,
     )
 
     def __repr__(self):

--- a/brian2/core/magic.py
+++ b/brian2/core/magic.py
@@ -37,16 +37,16 @@ def _get_contained_objects(obj):
 
     Returns
     -------
-    l : list of `BrianObject`
+    objects : list of `BrianObject`
         A list of all the objects contained in `obj`
     """
-    l = []
+    objects = []
     contained_objects = getattr(obj, "contained_objects", [])
-    l.extend(contained_objects)
+    objects.extend(contained_objects)
     for contained_obj in contained_objects:
-        l.extend(_get_contained_objects(contained_obj))
+        objects.extend(_get_contained_objects(contained_obj))
 
-    return l
+    return objects
 
 
 def get_objects_in_namespace(level):
@@ -69,7 +69,7 @@ def get_objects_in_namespace(level):
     # Get the locals and globals from the stack frame
     objects = set()
     frame = inspect.stack()[level + 1][0]
-    for k, v in itertools.chain(frame.f_globals.items(), frame.f_locals.items()):
+    for _, v in itertools.chain(frame.f_globals.items(), frame.f_locals.items()):
         # We are only interested in numbers and functions, not in
         # everything else (classes, modules, etc.)
         if isinstance(v, BrianObject):

--- a/brian2/core/names.py
+++ b/brian2/core/names.py
@@ -112,23 +112,23 @@ class Nameable(Trackable):
     name = property(
         fget=lambda self: self._name,
         doc="""
-                        The unique name for this object.
-                        
-                        Used when generating code. Should be an acceptable
-                        variable name, i.e. starting with a letter
-                        character and followed by alphanumeric characters and
-                        ``_``.
-                        """,
+        The unique name for this object.
+
+        Used when generating code. Should be an acceptable
+        variable name, i.e. starting with a letter
+        character and followed by alphanumeric characters and
+        ``_``.
+        """,
     )
 
     id = property(
         fget=lambda self: self._id,
         doc="""
-                        A unique id for this object.
+        A unique id for this object.
 
-                        In contrast to names, which may be reused, the id stays
-                        unique. This is used in the dependency checking to not
-                        have to deal with the chore of comparing weak
-                        references, weak proxies and strong references.
-                        """,
+        In contrast to names, which may be reused, the id stays
+        unique. This is used in the dependency checking to not
+        have to deal with the chore of comparing weak
+        references, weak proxies and strong references.
+        """,
     )

--- a/brian2/core/network.py
+++ b/brian2/core/network.py
@@ -856,7 +856,7 @@ class Network(Nameable):
         fset=_set_schedule,
         doc="""
         List of ``when`` slots in the order they will be updated, can be modified.
-        
+
         See notes on scheduling in `Network`. Note that additional ``when``
         slots can be added, but the schedule should contain at least all of the
         names in the default schedule:
@@ -915,7 +915,7 @@ class Network(Nameable):
         all_ids = [obj.id for obj in all_objects]
         for obj in all_objects:
             for dependency in obj._dependencies:
-                if not dependency in all_ids:
+                if dependency not in all_ids:
                     raise ValueError(
                         f"'{obj.name}' has been included in the network "
                         "but not the object on which it "

--- a/brian2/core/network.py
+++ b/brian2/core/network.py
@@ -20,7 +20,7 @@ from brian2.core.clocks import Clock, defaultclock
 from brian2.core.names import Nameable
 from brian2.core.namespace import get_local_namespace
 from brian2.core.preferences import BrianPreference, prefs
-from brian2.devices.device import RuntimeDevice, all_devices, get_device
+from brian2.devices.device import all_devices, get_device
 from brian2.groups.group import Group
 from brian2.synapses.synapses import SummedVariableUpdater
 from brian2.units.allunits import msecond, second
@@ -1347,8 +1347,8 @@ class ProfilingSummary:
 
         s = "Profiling summary"
         s += f"\n{'=' * len(s)}\n"
-        for name, time, percentage in zip(self.names, times, percentages):
-            s += f"{name}    {time}    {percentage}\n"
+        for name, t, percentage in zip(self.names, times, percentages):
+            s += f"{name}    {t}    {percentage}\n"
         return s
 
     def _repr_html_(self):
@@ -1356,10 +1356,10 @@ class ProfilingSummary:
         percentages = [f"{percentage:.2f} %" for percentage in self.percentages]
         s = '<h2 class="brian_prof_summary_header">Profiling summary</h2>\n'
         s += '<table class="brian_prof_summary_table">\n'
-        for name, time, percentage in zip(self.names, times, percentages):
+        for name, t, percentage in zip(self.names, times, percentages):
             s += "<tr>"
             s += f"<td>{name}</td>"
-            s += f'<td style="text-align: right">{time}</td>'
+            s += f'<td style="text-align: right">{t}</td>'
             s += f'<td style="text-align: right">{percentage}</td>'
             s += "</tr>\n"
         s += "</table>"

--- a/brian2/core/preferences.py
+++ b/brian2/core/preferences.py
@@ -236,7 +236,7 @@ class BrianGlobalPreferences(MutableMapping):
         if "pref_register" in self.__dict__ and name in self.pref_register:
             raise PreferenceError("Cannot delete a preference category.")
         else:
-            MutableMapping.__delattr__(self, name, value)
+            MutableMapping.__delattr__(self, name)
 
     toplevel_categories = property(
         fget=lambda self: [
@@ -611,7 +611,8 @@ class BrianGlobalPreferences(MutableMapping):
                 "The following preferences values have been set but "
                 "are not registered preferences:\n%s\nThis is usually "
                 "because of a spelling mistake or missing library "
-                "import." % ", ".join(self.prefs_unvalidated),
+                "import."
+                % ", ".join(self.prefs_unvalidated),
                 once=True,
             )
 

--- a/brian2/core/preferences.py
+++ b/brian2/core/preferences.py
@@ -159,7 +159,7 @@ class BrianGlobalPreferences(MutableMapping):
             deindent(
                 """
             from numpy import *
-            from brian2.units import *            
+            from brian2.units import *
             from brian2.units.stdunits import *
             """
             ),
@@ -240,7 +240,7 @@ class BrianGlobalPreferences(MutableMapping):
 
     toplevel_categories = property(
         fget=lambda self: [
-            category for category in self.pref_register if not "." in category
+            category for category in self.pref_register if "." not in category
         ],
         doc="The toplevel preference categories",
     )
@@ -303,7 +303,7 @@ class BrianGlobalPreferences(MutableMapping):
         """
 
         s = ""
-        if not basename in self.pref_register:
+        if basename not in self.pref_register:
             raise ValueError(
                 f"No preferences under the name '{basename}' are registered"
             )
@@ -611,8 +611,7 @@ class BrianGlobalPreferences(MutableMapping):
                 "The following preferences values have been set but "
                 "are not registered preferences:\n%s\nThis is usually "
                 "because of a spelling mistake or missing library "
-                "import."
-                % ", ".join(self.prefs_unvalidated),
+                "import." % ", ".join(self.prefs_unvalidated),
                 once=True,
             )
 

--- a/brian2/core/variables.py
+++ b/brian2/core/variables.py
@@ -1046,7 +1046,7 @@ class VariableView:
                         indexed_var = index_group.variables.get(
                             varname, index_group.variables.get(var.name)
                         )
-                        if not indexed_var is var:
+                        if indexed_var is not var:
                             logger.warn(
                                 "The string expression used for setting "
                                 f"'{self.name}' refers to '{varname}' which "

--- a/brian2/devices/cpp_standalone/device.py
+++ b/brian2/devices/cpp_standalone/device.py
@@ -20,12 +20,16 @@ import brian2
 from brian2.codegen.codeobject import check_compiler_kwds
 from brian2.codegen.cpp_prefs import get_compiler_and_args, get_msvc_env
 from brian2.codegen.generators.cpp_generator import c_data_type
-from brian2.core.base import BrianObject
 from brian2.core.functions import Function
 from brian2.core.namespace import get_local_namespace
-from brian2.core.network import Network
 from brian2.core.preferences import BrianPreference, prefs
-from brian2.core.variables import *
+from brian2.core.variables import (
+    ArrayVariable,
+    Constant,
+    DynamicArrayVariable,
+    Variable,
+    VariableView,
+)
 from brian2.devices.device import Device, all_devices, reset_device, set_device
 from brian2.groups.group import Group
 from brian2.parsing.rendering import CPPNodeRenderer
@@ -216,7 +220,9 @@ class CPPStandaloneDevice(Device):
         self.run_environment_variables = {}
         if sys.platform.startswith("darwin"):
             if "DYLD_LIBRARY_PATH" in os.environ:
-                dyld_library_path = f"{os.environ['DYLD_LIBRARY_PATH']}:{os.path.join(sys.prefix, 'lib')}"
+                dyld_library_path = (
+                    f"{os.environ['DYLD_LIBRARY_PATH']}:{os.path.join(sys.prefix, 'lib')}"
+                )
             else:
                 dyld_library_path = os.path.join(sys.prefix, "lib")
             self.run_environment_variables["DYLD_LIBRARY_PATH"] = dyld_library_path

--- a/brian2/devices/cpp_standalone/device.py
+++ b/brian2/devices/cpp_standalone/device.py
@@ -216,9 +216,7 @@ class CPPStandaloneDevice(Device):
         self.run_environment_variables = {}
         if sys.platform.startswith("darwin"):
             if "DYLD_LIBRARY_PATH" in os.environ:
-                dyld_library_path = (
-                    f"{os.environ['DYLD_LIBRARY_PATH']}:{os.path.join(sys.prefix, 'lib')}"
-                )
+                dyld_library_path = f"{os.environ['DYLD_LIBRARY_PATH']}:{os.path.join(sys.prefix, 'lib')}"
             else:
                 dyld_library_path = os.path.join(sys.prefix, "lib")
             self.run_environment_variables["DYLD_LIBRARY_PATH"] = dyld_library_path
@@ -716,7 +714,7 @@ class CPPStandaloneDevice(Device):
         for var in codeobj.variables.values():
             if (
                 isinstance(var, ArrayVariable)
-                and not var in do_not_invalidate
+                and var not in do_not_invalidate
                 and (not var.read_only or var in written_readonly_vars)
             ):
                 self.array_cache[var] = None
@@ -905,13 +903,11 @@ class CPPStandaloneDevice(Device):
             for line in lines:
                 # Sometimes an array is referred to by to different keys in our
                 # dictionary -- make sure to never add a line twice
-                if not line in code_object_defs[codeobj.name]:
+                if line not in code_object_defs[codeobj.name]:
                     code_object_defs[codeobj.name].append(line)
 
         # Generate the code objects
         for codeobj in self.code_objects.values():
-            ns = codeobj.variables
-
             # Before/after run code
             for block in codeobj.before_after_blocks:
                 cpp_code = getattr(codeobj.code, f"{block}_cpp_file")
@@ -1697,7 +1693,7 @@ class CPPStandaloneDevice(Device):
                 }
             }
             //less than one second
-            if(text.length() == 0) 
+            if(text.length() == 0)
             {
                 text = "< 1s";
             }

--- a/brian2/equations/equations.py
+++ b/brian2/equations/equations.py
@@ -442,7 +442,7 @@ def parse_string_equations(eqns):
             )
 
         expression = eq_content.get("expression", None)
-        if not expression is None:
+        if expression is not None:
             # Replace multiple whitespaces (arising from joining multiline
             # strings) with single space
             p = re.compile(r"\s{2,}")
@@ -519,7 +519,7 @@ class SingleEquation(Hashable, CacheKey):
     unit = property(lambda self: get_unit(self.dim), doc="The `Unit` of this equation.")
 
     identifiers = property(
-        lambda self: self.expr.identifiers if not self.expr is None else set(),
+        lambda self: self.expr.identifiers if self.expr is not None else set(),
         doc="All identifiers in the RHS of this equation.",
     )
 
@@ -566,7 +566,7 @@ class SingleEquation(Hashable, CacheKey):
         else:
             s = self.varname
 
-        if not self.expr is None:
+        if self.expr is not None:
             s += " = " + str(self.expr)
 
         s += " : " + get_unit_for_display(self.dim)
@@ -579,7 +579,7 @@ class SingleEquation(Hashable, CacheKey):
     def __repr__(self):
         s = "<" + self.type + " " + self.varname
 
-        if not self.expr is None:
+        if self.expr is not None:
             s += ": " + self.expr.code
 
         s += " (Unit: " + get_unit_for_display(self.dim)
@@ -603,7 +603,7 @@ class SingleEquation(Hashable, CacheKey):
         else:
             p.text(self.varname)
 
-        if not self.expr is None:
+        if self.expr is not None:
             p.text(" = ")
             p.pretty(self.expr)
 
@@ -671,7 +671,7 @@ class Equations(Hashable, Mapping):
         # Check for special symbol xi (stochastic term)
         uses_xi = None
         for eq in self._equations.values():
-            if not eq.expr is None and "xi" in eq.expr.identifiers:
+            if eq.expr is not None and "xi" in eq.expr.identifiers:
                 if not eq.type == DIFFERENTIAL_EQUATION:
                     raise EquationError(
                         f"The equation defining '{eq.varname}' "
@@ -816,7 +816,7 @@ class Equations(Hashable, Mapping):
             violates any rule.
 
         """
-        if not hasattr(func, "__call__"):
+        if not callable(func):
             raise ValueError("Can only register callables.")
 
         Equations.identifier_checks.add(func)
@@ -1258,11 +1258,11 @@ class Equations(Hashable, Mapping):
 
         for eq in self.values():
             for flag in eq.flags:
-                if not eq.type in allowed_flags or len(allowed_flags[eq.type]) == 0:
+                if eq.type not in allowed_flags or len(allowed_flags[eq.type]) == 0:
                     raise ValueError(
                         f"Equations of type '{eq.type}' cannot have any flags."
                     )
-                if not flag in allowed_flags[eq.type]:
+                if flag not in allowed_flags[eq.type]:
                     raise ValueError(
                         f"Equations of type '{eq.type}' cannot have a "
                         f"flag '{flag}', only the following flags "

--- a/brian2/equations/equations.py
+++ b/brian2/equations/equations.py
@@ -24,40 +24,7 @@ from pyparsing import (
 
 from brian2.core.namespace import DEFAULT_CONSTANTS, DEFAULT_FUNCTIONS, DEFAULT_UNITS
 from brian2.parsing.sympytools import str_to_sympy, sympy_to_str
-from brian2.units.allunits import (
-    amp,
-    ampere,
-    becquerel,
-    candle,
-    coulomb,
-    farad,
-    gray,
-    henry,
-    hertz,
-    joule,
-    katal,
-    kelvin,
-    kgram,
-    kgramme,
-    kilogram,
-    lumen,
-    lux,
-    meter,
-    metre,
-    mole,
-    newton,
-    ohm,
-    pascal,
-    radian,
-    second,
-    siemens,
-    sievert,
-    steradian,
-    tesla,
-    volt,
-    watt,
-    weber,
-)
+from brian2.units.allunits import second
 from brian2.units.fundamentalunits import (
     DIMENSIONLESS,
     DimensionMismatchError,

--- a/brian2/equations/unitcheck.py
+++ b/brian2/equations/unitcheck.py
@@ -8,7 +8,6 @@ from brian2.core.variables import Variable
 from brian2.parsing.expressions import parse_expression_dimensions
 from brian2.parsing.statements import parse_statement
 from brian2.units.fundamentalunits import (
-    Unit,
     fail_for_dimension_mismatch,
     get_dimensions,
     get_unit,

--- a/brian2/groups/group.py
+++ b/brian2/groups/group.py
@@ -145,7 +145,7 @@ def get_dtype(equation, dtype=None):
         if equation.varname in dtype:
             BASIC_TYPES = {BOOLEAN: "b", INTEGER: "iu", FLOAT: "f"}
             provided_dtype = np.dtype(dtype[equation.varname])
-            if not provided_dtype.kind in BASIC_TYPES[equation.var_type]:
+            if provided_dtype.kind not in BASIC_TYPES[equation.var_type]:
                 raise TypeError(
                     "Error determining dtype for variable "
                     f"{equation.varname}: {provided_dtype.name} is not "
@@ -226,7 +226,7 @@ class Indexing:
         self.N = group.variables["N"]
         self.default_index = default_index
 
-    def __call__(self, item=slice(None), index_var=None):
+    def __call__(self, item=slice(None), index_var=None):  # noqa: B008
         """
         Return flat indices to index into state variables from arbitrary
         group specific indices. In the default implementation, raises an error
@@ -344,7 +344,7 @@ class VariableOwner(Nameable):
             raise ValueError(
                 "Classes derived from VariableOwner need a variables attribute."
             )
-        if not "N" in self.variables:
+        if "N" not in self.variables:
             raise ValueError("Each VariableOwner needs an 'N' variable.")
         if not hasattr(self, "codeobj_class"):
             self.codeobj_class = None
@@ -394,7 +394,7 @@ class VariableOwner(Nameable):
         # called yet.
         if name == "_group_attribute_access_active":
             raise AttributeError
-        if not "_group_attribute_access_active" in self.__dict__:
+        if "_group_attribute_access_active" not in self.__dict__:
             raise AttributeError
         if (
             name in self.__getattribute__("__dict__")
@@ -1054,7 +1054,7 @@ class Group(VariableOwner, BrianObject):
         # the subgroup instead of the parent group. See github issue #922
         source_group = getattr(self, "source", None)
         if source_group is not None:
-            if not self in source_group.contained_objects:
+            if self not in source_group.contained_objects:
                 source_group.contained_objects.append(self)
 
         runner = CodeRunner(

--- a/brian2/groups/neurongroup.py
+++ b/brian2/groups/neurongroup.py
@@ -86,7 +86,7 @@ def _guess_membrane_potential(equations):
     """
     if len(equations) == 1:
         return list(equations.keys())[0]
-    for name, eq in equations.items():
+    for name in equations:
         if name in ["V", "v", "Vm", "vm"]:
             return name
 

--- a/brian2/hears.py
+++ b/brian2/hears.py
@@ -7,7 +7,7 @@ This is only a bridge for using Brian 1 hears with Brian 2.
 NOTES:
 
 * Slicing sounds with Brian 2 units doesn't work, you need to either use Brian 1 units or replace calls to
-  ``sound[:20*ms]`` with ``sound.slice(None, 20*ms)``, etc. 
+  ``sound[:20*ms]`` with ``sound.slice(None, 20*ms)``, etc.
 
 TODO: handle properties (e.g. sound.duration)
 

--- a/brian2/hears.py
+++ b/brian2/hears.py
@@ -31,7 +31,7 @@ except ImportError:
 
 from inspect import isclass, ismethod
 
-from numpy import array, asarray, ndarray
+from numpy import asarray, ndarray
 
 from brian2.core.clocks import Clock
 from brian2.core.operations import network_operation
@@ -52,11 +52,11 @@ logger.warn(
 
 
 def convert_unit_b1_to_b2(val):
-    return Quantity.with_dimensions(float(val), arg.dim._dims)
+    return Quantity.with_dimensions(float(val), val.dim._dims)
 
 
 def convert_unit_b2_to_b1(val):
-    return b1.Quantity.with_dimensions(float(val), arg.dim._dims)
+    return b1.Quantity.with_dimensions(float(val), val.dim._dims)
 
 
 def modify_arg(arg):

--- a/brian2/importexport/dictlike.py
+++ b/brian2/importexport/dictlike.py
@@ -31,7 +31,7 @@ class DictImportExport(ImportExport):
     @staticmethod
     def import_data(group, data, units=True, level=0):
         for key, value in data.items():
-            if getattr(group.variables[key], "read_only"):
+            if group.variables[key].read_only:
                 raise TypeError(f"Variable {key} is read-only.")
             group.state(key, use_units=units, level=level + 1)[:] = value
 
@@ -53,8 +53,7 @@ class PandasImportExport(ImportExport):
         except ImportError as ex:
             raise ImportError(
                 "Exporting to pandas needs a working installation"
-                " of pandas. Importing pandas failed: "
-                + str(ex)
+                " of pandas. Importing pandas failed: " + str(ex)
             )
         if units:
             raise NotImplementedError(
@@ -73,8 +72,7 @@ class PandasImportExport(ImportExport):
         except ImportError as ex:
             raise ImportError(
                 "Exporting to pandas needs a working installation"
-                " of pandas. Importing pandas failed: "
-                + str(ex)
+                " of pandas. Importing pandas failed: " + str(ex)
             )
         if units:
             raise NotImplementedError(
@@ -83,7 +81,7 @@ class PandasImportExport(ImportExport):
         colnames = data.columns
         array_data = data.values
         for e, colname in enumerate(colnames):
-            if getattr(group.variables[colname], "read_only"):
+            if group.variables[colname].read_only:
                 raise TypeError(f"Variable '{colname}' is read-only.")
             state = group.state(colname, use_units=units, level=level + 1)
             state[:] = np.squeeze(array_data[:, e])

--- a/brian2/importexport/dictlike.py
+++ b/brian2/importexport/dictlike.py
@@ -53,7 +53,8 @@ class PandasImportExport(ImportExport):
         except ImportError as ex:
             raise ImportError(
                 "Exporting to pandas needs a working installation"
-                " of pandas. Importing pandas failed: " + str(ex)
+                " of pandas. Importing pandas failed: "
+                + str(ex)
             )
         if units:
             raise NotImplementedError(
@@ -66,14 +67,6 @@ class PandasImportExport(ImportExport):
 
     @staticmethod
     def import_data(group, data, units=True, level=0):
-        # pandas is not a default brian2 dependency, only import it here
-        try:
-            import pandas as pd
-        except ImportError as ex:
-            raise ImportError(
-                "Exporting to pandas needs a working installation"
-                " of pandas. Importing pandas failed: " + str(ex)
-            )
         if units:
             raise NotImplementedError(
                 "Units not supported when importing from pandas data frame"

--- a/brian2/importexport/importexport.py
+++ b/brian2/importexport/importexport.py
@@ -5,7 +5,7 @@ data in and out of groups in various formats (see `Group.get_states` and
 """
 
 import abc
-from abc import abstractmethod, abstractproperty
+from abc import abstractmethod
 
 
 class ImportExport(metaclass=abc.ABCMeta):

--- a/brian2/input/spikegeneratorgroup.py
+++ b/brian2/input/spikegeneratorgroup.py
@@ -380,4 +380,7 @@ class SpikeGeneratorGroup(Group, CodeRunner, SpikeSource):
     def __repr__(self):
         cls = self.__class__.__name__
         size = self.variables["neuron_index"].size
-        return f"{cls}({self.N}, indices=<length {size} array>, times=<length {size} array>)"
+        return (
+            f"{cls}({self.N}, indices=<length {size} array>, times=<length"
+            f" {size} array>)"
+        )

--- a/brian2/input/spikegeneratorgroup.py
+++ b/brian2/input/spikegeneratorgroup.py
@@ -353,9 +353,9 @@ class SpikeGeneratorGroup(Group, CodeRunner, SpikeSource):
         indices = np.asarray(indices)
         if not sorted:
             # sort times and indices first by time, then by indices
-            I = np.lexsort((indices, times))
-            indices = indices[I]
-            times = times[I]
+            sort_indices = np.lexsort((indices, times))
+            indices = indices[sort_indices]
+            times = times[sort_indices]
 
         # We store the indices and times also directly in the Python object,
         # this way we can use them for checks in `before_run` even in standalone
@@ -379,5 +379,5 @@ class SpikeGeneratorGroup(Group, CodeRunner, SpikeSource):
 
     def __repr__(self):
         cls = self.__class__.__name__
-        l = self.variables["neuron_index"].size
-        return f"{cls}({self.N}, indices=<length {l} array>, times=<length {l} array>)"
+        size = self.variables["neuron_index"].size
+        return f"{cls}({self.N}, indices=<length {size} array>, times=<length {size} array>)"

--- a/brian2/memory/dynamicarray.py
+++ b/brian2/memory/dynamicarray.py
@@ -2,7 +2,7 @@
 TODO: rewrite this (verbatim from Brian 1.x), more efficiency
 """
 
-from numpy import *
+import numpy as np
 
 __all__ = ["DynamicArray", "DynamicArray1D"]
 
@@ -87,7 +87,7 @@ class DynamicArray:
     ):
         if isinstance(shape, int):
             shape = (shape,)
-        self._data = zeros(shape, dtype=dtype)
+        self._data = np.zeros(shape, dtype=dtype)
         self.data = self._data
         self.dtype = dtype
         self.shape = self._data.shape
@@ -101,17 +101,17 @@ class DynamicArray:
         current data, but should have the same rank, i.e. same number of
         dimensions.
         """
-        datashapearr = array(self._data.shape)
-        newshapearr = array(newshape)
+        datashapearr = np.array(self._data.shape)
+        newshapearr = np.array(newshape)
         resizedimensions = newshapearr > datashapearr
         if resizedimensions.any():
             # resize of the data is needed
             minnewshapearr = datashapearr  # .copy()
             dimstoinc = minnewshapearr[resizedimensions]
-            incdims = array(dimstoinc * self.factor, dtype=int)
-            newdims = maximum(incdims, dimstoinc + 1)
+            incdims = np.array(dimstoinc * self.factor, dtype=int)
+            newdims = np.maximum(incdims, dimstoinc + 1)
             minnewshapearr[resizedimensions] = newdims
-            newshapearr = maximum(newshapearr, minnewshapearr)
+            newshapearr = np.maximum(newshapearr, minnewshapearr)
             do_resize = False
             if self.use_numpy_resize and self._data.flags["C_CONTIGUOUS"]:
                 if sum(resizedimensions) == resizedimensions[0]:
@@ -120,7 +120,7 @@ class DynamicArray:
                 self.data = None
                 self._data.resize(tuple(newshapearr), refcheck=self.refcheck)
             else:
-                newdata = zeros(tuple(newshapearr), dtype=self.dtype)
+                newdata = np.zeros(tuple(newshapearr), dtype=self.dtype)
                 slices = getslices(self._data.shape)
                 newdata[slices] = self._data
                 self._data = newdata
@@ -134,14 +134,14 @@ class DynamicArray:
     def resize_along_first(self, newshape):
         new_dimension = newshape[0]
         if new_dimension > self._data.shape[0]:
-            new_size = maximum(self._data.shape[0] * self.factor, new_dimension + 1)
-            final_new_shape = array(self._data.shape)
+            new_size = np.maximum(self._data.shape[0] * self.factor, new_dimension + 1)
+            final_new_shape = np.array(self._data.shape)
             final_new_shape[0] = new_size
             if self.use_numpy_resize and self._data.flags["C_CONTIGUOUS"]:
                 self.data = None
                 self._data.resize(tuple(final_new_shape), refcheck=self.refcheck)
             else:
-                newdata = zeros(tuple(final_new_shape), dtype=self.dtype)
+                newdata = np.zeros(tuple(final_new_shape), dtype=self.dtype)
                 slices = getslices(self._data.shape)
                 newdata[slices] = self._data
                 self._data = newdata
@@ -163,10 +163,10 @@ class DynamicArray:
         """
         if isinstance(newshape, int):
             newshape = (newshape,)
-        shapearr = array(self.shape)
-        newshapearr = array(newshape)
+        shapearr = np.array(self.shape)
+        newshapearr = np.array(newshape)
         if (newshapearr <= shapearr).all():
-            newdata = zeros(newshapearr, dtype=self.dtype)
+            newdata = np.zeros(newshapearr, dtype=self.dtype)
             newdata[:] = self._data[getslices(newshapearr)]
             self._data = newdata
             self.shape = tuple(newshapearr)
@@ -203,7 +203,7 @@ class DynamicArray1D(DynamicArray):
                 self.data = None
                 self._data.resize(newdatashape, refcheck=self.refcheck)
             else:
-                newdata = zeros(newdatashape, dtype=self.dtype)
+                newdata = np.zeros(newdatashape, dtype=self.dtype)
                 newdata[:shape] = self.data
                 self._data = newdata
         elif newshape < self.shape[0]:

--- a/brian2/monitors/statemonitor.py
+++ b/brian2/monitors/statemonitor.py
@@ -301,7 +301,7 @@ class StateMonitor(Group, CodeRunner):
             self.variables.add_reference(
                 f"_source_{varname}", source, varname, index=index
             )
-            if not index in ("_idx", "0") and index not in variables:
+            if index not in ("_idx", "0") and index not in variables:
                 self.variables.add_reference(index, source)
             self.variables.add_dynamic_array(
                 varname,

--- a/brian2/numpy_.py
+++ b/brian2/numpy_.py
@@ -6,6 +6,7 @@ This can be used for example as ``import brian2.numpy_ as np``
 """
 
 # isort:skip_file
+# flake8: noqa
 
 from numpy import *
 from brian2.units.unitsafefunctions import *

--- a/brian2/only.py
+++ b/brian2/only.py
@@ -9,6 +9,7 @@ Usage: ``from brian2.only import *``
 # order
 
 # isort:skip_file
+# flake8: noqa
 
 # The units and utils package does not depend on any other Brian package and
 # should be imported first

--- a/brian2/parsing/bast.py
+++ b/brian2/parsing/bast.py
@@ -8,7 +8,7 @@ import weakref
 
 import numpy
 
-from brian2.parsing.rendering import NodeRenderer, get_node_value
+from brian2.parsing.rendering import get_node_value
 from brian2.utils.logger import get_logger
 
 __all__ = ["brian_ast", "BrianASTRenderer", "dtype_hierarchy"]

--- a/brian2/parsing/rendering.py
+++ b/brian2/parsing/rendering.py
@@ -160,13 +160,6 @@ class NodeRenderer:
         return self.render_BinOp_parentheses(node.left, node.right, node.op)
 
     def render_BoolOp(self, node):
-        op = node.op
-        left = node.values[0]
-        remaining = node.values[1:]
-        while len(remaining):
-            right = remaining[0]
-            remaining = remaining[1:]
-            s = self.render_BinOp_parentheses(left, right, op)
         op = self.expression_ops[node.op.__class__.__name__]
         return (f" {op} ").join(
             f"{self.render_element_parentheses(v)}" for v in node.values

--- a/brian2/parsing/rendering.py
+++ b/brian2/parsing/rendering.py
@@ -112,7 +112,9 @@ class NodeRenderer:
                 args = node.args + [vectorisation_idx]
             else:
                 args = node.args
-            return f"{self.render_func(node.func)}({', '.join(self.render_node(arg) for arg in args)})"
+            return (
+                f"{self.render_func(node.func)}({', '.join(self.render_node(arg) for arg in args)})"
+            )
 
     def render_element_parentheses(self, node):
         """
@@ -171,7 +173,9 @@ class NodeRenderer:
         )
 
     def render_UnaryOp(self, node):
-        return f"{self.expression_ops[node.op.__class__.__name__]} {self.render_element_parentheses(node.operand)}"
+        return (
+            f"{self.expression_ops[node.op.__class__.__name__]} {self.render_element_parentheses(node.operand)}"
+        )
 
     def render_Assign(self, node):
         if len(node.targets) > 1:

--- a/brian2/parsing/rendering.py
+++ b/brian2/parsing/rendering.py
@@ -112,9 +112,7 @@ class NodeRenderer:
                 args = node.args + [vectorisation_idx]
             else:
                 args = node.args
-            return (
-                f"{self.render_func(node.func)}({', '.join(self.render_node(arg) for arg in args)})"
-            )
+            return f"{self.render_func(node.func)}({', '.join(self.render_node(arg) for arg in args)})"
 
     def render_element_parentheses(self, node):
         """
@@ -173,9 +171,7 @@ class NodeRenderer:
         )
 
     def render_UnaryOp(self, node):
-        return (
-            f"{self.expression_ops[node.op.__class__.__name__]} {self.render_element_parentheses(node.operand)}"
-        )
+        return f"{self.expression_ops[node.op.__class__.__name__]} {self.render_element_parentheses(node.operand)}"
 
     def render_Assign(self, node):
         if len(node.targets) > 1:

--- a/brian2/spatialneuron/morphology.py
+++ b/brian2/spatialneuron/morphology.py
@@ -480,7 +480,7 @@ class Morphology(metaclass=abc.ABCMeta):
                     raise TypeError(
                         "Cannot provide a step argument when slicing with lengths"
                     )
-                l = np.cumsum(np.asarray(self.length))  # coordinate on the section
+                pos = np.cumsum(np.asarray(self.length))  # coordinate on the section
                 # We use a special handling for values very close to the points
                 # between the compartments to avoid non-intuitive rounding
                 # effects: a point closer than 1e-12*length of section will be
@@ -490,37 +490,37 @@ class Morphology(metaclass=abc.ABCMeta):
                 if item.start is None:
                     i = 0
                 else:
-                    diff = np.abs(float(item.start) - l)
-                    if min(diff) < 1e-12 * l[-1]:
+                    diff = np.abs(float(item.start) - pos)
+                    if min(diff) < 1e-12 * pos[-1]:
                         i = np.argmin(diff) + 1
                     else:
-                        i = np.searchsorted(l, item.start)
+                        i = np.searchsorted(pos, item.start)
                 if item.stop is None:
-                    j = len(l)
+                    j = len(pos)
                 else:
-                    diff = np.abs(float(item.stop) - l)
-                    if min(diff) < 1e-12 * l[-1]:
+                    diff = np.abs(float(item.stop) - pos)
+                    if min(diff) < 1e-12 * pos[-1]:
                         j = np.argmin(diff) + 1
                     else:
-                        j = np.searchsorted(l, item.stop) + 1
+                        j = np.searchsorted(pos, item.stop) + 1
             else:  # integers
                 i, j, step = item.indices(self.n)
                 if step != 1:
                     raise TypeError("Can only slice a contiguous segment")
         elif isinstance(item, Quantity) and have_same_dimensions(item, meter):
-            l = np.hstack(
+            pos = np.hstack(
                 [0, np.cumsum(np.asarray(self.length))]
             )  # coordinate on the section
-            if float(item) < 0 or float(item) > (1 + 1e-12) * l[-1]:
+            if float(item) < 0 or float(item) > (1 + 1e-12) * pos[-1]:
                 raise IndexError(
                     f"Invalid index {item}, has to be in the interval "
-                    f"[{0 * meter!s}, {l[-1] * meter!s}]."
+                    f"[{0 * meter!s}, {pos[-1] * meter!s}]."
                 )
-            diff = np.abs(float(item) - l)
-            if min(diff) < 1e-12 * l[-1]:
+            diff = np.abs(float(item) - pos)
+            if min(diff) < 1e-12 * pos[-1]:
                 i = np.argmin(diff)
             else:
-                i = np.searchsorted(l, item) - 1
+                i = np.searchsorted(pos, item) - 1
             j = i + 1
         elif isinstance(item, numbers.Integral):  # int: returns one compartment
             if item < 0:  # allows e.g. to use -1 to get the last compartment
@@ -1156,7 +1156,7 @@ class Morphology(metaclass=abc.ABCMeta):
                     f"{length_2:.3f}um, respectively, while the "
                     f"radius is {diameter / 2:.3f}um."
                 )
-            children = [c for c in compartment.children if not c in soma_c]
+            children = [c for c in compartment.children if c not in soma_c]
             compartment = Node(
                 index=compartment.index,
                 comp_name="soma",

--- a/brian2/spatialneuron/spatialneuron.py
+++ b/brian2/spatialneuron/spatialneuron.py
@@ -19,7 +19,7 @@ from brian2.equations.equations import (
     SingleEquation,
     extract_constant_subexpressions,
 )
-from brian2.groups.group import CodeRunner, Group, create_runner_codeobj
+from brian2.groups.group import CodeRunner, Group
 from brian2.groups.neurongroup import NeuronGroup, SubexpressionUpdater, to_start_stop
 from brian2.groups.subgroup import Subgroup
 from brian2.parsing.sympytools import str_to_sympy, sympy_to_str
@@ -715,7 +715,7 @@ class SpatialStateUpdater(CodeRunner, Group):
         if type(self.code_objects[0]) == NumpyCodeObject:
             # If numpy is used, raise a warning if scipy is not present
             try:
-                import scipy
+                import scipy  # noqa: F401
             except ImportError:
                 logger.info(
                     "SpatialNeuron will use numpy to do the numerical "

--- a/brian2/spatialneuron/spatialneuron.py
+++ b/brian2/spatialneuron/spatialneuron.py
@@ -269,7 +269,7 @@ class SpatialNeuron(NeuronGroup):
                 threshold_location = threshold_location._indices()
             # for now, only a single compartment allowed
             try:
-                treshold_location = int(threshold_location)
+                int(threshold_location)
             except TypeError:
                 raise AttributeError(
                     "Threshold can only be applied on a single location"

--- a/brian2/sphinxext/briandoc.py
+++ b/brian2/sphinxext/briandoc.py
@@ -22,7 +22,9 @@ import re
 
 from docutils import nodes, statemachine
 from docutils.parsers.rst import Directive, directives
-from sphinx.domains.python import PyXRefRole
+from docutils.statemachine import ViewList
+from sphinx.domains.c import CDomain
+from sphinx.domains.python import PythonDomain, PyXRefRole
 from sphinx.roles import XRefRole
 
 from brian2.core.preferences import prefs
@@ -214,10 +216,6 @@ def setup(app, get_doc_object_=get_doc_object):
 # ------------------------------------------------------------------------------
 # Docstring-mangling domains
 # ------------------------------------------------------------------------------
-
-from docutils.statemachine import ViewList
-from sphinx.domains.c import CDomain
-from sphinx.domains.python import PythonDomain
 
 
 class ManglingDomainBase:

--- a/brian2/sphinxext/briandoc.py
+++ b/brian2/sphinxext/briandoc.py
@@ -74,7 +74,7 @@ class BrianPrefsDirective(Directive):
             return []
 
 
-def brianobj_role(role, rawtext, text, lineno, inliner, options={}, content=[]):
+def brianobj_role(role, rawtext, text, lineno, inliner, options=None, content=None):
     """
     A Sphinx role, used as a wrapper for the default `py:obj` role, allowing
     us to use the simple backtick syntax for brian classes/functions without
@@ -82,6 +82,10 @@ def brianobj_role(role, rawtext, text, lineno, inliner, options={}, content=[]):
     a `from brian2 import *`, e.g `NeuronGroup`.
     Also allows to directly link to preference names using the same syntax.
     """
+    if options is None:
+        options = {}
+    if content is None:
+        content = []
     if text in prefs:
         linktext = text.replace("_", "-").replace(".", "-")
         text = f"{text} <brian-pref-{linktext}>"
@@ -89,7 +93,7 @@ def brianobj_role(role, rawtext, text, lineno, inliner, options={}, content=[]):
         xref = XRefRole(warn_dangling=True)
         return xref("std:ref", rawtext, text, lineno, inliner, options, content)
     else:
-        if text and (not "~" in text):
+        if text and ("~" not in text):
             try:
                 # A simple class or function name
                 if "." not in text:
@@ -127,7 +131,9 @@ def brianobj_role(role, rawtext, text, lineno, inliner, options={}, content=[]):
         return py_role(role, rawtext, text, lineno, inliner, options, content)
 
 
-def mangle_docstrings(app, what, name, obj, options, lines, reference_offset=[0]):
+def mangle_docstrings(app, what, name, obj, options, lines, reference_offset=None):
+    if reference_offset is None:
+        reference_offset = [0]
     cfg = dict()
     if what == "module":
         # Strip top title
@@ -157,7 +163,7 @@ def mangle_docstrings(app, what, name, obj, options, lines, reference_offset=[0]
     # start renaming from the longest string, to avoid overwriting parts
     references.sort(key=lambda x: -len(x))
     if references:
-        for i, line in enumerate(lines):
+        for i in range(len(lines)):
             for r in references:
                 if re.match(r"^\d+$", r):
                     new_r = f"R{int(reference_offset[0] + int(r))}"

--- a/brian2/sphinxext/docscrape.py
+++ b/brian2/sphinxext/docscrape.py
@@ -45,8 +45,8 @@ class Reader:
             return ""
 
     def seek_next_non_empty_line(self):
-        for l in self[self._l :]:
-            if l.strip():
+        for line in self[self._l :]:
+            if line.strip():
                 break
             else:
                 self._l += 1
@@ -89,7 +89,7 @@ class Reader:
 
 
 class NumpyDocString:
-    def __init__(self, docstring, config={}):
+    def __init__(self, docstring, config=None):
         docstring = textwrap.dedent(docstring).split("\n")
 
         self._doc = Reader(docstring)
@@ -134,21 +134,22 @@ class NumpyDocString:
         if l1.startswith(".. index::"):
             return True
 
-        l2 = self._doc.peek(1).strip()  #    ---------- or ==========
+        l2 = self._doc.peek(1).strip()  # ---------- or ==========
         return l2.startswith("-" * len(l1)) or l2.startswith("=" * len(l1))
 
     def _strip(self, doc):
-        i = 0
-        j = 0
+        start = stop = 0
         for i, line in enumerate(doc):
             if line.strip():
+                start = i
                 break
 
-        for j, line in enumerate(doc[::-1]):
+        for i, line in enumerate(doc[::-1]):
             if line.strip():
+                stop = i
                 break
 
-        return doc[i : len(doc) - j]
+        return doc[start:-stop]
 
     def _read_to_next_section(self):
         section = self._doc.read_to_next_empty_line()
@@ -424,7 +425,7 @@ def indent(str, indent=4):
     if str is None:
         return indent_str
     lines = str.split("\n")
-    return "\n".join(indent_str + l for l in lines)
+    return "\n".join(indent_str + line for line in lines)
 
 
 def dedent_lines(lines):
@@ -437,7 +438,7 @@ def header(text, style="-"):
 
 
 class FunctionDoc(NumpyDocString):
-    def __init__(self, func, role="func", doc=None, config={}):
+    def __init__(self, func, role="func", doc=None, config=None):
         self._f = func
         self._role = role  # e.g. "func" or "meth"
 
@@ -461,7 +462,10 @@ class FunctionDoc(NumpyDocString):
     def get_func(self):
         func_name = getattr(self._f, "__name__", self.__class__.__name__)
         if inspect.isclass(self._f):
-            func = getattr(self._f, "__call__", self._f.__init__)
+            if callable(self._f):
+                func = self._f.__call__
+            else:
+                func = self._f.__init__
         else:
             func = self._f
         return func, func_name
@@ -485,7 +489,7 @@ class FunctionDoc(NumpyDocString):
 class ClassDoc(NumpyDocString):
     extra_public_methods = ["__call__"]
 
-    def __init__(self, cls, doc=None, modulename="", func_doc=FunctionDoc, config={}):
+    def __init__(self, cls, doc=None, modulename="", func_doc=FunctionDoc, config=None):
         if not inspect.isclass(cls) and cls is not None:
             raise ValueError(f"Expected a class or None, but got {cls!r}")
         self._cls = cls
@@ -512,7 +516,7 @@ class ClassDoc(NumpyDocString):
             return []
         methods = [
             name
-            for name, func in getattr(self._cls, "__dict__").items()
+            for name, func in self._cls.__dict__.items()
             if (
                 (not name.startswith("_") or name in self.extra_public_methods)
                 and (
@@ -535,7 +539,7 @@ class ClassDoc(NumpyDocString):
         }
         class_members = {
             name
-            for name, func in getattr(self._cls, "__dict__").items()
+            for name, func in self._cls.__dict__.items()
             if not name.startswith("_")
             and (func is None or inspect.isdatadescriptor(func))
         }

--- a/brian2/sphinxext/docscrape_sphinx.py
+++ b/brian2/sphinxext/docscrape_sphinx.py
@@ -10,7 +10,9 @@ from .docscrape import ClassDoc, FunctionDoc, NumpyDocString
 
 
 class SphinxDocString(NumpyDocString):
-    def __init__(self, docstring, config={}):
+    def __init__(self, docstring, config=None):
+        if config is None:
+            config = {}
         NumpyDocString.__init__(self, docstring, config=config)
 
     # string conversion routines
@@ -231,23 +233,31 @@ class SphinxDocString(NumpyDocString):
 
 
 class SphinxFunctionDoc(SphinxDocString, FunctionDoc):
-    def __init__(self, obj, doc=None, config={}):
+    def __init__(self, obj, doc=None, config=None):
+        if config is None:
+            config = {}
         FunctionDoc.__init__(self, obj, doc=doc, config=config)
 
 
 class SphinxClassDoc(SphinxDocString, ClassDoc):
-    def __init__(self, obj, doc=None, func_doc=None, name=None, config={}):
+    def __init__(self, obj, doc=None, func_doc=None, name=None, config=None):
+        if config is None:
+            config = {}
         self.name = name
         ClassDoc.__init__(self, obj, doc=doc, func_doc=None, config=config)
 
 
 class SphinxObjDoc(SphinxDocString):
-    def __init__(self, obj, doc=None, config={}):
+    def __init__(self, obj, doc=None, config=None):
+        if config is None:
+            config = {}
         self._f = obj
         SphinxDocString.__init__(self, doc, config=config)
 
 
-def get_doc_object(obj, what=None, doc=None, name=None, config={}):
+def get_doc_object(obj, what=None, doc=None, name=None, config=None):
+    if config is None:
+        config = {}
     if what is None:
         if inspect.isclass(obj):
             what = "class"

--- a/brian2/sphinxext/docscrape_sphinx.py
+++ b/brian2/sphinxext/docscrape_sphinx.py
@@ -3,7 +3,6 @@ import pydoc
 import re
 import textwrap
 
-import sphinx
 from sphinx.pycode import ModuleAnalyzer
 
 from .docscrape import ClassDoc, FunctionDoc, NumpyDocString

--- a/brian2/sphinxext/examplefinder.py
+++ b/brian2/sphinxext/examplefinder.py
@@ -17,7 +17,9 @@ the_examples_map = defaultdict(list)
 the_tutorials_map = defaultdict(list)
 
 
-def get_map(environ_var, relrootdir, pattern, the_map, path_exclusions=[]):
+def get_map(environ_var, relrootdir, pattern, the_map, path_exclusions=None):
+    if path_exclusions is None:
+        path_exclusions = []
     if the_map:
         return the_map
     if environ_var in os.environ:
@@ -64,9 +66,7 @@ def auto_find_examples(obj, headersymbol="="):
     make mistakes but is usually going to be correct).
     """
     name = obj.__name__
-    examples_map = get_examples_map()
     examples = sorted(the_examples_map[name])
-    tutorials_map = get_tutorials_map()
     tutorials = sorted(the_tutorials_map[name])
     if len(examples + tutorials) == 0:
         return ""

--- a/brian2/sphinxext/examplefinder.py
+++ b/brian2/sphinxext/examplefinder.py
@@ -4,7 +4,6 @@ Automatically find examples of a Brian object or function.
 
 
 import os
-import re
 from collections import defaultdict
 
 from brian2.utils.stringtools import get_identifiers
@@ -82,6 +81,6 @@ def auto_find_examples(obj, headersymbol="="):
 
 
 if __name__ == "__main__":
-    from brian2 import NeuronGroup, SpatialNeuron
+    from brian2 import NeuronGroup
 
     print(auto_find_examples(NeuronGroup))

--- a/brian2/sphinxext/generate_examples.py
+++ b/brian2/sphinxext/generate_examples.py
@@ -75,7 +75,6 @@ def main(rootpath, destdir):
             examplescode.append(f.read())
     examplesdocs = []
     examplesafterdoccode = []
-    examplesdocumentablenames = []
     for code in examplescode:
         codesplit = code.split("\n")
         comment_lines = 0
@@ -126,7 +125,7 @@ def main(rootpath, destdir):
         os.path.join(rootdir, "../docs_sphinx/resources/examples_images")
     )
     print("Searching for example images in directory", eximgpath)
-    for fname, path, basename, code, docs, afterdoccode, relpath, exname in examples:
+    for _fname, _path, basename, _code, docs, afterdoccode, relpath, exname in examples:
         categories[relpath].append((exname, basename))
         title = "Example: " + basename
         output = ".. currentmodule:: brian2\n\n"
@@ -173,7 +172,7 @@ def main(rootpath, destdir):
             content = f.read()
         output = file + "\n" + "=" * len(file) + "\n\n"
         output += ".. code:: none\n\n"
-        content_lines = ["\t" + l for l in content.split("\n")]
+        content_lines = ["\t" + line for line in content.split("\n")]
         output += "\n".join(content_lines)
         output += "\n\n"
         with codecs.open(os.path.join(destdir, full_name), "w", "utf-8") as f:
@@ -189,7 +188,6 @@ def main(rootpath, destdir):
             mainpage_text += "\n" + category + "\n" + "-" * len(category) + "\n\n"
         mainpage_text += ".. toctree::\n"
         mainpage_text += "   :maxdepth: 1\n\n"
-        curpath = ""
         for exname, basename in sorted(categories[category]):
             mainpage_text += f"   {basename} <{exname}>\n"
         for fname, full_name in sorted(category_additional_files[category]):

--- a/brian2/sphinxext/generate_reference.py
+++ b/brian2/sphinxext/generate_reference.py
@@ -1,6 +1,6 @@
 """
     Automatically generate Brian's reference documentation.
-    
+
     Based on sphinx-apidoc, published under a BSD license: http://sphinx-doc.org/
 """
 
@@ -42,9 +42,7 @@ def write_file(name, text, destdir, suffix):
 
 def format_heading(level, text):
     """Create a heading of <level> [1, 2 or 3 supported]."""
-    underlining = ["=", "-", "~",][
-        level - 1
-    ] * len(text)
+    underlining = ["=", "-", "~"][level - 1] * len(text)
     return f"{text}\n{underlining}\n\n"
 
 
@@ -208,7 +206,7 @@ def recurse_tree(rootpath, exclude_dirs, exclude_files, destdir):
             [
                 f
                 for f in files
-                if (path.splitext(f)[1] == ".py" and not f in exclude_files)
+                if (path.splitext(f)[1] == ".py" and f not in exclude_files)
             ]
         )
         is_pkg = INITPY in py_files
@@ -280,4 +278,3 @@ def main(rootpath, exclude_dirs, exclude_files, destdir):
         os.makedirs(destdir)
 
     exclude_dirs = normalize_excludes(rootpath, exclude_dirs)
-    modules = recurse_tree(rootpath, exclude_dirs, exclude_files, destdir)

--- a/brian2/stateupdaters/GSL.py
+++ b/brian2/stateupdaters/GSL.py
@@ -41,9 +41,13 @@ class GSLContainer:
         method_options,
         integrator,
         abstract_code=None,
-        needed_variables=[],
-        variable_flags=[],
+        needed_variables=None,
+        variable_flags=None,
     ):
+        if needed_variables is None:
+            needed_variables = []
+        if variable_flags is None:
+            variable_flags = []
         self.method_options = method_options
         self.integrator = integrator
         self.abstract_code = abstract_code

--- a/brian2/stateupdaters/base.py
+++ b/brian2/stateupdaters/base.py
@@ -220,7 +220,7 @@ class StateUpdateMethod(metaclass=ABCMeta):
                 )
             logger.info(msg_text, "method_choice")
         else:
-            if hasattr(method, "__call__"):
+            if callable(method):
                 # if this is a standard state updater, i.e. if it has a
                 # can_integrate method, check this method and raise a warning if it
                 # claims not to be applicable.

--- a/brian2/stateupdaters/exact.py
+++ b/brian2/stateupdaters/exact.py
@@ -231,7 +231,7 @@ class LinearStateUpdater(StateUpdateMethod):
         # The solution contains _S[0, 0], _S[1, 0] etc. for the state variables,
         # replace them with the state variable names
         abstract_code = []
-        for idx, (variable, update) in enumerate(zip(varnames, updates)):
+        for variable, update in zip(varnames, updates):
             rhs = update
             if rhs.has(I, re, im):
                 raise UnsupportedEquationsException(

--- a/brian2/stateupdaters/explicit.py
+++ b/brian2/stateupdaters/explicit.py
@@ -748,7 +748,7 @@ class ExplicitStateUpdater(StateUpdateMethod):
             statements.append(f"_{var} = {RHS}")
 
         # Assign everything to the final variables
-        for var, expr in substituted_expressions:
+        for var, _ in substituted_expressions:
             statements.append(f"{var} = _{var}")
 
         return "\n".join(statements)

--- a/brian2/synapses/parse_synaptic_generator_syntax.py
+++ b/brian2/synapses/parse_synaptic_generator_syntax.py
@@ -1,6 +1,5 @@
 import ast
 
-from brian2 import *
 from brian2.parsing.rendering import NodeRenderer
 
 __all__ = ["parse_synapse_generator"]

--- a/brian2/synapses/spikequeue.py
+++ b/brian2/synapses/spikequeue.py
@@ -78,8 +78,6 @@ class SpikeQueue:
         homogeneous, in which case insertion will use a faster method
         implemented in `insert_homogeneous`.
         """
-        n_synapses = len(synapse_sources)
-
         if self._dt is not None:
             # store the current spikes
             spikes = self._extract_spikes()
@@ -103,13 +101,14 @@ class SpikeQueue:
         synapse_sources = synapse_sources[:]
         ss = np.ravel(synapse_sources)
         # mergesort to retain relative order, keeps the output lists in sorted order
-        I = np.argsort(ss, kind="mergesort")
-        ss_sorted = ss[I]
+        ss_sort_indices = np.argsort(ss, kind="mergesort")
+        ss_sorted = ss[ss_sort_indices]
         splitinds = np.searchsorted(
             ss_sorted, np.arange(self._source_start, self._source_end + 1)
         )
         self._neurons_to_synapses = [
-            I[splitinds[j] : splitinds[j + 1]] for j in range(len(splitinds) - 1)
+            ss_sort_indices[splitinds[j] : splitinds[j + 1]]
+            for j in range(len(splitinds) - 1)
         ]
         max_events = max(map(len, self._neurons_to_synapses))
 

--- a/brian2/synapses/synapses.py
+++ b/brian2/synapses/synapses.py
@@ -402,8 +402,7 @@ class SynapticPathway(CodeRunner, Group):
                 "it has not created synapses with 'connect'. "
                 "Set its active attribute to False if you "
                 "intend to do only do this for a subsequent"
-                " run."
-                % self.synapses.name
+                " run." % self.synapses.name
             )
 
         # Update the dt (might have changed between runs)
@@ -605,24 +604,26 @@ class SynapticIndexing:
             elif len(index) > 3:
                 raise IndexError(f"Need 1, 2 or 3 indices, got {len(index)}.")
 
-            I, J, K = index
+            i_indices, j_indices, k_indices = index
             # Convert to absolute indices (e.g. for subgroups)
             # Allow the indexing to fail, we'll later return an empty array in
             # that case
             try:
-                if hasattr(I, "_indices"):  # will return absolute indices already
-                    I = I._indices()
+                if hasattr(
+                    i_indices, "_indices"
+                ):  # will return absolute indices already
+                    i_indices = i_indices._indices()
                 else:
-                    I = self.source._indices(I)
-                pre_synapses = find_synapses(I, self.synaptic_pre.get_value())
+                    i_indices = self.source._indices(i_indices)
+                pre_synapses = find_synapses(i_indices, self.synaptic_pre.get_value())
             except IndexError:
                 pre_synapses = np.array([], dtype=np.int32)
             try:
-                if hasattr(J, "_indices"):
-                    J = J._indices()
+                if hasattr(j_indices, "_indices"):
+                    j_indices = j_indices._indices()
                 else:
-                    J = self.target._indices(J)
-                post_synapses = find_synapses(J, self.synaptic_post.get_value())
+                    j_indices = self.target._indices(j_indices)
+                post_synapses = find_synapses(j_indices, self.synaptic_post.get_value())
             except IndexError:
                 post_synapses = np.array([], dtype=np.int32)
 
@@ -630,7 +631,7 @@ class SynapticIndexing:
                 pre_synapses, post_synapses, assume_unique=True
             )
 
-            if isinstance(K, slice) and K == slice(None):
+            if isinstance(k_indices, slice) and k_indices == slice(None):
                 final_indices = matching_synapses
             else:
                 if self.synapse_number is None:
@@ -640,8 +641,8 @@ class SynapticIndexing:
                         "'multisynaptic_index' when you create "
                         "the Synapses object."
                     )
-                if isinstance(K, (numbers.Integral, slice)):
-                    test_k = slice_to_test(K)
+                if isinstance(k_indices, (numbers.Integral, slice)):
+                    test_k = slice_to_test(k_indices)
                 else:
                     raise NotImplementedError(
                         "Indexing synapses with arrays notimplemented yet"
@@ -903,7 +904,7 @@ class Synapses(Group):
                         "simulation unnecessarily if you only need the values of "
                         "this variable whenever a spike occurs. Specify the equation "
                         "as clock-driven explicitly to avoid this warning.",
-                        f"clock_driven",
+                        "clock_driven",
                         once=True,
                     )
                 continuous.append(single_equation)
@@ -1013,7 +1014,7 @@ class Synapses(Group):
 
         # Check whether any delays were specified for pathways that don't exist
         for pathway in delay:
-            if not pathway in self._synaptic_updaters:
+            if pathway not in self._synaptic_updaters:
                 raise ValueError(
                     f"Cannot set the delay for pathway '{pathway}': unknown pathway."
                 )
@@ -1053,7 +1054,7 @@ class Synapses(Group):
                     f"The summed variable '{varname}' does not end "
                     "in '_pre' or '_post'."
                 )
-            if not varname in self.variables:
+            if varname not in self.variables:
                 raise ValueError(
                     f"The summed variable '{varname}' does not refer "
                     "to any known variable in the "
@@ -1633,8 +1634,7 @@ class Synapses(Group):
         except IndexError as e:
             raise IndexError(
                 "Tried to create synapse indices outside valid "
-                "range. Original error message: "
-                + str(e)
+                "range. Original error message: " + str(e)
             )
 
     # Helper functions for Synapses.connect ↑
@@ -1921,7 +1921,7 @@ class Synapses(Group):
             additional_indices = {}
         identifiers = get_identifiers_recursively([expr], self.variables)
         variables = self.resolve_all(
-            {name for name in identifiers if not name in additional_indices}, namespace
+            {name for name in identifiers if name not in additional_indices}, namespace
         )
         if any(getattr(var, "auto_vectorise", False) for var in variables.values()):
             identifiers.add("_vectorisation_idx")

--- a/brian2/synapses/synapses.py
+++ b/brian2/synapses/synapses.py
@@ -38,7 +38,7 @@ from brian2.parsing.expressions import (
 )
 from brian2.parsing.rendering import NodeRenderer
 from brian2.stateupdaters.base import StateUpdateMethod, UnsupportedEquationsException
-from brian2.stateupdaters.exact import independent, linear
+from brian2.stateupdaters.exact import linear
 from brian2.synapses.parse_synaptic_generator_syntax import parse_synapse_generator
 from brian2.units.allunits import second
 from brian2.units.fundamentalunits import (
@@ -402,7 +402,8 @@ class SynapticPathway(CodeRunner, Group):
                 "it has not created synapses with 'connect'. "
                 "Set its active attribute to False if you "
                 "intend to do only do this for a subsequent"
-                " run." % self.synapses.name
+                " run."
+                % self.synapses.name
             )
 
         # Update the dt (might have changed between runs)
@@ -1634,7 +1635,8 @@ class Synapses(Group):
         except IndexError as e:
             raise IndexError(
                 "Tried to create synapse indices outside valid "
-                "range. Original error message: " + str(e)
+                "range. Original error message: "
+                + str(e)
             )
 
     # Helper functions for Synapses.connect ↑

--- a/brian2/units/allunits.py
+++ b/brian2/units/allunits.py
@@ -7,6 +7,7 @@ Instead edit the template:
     dev/tools/static_codegen/units_template.py
 """
 # fmt: off
+# flake8: noqa
 import itertools
 
 from .fundamentalunits import (

--- a/brian2/units/fundamentalunits.py
+++ b/brian2/units/fundamentalunits.py
@@ -1381,7 +1381,7 @@ class Quantity(np.ndarray):
                     s += f" * {repr(u.dim)}"
                 else:
                     s += f" {str(u.dim)}"
-        elif python_code == True:  # Make a quantity without unit recognisable
+        elif python_code:  # Make a quantity without unit recognisable
             return f"{self.__class__.__name__}({s.strip()})"
         return s.strip()
 

--- a/brian2/units/unitsafefunctions.py
+++ b/brian2/units/unitsafefunctions.py
@@ -5,7 +5,6 @@ Unit-aware replacements for numpy functions.
 from functools import wraps
 
 import numpy as np
-import pkg_resources
 
 from .fundamentalunits import (
     DIMENSIONLESS,

--- a/brian2/utils/arrays.py
+++ b/brian2/utils/arrays.py
@@ -25,13 +25,13 @@ def calc_repeats(delay):
     """
     # We use merge sort because it preserves the input order of equal
     # elements in the sorted output
-    I = np.argsort(delay, kind="mergesort")
-    xs = delay[I]
+    sort_indices = np.argsort(delay, kind="mergesort")
+    xs = delay[sort_indices]
     J = xs[1:] != xs[:-1]
     A = np.hstack((0, np.cumsum(J)))
     B = np.hstack((0, np.cumsum(np.logical_not(J))))
     BJ = np.hstack((0, B[:-1][J]))
     ei = B - BJ[A]
     ofs = np.zeros_like(delay, dtype=np.int32)
-    ofs[I] = np.array(ei, dtype=ofs.dtype)
+    ofs[sort_indices] = np.array(ei, dtype=ofs.dtype)
     return ofs

--- a/brian2/utils/filelock.py
+++ b/brian2/utils/filelock.py
@@ -291,7 +291,7 @@ class BaseFileLock:
                         poll_intervall,
                     )
                     time.sleep(poll_intervall)
-        except:
+        except BaseException:
             # Something did go wrong, so decrement the counter.
             with self._thread_lock:
                 self._lock_counter = max(0, self._lock_counter - 1)

--- a/brian2/utils/filetools.py
+++ b/brian2/utils/filetools.py
@@ -63,7 +63,7 @@ def copy_directory(source, target):
     """
     relnames = []
     sourcebase = os.path.normpath(source) + os.path.sep
-    for root, dirnames, filenames in os.walk(source):
+    for root, _, filenames in os.walk(source):
         for filename in filenames:
             fullname = os.path.normpath(os.path.join(root, filename))
             relname = fullname.replace(sourcebase, "")

--- a/brian2/utils/logger.py
+++ b/brian2/utils/logger.py
@@ -66,7 +66,7 @@ if "logging" not in prefs.pref_register:
             default=True,
             docs="""
             Whether to delete the log and script file on exit.
-            
+
             If set to ``True`` (the default), log files (and the copy of the main
             script) will be deleted after the brian process has exited, unless an
             uncaught exception occurred. If set to ``False``, all log files will be
@@ -77,7 +77,7 @@ if "logging" not in prefs.pref_register:
             default="DEBUG",
             docs="""
             What log level to use for the log written to the log file.
-            
+
             In case file logging is activated (see `logging.file_log`), which log
             level should be used for logging. Has to be one of CRITICAL, ERROR,
             WARNING, INFO, DEBUG or DIAGNOSTIC.
@@ -88,7 +88,7 @@ if "logging" not in prefs.pref_register:
             default="INFO",
             docs="""
             What log level to use for the log written to the console.
-            
+
             Has to be one of CRITICAL, ERROR, WARNING, INFO, DEBUG or DIAGNOSTIC.
             """,
             validator=log_level_validator,
@@ -97,7 +97,7 @@ if "logging" not in prefs.pref_register:
             default=True,
             docs="""
             Whether to log to a file or not.
-            
+
             If set to ``True`` (the default), logging information will be written
             to a file. The log level can be set via the `logging.file_log_level`
             preference.
@@ -122,7 +122,7 @@ if "logging" not in prefs.pref_register:
             default=True,
             docs="""
             Whether to save a copy of the script that is run.
-            
+
             If set to ``True`` (the default), a copy of the currently run script
             is saved to a temporary location. It is deleted after a successful
             run (unless `logging.delete_log_on_exit` is ``False``) but is kept after
@@ -134,7 +134,7 @@ if "logging" not in prefs.pref_register:
             default=True,
             docs="""
             Whether or not to redirect stdout/stderr to null at certain places.
-            
+
             This silences a lot of annoying compiler output, but will also hide
             error messages making it harder to debug problems. You can always
             temporarily switch it off when debugging. If
@@ -147,7 +147,7 @@ if "logging" not in prefs.pref_register:
             default=True,
             docs="""
             Whether to redirect stdout/stderr to a file.
-    
+
             If both ``logging.std_redirection`` and this preference are set to
             ``True``, all standard output/error (most importantly output from
             the compiler) will be stored in files and if an error occurs the name
@@ -155,7 +155,7 @@ if "logging" not in prefs.pref_register:
             and this preference is ``False``, then all standard output/error will
             be completely suppressed, i.e. neither be displayed nor stored in a
             file.
-    
+
             The value of this preference is ignore if `logging.std_redirection` is
             set to ``False``.
             """,
@@ -165,7 +165,7 @@ if "logging" not in prefs.pref_register:
             docs="""
             Whether to display a text for uncaught errors, mentioning the location
             of the log file, the mailing list and the github issues.
-            
+
             Defaults to ``True``.""",
         ),
     )

--- a/dev/tools/static_codegen/units_template.py
+++ b/dev/tools/static_codegen/units_template.py
@@ -7,6 +7,7 @@ Instead edit the template:
     dev/tools/static_codegen/units_template.py
 """
 # fmt: off
+# flake8: noqa
 import itertools
 
 from .fundamentalunits import (Unit, get_or_create_dimension,

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,3 +2,10 @@
 all-files=1
 source-dir=docs_sphinx
 build-dir=docs
+
+[flake8]
+# Whitespace before : is PEP8-compatible and used by black for slices (E203)
+# No need to check line length, enforced by black (E501)
+# Lambda expressions are ok (E731)
+# We sometimes use #### heading ### style comments (E266)
+extend-ignore=E203,E501,E731,E266


### PR DESCRIPTION
Continuing the work started with  #1435 to make Brian's code more readable and "best practice" compatible, this adds another precommit hook, this time for `flake8`. It will flag common issues such as local variables or imports that are never used, or minor stylistic issues such as using `not element in list` instead of `element not in list`. I configured it in a conservative way to not be too radical/annoying for Brian's code base, e.g. I excluded all tests and `__init__.py` files, since they use wildcard imports quite extensively.

Not sure anyone cares about this very much, but tagging @oleksii-leonov, @bdevans, @denisalevi just in case :yum: 
