### PR TITLE
Build wheels for linux-aarch64

### DIFF
--- a/.github/workflows/publish_to_pypi.yml
+++ b/.github/workflows/publish_to_pypi.yml
@@ -24,12 +24,13 @@ jobs:
           python setup.py sdist --formats=gztar --with-cython --fail-on-error
         if: ${{ startsWith(matrix.os, 'ubuntu-') }}
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.2.2
+        uses: pypa/cibuildwheel@v2.12.1
         with:
           output-dir: dist
         env:
           CIBW_PROJECT_REQUIRES_PYTHON: ">=3.7"
-          CIBW_ARCHS: auto64
+          CIBW_ARCHS_WINDOWS: auto64
+          CIBW_ARCHS_LINUX: auto64 aarch64 ppc64le
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
           CIBW_ARCHS_MACOS: x86_64 universal2
           CIBW_TEST_SKIP: '*_arm64 *_universal2:arm64'

--- a/.github/workflows/publish_to_pypi.yml
+++ b/.github/workflows/publish_to_pypi.yml
@@ -61,12 +61,16 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: '3.x'
-      - name: Build source tarball (only on Linux)
+      - name: Build source tarball
         run: |
           python -m pip install --upgrade pip
           python -m pip install "cython>=0.29" oldest-supported-numpy setuptools versioneer
           python setup.py sdist --formats=gztar --with-cython --fail-on-error
         if: ${{ matrix.arch == 'auto64' }}
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+        with:
+          platforms: all
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.12.1
         with:

--- a/.github/workflows/publish_to_pypi.yml
+++ b/.github/workflows/publish_to_pypi.yml
@@ -66,6 +66,7 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install "cython>=0.29" oldest-supported-numpy setuptools versioneer
           python setup.py sdist --formats=gztar --with-cython --fail-on-error
+        if: ${{ matrix.arch == 'auto64' }}
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.12.1
         with:

--- a/.github/workflows/publish_to_pypi.yml
+++ b/.github/workflows/publish_to_pypi.yml
@@ -8,7 +8,51 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-20.04, windows-2019, macOS-11 ]
+        os: [ windows-latest, macOS-latest ]
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Set up Python 3.x
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v2.12.1
+        with:
+          output-dir: dist
+        env:
+          CIBW_PROJECT_REQUIRES_PYTHON: ">=3.7"
+          CIBW_ARCHS_WINDOWS: auto64
+          CIBW_ARCHS_MACOS: x86_64 universal2
+          CIBW_TEST_SKIP: '*_arm64 *_universal2:arm64'
+          CIBW_SKIP: 'pp* *-musllinux_*'
+          CIBW_TEST_COMMAND: python {project}/dev/continuous-integration/run_simple_test.py
+          CIBW_TEST_REQUIRES: pytest
+      - name: Publish distribution 📦 to Test PyPI
+        if: github.ref == 'refs/heads/master' && github.repository == 'brian-team/brian2'
+        run: |
+          pip install twine
+          twine upload -r testpypi dist/*
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.test_pypi_password }}
+      - name: Publish distribution release 📦 to PyPI
+        if: ${{ startsWith(github.ref, 'refs/tags') && github.repository == 'brian-team/brian2' }}
+        run: |
+          pip install twine
+          twine upload dist/*
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.pypi_password }}
+
+  build-n-publish-linux:
+    name: Build ${{ matrix.arch }} wheels on Linux and publish to (Test)PyPI
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: [ auto64, aarch64, ppc64le ]
     steps:
       - uses: actions/checkout@v3
         with:
@@ -22,18 +66,14 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install "cython>=0.29" oldest-supported-numpy setuptools versioneer
           python setup.py sdist --formats=gztar --with-cython --fail-on-error
-        if: ${{ startsWith(matrix.os, 'ubuntu-') }}
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.12.1
         with:
           output-dir: dist
         env:
           CIBW_PROJECT_REQUIRES_PYTHON: ">=3.7"
-          CIBW_ARCHS_WINDOWS: auto64
-          CIBW_ARCHS_LINUX: auto64 aarch64 ppc64le
+          CIBW_ARCHS_LINUX: ${{ matrix.arch }}
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
-          CIBW_ARCHS_MACOS: x86_64 universal2
-          CIBW_TEST_SKIP: '*_arm64 *_universal2:arm64'
           CIBW_SKIP: 'pp* *-musllinux_*'
           CIBW_TEST_COMMAND: python {project}/dev/continuous-integration/run_simple_test.py
           CIBW_TEST_REQUIRES: pytest

--- a/.github/workflows/publish_to_pypi.yml
+++ b/.github/workflows/publish_to_pypi.yml
@@ -52,7 +52,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        arch: [ auto64, aarch64, ppc64le ]
+        arch: [ auto64, aarch64 ]
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
This builds binary wheels for the `linux-aarch64` architecture (emulated via `qemu`, all the difficult parts are handled by [`cibuildwheel`](https://cibuildwheel.readthedocs.io/) luckily…).

@bdevans made me aware that this architecture (Linux on ARM64 hardware) is not as niche as I had previously assumed: running Linux on newer Apple hardware (e.g. via docker) will require it.

When this is merged into master, packages will appear on https://test.pypi.org/project/Brian2/, and can be installed as explained here: https://brian2.readthedocs.io/en/stable/introduction/install.html#development-install