### PR TITLE
Fix reference doc issues

### DIFF
--- a/brian2/sphinxext/docscrape.py
+++ b/brian2/sphinxext/docscrape.py
@@ -148,7 +148,7 @@ class NumpyDocString:
                 stop = i
                 break
 
-        return doc[start:-stop]
+        return doc[start : len(doc) - stop]
 
     def _read_to_next_section(self):
         section = self._doc.read_to_next_empty_line()

--- a/brian2/sphinxext/examplefinder.py
+++ b/brian2/sphinxext/examplefinder.py
@@ -64,8 +64,12 @@ def auto_find_examples(obj, headersymbol="="):
     make mistakes but is usually going to be correct).
     """
     name = obj.__name__
-    examples = sorted(the_examples_map[name])
-    tutorials = sorted(the_tutorials_map[name])
+    # These will only go through the examples/tutorials once. The dictionaries are cached in the
+    # module variables `the_examples_map` and `the_tutorials_map`.
+    examples_map = get_examples_map()
+    examples = sorted(examples_map[name])
+    tutorials_map = get_tutorials_map()
+    tutorials = sorted(tutorials_map[name])
     if len(examples + tutorials) == 0:
         return ""
     txt = "Tutorials and examples using this"

--- a/dev/tools/docs/build_html_brian2.py
+++ b/dev/tools/docs/build_html_brian2.py
@@ -6,7 +6,7 @@ if not sphinx.version_info >= (1, 8):
 from sphinx.cmd.build import main as sphinx_main
 import sys
 
-os.chdir('../../../docs_sphinx')
+os.chdir(os.path.join(os.path.dirname(__file__), '../../../docs_sphinx'))
 if os.path.exists('../docs'):
     shutil.rmtree('../docs')
 # Some code (e.g. the definition of preferences) might need to know that Brian

--- a/dev/tools/docs/quick_rebuild_html_brian2.py
+++ b/dev/tools/docs/quick_rebuild_html_brian2.py
@@ -13,7 +13,7 @@ os.environ['BRIAN2_DOCS_QUICK_REBUILD'] = '1'
 # a documentation build
 os.environ['READTHEDOCS'] = 'True'
 
-os.chdir('../../../docs_sphinx')
+os.chdir(os.path.join(os.path.dirname(__file__), '../../../docs_sphinx'))
 if os.path.exists('../docs'):
     shutil.rmtree('../docs')
 sys.exit(sphinx_main(['-b', 'html', '.', '../docs']))


### PR DESCRIPTION
When fixing warnings about unused variables and similar issues quite a while back (commit 0344b00), I inadvertently broke a few features of the reference documentation – partly because some of the warnings were somewhat misleading (e.g. some function call return values weren't used, but the functions updated global variables). This should fix the issue dicussed in #1532. 

I've built the updated documentation here, from a quick glance it seems to be working correctly: https://brian2.readthedocs.io/en/fix_doc_reference_issues/

Closes #1532