### PR TITLE
Numpy 2 compatibility

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -83,7 +83,6 @@ jobs:
       - name: Build source tarball
         run: |
           python -m pip install --upgrade pip build
-          python -m pip install "cython>=0.29" oldest-supported-numpy "setuptools>=61" "setuptools_scm[toml]>=6.2"
           python -m build --sdist --config-setting=--formats=gztar --config-setting=--with-cython --config-setting=--fail-on-error
         if: ${{ matrix.arch == 'auto64' }}
       - name: Set up QEMU

--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ Try out Brian on the [mybinder](https://mybinder.org/) service:
 ## Dependencies
 The following packages need to be installed to use Brian 2 (cf. [`pyproject.toml`](pyproject.toml)):
 
-* Python >= 3.9
-* NumPy >=1.21
+* Python >= 3.10
+* NumPy >=1.23
 * SymPy >= 1.2
 * Cython >= 0.29.21
 * PyParsing

--- a/brian2/codegen/runtime/numpy_rt/numpy_rt.py
+++ b/brian2/codegen/runtime/numpy_rt/numpy_rt.py
@@ -127,11 +127,13 @@ class LazyArange(Iterable):
             return iter(self.indices)
 
     # Allow conversion to a proper array with np.array(...)
-    def __array__(self, dtype=None):
+    def __array__(self, dtype=None, copy=None):
+        if copy is False:
+            raise ValueError("LazyArange does not support copy=False")
         if self.indices is None:
-            return np.arange(self.start, self.stop)
+            return np.arange(self.start, self.stop, dtype=dtype)
         else:
-            return self.indices + self.start
+            return (self.indices + self.start).astype(dtype)
 
     # Allow basic arithmetics (used when shifting stuff for subgroups)
     def __add__(self, other):

--- a/brian2/core/variables.py
+++ b/brian2/core/variables.py
@@ -1337,11 +1337,13 @@ class VariableView:
         variable.get_value()[indices] = value
 
     # Allow some basic calculations directly on the ArrayView object
-    def __array__(self, dtype=None):
+    def __array__(self, dtype=None, copy=None):
         try:
             # This will fail for subexpressions that refer to external
             # parameters
-            self[:]
+            values = self[:]
+            # Never hand over copy = None
+            return np.array(values, dtype=dtype, copy=copy is not False, subok=True)
         except ValueError:
             var = self.variable.name
             raise ValueError(
@@ -1350,7 +1352,6 @@ class VariableView:
                 f"variables, use 'group.{var}[:]' instead of "
                 f"'group.{var}'"
             )
-        return np.asanyarray(self[:], dtype=dtype)
 
     def __array__ufunc__(self, ufunc, method, *inputs, **kwargs):
         if method == "__call__":

--- a/brian2/core/variables.py
+++ b/brian2/core/variables.py
@@ -1435,6 +1435,13 @@ class VariableView:
         self[:] = rhs
         return self
 
+    # Support matrix multiplication with @
+    def __matmul__(self, other):
+        return self.get_item(slice(None), level=1) @ np.asanyarray(other)
+
+    def __rmatmul__(self, other):
+        return np.asanyarray(other) @ self.get_item(slice(None), level=1)
+
     def __isub__(self, other):
         if isinstance(other, str):
             raise TypeError(

--- a/brian2/parsing/rendering.py
+++ b/brian2/parsing/rendering.py
@@ -1,6 +1,7 @@
 import ast
 import numbers
 
+import numpy as np
 import sympy
 
 from brian2.core.functions import DEFAULT_CONSTANTS, DEFAULT_FUNCTIONS
@@ -87,6 +88,9 @@ class NodeRenderer:
         return node.id
 
     def render_Constant(self, node):
+        if isinstance(node.value, np.number):
+            # repr prints the dtype in numpy 2.0
+            return repr(node.value.item())
         return repr(node.value)
 
     def render_Call(self, node):
@@ -344,7 +348,7 @@ class CPPNodeRenderer(NodeRenderer):
         elif node.value is False:
             return "false"
         else:
-            return repr(node.value)
+            return super().render_Constant(node)
 
     def render_Name(self, node):
         if node.id == "inf":

--- a/examples/advanced/stochastic_odes.py
+++ b/examples/advanced/stochastic_odes.py
@@ -55,8 +55,8 @@ figure(2, figsize=(16, 7))
 methods = ['milstein', 'heun']
 dts = [1*ms, 0.5*ms, 0.2*ms, 0.1*ms, 0.05*ms, 0.025*ms, 0.01*ms, 0.005*ms]
 
-rows = floor(sqrt(len(dts)))
-cols = ceil(1.0 * len(dts) / rows)
+rows = int(sqrt(len(dts)))
+cols = int(ceil(1.0 * len(dts) / rows))
 errors = dict([(method, zeros(len(dts))) for method in methods])
 for dt_idx, dt in enumerate(dts):
     print('dt: %s' % dt)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,9 +5,9 @@ authors = [
     {name = 'Dan Goodman'},
     {name ='Romain Brette'}
 ]
-requires-python = '>=3.9'
+requires-python = '>=3.10'
 dependencies = [
-    'numpy>=1.21',
+    'numpy>=1.23.5',
     'cython>=0.29.21',
     'sympy>=1.2',
     'pyparsing',
@@ -60,10 +60,11 @@ fallback_version = 'unknown'
 [build-system]
 requires = [
     "setuptools>=61",
-    "numpy>=1.10",
+    # By building against numpy 2.0, we make sure that the wheel is compatible with
+    # both numpy 2.0 and numpy>=1.23
+    "numpy>=2.0.0rc1",
     "wheel",
     "Cython",
-    "oldest-supported-numpy",
     "setuptools_scm[toml]>=6.2"
 ]
 build-backend = "setuptools.build_meta"

--- a/versions.md
+++ b/versions.md
@@ -6,7 +6,6 @@ This file contains a list of other files where versions of packages are specifie
 In the future it would be advantageous to implement an automated way of keep versions synchronised across files e.g. https://github.com/pre-commit/pre-commit/issues/945#issuecomment-527603460 or preferably parsing `.pre-commit-config.yaml` and using it to `pip install` requirements (see discussion here: https://github.com/brian-team/brian2/pull/1449#issuecomment-1372476018). Until then, the files are listed below for manual checking and updating. 
 
 * [`README.md`](https://github.com/brian-team/brian2/blob/master/README.md)
-* [`setup.py`](https://github.com/brian-team/brian2/blob/master/setup.py)
 * [`rtd-requirements.txt`](https://github.com/brian-team/brian2/blob/master/rtd-requirements.txt)
 * [`pyproject.toml`](https://github.com/brian-team/brian2/blob/master/pyproject.toml)
 * [`.pre-commit-config.yaml`](https://github.com/brian-team/brian2/blob/master/.pre-commit-config.yaml)


### PR DESCRIPTION
Yet another small PR to fix compatiblity with the upcoming numpy 2.0 release. Not sure whether we will do a release before the official numpy 2.0 release, but if we do, then our wheels built with the changes in this PR should already be compatible (while staying compatible with numpy 1.x). 

Following [NEP 29](https://numpy.org/neps/nep-0029-deprecation_policy.html), this also bumps up the minimal numpy and Python versions.