### PR TITLE
Codemeta.json and update for Zenodo/SWH identifiers

### DIFF
--- a/.codemeta/codemeta_base.json
+++ b/.codemeta/codemeta_base.json
@@ -1,0 +1,72 @@
+{
+  "@context": "https://w3id.org/codemeta/3.0",
+  "@type": "SoftwareSourceCode",
+  "targetProduct": {
+    "@type": "SoftwareLibrary",
+    "name": "brian2",
+    "runtimePlatform": [
+      "Python",
+      "Python 3"
+    ]
+  },
+  "maintainer": [
+    {
+      "@id": "https://orcid.org/0000-0002-2648-4790"
+    }
+  ],
+  "author": [
+    {
+      "@id": "https://orcid.org/0000-0002-2648-4790",
+      "@type": "Person",
+      "familyName": "Stimberg",
+      "givenName": "Marcel",
+      "identifier": "https://github.com/mstimberg"
+    },
+    {
+      "@id": "https://orcid.org/0000-0003-1007-6474",
+      "@type": "Person",
+      "familyName": "Goodman",
+      "givenName": "Dan F. M.",
+      "identifier": "https://github.com/thesamovar"
+    },
+    {
+      "@id": "https://orcid.org/0000-0002-1734-6070",
+      "@type": "Person",
+      "familyName": "Evans",
+      "givenName": "Benjamin D.",
+      "identifier": "https://github.com/bdevans"
+    },
+    {
+      "@id": "https://orcid.org/0000-0003-0110-1623",
+      "@type": "Person",
+      "familyName": "Brette",
+      "givenName": "Romain",
+      "identifier": "https://github.com/romainbrette"
+    }
+  ],
+  "codeRepository": "https://github.com/brian-team/brian2",
+  "continuousIntegration": "https://github.com/brian-team/brian2/actions",
+  "issueTracker": "https://github.com/brian-team/brian2/issues",
+  "keywords": [
+    "biological neural networks",
+    "computational neuroscience",
+    "neural networks",
+    "research",
+    "simulation",
+    "spiking neurons"
+  ],
+  "operatingSystem": "OS Independent",
+  "softwareHelp": "https://brian2.readthedocs.io/",
+  "developmentStatus": "active",
+  "description": "A clock-driven simulator for spiking neural networks",
+  "license": "https://spdx.org/licenses/CECILL-2.1",
+  "name": "Brian simulator",
+  "url": "https://briansimulator.org",
+  "programmingLanguage": [
+    "Python"
+  ],
+  "runtimePlatform": [
+    "Python",
+    "Python 3"
+  ]
+}

--- a/.codemeta/create_codemeta.py
+++ b/.codemeta/create_codemeta.py
@@ -1,0 +1,48 @@
+import re
+import os
+import pkg_resources
+import tomllib
+import setuptools_scm
+import json
+
+basedir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..")
+
+with open(os.path.join(basedir, "pyproject.toml"), "rb") as f:
+    pyproject = tomllib.load(f)
+with open(os.path.join(basedir, ".codemeta", "codemeta_base.json"), "r", encoding="utf-8") as f:
+    codemeta = json.load(f)
+with open(os.path.join(basedir, "AUTHORS"), "r", encoding="utf-8") as f:
+    authors = f.read().splitlines()[6:]
+
+# Add software requirements from pyproject.toml
+parsed_deps = pkg_resources.parse_requirements(pyproject['project']['dependencies'])
+codemeta["softwareRequirements"] = []
+for dep in parsed_deps:
+    version = ",".join(f"{op}{v}" for op,v in dep.specs)
+    requirement = {"name": dep.project_name,"@type": "SoftwareApplication", "runtimePlatform": "Python 3"}
+    if version:
+        requirement["version"] = version
+    codemeta["softwareRequirements"].append(requirement)
+
+# Add contributors from AUTHORS
+codemeta["contributor"] = []
+for author in authors:
+    matches = re.match(r"^(\w[\w-]*?) ([\w]+[.]? )??(\w+) \(@(.*)\)$", author)
+    if not matches:
+        raise ValueError("author not matched:", author)
+    given_name, middle_name, family_name, github = matches.groups()
+
+    contributor = {"@type": "Person", "givenName": given_name, "familyName": family_name, "identifier": f"https://github.com/{github}"}
+    # FIXME: additionalName does not seem to be recognized by codemeta (validation fails)
+    if middle_name:
+        contributor["givenName"] += " " + middle_name.strip()
+    codemeta["contributor"].append(contributor)
+
+# Add version from setuptools_scm
+version = setuptools_scm.get_version(root=basedir)
+codemeta["version"] = version
+codemeta["softwareVersion"] = version
+
+# Write codemeta.json
+with open(os.path.join(basedir, "codemeta.json"), "w", encoding="utf-8") as f:
+    json.dump(codemeta, f, indent=2, ensure_ascii=False)

