### PR TITLE
Document how to record population averages in a memory efficient way

### DIFF
--- a/docs_sphinx/user/recording.rst
+++ b/docs_sphinx/user/recording.rst
@@ -288,4 +288,4 @@ group and the `Synapse` class' :ref:`summed variable syntax
     vm_averager.connect()
 
     # Monitor recording the average membrane potential
-    vm_monitor = StateMonitor(vm_container, 'average_vm', record=0)
+    vm_monitor = StateMonitor(vm_container, 'average_vm', record=True)

--- a/docs_sphinx/user/recording.rst
+++ b/docs_sphinx/user/recording.rst
@@ -265,3 +265,27 @@ twice, and is therefore slightly less efficient. There's one additional caveat:
 you'll have to manually include ``and not_refractory`` in your ``events``
 definition if your neuron uses refractoriness. This is done automatically
 for the ``threshold`` condition, but not for any user-defined events.
+
+Recording population averages
+-----------------------------
+
+Continuous recordings from large groups over long simulation times can
+fill up the working memory quickly: recording a single variable from
+1000 neurons for 100 seconds at the default time resolution results in
+a 1 gigabyte array. While this issue can be ameliorated using the
+above approaches, the downstream data analysis is often based on
+population averages. These can be recorded efficiently using a dummy
+group and the `Synapse` class' :ref:`summed variable syntax
+<summed_variables>`::
+
+    group = NeuronGroup(..., 'dv/dt = ... : volt', ...)
+
+    # Dummy group to store the average membrane potential at every time step
+    vm_container = NeuronGroup(1, 'average_vm : volt')
+
+    # Synapses averaging the membrane potential of all neurons in group
+    vm_averager = Synapses(group, vm_container, 'average_vm_post = v_pre/N_pre : volt (summed)')
+    vm_averager.connect()
+
+    # Monitor recording the average membrane potential
+    vm_monitor = StateMonitor(vm_container, 'average_vm', record=0)

--- a/docs_sphinx/user/recording.rst
+++ b/docs_sphinx/user/recording.rst
@@ -272,10 +272,10 @@ Recording population averages
 Continuous recordings from large groups over long simulation times can
 fill up the working memory quickly: recording a single variable from
 1000 neurons for 100 seconds at the default time resolution results in
-a 1 gigabyte array. While this issue can be ameliorated using the
+an array of about 8 Gigabytes. While this issue can be ameliorated using the
 above approaches, the downstream data analysis is often based on
 population averages. These can be recorded efficiently using a dummy
-group and the `Synapse` class' :ref:`summed variable syntax
+group and the `Synapses` class' :ref:`summed variable syntax
 <summed_variables>`::
 
     group = NeuronGroup(..., 'dv/dt = ... : volt', ...)

--- a/docs_sphinx/user/synapses.rst
+++ b/docs_sphinx/user/synapses.rst
@@ -439,6 +439,8 @@ incorrect size, i.e. a negative size or a size bigger than the
 total population size. With ``skip_if_invalid=True``, no error will
 be raised and a size of 0 or the population size will be used.
 
+.. _summed_variables:
+
 Summed variables
 ----------------
 In many cases, the postsynaptic neuron has a variable that represents a sum of variables over all


### PR DESCRIPTION
Hi, following our discussion [here](https://brian.discourse.group/t/how-to-implement-a-populationstatemonitor/1138), I added a small section to the documentation that outlines how to continuously record population averages in a memory efficient way (so I can find the information next time I need it). 

The section is based on the example given by @mstimberg [here](https://brian.discourse.group/t/is-there-a-way-to-monitor-the-average-membrane-potential-of-a-group-of-neurons/658/3).
 
```python
group = NeuronGroup(..., 'dv/dt = ...', ...)

# Dummy group to store the average membrane potential at every time step
vm_container = NeuronGroup(1, 'average_vm : volt')
# Synapses averaging the membrane potential of all neurons
vm_averager = Synapses(group, average_vm, 'average_vm_post = v_pre/N_pre : volt (summed)')
vm_averager.connect()
# Monitor recording the average membrane potential
vm_mon = StateMonitor(vm_container, 'average_vm', record=0)
```

I made the following changes:

1. I indicated that the units of the variable and the variable average need to match: `group = NeuronGroup(..., 'dv/dt = ... : volt', ...)`
2. I corrected a typo: `vm_averager = Synapses(group, vm_container, ...)`
3. I set `record=True` to match the examples in the same section.