### PR TITLE
Setuptools compatibility and Windows fixes

### DIFF
--- a/brian2/codegen/cpp_prefs.py
+++ b/brian2/codegen/cpp_prefs.py
@@ -17,9 +17,8 @@ import struct
 import subprocess
 import sys
 import tempfile
+from distutils._msvccompiler import _get_vc_env
 from distutils.ccompiler import get_default_compiler
-
-from setuptools import msvc
 
 from brian2.core.preferences import BrianPreference, prefs
 from brian2.utils.filetools import ensure_directory
@@ -352,7 +351,7 @@ def get_msvc_env():
     # Search for MSVC environment if not already cached
     if _msvc_env is None:
         try:
-            _msvc_env = msvc.msvc14_get_vc_env(arch_name)
+            _msvc_env = _get_vc_env(arch_name)
         except distutils.errors.DistutilsPlatformError:
             raise OSError(
                 "Cannot find Microsoft Visual Studio, You "

--- a/brian2/codegen/cpp_prefs.py
+++ b/brian2/codegen/cpp_prefs.py
@@ -17,7 +17,12 @@ import struct
 import subprocess
 import sys
 import tempfile
-from distutils._msvccompiler import _get_vc_env
+
+try:
+    from setuptools.msvc import msvc14_get_vc_env as _get_vc_env
+except ImportError:  # Setuptools 0.74.0 removed this function
+    from distutils._msvccompiler import _get_vc_env
+
 from distutils.ccompiler import get_default_compiler
 
 from brian2.core.preferences import BrianPreference, prefs

--- a/brian2/devices/cpp_standalone/device.py
+++ b/brian2/devices/cpp_standalone/device.py
@@ -1554,10 +1554,20 @@ class CPPStandaloneDevice(Device):
         libraries = self.libraries + prefs["codegen.cpp.libraries"] + codeobj_libraries
 
         compiler_obj = ccompiler.new_compiler(compiler=compiler)
+
+        # Distutils does not use the shell, so it does not need to quote filenames/paths
+        # Since we include the compiler flags in the makefile, we need to quote them
+        include_dirs = [f'"{include_dir}"' for include_dir in include_dirs]
+        library_dirs = [f'"{library_dir}"' for library_dir in library_dirs]
+        runtime_library_dirs = [
+            f'"{runtime_dir}"' for runtime_dir in runtime_library_dirs
+        ]
+
         compiler_flags = (
             ccompiler.gen_preprocess_options(define_macros, include_dirs)
             + extra_compile_args
         )
+
         linker_flags = (
             ccompiler.gen_lib_options(
                 compiler_obj,

--- a/brian2/devices/cpp_standalone/device.py
+++ b/brian2/devices/cpp_standalone/device.py
@@ -1174,12 +1174,7 @@ class CPPStandaloneDevice(Device):
                         self.timers["compile"]["make"] = time.time() - start_time
 
                     if x != 0:
-                        if os.path.exists("winmake.log"):
-                            with open("winmake.log") as f:
-                                print(f.read())
-                        error_message = (
-                            "Project compilation failed (error code: %u)." % x
-                        )
+                        error_message = f"Project compilation failed (error code: {x}), consider having a look at 'winmake.log'."
                         if not clean:
                             error_message += (
                                 " Consider running with "


### PR DESCRIPTION
This replaces `msvc.msvc14_get_vc_env` (the `msvc` module has been removed from `setuptools` in version 74), by `distutils._msvccompiler import _get_vc_env`, which appears to work as a drop-in replacement. IIUC, the `setuptools.msvc` added a bit of functionality for newer compilers compared to the support in `distutils`, but those changes have been contributed to `distutils` since. This is maybe not the cleanest solution (`_get_vc_env` is not really meant for public use), but the `distutils` infrastructure is meant to be used for building Python extension packages, not for generating code at runtime, so we'll always have to work around its limitations a bit.
Speaking of which, this PR also fixes a few issues that I noted during testing on my Windows VM, most importantly quoting include/library directory names.

CC @bvogginger, @neworderofjamie

Closes #1557 