### PR TITLE
Fix `on_event` with pathway names

### DIFF
--- a/brian2/synapses/synapses.py
+++ b/brian2/synapses/synapses.py
@@ -1014,7 +1014,7 @@ class Synapses(Group):
                         prepost,
                         objname=key,
                         delay=pathway_delay,
-                        event=self.events.get(prepost, self.default_event),
+                        event=self.events.get(key, self.default_event),
                     )
 
         # Check whether any delays were specified for pathways that don't exist

--- a/brian2/tests/test_cpp_standalone.py
+++ b/brian2/tests/test_cpp_standalone.py
@@ -1,4 +1,5 @@
 import os
+import platform
 import tempfile
 
 import pytest
@@ -947,6 +948,10 @@ class RunSim:
 
 @pytest.mark.cpp_standalone
 @pytest.mark.standalone_only
+@pytest.mark.skipif(
+    platform.system() == "Darwin" and platform.processor() == "arm",
+    reason="multiprocessing hangs on macOS with Apple Silicon",
+)
 def test_change_parameters_multiprocessing():
     set_device("cpp_standalone", directory=None)
     sim = RunSim()

--- a/brian2/tests/test_synapses.py
+++ b/brian2/tests/test_synapses.py
@@ -1058,6 +1058,37 @@ def test_transmission_custom_event():
     assert_allclose(mon[1].v[mon.t >= 1 * ms], 1.0)
 
 
+@pytest.mark.standalone_compatible
+def test_transmission_custom_event_complex():
+    # This was broken with release 2.6, entries in on_event where checked against pre/post
+    # instead of the pathway name
+    group = NeuronGroup(3, "v:1", threshold="v>1 and v<2", events={"over_2": "v>2"})
+    group.v = [0, 1.5, 2.5]
+
+    s = Synapses(
+        group,
+        group,
+        model="""a:integer
+                b:integer
+                c:integer
+                d:integer""",
+        on_event={
+            "path_a": "spike",
+            "path_b": "over_2",
+            "path_c": "spike",
+            "path_d": "over_2",
+        },
+        on_pre={"path_a": "a+=1", "path_b": "b+=1"},
+        on_post={"path_c": "c+=1", "path_d": "d+=1"},
+    )
+    s.connect()
+    run(defaultclock.dt)
+    assert all(s.a[:] == [0, 0, 0, 1, 1, 1, 0, 0, 0])
+    assert all(s.b[:] == [0, 0, 0, 0, 0, 0, 1, 1, 1])
+    assert all(s.c[:] == [0, 1, 0, 0, 1, 0, 0, 1, 0])
+    assert all(s.d[:] == [0, 0, 1, 0, 0, 1, 0, 0, 1])
+
+
 @pytest.mark.codegen_independent
 def test_invalid_custom_event():
     group1 = NeuronGroup(

--- a/docs_sphinx/introduction/release_notes.rst
+++ b/docs_sphinx/introduction/release_notes.rst
@@ -1,5 +1,22 @@
 Release notes
 =============
+Next release
+------------
+
+Selected improvements and bug fixes
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+- Fix a bug in interpreting the ```on_event`` argument of `Synapses` for custom events and non-default pathways (a regression introduced with Brian 2.6). Thanks to forum users
+  ``mreynes`` and ``mmiekus`` for making us aware of this issue.
+
+Contributions
+~~~~~~~~~~~~~
+
+Other contributions outside of GitHub (ordered alphabetically, apologies to
+anyone we forgot...):
+
+- `mmiekus <https://brian.discourse.group/u/mmiekus/summary>`_
+- `mreynes <https://brian.discourse.group/u/mreynes/summary>`_
+
 Brian 2.7.0
 -----------
 This release contains a number of bug fixes and improvements. Notably, it is fully compatible with the upcoming numpy 2.0 release and can be installed 


### PR DESCRIPTION
This worked previously, but was broken with commit d3d9e1684b4308fe See https://brian.discourse.group/t/how-to-activate-synaptic-pathways-on-custom-events-only/1213 and https://brian.discourse.group/t/reproducibility-issue-between-brian2-5-and-2-7/1240.