### PR TITLE
Python3.13

### DIFF
--- a/brian2/codegen/optimisation.py
+++ b/brian2/codegen/optimisation.py
@@ -444,11 +444,11 @@ def reduced_node(terms, op):
     --------
     >>> import ast
     >>> nodes = [ast.Name(id='x'), ast.Name(id='y'), ast.Name(id='z')]
-    >>> ast.dump(reduced_node(nodes, ast.Mult), annotate_fields=False)
-    "BinOp(BinOp(Name('x'), Mult(), Name('y')), Mult(), Name('z'))"
+    >>> ast.unparse(reduced_node(nodes, ast.Mult))
+    'x * y * z'
     >>> nodes = [ast.Name(id='x')]
-    >>> ast.dump(reduced_node(nodes, ast.Add), annotate_fields=False)
-    "Name('x')"
+    >>> ast.unparse(reduced_node(nodes, ast.Add))
+    'x'
     """
     # Remove None terms
     terms = [term for term in terms if term is not None]

--- a/brian2/conftest.py
+++ b/brian2/conftest.py
@@ -14,12 +14,12 @@ from brian2.devices.device import reinit_and_delete, set_device
 from brian2.units import ms
 
 
-def pytest_ignore_collect(path, config):
+def pytest_ignore_collect(collection_path, config):
     if config.option.doctestmodules:
-        if "tests" in str(path):
+        if "tests" in collection_path.parts:
             return True  # Ignore tests package for doctests
     # Do not test brian2.hears bridge (needs Brian1)
-    if str(path).endswith("hears.py"):
+    if collection_path.name == "hears.py":
         return True
 
 

--- a/brian2/parsing/functions.py
+++ b/brian2/parsing/functions.py
@@ -146,8 +146,6 @@ class VarRewriter(ast.NodeTransformer):
             func=ast.Name(id=node.func.id, ctx=ast.Load()),
             args=args,
             keywords=[],
-            starargs=None,
-            kwargs=None,
         )
 
 

--- a/brian2/parsing/rendering.py
+++ b/brian2/parsing/rendering.py
@@ -102,8 +102,7 @@ class NodeRenderer:
             raise ValueError("Keyword arguments not supported")
         else:
             if node.func.id in self.auto_vectorise:
-                vectorisation_idx = ast.Name()
-                vectorisation_idx.id = "_vectorisation_idx"
+                vectorisation_idx = ast.Name("_vectorisation_idx")
                 args = node.args + [vectorisation_idx]
             else:
                 args = node.args

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ classifiers = [
 ]
 
 [project.optional-dependencies]
-test = ['pytest', 'pytest-xdist>=1.22.3', 'pytest-cov>=2.0', 'pytest-timeout']
+test = ['pytest>=8', 'pytest-xdist>=1.22.3', 'pytest-cov>=2.0', 'pytest-timeout']
 docs = ['sphinx>=7', 'ipython>=5', 'sphinx-tabs']
 
 [project.urls]


### PR DESCRIPTION
Nothing particular interesting here, but one doctest failed with Python 3.13 (output of `ast.dump` changed slightly). The remaining changes only prevent deprecation warnings, nothing would break yet.