### PR TITLE
Mark GSL functions as extern

### DIFF
--- a/brian2/codegen/generators/GSL_generator.py
+++ b/brian2/codegen/generators/GSL_generator.py
@@ -1053,7 +1053,7 @@ class GSLCythonCodeGenerator(GSLCodeGenerator):
     syntax = {
         "end_statement": "",
         "access_pointer": ".",
-        "start_declare": "cdef ",
+        "start_declare": "cdef extern ",
         "open_function": ":",
         "open_struct": ":",
         "end_function": "",
@@ -1113,7 +1113,7 @@ class GSLCPPCodeGenerator(GSLCodeGenerator):
     syntax = {
         "end_statement": ";",
         "access_pointer": "->",
-        "start_declare": "",
+        "start_declare": 'extern "C" ',
         "open_function": "\n{",
         "open_struct": "\n{",
         "end_function": "\n}",


### PR DESCRIPTION
 Fixes an incompatibility with latest Cython beta, related to exception
 handling (which is automatically switched off if a function is marked
 as extern)

 Fixes #1470