### PR TITLE
Release notes for 2.7

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
     rev: v3.15.1
     hooks:
       - id: pyupgrade
-        args: [--py39-plus]
+        args: [--py310-plus]
         files: '^brian2/.*\.pyi?$'
   - repo: https://github.com/pycqa/flake8
     rev: 7.0.0

--- a/brian2/core/functions.py
+++ b/brian2/core/functions.py
@@ -1,7 +1,6 @@
 import inspect
 import types
-from collections.abc import Mapping
-from typing import Callable
+from collections.abc import Callable, Mapping
 
 import numpy as np
 import sympy

--- a/brian2/units/fundamentalunits.py
+++ b/brian2/units/fundamentalunits.py
@@ -19,7 +19,7 @@ import itertools
 import numbers
 import operator
 import sys
-from typing import Callable
+from collections.abc import Callable
 from warnings import warn
 
 import numpy as np

--- a/docs_sphinx/introduction/release_notes.rst
+++ b/docs_sphinx/introduction/release_notes.rst
@@ -1,5 +1,48 @@
 Release notes
 =============
+Brian 2.7.0
+-----------
+This release contains a number of bug fixes and improvements. Notably, it is fully compatible with the upcoming numpy 2.0 release and can be installed 
+alongside either numpy versions 1.23–1.26, or numpy 2.0.
+
+Selected improvements and bug fixes
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+- Objects (e.g. `NeuronGroup` or `Synapses`) that are not used now raise warnings, avoiding errors for accidentally unused objects (:issue:`1536`). Thanks
+  to Jannik Luboeinski for suggesting this feature.
+- Fix the :doc:`run_args <../user/computation>` feature for object names with upper case letters (:issue:`1533`). Thanks to DavidKing2020 for making us aware of this issue.
+- Extremely short refractoriness periods were not converted into code correctly, truncating their value (:issue:`1521`). Thanks to YannaelB for reporting this issue.
+- The numbers 0 and 1 were converted into ``true``/``false`` in C++ code, breaking tests expecting the numbers to appear (:issue:`1520`)
+- The logging system was broken for 3rd-party packages that have names starting with ``brian`` (:issue:`1519`)
+
+Infrastructure and documentation improvements
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+- The reference documentation was not correctly built, missing a lot of the information present in the source code. Thanks to Harsh Khilawala for making us aware of
+  this issue (:issue:`1534`)
+- Binary wheels are built against numpy 2.0. These wheels are still backwards compatible with numpy >= 1.23 (:issue:`1527`)
+- Faster tests on GitHub actions by caching the compiled Cython code (:issue:`1528`)
+- The test suite was no longer testing the GSL integration (:issue:`1523` and :issue:`1526`)
+- Brian no longer includes the date in its documentation for `reproducible builds <https://reproducible-builds.org/docs/source-date-epoch/>`_ (:issue:`1518`).
+
+Contributions
+~~~~~~~~~~~~~
+
+GitHub code, documentation, and issue contributions (ordered by the number of
+contributions):
+
+* Marcel Stimberg (`@mstimberg <https://github.com/mstimberg>`_)
+* Dan Goodman (`@thesamovar <https://github.com/thesamovar>`_)
+* Harsh Khilawala (`@HarshKhilawala <https://github.com/HarshKhilawala>`_)
+* Ben Evans (`@bdevans <https://github.com/bdevans>`_)
+* Jannik Luboeinski (`@jlubo <https://github.com/jlubo>`_)
+* `@flomlo <https://github.com/flomlo>`_
+* Sven Leach (`@SvennoNito <https://github.com/SvennoNito>`_)
+
+Other contributions outside of GitHub (ordered alphabetically, apologies to
+anyone we forgot...):
+
+* `DavidKing2020 <https://brian.discourse.group/u/davidking2020/summary>`_
+* `YannaelB <https://brian.discourse.group/u/YannaelB/summary>`_
+
 Brian 2.6.0
 -----------
 This release introduces a major new feature for running standalone simulations repeatedly (or in parallel), without having to recompile the code.
@@ -55,6 +98,7 @@ contributions):
 
 Other contributions outside of GitHub (ordered alphabetically, apologies to
 anyone we forgot...):
+
 * `ansuz <https://brian.discourse.group/u/ansuz/summary>`_`
 * `@l-luo1 <https://github.com/l-luo1>_``
 * Klaus Wimmer (`@wklausitor <https://github.com/wklausito>_`)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,13 +70,13 @@ requires = [
 build-backend = "setuptools.build_meta"
 
 [tool.black]
-target-version = ['py39']
+target-version = ['py310']
 include = '^/brian2/.*\.pyi?$'
 
 [tool.isort]
 atomic = true
 profile = "black"
-py_version = "39"
+py_version = "310"
 skip_gitignore = true
 # NOTE: isort has no "include" option, only "skip".
 skip_glob = ["dev/*", "docs_sphinx/*", "examples/*", "tutorials/*"]


### PR DESCRIPTION
Release notes for the upcoming 2.7 release (most importantly to ensure compatibility with numpy 2.0).

Also changes our pre-commit hooks to target Python >3.10