### PR TITLE
Better logging for extension modules

### DIFF
--- a/docs_sphinx/developer/guidelines/logging.rst
+++ b/docs_sphinx/developer/guidelines/logging.rst
@@ -101,3 +101,11 @@ warning and error messages)::
         assert len(logs) == 1
         # logs contains tuples of (log level, name, message)
         assert logs[0][0] == 'WARNING' and logs[0][1].endswith('warning_type')
+
+Logging in extension packages
+-----------------------------
+Extension packages such as `brian2cuda <https://brian2cuda.readthedocs.io>`_ can use Brian's logging infrastructure by
+using the `~brian2.utils.logger.get_logger` function to get a logger instance. They should use their own module name,
+e.g. a name starting with ``brian2cuda.`` so that it is clear whether a log message comes from Brian or from an
+extension package. This is also used by the `~.catch_logs` context manager (see above) to only consider log messages
+from the ``brian2`` package.


### PR DESCRIPTION
Brian configures the logging infrastructure under the `brian2` logger root, so all uses of the logger need to have a `brian2.something` name.  This leads extension packages like `brian2cuda` to use names that do not correspond to actual module names, e.g.:

https://github.com/brian-team/brian2cuda/blob/f240d34c45daa858716da9176936cd642f17ccb2/brian2cuda/cuda_generator.py#L24C1-L24C64

This can be potentially confusing for users, but also for the test suite: in several places the test suite checks for specific warnings (or the absence of such warnings). If `brian2cuda` logs a warning in one of those tests, the test will fail even though the warning is not relevant to the test.

With this PR, packages can use Brian's logger with `get_logger` using their own name (typically `get_logger(__name__)`). When interacting with Python's `logging` module internally, this name will be prefixed with `brian2`, so that all the configuration (file log etc.) is still applicable. However, when log messages are printed or written to a file, they appear without the prefix. Also, the `catch_logs` context manager will by default ignore messages that do not have names starting with `brian2`, so that tests are not affected by warnings printed by extension packages.