### PR TITLE
Setuptools related improvements

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -23,3 +23,12 @@ exclude .coveragerc
 exclude .gitattributes
 exclude .gitmodules
 include brian2/_version.py
+
+include brian2/devices/cpp_standalone/templates/*
+include brian2/devices/cpp_standalone/templates_GSL/*
+include brian2/tests/test_templates/fake_package_1/templates/*
+include brian2/tests/test_templates/fake_package_2/templates/*
+include brian2/codegen/runtime/numpy_rt/templates/*
+include brian2/codegen/runtime/GSLcython_rt/templates/*
+include brian2/codegen/runtime/cython_rt/templates/*
+include brian2/tests/*.ini

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -32,3 +32,5 @@ include brian2/codegen/runtime/numpy_rt/templates/*
 include brian2/codegen/runtime/GSLcython_rt/templates/*
 include brian2/codegen/runtime/cython_rt/templates/*
 include brian2/tests/*.ini
+include brian2/tests/*.pyx
+include brian2/tests/rallpack_data/*.0

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -34,3 +34,4 @@ include brian2/codegen/runtime/cython_rt/templates/*
 include brian2/tests/*.ini
 include brian2/tests/*.pyx
 include brian2/tests/rallpack_data/*.0
+include brian2/tests/rallpack_data/*.x

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -33,5 +33,6 @@ include brian2/codegen/runtime/GSLcython_rt/templates/*
 include brian2/codegen/runtime/cython_rt/templates/*
 include brian2/tests/*.ini
 include brian2/tests/*.pyx
+include brian2/tests/*.pxd
 include brian2/tests/rallpack_data/*.0
 include brian2/tests/rallpack_data/*.x

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,10 @@ Tracker = 'https://github.com/brian-team/brian2/issues'
 
 [tool.setuptools]
 zip-safe = false
-packages = ['brian2']
+include-package-data = true
+
+[tool.setuptools.packages.find]
+include = ["brian2*"]
 
 [tool.setuptools.dynamic]
 readme = {file = 'README.rst', content-type = "text/x-rst"}


### PR DESCRIPTION
I'm going to preface this PR by saying that I do not know why the current upstream configuration works. From what I see in the various docs, it shouldn't, but there's so much going on in the Python packaging ecosystem that I'm no longer confident I understand it all properly :joy: 

While building on Fedora, the current pyproject.toml etc., doesn't work---it only includes the top level brian2 package in the generated wheels. This seems to be the correct behaviour because as the setuptools documentation notes (or suggests rather), only including the top level package name in the package list is not enough. One either has to list all sub-packages, or use the discovery tools.

https://setuptools.pypa.io/en/latest/userguide/package_discovery.html#package-discovery-and-namespace-packages

So, to ensure that all sub-packages and the necessary template/data is included, I had to tweak these files as noted in the PR. (the tests from my local build are still running, so there may be more data files that are needed to be added to the manifest etc.).