### PR TITLE
Number 0 and 1 were rendered as false and true in C++ code

### DIFF
--- a/brian2/parsing/rendering.py
+++ b/brian2/parsing/rendering.py
@@ -339,7 +339,12 @@ class CPPNodeRenderer(NodeRenderer):
             return NodeRenderer.render_BinOp(self, node)
 
     def render_Constant(self, node):
-        return {True: "true", False: "false"}.get(node.value, repr(node.value))
+        if node.value is True:
+            return "true"
+        elif node.value is False:
+            return "false"
+        else:
+            return repr(node.value)
 
     def render_Name(self, node):
         if node.id == "inf":


### PR DESCRIPTION
Usually, this shouldn't be a problem (implicit type cast), but it is at least surprising and may also break tests assuming that the numbers appear in the code.