### PR TITLE
Cache cython on CI

### DIFF
--- a/.github/workflows/test_latest.yml
+++ b/.github/workflows/test_latest.yml
@@ -122,12 +122,18 @@ jobs:
           ${{ steps.python.outputs.python-path }} -m pip install --pre pytest cython sympy pyparsing jinja2 sphinx
       - name: Install Brian2
         run: ${{ steps.python.outputs.python-path }} -m pip install --pre -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple --extra-index-url https://pypi.org/simple .
+      - name: Determine Cython cache dir
+        id: cython-cache
+        run: |
+          CACHE_DIR=$(python -c 'import os; from Cython.Utils import get_cython_cache_dir; print(os.path.join(get_cython_cache_dir(), "brian_extensions"))')
+          echo "Cython cache dir: $CACHE_DIR"
+          echo "cachedir=$CACHE_DIR" >> "$GITHUB_OUTPUT"
       - name: restore Cython cache
         uses: actions/cache@v4
         if: ${{ ! matrix.standalone }}
         with:
           key: cython-extensions-latest-${{ matrix.os }}-${{ matrix.python-version }}-32bit-${{ matrix.float_dtype_32 }}
-          path: ~/.cython/brian_extensions
+          path: ${{ steps.cython-cache.outputs.cachedir }}
       - name: Run Tests
         run: |
           cd  ${{ github.workspace }}/.. # move out of the workspace to avoid direct import

--- a/.github/workflows/test_latest.yml
+++ b/.github/workflows/test_latest.yml
@@ -122,6 +122,12 @@ jobs:
           ${{ steps.python.outputs.python-path }} -m pip install --pre pytest cython sympy pyparsing jinja2 sphinx
       - name: Install Brian2
         run: ${{ steps.python.outputs.python-path }} -m pip install --pre -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple --extra-index-url https://pypi.org/simple .
+      - name: restore Cython cache
+        uses: actions/cache@v4
+        if: ${{ ! matrix.standalone }}
+        with:
+          key: cython-extensions-latest-${{ matrix.os }}-${{ matrix.python-version }}-32bit-${{ matrix.float_dtype_32 }}
+          path: ~/.cython/brian_extensions
       - name: Run Tests
         run: |
           cd  ${{ github.workspace }}/.. # move out of the workspace to avoid direct import

--- a/.github/workflows/testsuite.yml
+++ b/.github/workflows/testsuite.yml
@@ -75,6 +75,13 @@ jobs:
           conda install --quiet --yes pip gsl
           python -m pip install .[test] coverage
 
+      - name: restore Cython cache
+        uses: actions/cache@v4
+        if: ${{ ! matrix.standalone }}
+        with:
+          key: cython-extensions-${{ matrix.os }}-${{ matrix.python-version }}-32bit-${{ matrix.float_dtype_32 }}
+          path: ~/.cython/brian_extensions
+
       - name: Run Tests
         run: |
           cd  $GITHUB_WORKSPACE/.. # move out of the workspace to avoid direct import

--- a/.github/workflows/testsuite.yml
+++ b/.github/workflows/testsuite.yml
@@ -74,13 +74,20 @@ jobs:
         run: |
           conda install --quiet --yes pip gsl
           python -m pip install .[test] coverage
+      
+      - name: Determine Cython cache dir
+        id: cython-cache
+        run: |
+          CACHE_DIR=$(python -c 'import os; from Cython.Utils import get_cython_cache_dir; print(os.path.join(get_cython_cache_dir(), "brian_extensions"))')
+          echo "Cython cache dir: $CACHE_DIR"
+          echo "cachedir=$CACHE_DIR" >> "$GITHUB_OUTPUT"
 
       - name: restore Cython cache
         uses: actions/cache@v4
         if: ${{ ! matrix.standalone }}
         with:
           key: cython-extensions-${{ matrix.os }}-${{ matrix.python-version }}-32bit-${{ matrix.float_dtype_32 }}
-          path: ~/.cython/brian_extensions
+          path: ${{ steps.cython-cache.outputs.cachedir }}
 
       - name: Run Tests
         run: |


### PR DESCRIPTION
This PR enables caching the Cython cache directory on GitHub actions. For repeated CI runs on the same branch (assuming no major changes that affect the generated Cython code), this greatly reduces the time for the test suite to run through (from about 1h15 to 0h30).