### PR TITLE
AST deprecation fixes

### DIFF
--- a/brian2/codegen/optimisation.py
+++ b/brian2/codegen/optimisation.py
@@ -167,14 +167,14 @@ def _replace_with_zero(zero_node, node):
 
     Parameters
     ----------
-    zero_node : `ast.Num`
+    zero_node : `ast.Constant`
         The node to replace
     node : `ast.Node`
         The node that determines the type
 
     Returns
     -------
-    zero_node : `ast.Num`
+    zero_node : `ast.Constant`
         The original ``zero_node`` with its value replaced by 0 or 0.0.
     """
     # must not change the dtype of the output,
@@ -244,10 +244,7 @@ class ArithmeticSimplifier(BrianASTRenderer):
             else:
                 val = prefs.core.default_float_dtype(val)
             if node.dtype != "boolean":
-                if hasattr(ast, "Constant"):
-                    newnode = ast.Constant(val)
-                else:
-                    newnode = ast.Num(val)
+                newnode = ast.Constant(val)
             newnode.dtype = node.dtype
             newnode.scalar = True
             newnode.stateless = node.stateless
@@ -588,10 +585,7 @@ def collect(node):
     # if the fully evaluated node is just the identity/null element then we
     # don't have to make it into an explicit term
     if x != op_null:
-        if hasattr(ast, "Constant"):
-            num_node = ast.Constant(x)
-        else:
-            num_node = ast.Num(x)
+        num_node = ast.Constant(x)
     else:
         num_node = None
     terms_primary = remaining_terms_primary
@@ -612,22 +606,16 @@ def collect(node):
         node = reduced_node([node, prod_primary], op_primary)
         if prod_inverted is not None:
             if node is None:
-                if hasattr(ast, "Constant"):
-                    node = ast.Constant(op_null_with_dtype)
-                else:
-                    node = ast.Num(op_null_with_dtype)
+                node = ast.Constant(op_null_with_dtype)
             node = ast.BinOp(node, op_inverted(), prod_inverted)
 
     if node is None:  # everything cancelled
-        if hasattr(ast, "Constant"):
-            node = ast.Constant(op_null_with_dtype)
-        else:
-            node = ast.Num(op_null_with_dtype)
+        node = ast.Constant(op_null_with_dtype)
     if (
         hasattr(node, "dtype")
         and dtype_hierarchy[node.dtype] < dtype_hierarchy[orignode_dtype]
     ):
-        node = ast.BinOp(ast.Num(op_null_with_dtype), op_primary(), node)
+        node = ast.BinOp(ast.Constant(op_null_with_dtype), op_primary(), node)
     node.collected = True
     return node
 

--- a/brian2/parsing/bast.py
+++ b/brian2/parsing/bast.py
@@ -8,7 +8,6 @@ import weakref
 
 import numpy
 
-from brian2.parsing.rendering import get_node_value
 from brian2.utils.logger import get_logger
 
 __all__ = ["brian_ast", "BrianASTRenderer", "dtype_hierarchy"]
@@ -168,7 +167,7 @@ class BrianASTRenderer:
 
     def render_Num(self, node):
         node.complexity = 0
-        node.dtype = brian_dtype_from_value(get_node_value(node))
+        node.dtype = brian_dtype_from_value(node.value)
         node.scalar = True
         node.stateless = True
         return node

--- a/brian2/parsing/bast.py
+++ b/brian2/parsing/bast.py
@@ -173,7 +173,7 @@ class BrianASTRenderer:
         node.stateless = True
         return node
 
-    def render_Constant(self, node):  # For literals in Python 3.8
+    def render_Constant(self, node):  # For literals in Python >= 3.8
         if node.value is True or node.value is False or node.value is None:
             return self.render_NameConstant(node)
         else:

--- a/brian2/parsing/expressions.py
+++ b/brian2/parsing/expressions.py
@@ -4,7 +4,7 @@ AST parsing based analysis of expressions
 import ast
 
 from brian2.core.functions import Function
-from brian2.parsing.rendering import NodeRenderer, get_node_value
+from brian2.parsing.rendering import NodeRenderer
 from brian2.units.fundamentalunits import (
     DIMENSIONLESS,
     DimensionMismatchError,
@@ -138,7 +138,7 @@ def _get_value_from_expression(expr, variables):
         else:
             raise ValueError(f"Unknown identifier {name}")
     elif expr.__class__ is ast.Constant:
-        return get_node_value(expr)
+        return expr.value
     elif expr.__class__ is ast.BoolOp:
         raise SyntaxError(
             "Cannot determine the numerical value for a boolean operation."

--- a/brian2/parsing/rendering.py
+++ b/brian2/parsing/rendering.py
@@ -90,14 +90,20 @@ class NodeRenderer:
     def render_func(self, node):
         return self.render_Name(node)
 
+    def render_NameConstant(self, node):
+        return str(node.value)
+
     def render_Name(self, node):
         return node.id
 
     def render_Num(self, node):
         return repr(get_node_value(node))
 
-    def render_Constant(self, node):
-        return self.render_Num(node)
+    def render_Constant(self, node):  # For literals in Python 3.8
+        if node.value is True or node.value is False or node.value is None:
+            return self.render_NameConstant(node)
+        else:
+            return self.render_Num(node)
 
     def render_Call(self, node):
         if len(node.keywords):
@@ -349,6 +355,9 @@ class CPPNodeRenderer(NodeRenderer):
             )
         else:
             return NodeRenderer.render_BinOp(self, node)
+
+    def render_NameConstant(self, node):
+        return {True: "true", False: "false"}.get(node.value, node.value)
 
     def render_Name(self, node):
         # Replace Python's True and False with their C++ bool equivalents

--- a/brian2/parsing/rendering.py
+++ b/brian2/parsing/rendering.py
@@ -278,6 +278,12 @@ class SympyNodeRenderer(NodeRenderer):
         else:
             return sympy.Symbol(node.id, real=True)
 
+    def render_NameConstant(self, node):
+        if node.value in [True, False]:
+            return node.value
+        else:
+            return str(node.value)
+
     def render_Num(self, node):
         if isinstance(get_node_value(node), numbers.Integral):
             return sympy.Integer(get_node_value(node))

--- a/brian2/parsing/rendering.py
+++ b/brian2/parsing/rendering.py
@@ -10,23 +10,7 @@ __all__ = [
     "NumpyNodeRenderer",
     "CPPNodeRenderer",
     "SympyNodeRenderer",
-    "get_node_value",
 ]
-
-
-def get_node_value(node):
-    """Helper function to mask differences between Python versions"""
-    try:
-        value = node.value
-    except AttributeError:
-        try:
-            value = node.n
-        except AttributeError:
-            value = None
-
-    if value is None:
-        raise AttributeError(f'Node {node} has neither "n" nor "value" attribute')
-    return value
 
 
 class NodeRenderer:
@@ -97,9 +81,9 @@ class NodeRenderer:
         return node.id
 
     def render_Num(self, node):
-        return repr(get_node_value(node))
+        return repr(node.value)
 
-    def render_Constant(self, node):  # For literals in Python 3.8
+    def render_Constant(self, node):
         if node.value is True or node.value is False or node.value is None:
             return self.render_NameConstant(node)
         else:
@@ -130,9 +114,7 @@ class NodeRenderer:
         """
         if node.__class__.__name__ == "Name":
             return self.render_node(node)
-        elif (
-            node.__class__.__name__ in ["Num", "Constant"] and get_node_value(node) >= 0
-        ):
+        elif node.__class__.__name__ in ["Num", "Constant"] and node.value >= 0:
             return self.render_node(node)
         elif node.__class__.__name__ == "Call":
             return self.render_node(node)
@@ -285,10 +267,10 @@ class SympyNodeRenderer(NodeRenderer):
             return str(node.value)
 
     def render_Num(self, node):
-        if isinstance(get_node_value(node), numbers.Integral):
-            return sympy.Integer(get_node_value(node))
+        if isinstance(node.value, numbers.Integral):
+            return sympy.Integer(node.value)
         else:
-            return sympy.Float(get_node_value(node))
+            return sympy.Float(node.value)
 
     def render_BinOp(self, node):
         op_name = node.op.__class__.__name__


### PR DESCRIPTION
This removes references to deprecated classes/attributes of Python's `ast` module (which raise warnings with Python 3.12 and will be removed in 3.14). It also removes alternative code paths that were necessary for backwards compatibility with Python ≤3.7.