### PR TITLE
Sphinx update

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -95,7 +95,7 @@ For full functionality, you might also want to install:
 
 To build the documentation:
 
-* Sphinx (>=1.8)
+* Sphinx (>=7)
 
 To run the test suite:
 

--- a/docs_sphinx/conf.py
+++ b/docs_sphinx/conf.py
@@ -310,10 +310,10 @@ texinfo_documents = [
 
 
 intersphinx_mapping = {
-    'https://docs.python.org/3': None,
-    'https://numpy.org/doc/stable': None,
-    'https://docs.scipy.org/doc/scipy': None,
-    'https://docs.sympy.org/dev/': None
+    'python': ('https://docs.python.org/3', None),
+    'numpy' : ('https://numpy.org/doc/stable', None),
+    'scipy' : ('https://docs.scipy.org/doc/scipy', None),
+    'sympy' : ('https://docs.sympy.org/dev/', None)
 }
 
 autodoc_default_options = {'show-inheritance': True}

--- a/docs_sphinx/developer/standalone.rst
+++ b/docs_sphinx/developer/standalone.rst
@@ -50,7 +50,7 @@ to the ``main`` binary. A call such as::
 
 will be executed by calling the compiled binary as follows:
 
-.. code-block:: verbatim
+.. code-block:: shell
 
     ./main --results_dir /full/path/to/results_1 neurongroup.tau=0.01
 
@@ -64,7 +64,7 @@ For initializations with a vector of values, the values are written to disk (in 
 binary format that is used elsewhere, e.g. for the results). The command line argument then
 specifies the file name instead of a value:
 
-.. code-block:: verbatim
+.. code-block:: shell
 
     ./main neurongroup.tau=static_arrays/init_neurongroup_v_aca4cd6a3f7e526a61bb5a07468b377e.dat
 

--- a/examples/frompapers/Naud_et_al_2008_adex_firing_patterns.py
+++ b/examples/frompapers/Naud_et_al_2008_adex_firing_patterns.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 """
 Firing patterns in the adaptive exponential integrate-and-fire model
------------------------
+--------------------------------------------------------------------
 Naud R et al. (2008): Firing patterns in the adaptive exponential integrate-and-fire model.
 Biol Cybern. 2008; 99(4): 335–347.
 doi:10.1007/s00422-008-0264-7

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ classifiers = [
 
 [project.optional-dependencies]
 test = ['pytest', 'pytest-xdist>=1.22.3']
-docs = ['sphinx>=1.8', 'ipython>=5', 'sphinx-tabs']
+docs = ['sphinx>=7', 'ipython>=5', 'sphinx-tabs']
 
 [project.urls]
 Homepage = 'https://briansimulator.org'

--- a/rtd-requirements.txt
+++ b/rtd-requirements.txt
@@ -4,8 +4,5 @@
 # highlighting) get displayed correctly
 ipython >= 5
 sphinx-tabs
-sphinx==1.8.6
-Jinja2<3.1.0
-commonmark==0.9.1
-recommonmark==0.5.0
+sphinx>=7
 sphinx_rtd_theme


### PR DESCRIPTION
Builds on readthedocs were failing due to a dependency conflict – we were requiring a very old version of Sphinx, this PR updates the dependency to Sphinx >= 7 (latest major version).