### PR TITLE
Enable M1 runner on workflows

### DIFF
--- a/.github/workflows/publish_to_pypi.yml
+++ b/.github/workflows/publish_to_pypi.yml
@@ -24,17 +24,17 @@ jobs:
       matrix:
         os: [ windows-latest, macOS-12, macOS-14 ]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Set up Python 3.x
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.x'
+      - name: Install cibuildwheel
+        run: python -m pip install cibuildwheel==2.16.5
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.12.1
-        with:
-          output-dir: dist
+        run: python -m cibuildwheel --output-dir dist
         env:
           CIBW_PROJECT_REQUIRES_PYTHON: ">=${{ needs.get_python_versions.outputs.min-python }}"
           CIBW_ARCHS: auto64
@@ -57,11 +57,11 @@ jobs:
       matrix:
         arch: [ auto64, aarch64 ]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Set up Python 3.x
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.x'
       - name: Build source tarball
@@ -74,10 +74,10 @@ jobs:
         uses: docker/setup-qemu-action@v2
         with:
           platforms: all
+      - name: Install cibuildwheel
+        run: python -m pip install cibuildwheel==2.16.5
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.12.1
-        with:
-          output-dir: dist
+        run: python -m cibuildwheel --output-dir dist
         env:
           CIBW_PROJECT_REQUIRES_PYTHON: ">=${{ needs.get_python_versions.outputs.min-python }}"
           CIBW_ARCHS_LINUX: ${{ matrix.arch }}

--- a/.github/workflows/publish_to_pypi.yml
+++ b/.github/workflows/publish_to_pypi.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ windows-latest, macOS-latest ]
+        os: [ windows-latest, macOS-12, macOS-14 ]
     steps:
       - uses: actions/checkout@v3
         with:
@@ -37,9 +37,8 @@ jobs:
           output-dir: dist
         env:
           CIBW_PROJECT_REQUIRES_PYTHON: ">=${{ needs.get_python_versions.outputs.min-python }}"
-          CIBW_ARCHS_WINDOWS: auto64
-          CIBW_ARCHS_MACOS: x86_64 universal2
-          CIBW_TEST_SKIP: '*_arm64 *_universal2:arm64'
+          CIBW_ARCHS: auto64
+          # Do not build for PyPy
           CIBW_SKIP: 'pp*'
           CIBW_TEST_COMMAND: python {project}/dev/continuous-integration/run_simple_test.py
           CIBW_TEST_REQUIRES: pytest

--- a/.github/workflows/test_latest.yml
+++ b/.github/workflows/test_latest.yml
@@ -38,7 +38,7 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Install GSL
@@ -52,7 +52,7 @@ jobs:
           token: ${{ github.token }}
       - name: Install Python
         id: python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           cache: 'pip'
           python-version: ${{ matrix.python-version }}
@@ -85,7 +85,7 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Install GSL
@@ -99,7 +99,7 @@ jobs:
           token: ${{ github.token }}
       - name: Install Python
         id: python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           cache: 'pip'
           python-version: ${{ matrix.python-version }}

--- a/.github/workflows/test_latest.yml
+++ b/.github/workflows/test_latest.yml
@@ -30,7 +30,8 @@ jobs:
       matrix:
         os: [{image: ubuntu-latest, triplet: x64-linux},
              {image: windows-latest, triplet: x64-windows},
-             {image: macOS-latest, triplet: x64-osx}]
+             {image: macOS-12, triplet: x64-osx},
+             {image: macOS-14, truplet: arm64-osx}]
         standalone: [false, true]
         float_dtype_32: [false, true]
         python-version: ["${{ needs.get_python_versions.outputs.max-python }}"]

--- a/.github/workflows/testsuite.yml
+++ b/.github/workflows/testsuite.yml
@@ -20,8 +20,8 @@ jobs:
     name: Run linters with pre-commit
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.10'
           cache: 'pip'
@@ -57,12 +57,12 @@ jobs:
         shell: bash -l {0}
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Setup Conda and Python
-        uses: conda-incubator/setup-miniconda@v2
+        uses: conda-incubator/setup-miniconda@v3
         with:
           auto-update-conda: true
           auto-activate-base: false
@@ -120,13 +120,13 @@ jobs:
         shell: bash -l {0}
     steps:
     - name: Checkout Repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         fetch-depth: 0
         submodules: true
 
     - name: Setup Conda and Python
-      uses: conda-incubator/setup-miniconda@v2
+      uses: conda-incubator/setup-miniconda@v3
       with:
         auto-update-conda: true
         auto-activate-base: false

--- a/.github/workflows/testsuite.yml
+++ b/.github/workflows/testsuite.yml
@@ -38,16 +38,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, windows-2019, macOS-11]
+        os: [ubuntu-22.04, windows-2022, macOS-12, macOS-14]
         standalone: [false, true]
         float_dtype_32: [false, true]
         python-version: ["${{ needs.get_python_versions.outputs.max-python }}"]
         include:
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             standalone: false
             python-version: "${{ needs.get_python_versions.outputs.min-python }}"
             float_dtype_32: false
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             standalone: true
             python-version: "${{ needs.get_python_versions.outputs.min-python }}"
             float_dtype_32: false

--- a/.github/workflows/testsuite.yml
+++ b/.github/workflows/testsuite.yml
@@ -66,15 +66,14 @@ jobs:
         with:
           auto-update-conda: true
           auto-activate-base: false
-          channels: conda-forge,defaults
-          channel-priority: true
+          miniforge-version: latest
           activate-environment: 'test_env'
           python-version: ${{ matrix.python-version }}
 
       - name: Install Brian2 and dependencies
         run: |
-          conda install -n test_env --quiet --yes -c conda-forge pip pytest cython sympy future pyparsing numpy jinja2 six scipy sphinx gsl coverage
-          pip install .
+          conda install --quiet --yes pip gsl
+          python -m pip install .[test] coverage
 
       - name: Run Tests
         run: |
@@ -130,8 +129,7 @@ jobs:
       with:
         auto-update-conda: true
         auto-activate-base: false
-        channels: conda-forge,defaults
-        channel-priority: true
+        miniforge-version: latest
         activate-environment: 'test_env'
         python-version: "${{ needs.get_python_versions.outputs.max-python }}"
 


### PR DESCRIPTION
This PR enables the new [M1 runners for open source projects](https://github.blog/changelog/2024-01-30-github-actions-introducing-the-new-m1-macos-runner-available-to-open-source/), i.e. we can now test and build packages on Apple M1 hardware. We've already built packages for `macos-arm64` via cross-compilation before, but we couldn't test them. This PR also updates the workflows in a few other minor ways.