### PR TITLE
Test against python312

### DIFF
--- a/.github/workflows/test_latest.yml
+++ b/.github/workflows/test_latest.yml
@@ -35,9 +35,6 @@ jobs:
         float_dtype_32: [false, true]
         python-version: ["${{ needs.get_python_versions.outputs.max-python }}"]
 
-    defaults:
-      run:
-        shell: bash -l {0}
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v3

--- a/.github/workflows/test_latest.yml
+++ b/.github/workflows/test_latest.yml
@@ -22,11 +22,13 @@ jobs:
   testing:
     needs: [get_python_versions]
     name: "Python ${{ matrix.python-version }} on ${{ matrix.os }} (standalone: ${{ matrix.standalone }}, 32bit: ${{ matrix.float_dtype_32 }})"
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.os.image }}
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macOS-latest]
+        os: [{image: ubuntu-latest, triplet: x64-linux },
+             {image: windows-latest, triplet: x64-windows },
+             {image: macOS-latest, triplet: x64-osx }]
         standalone: [false, true]
         float_dtype_32: [false, true]
         python-version: ["${{ needs.get_python_versions.outputs.max-python }}"]
@@ -39,24 +41,24 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-
-      - name: Setup Conda and Python
-        uses: conda-incubator/setup-miniconda@v2
+      - name: Install GSL
+        uses: johnwason/vcpkg-action@v5
+        id: vcpkg
         with:
-          auto-update-conda: true
-          auto-activate-base: false
-          channels: conda-forge,defaults
-          channel-priority: true
-          activate-environment: 'test_env'
+          pkgs: gsl
+          triplet: ${{ matrix.os.triplet }}
+          cache-key: gsl-${{ matrix.os.triplet }}
+          revision: master
+          token: ${{ github.token }}
+      - name: Install Python
+        uses: actions/setup-python@v4
+        with:
+          cache: 'pip'
           python-version: ${{ matrix.python-version }}
-
-      - name: Install Brian2 and dependencies
-        run: |
-          conda install -n test_env --quiet --yes -c conda-forge gsl pip
-          conda activate test_env
-          python -m pip install --pre pytest cython sympy pyparsing numpy jinja2 scipy sphinx
-          python -m pip install .
-
+      - name: Install dependencies
+        run: python -m pip install --pre pytest cython sympy pyparsing numpy jinja2 scipy sphinx
+      - name: Install Brian2
+        run: python -m pip install .
       - name: Run Tests
         run: |
           cd  $GITHUB_WORKSPACE/.. # move out of the workspace to avoid direct import
@@ -66,4 +68,3 @@ jobs:
           AGENT_OS: ${{runner.os}}
           STANDALONE: ${{ matrix.standalone }}
           FLOAT_DTYPE_32: ${{ matrix.float_dtype_32 }}
-

--- a/.github/workflows/test_latest.yml
+++ b/.github/workflows/test_latest.yml
@@ -15,20 +15,22 @@ jobs:
     steps:
       - name: "calculate versions according to NEP29"
         id: nep29
-        uses: mstimberg/github-calc-nep29@v0.5
+        uses: mstimberg/github-calc-nep29@v0.6
         with:
+          include-release-candidates: true
+          include-beta-releases: true
           token: ${{ secrets.GITHUB_TOKEN }}
   
   testing:
     needs: [get_python_versions]
-    name: "Python ${{ matrix.python-version }} on ${{ matrix.os }} (standalone: ${{ matrix.standalone }}, 32bit: ${{ matrix.float_dtype_32 }})"
+    name: "Python ${{ matrix.python-version }} on ${{ matrix.os.image }} (standalone: ${{ matrix.standalone }}, 32bit: ${{ matrix.float_dtype_32 }})"
     runs-on: ${{ matrix.os.image }}
     strategy:
       fail-fast: false
       matrix:
-        os: [{image: ubuntu-latest, triplet: x64-linux },
-             {image: windows-latest, triplet: x64-windows },
-             {image: macOS-latest, triplet: x64-osx }]
+        os: [{image: ubuntu-latest, triplet: x64-linux},
+             {image: windows-latest, triplet: x64-windows},
+             {image: macOS-latest, triplet: x64-osx}]
         standalone: [false, true]
         float_dtype_32: [false, true]
         python-version: ["${{ needs.get_python_versions.outputs.max-python }}"]
