### PR TITLE
Move to pytest-cov

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,6 +1,9 @@
 # .coveragerc to control coverage.py
 # following the example at http://nedbatchelder.com/code/coverage/config.html
 [run]
+concurrency = multiprocessing
+parallel = True
+sigterm = True
 relative_files = True
 branch = True
 source_pkgs = brian2

--- a/.github/workflows/testsuite.yml
+++ b/.github/workflows/testsuite.yml
@@ -73,7 +73,7 @@ jobs:
       - name: Install Brian2 and dependencies
         run: |
           conda install --quiet --yes pip gsl
-          python -m pip install .[test] coverage
+          python -m pip install .[test]
       
       - name: Determine Cython cache dir
         id: cython-cache
@@ -92,9 +92,8 @@ jobs:
       - name: Run Tests
         run: |
           cd  $GITHUB_WORKSPACE/.. # move out of the workspace to avoid direct import
-          coverage run --rcfile=$GITHUB_WORKSPACE/.coveragerc $GITHUB_WORKSPACE/$SCRIPT_NAME
-          coverage lcov --rcfile=$GITHUB_WORKSPACE/.coveragerc
-          cp coverage.lcov $GITHUB_WORKSPACE/
+          python $GITHUB_WORKSPACE/$SCRIPT_NAME
+          cp coverage.xml $GITHUB_WORKSPACE/
         env:
           SCRIPT_NAME: dev/continuous-integration/run_test_suite.py
           SPHINX_DIR: ${{ github.workspace }}/docs_sphinx
@@ -106,8 +105,6 @@ jobs:
         uses: coverallsapp/github-action@v2.3.0
         with:
           parallel: true
-          format: lcov
-          file: coverage.lcov
           flag-name: run ${{ join(matrix.*, ' - ') }}
 
   coveralls:

--- a/brian2/tests/pytest.ini
+++ b/brian2/tests/pytest.ini
@@ -20,3 +20,6 @@ filterwarnings =
     ignore:BaseException:DeprecationWarning
     ignore:invalid value:RuntimeWarning
     ignore:divide by zero:RuntimeWarning
+
+# Fail tests after 5 minutes
+timeout = 300

--- a/brian2/tests/pytest.ini
+++ b/brian2/tests/pytest.ini
@@ -20,6 +20,7 @@ filterwarnings =
     ignore:BaseException:DeprecationWarning
     ignore:invalid value:RuntimeWarning
     ignore:divide by zero:RuntimeWarning
+    ignore:overflow:RuntimeWarning
 
-# Fail tests after 5 minutes
-timeout = 300
+# Fail tests after 10 minutes
+timeout = 600

--- a/brian2/tests/test_cpp_standalone.py
+++ b/brian2/tests/test_cpp_standalone.py
@@ -958,8 +958,12 @@ def test_change_parameters_multiprocessing():
 
     import multiprocessing
 
-    with multiprocessing.Pool() as p:
+    p = multiprocessing.Pool()
+    try:
         results = p.map(sim.run_sim, range(5))
+    finally:
+        p.close()
+        p.join()
 
     for idx, result in zip(range(5), results):
         v, w, x = result

--- a/brian2/tests/test_logger.py
+++ b/brian2/tests/test_logger.py
@@ -59,9 +59,13 @@ def run_in_process_with_logger(x):
 @pytest.mark.codegen_independent
 def test_file_logging_multiprocessing():
     logger.info("info message before multiprocessing")
+    p = multiprocessing.Pool()
 
-    with multiprocessing.Pool() as p:
+    try:
         p.map(run_in_process, range(3))
+    finally:
+        p.close()
+        p.join()
 
     BrianLogger.file_handler.flush()
     assert os.path.isfile(BrianLogger.tmp_log)
@@ -75,8 +79,12 @@ def test_file_logging_multiprocessing():
 def test_file_logging_multiprocessing_with_loggers():
     logger.info("info message before multiprocessing")
 
-    with multiprocessing.Pool() as p:
+    p = multiprocessing.Pool()
+    try:
         log_files = p.map(run_in_process_with_logger, range(3))
+    finally:
+        p.close()
+        p.join()
 
     BrianLogger.file_handler.flush()
     assert os.path.isfile(BrianLogger.tmp_log)

--- a/brian2/utils/logger.py
+++ b/brian2/utils/logger.py
@@ -697,8 +697,6 @@ class BrianLogger:
         # interface...
         warn_logger = logging.getLogger("py.warnings")
         warn_logger.addHandler(BrianLogger.console_handler)
