### PR TITLE
Add dependabot configuration file

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  # Maintain dependencies for the dev container
+  - package-ecosystem: "devcontainer"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
This should activate dependabot for github-actions and the devcontainer, let's see how this works.

CC @bdevans

https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/about-dependabot-version-updates