--- a/.github/workflows/post_release_updates.yml
+++ b/.github/workflows/post_release_updates.yml
@@ -1,0 +1,35 @@
+name: Update metadata after release
+
+on: workflow_dispatch
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+        # Give the default GITHUB_TOKEN write permission to commit and push the
+        # added or changed files to the repository.
+        contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+          fetch-tags: true
+      - name: Install Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.12
+      - name: Install dependencies
+        run: python -m pip install cffconvert pyaml ruamel.yaml requests
+      - name: Update metadata
+        run: python dev/continuous-integration/update_zenodo_swh.py
+      - name: Verify CITATION.cff
+        run: cffconvert --validate
+      - name: Commit changes
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          file_pattern: CITATION.cff README.md
+          commit_message: |
+            Update CITATION.cff and README.md with metadata from Zenodo/SWH 
+
+            [ci skip]

--- a/dev/continuous-integration/update_zenodo_swh.py
+++ b/dev/continuous-integration/update_zenodo_swh.py
@@ -1,0 +1,120 @@
+"""
+Update CITATION.cff and README.md with the latest Zenodo and Software Heritage records
+"""
+import os
+import re
+import subprocess
+
+import pyaml
+import requests
+import yaml
+
+basedir = os.path.abspath(
+    os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "..")
+)
+
+# Get the latest tag from git
+tag = (
+    subprocess.check_output(["git", "describe", "--tags", "--abbrev=0"])
+    .strip()
+    .decode("utf-8")
+)
+
+print("Latest tag/release:", tag)
+ZENODO_API = "https://zenodo.org/api"
+# DOI always linking to the latest version (escaped slash for elasticsearch syntax)
+CONCEPT_DOI = r"10.5281\/zenodo.654861"
+
+print("Searching for Zenodo record...")
+# Get the latest version via concept doi
+# The Zenodo search guide says that one can directly search by "version:...", but it does not work (BAD REQUEST)
+r = requests.get(ZENODO_API + "/records", params={"q": f"conceptdoi:{CONCEPT_DOI}"})
+if not r.ok:
+    raise RuntimeError("Request failed: ", r.reason)
+data = r.json()
+assert data["hits"]["total"] == 1
+latest_zenodo_id = data["hits"]["hits"][0]["id"]
+
+# Get all versions
+r = requests.get(ZENODO_API + f"/records/{latest_zenodo_id}/versions")
+if not r.ok:
+    raise RuntimeError("Request failed: ", r.reason)
+data = r.json()
+versions = data["hits"]["hits"]
+latest_version = [v for v in versions if v["metadata"]["version"] == tag]
+if latest_version:
+    zenodo_record = latest_version[0]
+    print("Found Zenodo record for version", tag)
+else:
+    raise RuntimeError("No Zenodo record found for version " + tag)
+
+print("Searching for SWH record...")
+
+# Find Software Heritage
+resp = requests.get(
+    "https://archive.softwareheritage.org/api/1/origin/https://github.com/brian-team/brian2/get/"
+)
+if not resp.ok:
+    raise RuntimeError("Request failed: ", resp.reason)
+data = resp.json()
+visits_url = data["origin_visits_url"]
+resp = requests.get(visits_url)
+if not resp.ok:
+    raise RuntimeError("Request failed: ", resp.reason)
+data = resp.json()
+latest_visit = sorted(data, key=lambda x: x["date"], reverse=True)[0]
+snapshot_url = latest_visit["snapshot_url"]
+resp = requests.get(snapshot_url)
+if not resp.ok:
+    raise RuntimeError("Request failed: ", resp.reason)
+data = resp.json()
+swh_record = data["branches"].get(f"refs/tags/{tag}")
+
+if swh_record:
+    print("Found SWH record for version", tag)
+else:
+    swh_record = None
+    print("No SWH record found for version", tag)
+
+print("Updating CITATION.cff and README.md...")
+with open(os.path.join(basedir, "CITATION.cff"), "r") as f:
+    citation_cff = yaml.load(f, Loader=yaml.SafeLoader)
+for identifier in citation_cff["identifiers"]:
+    if zenodo_record and identifier["description"].startswith(
+        "This is the archived snapshot of version"
+    ):
+        identifier["value"] = zenodo_record["metadata"]["doi"]
+        identifier["description"] = (
+            f"This is the archived snapshot of version {tag} of Brian 2"
+        )
+    if swh_record and identifier["type"] == "swh":
+        identifier["value"] = f"swh:1:rel:{swh_record['target']}"
+        identifier["description"] = (
+            f"Software Heritage identifier for version {tag} of Brian 2"
+        )
+
+with open(os.path.join(basedir, "CITATION.cff"), "w") as f:
+    pyaml.dump(citation_cff, f, sort_keys=False)
+
+with open(os.path.join(basedir, "README.md"), "r") as f:
+    readme = f.read()
+
+if zenodo_record:
+    # Replace the old DOI with the new one
+    readme = re.sub(
+        r"\[!\[DOI\]\(https://zenodo.org/badge/DOI/.*\.svg\)\]\(https://zenodo.org/doi/.*\)",
+        f"[![DOI](https://zenodo.org/badge/DOI/{zenodo_record['metadata']['doi']}.svg)](https://zenodo.org/doi/{zenodo_record['metadata']['doi']})",
+        readme,
+    )
+
+if swh_record:
+    # Replace the old SWH badge with the new one
+    # [![Software Heritage (release)](https://archive.softwareheritage.org/badge/swh:1:rel:2d4c5c8c8a6d2318332889df93ab74aef53e2c61/)](https://archive.softwareheritage.org/swh:1:rel:2d4c5c8c8a6d2318332889df93ab74aef53e2c61;origin=https://github.com/brian-team/brian2;visit=swh:1:snp:a90ab7416901a9c5cf6f56d68b3455c65d322afc)
+    readme = re.sub(
+        r"\[!\[Software Heritage \(release\)\]\(https://archive.softwareheritage.org/badge/swh:1:rel:.*\)\]\(https://archive.softwareheritage.org/swh:1:rel:.*;origin=.*\)",
+        f"[![Software Heritage (release)](https://archive.softwareheritage.org/badge/swh:1:rel:{swh_record['target']}/)](https://archive.softwareheritage.org/swh:1:rel:{swh_record['target']};origin=https://github.com/brian-team/brian2;visit=swh:1:snp:{latest_visit['snapshot']})",
+        readme,
+    )
+
+with open(os.path.join(basedir, "README.md"), "w") as f:
+    f.write(readme)

