### PR TITLE
Use `cpow=True` in Python

### DIFF
--- a/brian2/codegen/runtime/cython_rt/templates/common_group.pyx
+++ b/brian2/codegen/runtime/cython_rt/templates/common_group.pyx
@@ -3,6 +3,7 @@
 #cython: boundscheck=False
 #cython: wraparound=False
 #cython: cdivision=False
+#cython: cpow=True
 #cython: infer_types=True
 {% endmacro %}
 

--- a/brian2/tests/test_functions.py
+++ b/brian2/tests/test_functions.py
@@ -187,6 +187,24 @@ def test_bool_to_int():
     assert_equal(s_mon.intexpr2.flatten(), [1, 0])
 
 
+@pytest.mark.standalone_compatible
+def test_integer_power():
+    # See github issue #1500
+    G = NeuronGroup(
+        3,
+        """
+        intval1 : integer
+        intval2 : integer
+        k : integer (constant)
+        """,
+    )
+    G.k = [0, 1, 2]
+    G.run_regularly("intval1 = 2**k; intval2 = (-1)**k")
+    run(defaultclock.dt)
+    assert_equal(G.intval1[:], [1, 2, 4])
+    assert_equal(G.intval2[:], [1, -1, 1])
+
+
 @pytest.mark.codegen_independent
 def test_timestep_function():
     dt = defaultclock.dt_


### PR DESCRIPTION
Avoids that `x**y` becomes a float for two integers, leading to compilation errors. This behaviour changed with Cython 3.0. While I think there's a point for having `x**y` only being an integer if the compiler knows that `y` is non-negative, in practice I don't think there is much use of this kind of exponentiation outside of expressions such as `(-1)**k`. Whatever we'd decide for this in the long run, right now this fix assures that there is no difference depending on your version of Cython.

Fixes #1500