### PR TITLE
Fix GSL to work with vcpkg installation (used in test_latest.yml)

### DIFF
--- a/.github/workflows/test_latest.yml
+++ b/.github/workflows/test_latest.yml
@@ -82,6 +82,7 @@ jobs:
           AGENT_OS: ${{runner.os}}
           STANDALONE: ${{ matrix.standalone }}
           FLOAT_DTYPE_32: ${{ matrix.float_dtype_32 }}
+          DO_NOT_RESET_PREFERENCES: true  # Make sure that GSL setting is used
 
   test-deprecations:
     needs: [ get_python_versions ]

--- a/.github/workflows/test_latest.yml
+++ b/.github/workflows/test_latest.yml
@@ -50,6 +50,13 @@ jobs:
           cache-key: gsl-${{ matrix.os.triplet }}
           revision: master
           token: ${{ github.token }}
+      - name: Set GSL preference for vcpkg
+        shell: bash
+        run: |
+          mkdir ~/.brian/
+          # Replaces backslashes with forward slashes
+          echo "GSL.directory=\"${{ github.workspace }}\\vcpkg\\installed\${{ matrix.os.triplet }}\\include"\" | tr '\\' '/' > ~/.brian/user_preferences
+          cat ~/.brian/user_preferences
       - name: Install Python
         id: python
         uses: actions/setup-python@v5

--- a/brian2/codegen/runtime/GSLcython_rt/GSLcython_rt.py
+++ b/brian2/codegen/runtime/GSLcython_rt/GSLcython_rt.py
@@ -3,6 +3,7 @@ Module containing the Cython CodeObject for code generation for integration usin
 GNU Scientific Library (GSL)
 """
 
+import os
 import sys
 from distutils.errors import CompileError
 
@@ -47,6 +48,14 @@ class GSLCythonCodeObject(CythonCodeObject):
             self.define_macros += [("WIN32", "1"), ("GSL_DLL", "1")]
         if prefs.GSL.directory is not None:
             self.include_dirs += [prefs.GSL.directory]
+            self.library_dirs += [
+                os.path.abspath(os.path.join(prefs.GSL.directory, "..", "lib"))
+            ]
+            if sys.platform == "win32":
+                GSL_bin = os.path.abspath(
+                    os.path.join(os.path.join(prefs.GSL.directory, "..", "bin"))
+                )
+                os.add_dll_directory(GSL_bin)
         try:
             super().compile()
         except CompileError as err:

--- a/dev/continuous-integration/run_test_suite.py
+++ b/dev/continuous-integration/run_test_suite.py
@@ -19,6 +19,7 @@ if __name__ == '__main__':
     # If TRAVIS_OS_NAME is not defined, we are testing on appveyor
     operating_system = os.environ.get('AGENT_OS', 'unknown').lower()
     cross_compiled = os.environ.get('CROSS_COMPILED', 'FALSE').lower() in ['yes', 'true']
+    do_not_reset_preferences = os.environ.get('DO_NOT_RESET_PREFERENCES', 'false').lower() in ['yes', 'true']
     report_coverage = os.environ.get('REPORT_COVERAGE', 'no').lower() in ['yes', 'true']
     dtype_32_bit = os.environ.get('FLOAT_DTYPE_32', 'no').lower() in ['yes', 'true']
     sphinx_dir = os.environ.get('SPHINX_DIR')
@@ -44,7 +45,7 @@ if __name__ == '__main__':
     else:
         openmp = False
 
-    reset_preferences = not cross_compiled
+    reset_preferences = not (cross_compiled or do_not_reset_preferences)
     if dtype_32_bit:
         float_dtype = np.float32
     else:


### PR DESCRIPTION
On `test_latest.yml`, we use Microsoft's `vcpkg` manager to install the GSL for all operating systems. Until recently (see #1523), we weren't actually running the GSL tests, so it went unnoticed that this doesn't quite work. In contrast to the installation of GSL via `conda`, we need to manually set the path with the `GSL.directory` preference. During fixing this, I also realized that our current GSL code did only use this preference for the include path with isn't enough, we only need it for the library path (and the DLL path on Windows).
These tests show that it now runs correctly: https://github.com/brian-team/brian2/actions/runs/8706379543
(The checks in this PR only show that it didn't break anything for code that doesn't need the `GSL.directory` preference).