@@ -51,18 +53,20 @@ jobs:
           revision: master
           token: ${{ github.token }}
       - name: Install Python
+        id: python
         uses: actions/setup-python@v4
         with:
           cache: 'pip'
           python-version: ${{ matrix.python-version }}
+          allow-prereleases: true
       - name: Install dependencies
-        run: python -m pip install --pre pytest cython sympy pyparsing numpy jinja2 scipy sphinx
+        run: ${{ steps.python.outputs.python-path }} -m pip install --pre pytest cython sympy pyparsing numpy jinja2 scipy sphinx
       - name: Install Brian2
-        run: python -m pip install .
+        run: ${{ steps.python.outputs.python-path }} -m pip install .
       - name: Run Tests
         run: |
           cd  $GITHUB_WORKSPACE/.. # move out of the workspace to avoid direct import
-          python -Wd $GITHUB_WORKSPACE/dev/continuous-integration/run_test_suite.py
+          ${{ steps.python.outputs.python-path }} -Wd $GITHUB_WORKSPACE/dev/continuous-integration/run_test_suite.py
         env:
           DEPRECATION_ERROR: true
           AGENT_OS: ${{runner.os}}

--- a/.github/workflows/test_latest.yml
+++ b/.github/workflows/test_latest.yml
@@ -60,7 +60,9 @@ jobs:
           python-version: ${{ matrix.python-version }}
           allow-prereleases: true
       - name: Install dependencies
-        run: ${{ steps.python.outputs.python-path }} -m pip install --pre pytest cython sympy pyparsing numpy jinja2 scipy sphinx
+        run: |
+          ${{ steps.python.outputs.python-path }} -m pip install --upgrade pip
+          ${{ steps.python.outputs.python-path }} -m pip install --pre pytest cython sympy pyparsing numpy jinja2 scipy sphinx
       - name: Install Brian2
         run: ${{ steps.python.outputs.python-path }} -m pip install .
       - name: Run Tests

--- a/.github/workflows/test_latest.yml
+++ b/.github/workflows/test_latest.yml
@@ -58,7 +58,7 @@ jobs:
           allow-prereleases: true
       - name: Install dependencies
         run: |
-          ${{ steps.python.outputs.python-path }} -m pip install --upgrade pip
+          ${{ steps.python.outputs.python-path }} -m pip install --upgrade pip setuptools
           ${{ steps.python.outputs.python-path }} -m pip install --pre pytest cython sympy pyparsing numpy jinja2 scipy sphinx
       - name: Install Brian2
         run: ${{ steps.python.outputs.python-path }} -m pip install .

--- a/.github/workflows/test_latest.yml
+++ b/.github/workflows/test_latest.yml
@@ -59,7 +59,8 @@ jobs:
       - name: Install dependencies
         run: |
           ${{ steps.python.outputs.python-path }} -m pip install --upgrade pip setuptools
-          ${{ steps.python.outputs.python-path }} -m pip install --pre pytest cython sympy pyparsing numpy jinja2 scipy sphinx
+          ${{ steps.python.outputs.python-path }} -m pip install --pre -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple numpy scipy
+          ${{ steps.python.outputs.python-path }} -m pip install --pre pytest cython sympy pyparsing jinja2 sphinx
       - name: Install Brian2
         run: ${{ steps.python.outputs.python-path }} -m pip install .
       - name: Run Tests

--- a/.github/workflows/test_latest.yml
+++ b/.github/workflows/test_latest.yml
@@ -62,7 +62,7 @@ jobs:
           ${{ steps.python.outputs.python-path }} -m pip install --pre -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple numpy scipy
           ${{ steps.python.outputs.python-path }} -m pip install --pre pytest cython sympy pyparsing jinja2 sphinx
       - name: Install Brian2
-        run: ${{ steps.python.outputs.python-path }} -m pip install .
+        run: ${{ steps.python.outputs.python-path }} -m pip install --pre -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple --extra-index-url https://pypi.org/simple .
       - name: Run Tests
         run: |
           cd  $GITHUB_WORKSPACE/.. # move out of the workspace to avoid direct import


### PR DESCRIPTION
Update our `test_latest` workflow so that we can already test against Python 3.12 pre-releases (release expected in October).