### PR TITLE
Do not convert run_args values to lower case

### DIFF
--- a/brian2/devices/cpp_standalone/templates/objects.cpp
+++ b/brian2/devices/cpp_standalone/templates/objects.cpp
@@ -78,13 +78,10 @@ template<class T> void set_variable_from_file(std::string varname, T* var_pointe
 void set_variable_by_name(std::string name, std::string s_value) {
 	size_t var_size;
 	size_t data_size;
-	std::for_each(s_value.begin(), s_value.end(), [](char& c) // modify in-place
-    {
-        c = std::tolower(static_cast<unsigned char>(c));
-    });
-    if (s_value == "true")
+	// C-style or Python-style capitalization is allowed for boolean values
+    if (s_value == "true" || s_value == "True")
         s_value = "1";
-    else if (s_value == "false")
+    else if (s_value == "false" || s_value == "False")
         s_value = "0";
 	// non-dynamic arrays
 	{% for var, varname in array_specs | dictsort(by='value') %}

--- a/brian2/tests/test_cpp_standalone.py
+++ b/brian2/tests/test_cpp_standalone.py
@@ -868,7 +868,7 @@ def test_change_parameter_without_recompile_dict_syntax():
 def test_change_synapse_parameter_without_recompile_dict_syntax():
     set_device("cpp_standalone", directory=None, with_output=False)
     G = NeuronGroup(10, "", name="neurons")
-    S = Synapses(G, G, "w:1", name="synapses")
+    S = Synapses(G, G, "w:1", name="Synapses")
     S.connect(j="i")
     S.w = np.arange(10)
     run(0 * ms)


### PR DESCRIPTION
This broke setting values with arrays for group names with upper case characters.

This issue was reported by `DavidKing2020` on the [Brian discussion forum](https://brian.discourse.group/t/cant-modify-synaptic-group-attribute-using-run-args-in-standalone-mode/1219/8).