### PR TITLE
Failure to produce documentation with python3.11.

### DIFF
--- a/.github/workflows/testsuite.yml
+++ b/.github/workflows/testsuite.yml
@@ -110,3 +110,40 @@ jobs:
         coveralls --finish
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  test_doc_build:
+    needs: get_python_versions
+    name: Test building the documentation
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash -l {0}
+    steps:
+    - name: Checkout Repository
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+        submodules: true
+
+    - name: Setup Conda and Python
+      uses: conda-incubator/setup-miniconda@v2
+      with:
+        auto-update-conda: true
+        auto-activate-base: false
+        channels: conda-forge,defaults
+        channel-priority: true
+        activate-environment: 'test_env'
+        python-version: "${{ needs.get_python_versions.outputs.max-python }}"
+
+    - name: Install dependencies
+      run: pip install -r rtd-requirements.txt
+
+    - name: Install brian2
+      run: pip install .
+
+    - name: Build HTML documentation
+      run: |
+        cd docs_sphinx
+        sphinx-build -b html . ../docs
+      env:
+        READTHEDOCS: True

--- a/brian2/sphinxext/generate_examples.py
+++ b/brian2/sphinxext/generate_examples.py
@@ -71,7 +71,7 @@ def main(rootpath, destdir):
     # We assume all files are encoded as UTF-8
     examplescode = []
     for fname in examplesfnames:
-        with codecs.open(fname, "rU", encoding="utf-8") as f:
+        with codecs.open(fname, "r", encoding="utf-8") as f:
             examplescode.append(f.read())
     examplesdocs = []
     examplesafterdoccode = []
@@ -168,7 +168,7 @@ def main(rootpath, destdir):
             relpath = ""
         full_name = relpath.replace("/", ".").replace("\\", ".") + "." + file + ".rst"
         category_additional_files[relpath].append((file, full_name))
-        with codecs.open(fname, "rU", encoding="utf-8") as f:
+        with codecs.open(fname, "r", encoding="utf-8") as f:
             print(fname)
             content = f.read()
         output = file + "\n" + "=" * len(file) + "\n\n"

--- a/brian2/sphinxext/generate_examples.py
+++ b/brian2/sphinxext/generate_examples.py
@@ -1,4 +1,3 @@
-import codecs
 import fnmatch
 import glob
 import os
@@ -71,7 +70,7 @@ def main(rootpath, destdir):
     # We assume all files are encoded as UTF-8
     examplescode = []
     for fname in examplesfnames:
-        with codecs.open(fname, "r", encoding="utf-8") as f:
+        with open(fname, encoding="utf-8") as f:
             examplescode.append(f.read())
     examplesdocs = []
     examplesafterdoccode = []
@@ -157,7 +156,7 @@ def main(rootpath, destdir):
             print("Found example image file", image)
             output += f".. image:: ../resources/examples_images/{image}\n\n"
 
-        with codecs.open(os.path.join(destdir, exname + ".rst"), "w", "utf-8") as f:
+        with open(os.path.join(destdir, exname + ".rst"), "w", encoding="utf-8") as f:
             f.write(output)
 
     category_additional_files = defaultdict(list)
@@ -168,7 +167,7 @@ def main(rootpath, destdir):
             relpath = ""
         full_name = relpath.replace("/", ".").replace("\\", ".") + "." + file + ".rst"
         category_additional_files[relpath].append((file, full_name))
-        with codecs.open(fname, "r", encoding="utf-8") as f:
+        with open(fname, encoding="utf-8") as f:
             print(fname)
             content = f.read()
         output = file + "\n" + "=" * len(file) + "\n\n"
@@ -176,7 +175,7 @@ def main(rootpath, destdir):
         content_lines = ["\t" + l for l in content.split("\n")]
         output += "\n".join(content_lines)
         output += "\n\n"
-        with codecs.open(os.path.join(destdir, full_name), "w", "utf-8") as f:
+        with open(os.path.join(destdir, full_name), "w", encoding="utf-8") as f:
             f.write(output)
 
     mainpage_text = "Examples\n"


### PR DESCRIPTION
In [Debian Bug#1027936], Adrian Bunk noticed that the documentation failed to be produced with python3.11 with the following symptom:

	Traceback (most recent call last):
	  File "/usr/lib/python3/dist-packages/sphinx/config.py", line 350, in eval_config_file
	    exec(code, namespace)
	  File "/<<PKGBUILDDIR>>/docs_sphinx/conf.py", line 71, in <module>
	    generate_examples.main(root_dir, target_dir)
	  File "/<<PKGBUILDDIR>>/debian/tmp/usr/lib/python3.11/dist-packages/brian2/sphinxext/generate_examples.py", line 72, in main
	    with codecs.open(fname, 'rU', encoding='utf-8') as f:
	         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
	  File "<frozen codecs>", line 906, in open
	ValueError: invalid mode: 'rUb'

This patch removes a couple of uses of unified newline "open" invocations, which have no effect since the first version of python3. This may cause changes of behavior with python2, but this interpreter is unmaintained since 2020.

[Debian Bug#1027936]: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1027936

Signed-off-by: Étienne Mollier <emollier@debian.org>