### PR TITLE
Extend compiler cpu optmizations to loongarch64.

### DIFF
--- a/brian2/codegen/cpp_prefs.py
+++ b/brian2/codegen/cpp_prefs.py
@@ -124,7 +124,7 @@ else:
             "-mtune=native",
             "-std=c++11",
         ]
-    elif re.match("^(parisc.*|riscv.*|mips.*)$", machine):
+    elif re.match("^(parisc.*|riscv.*|mips.*|loong64.*)$", machine):
         default_buildopts = [
             "-w",
             "-O3",


### PR DESCRIPTION
This patch extends the just-in-time compiler options in brian2/codegen/cpp_prefs.py to optimize aggressively on loongarch64 CPU, similarly to numerous other platforms already supported by brian2.

It was originally published in [Debian bug #1059428] and provided by Loongson.

[Debian bug #1059428]: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1059428