### PR TITLE
Check out submodules to correctly build example/tutorial docs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,5 +1,9 @@
 version: 2
 
+submodules:
+  include: all
+
+
 build:
   os: "ubuntu-20.04"
   tools:


### PR DESCRIPTION
As @kernfel noticed, our documentation wasn't including the tutorials anymore. In addition, the examples were included without their plots. The reason was simply that readthedocs wasn't checking out the `docs_sphinx/resources` submodule, this should be fixed with this change to the rtd configuration file.

Closes #1477 