### PR TITLE
Separate the tests for deprecation warnings

### DIFF
--- a/.github/workflows/test_latest.yml
+++ b/.github/workflows/test_latest.yml
@@ -68,7 +68,53 @@ jobs:
           cd  ${{ github.workspace }}/.. # move out of the workspace to avoid direct import
           ${{ steps.python.outputs.python-path }} -Wd ${{ github.workspace }}/dev/continuous-integration/run_test_suite.py
         env:
-          DEPRECATION_ERROR: true
           AGENT_OS: ${{runner.os}}
           STANDALONE: ${{ matrix.standalone }}
           FLOAT_DTYPE_32: ${{ matrix.float_dtype_32 }}
+
+  test-deprecations:
+    needs: [ get_python_versions ]
+    name: "Python ${{ matrix.python-version }} check for deprecation warnings on (standalone: ${{ matrix.standalone }}"
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        standalone: [ false, true ]
+        python-version: [ "${{ needs.get_python_versions.outputs.max-python }}" ]
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Install GSL
+        uses: johnwason/vcpkg-action@v5
+        id: vcpkg
+        with:
+          pkgs: gsl
+          triplet: x64-linux
+          cache-key: gsl-x64-linux
+          revision: master
+          token: ${{ github.token }}
+      - name: Install Python
+        id: python
+        uses: actions/setup-python@v4
+        with:
+          cache: 'pip'
+          python-version: ${{ matrix.python-version }}
+          allow-prereleases: true
+      - name: Install dependencies
+        run: |
+          ${{ steps.python.outputs.python-path }} -m pip install --upgrade pip setuptools
+          ${{ steps.python.outputs.python-path }} -m pip install --pre -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple numpy scipy
+          ${{ steps.python.outputs.python-path }} -m pip install --pre pytest cython sympy pyparsing jinja2 sphinx
+      - name: Install Brian2
+        run: ${{ steps.python.outputs.python-path }} -m pip install --pre -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple --extra-index-url https://pypi.org/simple .
+      - name: Run Tests
+        run: |
+          cd  ${{ github.workspace }}/.. # move out of the workspace to avoid direct import
+          ${{ steps.python.outputs.python-path }} -Wd ${{ github.workspace }}/dev/continuous-integration/run_test_suite.py || echo "Tests failed (but not marked as failed on GA)"
+        env:
+          DEPRECATION_ERROR: true
+          AGENT_OS: linux
+          STANDALONE: ${{ matrix.standalone }}

--- a/dev/continuous-integration/run_test_suite.py
+++ b/dev/continuous-integration/run_test_suite.py
@@ -51,7 +51,7 @@ if __name__ == '__main__':
         float_dtype = None
 
     if deprecation_error:
-        args = ['-W', 'error::DeprecationWarning']
+        args = ['-W', 'error::DeprecationWarning', '--tb=short']
     else:
         args = []
 


### PR DESCRIPTION
We run tests against the latest versions of numpy, etc. (including pre-releases) every week. Currently, these tests fail even if they just raise deprecation warnings. I separated out these tests and no longer mark them as failed – we still have the log output if we want to check manually.

In the long run, we could maybe have the GitHub action post the results about deprecation warnings to an issue as a comment.