### PR TITLE
Fix Error in Brunel_Wang_2001.py

### DIFF
--- a/examples/frompapers/Brunel_Wang_2001.py
+++ b/examples/frompapers/Brunel_Wang_2001.py
@@ -128,10 +128,6 @@ eqs_pre_gaba = '''
 s_GABA += 1
 '''
 
-eqs_pre_ext = '''
-s_AMPA_ext += 1
-'''
-
 # E to E
 C_E_E = Synapses(P_E, P_E, model=eqs_glut, on_pre=eqs_pre_glut, method='euler')
 C_E_E.connect('i != j')


### PR DESCRIPTION
Deleted "eqs_pre_ext" in rhe Brunel-Wang 2001 example implementation.

These equations aren't used anywhere in the simulation. 

Their inclusion is likely an oversight. 

Removed to make the code more clear.