-        if BrianLogger.file_handler is not None:
-            warn_logger.addHandler(BrianLogger.file_handler)
 
         # Put some standard info into the log file
         logger.log(

--- a/dev/continuous-integration/run_test_suite.py
+++ b/dev/continuous-integration/run_test_suite.py
@@ -5,6 +5,8 @@ the logic into Windows batch/bash statements)
 # Importing multiprocessing here seems to fix hangs in the test suite on OS X
 # see https://github.com/scipy/scipy/issues/11835
 import multiprocessing
+# Prevent potential issues on multi-threaded execution
+multiprocessing.set_start_method('spawn')
 import os
 import sys
 

--- a/dev/continuous-integration/run_test_suite.py
+++ b/dev/continuous-integration/run_test_suite.py
@@ -6,7 +6,7 @@ the logic into Windows batch/bash statements)
 # see https://github.com/scipy/scipy/issues/11835
 import multiprocessing
 # Prevent potential issues on multi-threaded execution
-multiprocessing.set_start_method('spawn')
+multiprocessing.set_start_method('spawn', force=True)
 import os
 import sys
 

--- a/dev/continuous-integration/run_test_suite.py
+++ b/dev/continuous-integration/run_test_suite.py
@@ -20,7 +20,6 @@ if __name__ == '__main__':
     operating_system = os.environ.get('AGENT_OS', 'unknown').lower()
     cross_compiled = os.environ.get('CROSS_COMPILED', 'FALSE').lower() in ['yes', 'true']
     do_not_reset_preferences = os.environ.get('DO_NOT_RESET_PREFERENCES', 'false').lower() in ['yes', 'true']
-    report_coverage = os.environ.get('REPORT_COVERAGE', 'no').lower() in ['yes', 'true']
     dtype_32_bit = os.environ.get('FLOAT_DTYPE_32', 'no').lower() in ['yes', 'true']
     sphinx_dir = os.environ.get('SPHINX_DIR')
     src_dir = os.environ.get('SRCDIR')
@@ -54,7 +53,18 @@ if __name__ == '__main__':
     if deprecation_error:
         args = ['-W', 'error::DeprecationWarning', '--tb=short']
     else:
-        args = []
+        # Use coverage when running on GitHub
+        if "GITHUB_WORKSPACE" in os.environ:
+            args = [
+                "--cov",
+                "--cov-append",
+                "--cov-report",
+                "xml",
+                "--cov-report",
+                "term",
+                "--cov-config",
+                os.path.join(os.environ["GITHUB_WORKSPACE"], ".coveragerc"),
+            ]
 
     if standalone:
         result = brian2.test([],

--- a/numpy2.pyproject.toml
+++ b/numpy2.pyproject.toml
@@ -31,7 +31,7 @@ classifiers = [
 ]
 
 [project.optional-dependencies]
-test = ['pytest', 'pytest-xdist>=1.22.3']
+test = ['pytest', 'pytest-xdist>=1.22.3', 'pytest-cov>=2.0']
 docs = ['sphinx>=7', 'ipython>=5', 'sphinx-tabs']
 
 [project.urls]

--- a/numpy2.pyproject.toml
+++ b/numpy2.pyproject.toml
@@ -31,7 +31,7 @@ classifiers = [
 ]
 
 [project.optional-dependencies]
-test = ['pytest', 'pytest-xdist>=1.22.3', 'pytest-cov>=2.0']
+test = ['pytest', 'pytest-xdist>=1.22.3', 'pytest-cov>=2.0', 'pytest-timeout']
 docs = ['sphinx>=7', 'ipython>=5', 'sphinx-tabs']
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ classifiers = [
 ]
 
 [project.optional-dependencies]
-test = ['pytest', 'pytest-xdist>=1.22.3']
+test = ['pytest', 'pytest-xdist>=1.22.3', 'pytest-cov>=2.0']
 docs = ['sphinx>=7', 'ipython>=5', 'sphinx-tabs']
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ classifiers = [
 ]
 
 [project.optional-dependencies]
-test = ['pytest', 'pytest-xdist>=1.22.3', 'pytest-cov>=2.0']
+test = ['pytest', 'pytest-xdist>=1.22.3', 'pytest-cov>=2.0', 'pytest-timeout']
 docs = ['sphinx>=7', 'ipython>=5', 'sphinx-tabs']
 
 [project.urls]


### PR DESCRIPTION
We previously used the separate `coverage.py` utility, which seems not to handle our somewhat convoluted `pytest` setup 100% correctly  – I did not look into it in much detail, but our coverage on coveralls clearly showed code as not covered that was covered by tests (I double-checked by raising an Exception in the "uncovered" code). Using `pytest-cov` seems to be the better solution, and while there were a few issues with multiprocessing (since we also run our tests in parallel), it now seems to run smoothly. Without adding a single test, our test coverage jumps from 82% to 92% :laughing: 