### PR TITLE
Correct C++ floor division for integers

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -732,9 +732,9 @@ Constants used in the rk_double implementation by Isaku Wada.
 
 --
 
-The floor division implementation for integer numbers in C++ standalone is based
-on the implementation in Cython (https://github.com/cython/cython), published under
-the Apache License 2.0:
+The floor division and modulo implementations for integer numbers in C++ standalone
+are based on the implementation in Cython (https://github.com/cython/cython), published
+under the Apache License 2.0:
                                  Apache License
                            Version 2.0, January 2004
                         https://www.apache.org/licenses/

--- a/LICENSE
+++ b/LICENSE
@@ -729,3 +729,185 @@ Magnus Jonsson.
 --
 
 Constants used in the rk_double implementation by Isaku Wada.
+
+--
+
+The floor division implementation for integer numbers in C++ standalone is based
+on the implementation in Cython (https://github.com/cython/cython), published under
+the Apache License 2.0:
+                                 Apache License
+                           Version 2.0, January 2004
+                        https://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS

--- a/brian2/codegen/generators/cpp_generator.py
+++ b/brian2/codegen/generators/cpp_generator.py
@@ -111,13 +111,43 @@ _brian_mod(T1 x, T2 y)
 """
 
 floordiv_support_code = """
-
+// General template for floating point types
 template < typename T1, typename T2 >
 static inline typename _higher_type<T1,T2>::type
 _brian_floordiv(T1 x, T2 y)
 {{
     return floor(1.0*x/y);
 }}
+
+// Specific templates for integer types
+template <>
+inline int _brian_floordiv<int, int>(int a, int b) {
+    long q = a / b;
+    long r = a - q*b;
+    q -= ((r != 0) & ((r ^ b) < 0));
+    return q;
+}
+template <>
+inline long _brian_floordiv<int, long>(int a, long b) {
+    long q = a / b;
+    long r = a - q*b;
+    q -= ((r != 0) & ((r ^ b) < 0));
+    return q;
+}
+template <>
+inline long _brian_floordiv<long, int>(long a, int b) {
+    long q = a / b;
+    long r = a - q*b;
+    q -= ((r != 0) & ((r ^ b) < 0));
+    return q;
+}
+template <>
+inline long _brian_floordiv<long, long>(long a, long b) {
+    long q = a / b;
+    long r = a - q*b;
+    q -= ((r != 0) & ((r ^ b) < 0));
+    return q;
+}
 """
 
 pow_support_code = """

--- a/brian2/codegen/generators/cpp_generator.py
+++ b/brian2/codegen/generators/cpp_generator.py
@@ -91,7 +91,6 @@ prefs.register_preferences(
 
 
 typestrs = ["int32_t", "int64_t", "float", "double", "long double"]
-floattypestrs = ["float", "double", "long double"]
 hightype_support_code = "template < typename T1, typename T2 > struct _higher_type;\n"
 for ix, xtype in enumerate(typestrs):
     for iy, ytype in enumerate(typestrs):

--- a/brian2/codegen/generators/cpp_generator.py
+++ b/brian2/codegen/generators/cpp_generator.py
@@ -90,7 +90,7 @@ prefs.register_preferences(
 )
 
 
-typestrs = ["int", "long", "long long", "float", "double", "long double"]
+typestrs = ["int32_t", "int64_t", "float", "double", "long double"]
 floattypestrs = ["float", "double", "long double"]
 hightype_support_code = "template < typename T1, typename T2 > struct _higher_type;\n"
 for ix, xtype in enumerate(typestrs):
@@ -112,33 +112,33 @@ _brian_mod(T1 x, T2 y)
 // Specific implementations for integer types
 // (from Cython, see LICENSE file)
 template <>
-inline int _brian_mod(int x, int y)
+inline int32_t _brian_mod(int32_t x, int32_t y)
 {
-    int r = x % y;
+    int32_t r = x % y;
     r += ((r != 0) & ((r ^ y) < 0)) * y;
     return r;
 }
 
 template <>
-inline long _brian_mod(int x, long y)
+inline int64_t _brian_mod(int32_t x, int64_t y)
 {
-    long r = x % y;
+    int64_t r = x % y;
     r += ((r != 0) & ((r ^ y) < 0)) * y;
     return r;
 }
 
 template <>
-inline long _brian_mod(long x, int y)
+inline int64_t _brian_mod(int64_t x, int32_t y)
 {
-    long r = x % y;
+    int64_t r = x % y;
     r += ((r != 0) & ((r ^ y) < 0)) * y;
     return r;
 }
 
 template <>
-inline long _brian_mod(long x, long y)
+inline int64_t _brian_mod(int64_t x, int64_t y)
 {
-    long r = x % y;
+    int64_t r = x % y;
     r += ((r != 0) & ((r ^ y) < 0)) * y;
     return r;
 }
@@ -156,30 +156,30 @@ _brian_floordiv(T1 x, T2 y)
 // Specific implementations for integer types
 // (from Cython, see LICENSE file)
 template <>
-inline int _brian_floordiv<int, int>(int a, int b) {
-    int q = a / b;
-    int r = a - q*b;
+inline int32_t _brian_floordiv<int32_t, int32_t>(int32_t a, int32_t b) {
+    int32_t q = a / b;
+    int32_t r = a - q*b;
     q -= ((r != 0) & ((r ^ b) < 0));
     return q;
 }
 template <>
-inline long _brian_floordiv<int, long>(int a, long b) {
-    long q = a / b;
-    long r = a - q*b;
+inline int64_t _brian_floordiv<int32_t, int64_t>(int32_t a, int64_t b) {
+    int64_t q = a / b;
+    int64_t r = a - q*b;
     q -= ((r != 0) & ((r ^ b) < 0));
     return q;
 }
 template <>
-inline long _brian_floordiv<long, int>(long a, int b) {
-    long q = a / b;
-    long r = a - q*b;
+inline int64_t _brian_floordiv<int64_t, int>(int64_t a, int32_t b) {
+    int64_t q = a / b;
+    int64_t r = a - q*b;
     q -= ((r != 0) & ((r ^ b) < 0));
     return q;
 }
 template <>
-inline long _brian_floordiv<long, long>(long a, long b) {
-    long q = a / b;
-    long r = a - q*b;
+inline int64_t _brian_floordiv<int64_t, int64_t>(int64_t a, int64_t b) {
+    int64_t q = a / b;
+    int64_t r = a - q*b;
     q -= ((r != 0) & ((r ^ b) < 0));
     return q;
 }

--- a/brian2/codegen/generators/cpp_generator.py
+++ b/brian2/codegen/generators/cpp_generator.py
@@ -101,17 +101,51 @@ template < > struct _higher_type<{xtype},{ytype}> {{ typedef {hightype} type; }}
         """
 
 mod_support_code = """
-
+// General template, used for floating point types
 template < typename T1, typename T2 >
 static inline typename _higher_type<T1,T2>::type
 _brian_mod(T1 x, T2 y)
-{{
+{
     return x-y*floor(1.0*x/y);
-}}
+}
+
+// Specific implementations for integer types
+// (from Cython, see LICENSE file)
+template <>
+inline int _brian_mod(int x, int y)
+{
+    int r = x % y;
+    r += ((r != 0) & ((r ^ y) < 0)) * y;
+    return r;
+}
+
+template <>
+inline long _brian_mod(int x, long y)
+{
+    long r = x % y;
+    r += ((r != 0) & ((r ^ y) < 0)) * y;
+    return r;
+}
+
+template <>
+inline long _brian_mod(long x, int y)
+{
+    long r = x % y;
+    r += ((r != 0) & ((r ^ y) < 0)) * y;
+    return r;
+}
+
+template <>
+inline long _brian_mod(long x, long y)
+{
+    long r = x % y;
+    r += ((r != 0) & ((r ^ y) < 0)) * y;
+    return r;
+}
 """
 
 floordiv_support_code = """
-// General template for floating point types
+// General implementation, used for floating point types
 template < typename T1, typename T2 >
 static inline typename _higher_type<T1,T2>::type
 _brian_floordiv(T1 x, T2 y)
@@ -119,11 +153,12 @@ _brian_floordiv(T1 x, T2 y)
     return floor(1.0*x/y);
 }}
 
-// Specific templates for integer types
+// Specific implementations for integer types
+// (from Cython, see LICENSE file)
 template <>
 inline int _brian_floordiv<int, int>(int a, int b) {
-    long q = a / b;
-    long r = a - q*b;
+    int q = a / b;
+    int r = a - q*b;
     q -= ((r != 0) & ((r ^ b) < 0));
     return q;
 }

--- a/brian2/tests/test_neurongroup.py
+++ b/brian2/tests/test_neurongroup.py
@@ -2188,7 +2188,7 @@ def test_semantics_floating_point_division():
 def test_semantics_mod():
     # See github issues #815 and #661
     G = NeuronGroup(
-        11,
+        300,
         """
         a : integer
         b : integer
@@ -2199,26 +2199,25 @@ def test_semantics_mod():
         """,
         dtype={"a": np.int32, "b": np.int64, "x": float, "y": float},
     )
-    int_values = np.arange(-5, 6)
-    float_values = np.arange(-5.0, 6.0, dtype=np.float64)
+    int_values = np.arange(-150, 150)
+    float_values = np.linspace(-100, 100, 300, dtype=np.float64)
     G.ivalue = int_values
     G.fvalue = float_values
     with catch_logs() as l:
         G.run_regularly(
             """
-            a = ivalue % 3
-            b = ivalue % 3
-            x = fvalue % 3
-            y = fvalue % 3
+            a = ivalue % 98
+            b = ivalue % 98
+            x = fvalue % 98
+            y = fvalue % 98
             """
         )
         run(defaultclock.dt)
     assert len(l) == 0
-    assert_equal(G.a[:], int_values % 3)
-    assert_equal(G.b[:], int_values % 3)
-    assert_allclose(G.x[:], float_values % 3)
-    assert_allclose(G.y[:], float_values % 3)
-
+    assert_equal(G.a[:], int_values % 98)
+    assert_equal(G.b[:], int_values % 98)
+    assert_allclose(G.x[:], float_values % 98)
+    assert_allclose(G.y[:], float_values % 98)
 
 if __name__ == "__main__":
     test_set_states()

--- a/brian2/tests/test_neurongroup.py
+++ b/brian2/tests/test_neurongroup.py
@@ -2114,9 +2114,9 @@ def test_run_regularly_shared():
 
 @pytest.mark.standalone_compatible
 def test_semantics_floor_division():
-    # See github issues #815 and #661
+    # See github issues #815, #661, and #1495
     G = NeuronGroup(
-        11,
+        300,
         """
         a : integer
         b : integer
@@ -2127,25 +2127,25 @@ def test_semantics_floor_division():
         """,
         dtype={"a": np.int32, "b": np.int64, "x": float, "y": float},
     )
-    int_values = np.arange(-5, 6)
-    float_values = np.arange(-5.0, 6.0, dtype=np.float64)
+    int_values = np.arange(-150, 150)
+    float_values = np.linspace(-100, 100, 300, dtype=np.float64)
     G.ivalue = int_values
     G.fvalue = float_values
     with catch_logs() as l:
         G.run_regularly(
             """
-            a = ivalue//3
-            b = ivalue//3
-            x = fvalue//3
-            y = fvalue//3
+            a = ivalue//98
+            b = ivalue//98
+            x = fvalue//98
+            y = fvalue//98
             """
         )
         run(defaultclock.dt)
     assert len(l) == 0
-    assert_equal(G.a[:], int_values // 3)
-    assert_equal(G.b[:], int_values // 3)
-    assert_allclose(G.x[:], float_values // 3)
-    assert_allclose(G.y[:], float_values // 3)
+    assert_equal(G.a[:], int_values // 98)
+    assert_equal(G.b[:], int_values // 98)
+    assert_allclose(G.x[:], float_values // 98)
+    assert_allclose(G.y[:], float_values // 98)
 
 
 @pytest.mark.standalone_compatible

--- a/brian2/tests/test_neurongroup.py
+++ b/brian2/tests/test_neurongroup.py
@@ -2219,6 +2219,7 @@ def test_semantics_mod():
     assert_allclose(G.x[:], float_values % 98)
     assert_allclose(G.y[:], float_values % 98)
 
+
 if __name__ == "__main__":
     test_set_states()
     test_creation()


### PR DESCRIPTION
This fixes #1495. As mentioned in the issue, the problem is that we use `floor(1.0*x/y)` to calculate floor division with Python semantics in C++. By default, we have unsafe math optimizations enabled, which leads to this not always being correct (e.g. 98/98 would be rounded down to 0). I think this is due to replacing the division by multiplication with an approximated reciprocal, or something along these lines. Switching off unsafe optimizations would be an option, but it would slow down code in other places.
In this PR, I instead create function specializations for integer arguments, which then use a rather complex calculation to get the value:
```c++
q = a / b;
r = a - q*b;
q -= ((r != 0) & ((r ^ b) < 0));  // result
```
This is the implementation used by Cython (`cdivision: false`, obviously), and it should cover all corner cases. I didn't benchmark this, but it is probably quite a bit slower than the previous solution. This could bring up #993 on the table (the issue is about Cython, but the same is now relevant for C++), but on the other hand all use cases I can think of for floor division and modulo operations are initializations and `run_regularly` operations, nothing that is time-critical. As a data point, all usages of `//` in our examples are for initializations like `x = i // columns`.