### PR TITLE
New array copy semantics

### DIFF
--- a/.github/workflows/test_latest.yml
+++ b/.github/workflows/test_latest.yml
@@ -64,7 +64,9 @@ jobs:
           ${{ steps.python.outputs.python-path }} -m pip install mpmath  # install stable version
           ${{ steps.python.outputs.python-path }} -m pip install --pre pytest cython sympy pyparsing jinja2 sphinx
       - name: Install Brian2
-        run: ${{ steps.python.outputs.python-path }} -m pip install --pre -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple --extra-index-url https://pypi.org/simple .
+        run: |
+          cp numpy2.pyproject.toml pyproject.toml
+          ${{ steps.python.outputs.python-path }} -m pip install --pre -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple --extra-index-url https://pypi.org/simple .
       - name: Run Tests
         run: |
           cd  ${{ github.workspace }}/.. # move out of the workspace to avoid direct import

--- a/brian2/core/network.py
+++ b/brian2/core/network.py
@@ -451,10 +451,8 @@ class Network(Nameable):
         self._schedule = None
 
     t = property(
-        fget=lambda self: Quantity(self.t_, dim=second.dim, copy=False),
-        doc="""
-                     Current simulation time in seconds (`Quantity`)
-                     """,
+        fget=lambda self: Quantity(self.t_, dim=second.dim),
+        doc="Current simulation time in seconds (`Quantity`)",
     )
 
     @device_override("network_get_profiling_info")

--- a/brian2/core/variables.py
+++ b/brian2/core/variables.py
@@ -1326,7 +1326,7 @@ class VariableView:
         else:
             indices = self.indexing(item, self.index_var)
 
-            q = Quantity(value, copy=False)
+            q = Quantity(value)
             if len(q.shape):
                 if not len(q.shape) == 1 or len(q) != 1 and len(q) != len(indices):
                     raise ValueError(

--- a/brian2/monitors/spikemonitor.py
+++ b/brian2/monitors/spikemonitor.py
@@ -258,11 +258,10 @@ class EventMonitor(Group, CodeRunner):
                             first_pos[current_pos] : first_pos[current_pos + 1]
                         ],
                         dim=dim,
-                        copy=False,
                     )
                 else:
                     event_values[idx] = Quantity(
-                        sorted_values[first_pos[current_pos] :], dim=dim, copy=False
+                        sorted_values[first_pos[current_pos] :], dim=dim
                     )
                 current_pos += 1
             else:

--- a/brian2/units/unitsafefunctions.py
+++ b/brian2/units/unitsafefunctions.py
@@ -209,7 +209,6 @@ def arange(*args, **kwargs):
                 **kwargs,
             ),
             dim=dim,
-            copy=False,
         )
     else:
         return Quantity(
@@ -220,7 +219,6 @@ def arange(*args, **kwargs):
                 **kwargs,
             ),
             dim=dim,
-            copy=False,
         )
 
 
@@ -247,7 +245,7 @@ def linspace(start, stop, num=50, endpoint=True, retstep=False, dtype=None):
         retstep=retstep,
         dtype=dtype,
     )
-    return Quantity(result, dim=dim, copy=False)
+    return Quantity(result, dim=dim)
 
 
 linspace._do_not_run_doctests = True

--- a/numpy2.pyproject.toml
+++ b/numpy2.pyproject.toml
@@ -1,0 +1,80 @@
+[project]
+name = "Brian2"
+authors = [
+    {name = 'Marcel Stimberg'},
+    {name = 'Dan Goodman'},
+    {name ='Romain Brette'}
+]
+requires-python = '>=3.9'
+dependencies = [
+    'numpy>=2.0.0b1',
+    'cython>=0.29.21',
+    'sympy>=1.2',
+    'pyparsing',
+    'jinja2>=2.7',
+    'py-cpuinfo;platform_system=="Windows"',
+    'setuptools>=61',
+    'packaging',
+]
+dynamic = ["version", "readme"]
+description = 'A clock-driven simulator for spiking neural networks'
+keywords = ['computational neuroscience', 'simulation', 'neural networks', 'spiking neurons', 'biological neural networks', 'research']
+classifiers = [
+    'Development Status :: 5 - Production/Stable',
+    'Intended Audience :: Science/Research',
+    'License :: OSI Approved :: CEA CNRS Inria Logiciel Libre License, version 2.1 (CeCILL-2.1)',
+    'Natural Language :: English',
+    'Operating System :: OS Independent',
+    'Programming Language :: Python',
+    'Programming Language :: Python :: 3',
+    'Topic :: Scientific/Engineering :: Bio-Informatics'
+]
+
+[project.optional-dependencies]
+test = ['pytest', 'pytest-xdist>=1.22.3']
+docs = ['sphinx>=7', 'ipython>=5', 'sphinx-tabs']
+
+[project.urls]
+Homepage = 'https://briansimulator.org'
+Documentation ='https://brian2.readthedocs.io/'
+Source = 'https://github.com/brian-team/brian2'
+Tracker = 'https://github.com/brian-team/brian2/issues'
+
+[tool.setuptools]
+zip-safe = false
+include-package-data = true
+
+[tool.setuptools.packages.find]
+include = ["brian2*"]
+
+[tool.setuptools.dynamic]
+readme = {file = 'README.rst', content-type = "text/x-rst"}
+
+[tool.setuptools_scm]
+version_scheme = 'post-release'
+local_scheme = 'no-local-version'
+write_to = 'brian2/_version.py'
+tag_regex = '^(?P<version>\d+(?:\.\d+){0,2}[^\+]*(?:\+.*)?)$'
+fallback_version = 'unknown'
+
+[build-system]
+requires = [
+    "setuptools>=61",
+    'numpy>=2.0.0b1 ',
+    "wheel",
+    "Cython",
+    "setuptools_scm[toml]>=6.2"
+]
+build-backend = "setuptools.build_meta"
+
+[tool.black]
+target-version = ['py39']
+include = '^/brian2/.*\.pyi?$'
+
+[tool.isort]
+atomic = true
+profile = "black"
+py_version = "39"
+skip_gitignore = true
+# NOTE: isort has no "include" option, only "skip".
+skip_glob = ["dev/*", "docs_sphinx/*", "examples/*", "tutorials/*"]


### PR DESCRIPTION
In numpy 1.x, `array(x, copy=False)` meant : do not copy if possible. In numpy 2.0, it will raise an error if copying is not possible. This commit replaces the use of `array(x, copy=False)` by `asarray(x)`, which has the "do not copy if possible" in both numpy 1.x and numpy 2.0.