### PR TITLE
Force UTF-8 encoding for file logs

### DIFF
--- a/brian2/tests/test_logger.py
+++ b/brian2/tests/test_logger.py
@@ -11,6 +11,7 @@ logger = get_logger("brian2.tests.test_logger")
 
 @pytest.mark.codegen_independent
 def test_file_logging():
+    BrianLogger.initialize()
     logger.error("error message xxx")
     logger.warn("warning message xxx")
     logger.info("info message xxx")
@@ -19,12 +20,28 @@ def test_file_logging():
     BrianLogger.file_handler.flush()
     # By default, only >= debug messages should show up
     assert os.path.isfile(BrianLogger.tmp_log)
-    with open(BrianLogger.tmp_log) as f:
+    with open(BrianLogger.tmp_log, encoding="utf-8") as f:
         log_content = f.readlines()
     for level, line in zip(["error", "warning", "info", "debug"], log_content[-4:]):
         assert "brian2.tests.test_logger" in line
         assert f"{level} message xxx" in line
         assert level.upper() in line
+
+
+@pytest.mark.codegen_independent
+def test_file_logging_special_characters():
+    BrianLogger.initialize()
+    # Test logging with special characters that could occur in log messages and
+    # require UTF-8
+    special_chars = "→ ≠ ≤ ≥ ← ∞ µ ∝ ∂ ∅"
+    logger.debug(special_chars)
+    BrianLogger.file_handler.flush()
+    assert os.path.isfile(BrianLogger.tmp_log)
+    with open(BrianLogger.tmp_log, encoding="utf-8") as f:
+        log_content = f.readlines()
+    last_line = log_content[-1]
+    assert "brian2.tests.test_logger" in last_line
+    assert special_chars in last_line
 
 
 def run_in_process(x):
@@ -48,7 +65,7 @@ def test_file_logging_multiprocessing():
 
     BrianLogger.file_handler.flush()
     assert os.path.isfile(BrianLogger.tmp_log)
-    with open(BrianLogger.tmp_log) as f:
+    with open(BrianLogger.tmp_log, encoding="utf-8") as f:
         log_content = f.readlines()
     # The subprocesses should not have written to the log file
     assert "info message before multiprocessing" in log_content[-1]
@@ -63,7 +80,7 @@ def test_file_logging_multiprocessing_with_loggers():
 
     BrianLogger.file_handler.flush()
     assert os.path.isfile(BrianLogger.tmp_log)
-    with open(BrianLogger.tmp_log) as f:
+    with open(BrianLogger.tmp_log, encoding="utf-8") as f:
         log_content = f.readlines()
     # The subprocesses should not have written to the main log file
     assert "info message before multiprocessing" in log_content[-1]
@@ -71,7 +88,7 @@ def test_file_logging_multiprocessing_with_loggers():
     # Each subprocess should have their own log file
     for x, log_file in enumerate(log_files):
         assert os.path.isfile(log_file)
-        with open(log_file) as f:
+        with open(log_file, encoding="utf-8") as f:
             log_content = f.readlines()
         assert f"subprocess info message {x}" in log_content[-1]
 
@@ -80,5 +97,6 @@ def test_file_logging_multiprocessing_with_loggers():
 
 if __name__ == "__main__":
     test_file_logging()
+    test_file_logging_special_characters()
     test_file_logging_multiprocessing()
     test_file_logging_multiprocessing_with_loggers()

--- a/brian2/utils/logger.py
+++ b/brian2/utils/logger.py
@@ -592,6 +592,7 @@ class BrianLogger:
                     mode="a",
                     maxBytes=prefs["logging.file_log_max_size"],
                     backupCount=1,
+                    encoding="utf-8",
                 )
                 BrianLogger.file_handler.setLevel(
                     LOG_LEVELS[prefs["logging.file_log_level"].upper()]


### PR DESCRIPTION
Makes non-ASCII characters in log messages work on Windows.

See https://brian.discourse.group/t/logging-error-on-windows/872/3