### PR TITLE
Numpy 2 compatibility

### DIFF
--- a/.github/workflows/test_latest.yml
+++ b/.github/workflows/test_latest.yml
@@ -65,8 +65,8 @@ jobs:
         run: ${{ steps.python.outputs.python-path }} -m pip install --pre -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple --extra-index-url https://pypi.org/simple .
       - name: Run Tests
         run: |
-          cd  $GITHUB_WORKSPACE/.. # move out of the workspace to avoid direct import
-          ${{ steps.python.outputs.python-path }} -Wd $GITHUB_WORKSPACE/dev/continuous-integration/run_test_suite.py
+          cd  ${{ github.workspace }}/.. # move out of the workspace to avoid direct import
+          ${{ steps.python.outputs.python-path }} -Wd ${{ github.workspace }}/dev/continuous-integration/run_test_suite.py
         env:
           DEPRECATION_ERROR: true
           AGENT_OS: ${{runner.os}}

--- a/README.rst
+++ b/README.rst
@@ -78,13 +78,13 @@ Dependencies
 ------------
 The following packages need to be installed to use Brian 2 (cf. `setup.py <setup.py>`_):
 
-* Python >= 3.7
-* NumPy >=1.17
+* Python >= 3.9
+* NumPy >=1.21
 * SymPy >= 1.2
-* Cython >= 0.29
+* Cython >= 0.29.21
 * PyParsing
 * Jinja2 >= 2.7
-* setuptools >= 24.2
+* setuptools >= 61
 * py-cpuinfo (only required on Windows)
 
 For full functionality, you might also want to install:

--- a/brian2/core/variables.py
+++ b/brian2/core/variables.py
@@ -58,7 +58,7 @@ def get_dtype(obj):
     if hasattr(obj, "dtype"):
         return obj.dtype
     else:
-        return np.obj2sctype(type(obj))
+        return np.dtype(type(obj))
 
 
 def get_dtype_str(val):
@@ -353,11 +353,11 @@ class Constant(Variable):
         # Use standard Python types if possible for numpy scalars
         if getattr(value, "shape", None) == () and hasattr(value, "dtype"):
             numpy_type = value.dtype
-            if np.can_cast(numpy_type, np.int_):
+            if np.can_cast(numpy_type, int):
                 value = int(value)
-            elif np.can_cast(numpy_type, np.float_):
+            elif np.can_cast(numpy_type, float):
                 value = float(value)
-            elif np.can_cast(numpy_type, np.complex_):
+            elif np.can_cast(numpy_type, complex):
                 value = complex(value)
             elif value is np.True_:
                 value = True

--- a/brian2/groups/neurongroup.py
+++ b/brian2/groups/neurongroup.py
@@ -822,7 +822,7 @@ class NeuronGroup(Group, SpikeSource):
             if value.index is not None:
                 try:
                     index_array = np.asarray(value.index)
-                    if not np.issubsctype(index_array.dtype, int):
+                    if not np.issubdtype(index_array.dtype, int):
                         raise TypeError()
                 except TypeError:
                     raise TypeError(

--- a/brian2/units/fundamentalunits.py
+++ b/brian2/units/fundamentalunits.py
@@ -23,7 +23,12 @@ from typing import Callable
 from warnings import warn
 
 import numpy as np
-from numpy import VisibleDeprecationWarning
+
+try:
+    from numpy.exceptions import VisibleDeprecationWarning  # numpy 2.x
+except ImportError:
+    from numpy import VisibleDeprecationWarning  # numpy 1.x
+
 from sympy import latex
 
 __all__ = [

--- a/brian2/units/fundamentalunits.py
+++ b/brian2/units/fundamentalunits.py
@@ -1070,7 +1070,7 @@ class Quantity(np.ndarray):
         subarr = np.array(arr, dtype=dtype, copy=copy).view(cls)
 
         # We only want numerical datatypes
-        if not np.issubclass_(np.dtype(subarr.dtype).type, (np.number, np.bool_)):
+        if not issubclass(np.dtype(subarr.dtype).type, (np.number, np.bool_)):
             raise TypeError("Quantities can only be created from numerical data.")
 
         # If a dimension is given, force this dimension

--- a/dev/continuous-integration/run_test_suite.py
+++ b/dev/continuous-integration/run_test_suite.py
@@ -63,7 +63,7 @@ if __name__ == '__main__':
                              test_in_parallel=in_parallel,
                              reset_preferences=reset_preferences,
                              float_dtype=float_dtype,
-                             test_GSL=True,
+                             test_GSL=False,
                              sphinx_dir=sphinx_dir,
                              additional_args=args)
     else:
@@ -73,7 +73,7 @@ if __name__ == '__main__':
                              test_in_parallel=in_parallel,
                              reset_preferences=reset_preferences,
                              float_dtype=float_dtype,
-                             test_GSL=True,
+                             test_GSL=False,
                              sphinx_dir=sphinx_dir,
                              additional_args=args)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ authors = [
 requires-python = '>=3.9'
 dependencies = [
     'numpy>=1.21',
-    'cython>=0.29',
+    'cython>=0.29.21',
     'sympy>=1.2',
     'pyparsing',
     'jinja2>=2.7',


### PR DESCRIPTION
This fixes a few issues for compatibility with the upcoming (backwards-compatibililty breaking) 2.0 version of numpy. It also switches off the GSL tests for now – GSL is broken on C++ standalone for unrelated reasons (and by chance/bad luck, the way it broke made it skip the tests so I only realized recently…). 

I still need to check whether any of the changes requires us to update our minimum version requirement for numpy, but I don't think it is.