--- a/dev/tools/release/release.py
+++ b/dev/tools/release/release.py
@@ -2,6 +2,8 @@ import os
 
 import brian2
 
+basedir = os.path.abspath(os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "..", ".."))
+
 # Ask for version number
 print('Current version is: ' + brian2.__version__)
 version = input('Enter new Brian2 version number: ').strip()
@@ -9,7 +11,11 @@ version = input('Enter new Brian2 version number: ').strip()
 # commit
 os.system('git commit -a -v --allow-empty -m "***** Release Brian2 %s *****"' % version)
 # add tag
-os.system('git tag -a -m "Release Brian2 %s" %s' % (version, version))
+os.system(f'git tag -a -m "Release Brian2 {version}" {version}')
+# Run script to update codemeta.json
+os.system(f'python {basedir}/.codemeta/create_codemeta.py')
+# Include codemeta.json update in commit and update tag
+os.system(f'git add {basedir}/codemeta.json && git commit --amend --no-edit && git tag -f -a -m "Release Brian2 {version}" {version}')
 
 # print commands necessary for pushing
 print('Review the last commit: ')


### PR DESCRIPTION
This PR integrates the update of a `codemeta.json` file into the release script. This file is mostly static, but needs to be updated with the contributors and the current version. The reason for this is mostly that this file is mandatory for uploading software to HAL (https://doc.hal.science/deposer/deposer-le-code-source/#sur-linterface-de-hal-cliquer-sur-longlet-depot_1), France's official pre-/post-print server that is sometimes queried to get all contributions by a researcher, etc. 
This PR also adds a GitHub action to update README file and CITATION.cff with the latest Zenodo archive and Software Heritage ID (which I regularly forgot). This action needs to be triggered manually, since it requires that the archives already exist.