### PR TITLE
Extend linked variables functionality

### DIFF
--- a/brian2/core/variables.py
+++ b/brian2/core/variables.py
@@ -767,6 +767,12 @@ class LinkedVariable:
     """
 
     def __init__(self, group, name, variable, index=None):
+        if isinstance(variable, DynamicArrayVariable):
+            raise NotImplementedError(
+                f"Linking to variable {variable.name} is "
+                "not supported, can only link to "
+                "state variables of fixed size."
+            )
         self.group = group
         self.name = name
         self.variable = variable

--- a/brian2/groups/group.py
+++ b/brian2/groups/group.py
@@ -30,6 +30,7 @@ from brian2.core.variables import (
     AuxiliaryVariable,
     Constant,
     DynamicArrayVariable,
+    LinkedVariable,
     Subexpression,
     Variable,
     Variables,
@@ -38,6 +39,7 @@ from brian2.equations.equations import BOOLEAN, FLOAT, INTEGER, Equations
 from brian2.importexport.importexport import ImportExport
 from brian2.units.fundamentalunits import (
     DIMENSIONLESS,
+    DimensionMismatchError,
     fail_for_dimension_mismatch,
     get_unit,
 )
@@ -420,85 +422,217 @@ class VariableOwner(Nameable):
         except KeyError:
             raise AttributeError(f"No attribute with name {name}")
 
-    def __setattr__(self, name, val, level=0):
+    def __setattr__(self, key, value, level=0):
         # attribute access is switched off until this attribute is created by
         # _enable_group_attributes
-        if not hasattr(self, "_group_attribute_access_active") or name in self.__dict__:
-            object.__setattr__(self, name, val)
-        elif (
-            name in self.__getattribute__("__dict__")
-            or name in self.__getattribute__("__class__").__dict__
-        ):
-            # Makes sure that classes can override the "variables" mechanism
-            # with instance/class attributes and properties
-            return object.__setattr__(self, name, val)
-        elif name in self.variables:
-            var = self.variables[name]
-            if not isinstance(val, str):
-                if var.dim is DIMENSIONLESS:
-                    fail_for_dimension_mismatch(
-                        val,
-                        var.dim,
-                        "%s should be set with a dimensionless value, but got {value}"
-                        % name,
-                        value=val,
-                    )
-                else:
-                    fail_for_dimension_mismatch(
-                        val,
-                        var.dim,
-                        "%s should be set with a value with units %r, but got {value}"
-                        % (name, get_unit(var.dim)),
-                        value=val,
-                    )
-            if var.read_only:
-                raise TypeError(f"Variable {name} is read-only.")
-            # Make the call X.var = ... equivalent to X.var[:] = ...
-            var.get_addressable_value_with_unit(name, self).set_item(
-                slice(None), val, level=level + 1
-            )
-        elif len(name) and name[-1] == "_" and name[:-1] in self.variables:
-            # no unit checking
-            var = self.variables[name[:-1]]
-            if var.read_only:
-                raise TypeError(f"Variable {name[:-1]} is read-only.")
-            # Make the call X.var = ... equivalent to X.var[:] = ...
-            var.get_addressable_value(name[:-1], self).set_item(
-                slice(None), val, level=level + 1
-            )
-        elif hasattr(self, name) or name.startswith("_"):
-            object.__setattr__(self, name, val)
-        else:
-            # Try to suggest the correct name in case of a typo
-            checker = SpellChecker(
-                [
-                    varname
-                    for varname, var in self.variables.items()
-                    if not (varname.startswith("_") or var.read_only)
-                ]
-            )
-            if name.endswith("_"):
-                suffix = "_"
-                name = name[:-1]
+        if not hasattr(self, "_group_attribute_access_active") or key in self.__dict__:
+            object.__setattr__(self, key, value)
+        elif key in getattr(self, "_linked_variables", set()):
+            if not isinstance(value, LinkedVariable):
+                raise ValueError(
+                    "Cannot set a linked variable directly, link "
+                    "it to another variable using 'linked_var'."
+                )
+            linked_var = value.variable
+
+            if isinstance(linked_var, DynamicArrayVariable):
+                raise NotImplementedError(
+                    f"Linking to variable {linked_var.name} is "
+                    "not supported, can only link to "
+                    "state variables of fixed size."
+                )
+
+            eq = self.equations[key]
+            if eq.dim is not linked_var.dim:
+                raise DimensionMismatchError(
+                    f"Unit of variable '{key}' does not "
+                    "match its link target "
+                    f"'{linked_var.name}'"
+                )
+
+            if not isinstance(linked_var, Subexpression):
+                var_length = len(linked_var)
             else:
-                suffix = ""
-            error_msg = f'Could not find a state variable with name "{name}".'
-            suggestions = checker.suggest(name)
-            if len(suggestions) == 1:
-                (suggestion,) = suggestions
-                error_msg += f' Did you mean to write "{suggestion}{suffix}"?'
-            elif len(suggestions) > 1:
-                suggestion_str = ", ".join(
-                    [f"'{suggestion}{suffix}'" for suggestion in suggestions]
+                var_length = len(linked_var.owner)
+
+            if value.index is not None:
+                if isinstance(value.index, str):
+                    if value.index not in self.variables:
+                        raise ValueError(f"Index variable '{value.index}' not found.")
+                    if (
+                        self.variables.indices[value.index]
+                        != self.variables.default_index
+                    ):
+                        raise ValueError(
+                            f"Index variable '{value.index}' should use the default index itself."
+                        )
+                    if not np.issubdtype(self.variables[value.index].dtype, np.integer):
+                        raise TypeError(
+                            f"Index variable '{value.index}' should be an integer parameter."
+                        )
+                    index = value.index
+                else:
+                    # Index arrays are not allowed for classes with dynamic size (Synapses)
+                    if not isinstance(self.variables["N"], Constant):
+                        raise TypeError(
+                            "Cannot link a variable with an index array for a class with dynamic size – use a variable name instead."
+                        )
+                    try:
+                        index_array = np.asarray(value.index)
+                        if not np.issubdtype(index_array.dtype, int):
+                            raise TypeError()
+                    except TypeError:
+                        raise TypeError(
+                            "The index for a linked variable has to be an integer array"
+                        )
+                    size = len(index_array)
+                    source_index = value.group.variables.indices[value.name]
+                    if source_index not in ("_idx", "0"):
+                        # we are indexing into an already indexed variable,
+                        # calculate the indexing into the target variable
+                        index_array = value.group.variables[source_index].get_value()[
+                            index_array
+                        ]
+
+                    if not index_array.ndim == 1 or size != len(self):
+                        raise TypeError(
+                            f"Index array for linked variable '{key}' "
+                            "has to be a one-dimensional array of "
+                            f"length {len(self)}, but has shape "
+                            f"{index_array.shape!s}"
+                        )
+                    if min(index_array) < 0 or max(index_array) >= var_length:
+                        raise ValueError(
+                            f"Index array for linked variable {key} "
+                            "contains values outside of the valid "
+                            f"range [0, {var_length}["
+                        )
+                    self.variables.add_array(
+                        f"_{key}_indices",
+                        size=size,
+                        dtype=index_array.dtype,
+                        constant=True,
+                        read_only=True,
+                        values=index_array,
+                    )
+                    index = f"_{key}_indices"
+            else:
+                # The check at the end is to avoid the case that a size 1 NeuronGroup
+                # links to another NeuronGroup of size 1 and cannot do certain operations
+                # since the linked variable is considered scalar.
+                if linked_var.scalar or (
+                    var_length == 1 and getattr(self, "_N", 0) != 1
+                ):
+                    index = "0"
+                else:
+                    index = value.group.variables.indices[value.name]
+                    if index == "_idx":
+                        target_length = var_length
+                    else:
+                        target_length = len(value.group.variables[index])
+                        # we need a name for the index that does not clash with
+                        # other names and a reference to the index
+                        new_index = f"_{value.name}_index_{index}"
+                        self.variables.add_reference(new_index, value.group, index)
+                        index = new_index
+
+                    if len(self) != target_length:
+                        raise ValueError(
+                            f"Cannot link variable '{key}' to "
+                            f"'{linked_var.name}', the size of the "
+                            "target group does not match "
+                            f"({len(self)} != {target_length}). You can "
+                            "provide an indexing scheme with the "
+                            "'index' keyword to link groups with "
+                            "different sizes"
+                        )
+            self.variables.add_reference(key, value.group, value.name, index=index)
+            source = (value.variable.owner.name,)
+            sourcevar = value.variable.name
+            log_msg = f"Setting {self.name}.{key} as a link to {source}.{sourcevar}"
+            if index is not None:
+                log_msg += f'(using "{index}" as index variable)'
+            logger.diagnostic(log_msg)
+        else:
+            if isinstance(value, LinkedVariable):
+                raise TypeError(
+                    f"Cannot link variable '{key}', it has to be marked "
+                    "as a linked variable with '(linked)' in the model "
+                    "equations."
                 )
-                error_msg += (
-                    f" Did you mean to write any of the following: {suggestion_str} ?"
-                )
-            error_msg += (
-                " Use the add_attribute method if you intend to add "
-                "a new attribute to the object."
-            )
-            raise AttributeError(error_msg)
+            else:
+                if (
+                    key in self.__getattribute__("__dict__")
+                    or key in self.__getattribute__("__class__").__dict__
+                ):
+                    # Makes sure that classes can override the "variables" mechanism
+                    # with instance/class attributes and properties
+                    return object.__setattr__(self, key, value)
+                elif key in self.variables:
+                    var = self.variables[key]
+                    if not isinstance(value, str):
+                        if var.dim is DIMENSIONLESS:
+                            fail_for_dimension_mismatch(
+                                value,
+                                var.dim,
+                                "%s should be set with a dimensionless value, but got {value}"
+                                % key,
+                                value=value,
+                            )
+                        else:
+                            fail_for_dimension_mismatch(
+                                value,
+                                var.dim,
+                                "%s should be set with a value with units %r, but got {value}"
+                                % (key, get_unit(var.dim)),
+                                value=value,
+                            )
+                    if var.read_only:
+                        raise TypeError(f"Variable {key} is read-only.")
+                    # Make the call X.var = ... equivalent to X.var[:] = ...
+                    var.get_addressable_value_with_unit(key, self).set_item(
+                        slice(None), value, level=level + 1
+                    )
+                elif len(key) and key[-1] == "_" and key[:-1] in self.variables:
+                    # no unit checking
+                    var = self.variables[key[:-1]]
+                    if var.read_only:
+                        raise TypeError(f"Variable {key[:-1]} is read-only.")
+                    # Make the call X.var = ... equivalent to X.var[:] = ...
+                    var.get_addressable_value(key[:-1], self).set_item(
+                        slice(None), value, level=level + 1
+                    )
+                elif hasattr(self, key) or key.startswith("_"):
+                    object.__setattr__(self, key, value)
+                else:
+                    # Try to suggest the correct name in case of a typo
+                    checker = SpellChecker(
+                        [
+                            varname
+                            for varname, var in self.variables.items()
+                            if not (varname.startswith("_") or var.read_only)
+                        ]
+                    )
+                    if key.endswith("_"):
+                        suffix = "_"
+                        key = key[:-1]
+                    else:
+                        suffix = ""
+                    error_msg = f'Could not find a state variable with name "{key}".'
+                    suggestions = checker.suggest(key)
+                    if len(suggestions) == 1:
+                        (suggestion,) = suggestions
+                        error_msg += f' Did you mean to write "{suggestion}{suffix}"?'
+                    elif len(suggestions) > 1:
+                        suggestion_str = ", ".join(
+                            [f"'{suggestion}{suffix}'" for suggestion in suggestions]
+                        )
+                        error_msg += f" Did you mean to write any of the following: {suggestion_str} ?"
+                    error_msg += (
+                        " Use the add_attribute method if you intend to add "
+                        "a new attribute to the object."
+                    )
+                    raise AttributeError(error_msg)
 
     def add_attribute(self, name):
         """

--- a/brian2/synapses/synapses.py
+++ b/brian2/synapses/synapses.py
@@ -854,7 +854,7 @@ class Synapses(Group):
             {
                 DIFFERENTIAL_EQUATION: ["event-driven", "clock-driven"],
                 SUBEXPRESSION: ["summed", "shared", "constant over dt"],
-                PARAMETER: ["constant", "shared"],
+                PARAMETER: ["constant", "shared", "linked"],
             },
             incompatible_flags=[
                 ("event-driven", "clock-driven"),
@@ -943,6 +943,8 @@ class Synapses(Group):
             model += Equations("lastupdate : second")
         else:
             self.event_driven = None
+
+        self._linked_variables = set()
 
         self._create_variables(model, user_dtype=dtype)
         self.equations = Equations(continuous)
@@ -1372,7 +1374,10 @@ class Synapses(Group):
                 check_identifier_pre_post(eq.varname)
                 constant = "constant" in eq.flags
                 shared = "shared" in eq.flags
-                if shared:
+                linked = "linked" in eq.flags
+                if linked:
+                    self._linked_variables.add(eq.varname)
+                elif shared:
                     self.variables.add_array(
                         eq.varname,
                         size=1,

--- a/brian2/tests/test_neurongroup.py
+++ b/brian2/tests/test_neurongroup.py
@@ -463,6 +463,30 @@ def test_linked_variable_indexed():
 
 
 @pytest.mark.codegen_independent
+def test_linked_variable_index_variable():
+    """
+    Test linking a variable with an index specified as an array
+    """
+    G = NeuronGroup(
+        10,
+        """
+        x : 1
+        index_var : integer
+        not_an_index_var : 1
+        y : 1 (linked)
+        """,
+    )
+
+    G.x = np.arange(10) * 0.1
+    with pytest.raises(TypeError):
+        G.y = linked_var(G.x, index="not_an_index_var")
+    G.y = linked_var(G.x, index="index_var")
+    G.index_var = np.arange(10)[::-1]
+    # G.y should refer to an inverted version of G.x
+    assert_allclose(G.y[:], np.arange(10)[::-1] * 0.1)
+
+
+@pytest.mark.codegen_independent
 def test_linked_variable_repeat():
     """
     Test a "repeat"-like connection between two groups of different size

--- a/docs_sphinx/introduction/release_notes.rst
+++ b/docs_sphinx/introduction/release_notes.rst
@@ -1,6 +1,27 @@
 Release notes
 =============
 
+Next release
+------------
+
+Selected improvements and bug fixes
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+- A more powerful :ref:`linked_variables` mechanism, now also supporting linked variables that use another variable for indexing, and linked variables in
+  `Synapses` (:issue:`1584`).
+
+Infrastructure and documentation improvements
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+- A new example :doc:`../examples/synapses.homeostatic_stdp_at_inhibitory_synapes`, demonstrating a homoestatic modulation of STDP, based on a population firing rate.
+  Thanks to Paul Brodersen for contributing this example (:issue:`1581`).
+
+Contributions
+~~~~~~~~~~~~~
+GitHub code, documentation, and issue contributions (ordered by the number of
+contributions):
+
+TODO
+
+
 Brian 2.8.0.1-2.8.0.4
 ---------------------
 Several patch-level releases, correcting metadata files about authors and contributors, updating release scripts, and fixing issues in a test and in the

--- a/docs_sphinx/user/equations.rst
+++ b/docs_sphinx/user/equations.rst
@@ -180,8 +180,8 @@ qualifies the equations. There are several keywords:
   but rather a single value for the whole `NeuronGroup` or `Synapses`. A shared
   subexpression can only refer to other shared variables.
 *linked*
-  this means that a parameter refers to a parameter in another `NeuronGroup`.
-  See :ref:`linked_variables` for more details.
+  this means that a parameter refers to a variable in another `NeuronGroup`
+  or `SpatialNeuron`. See :ref:`linked_variables` for more details.
 
 Multiple flags may be specified as follows::
 

--- a/docs_sphinx/user/models.rst
+++ b/docs_sphinx/user/models.rst
@@ -293,9 +293,9 @@ The data (without physical units) can also be exported/imported to/from
 Linked variables
 ----------------
 
-A `NeuronGroup` can define parameters that are not stored in this group, but are
-instead a reference to a state variable in another group. For this, a group
-defines a parameter as ``linked`` and then uses `linked_var` to
+A `NeuronGroup`, `Synapses`, or `SpatialNeuron` can define parameters that are
+not stored in this group, but are instead a reference to a variable in another group.
+For this, a group defines a parameter as ``linked`` and then uses `linked_var` to
 specify the linking. This can for example be useful to model shared noise
 between cells::
 
@@ -319,8 +319,23 @@ linking explicitly::
     neurons = NeuronGroup(100, '''inp : volt (linked)
                                   dv/dt = (-v + inp) / tau : volt''')
     # Half of the cells get the first input, other half gets the second
-    neurons.inp = linked_var(inp, 'x', index=repeat([0, 1], 50))
+    neurons.inp = linked_var(inp, 'x', index=np.repeat([0, 1], 50))
 
+Note that this linking does not work for `Synapses`, since the number of synapses
+is not known in advance. However, all groups supported linking with an index variable.
+The above example could also be written as::
+
+    # two inputs with different phases
+    inp = NeuronGroup(2, '''phase : 1
+                            dx/dt = 1*mV/ms*sin(2*pi*100*Hz*t-phase) : volt''')
+    inp.phase = [0, pi/2]
+
+    neurons = NeuronGroup(100, '''inp : volt (linked)
+                                  index_var : integer (constant)
+                                  dv/dt = (-v + inp) / tau : volt''')
+    # Half of the cells get the first input, other half gets the second
+    neurons.inp = linked_var(inp, 'x', index='index_var')
+    neurons.index_var = np.repeat([0, 1], 50)
 
 .. _time_scaling_of_noise:
 

--- a/examples/synapses/homeostatic_stdp_at_inhibitory_synapes.py
+++ b/examples/synapses/homeostatic_stdp_at_inhibitory_synapes.py
@@ -72,6 +72,7 @@ net.add(postsynaptic_neuron)
 tau_stdp = 20. * b2.msecond
 eta = 1. * b2.nsiemens * b2.second
 synapse_model = """
+G : Hz (linked)
 wij : siemens
 dzi/dt = -zi / tau_stdp : 1 (event-driven)
 dzj/dt = -zj / tau_stdp : 1 (event-driven)
@@ -89,13 +90,7 @@ synapse = b2.Synapses(
     model=synapse_model, on_pre=on_pre, on_post=on_post
 )
 synapse.connect(i=0, j=0)
-# Synapses currently don't support linked variables.
-# The following syntax hence results in an error:
-# synapses.G = b2.linked_var(global_factor, "G")
-# Instead we add the reference G as shown below.
-# See also:
-# https://brian.discourse.group/t/valueerror-equations-of-type-parameter-cannot-have-a-flag-linked-only-the-following-flags-are-allowed-constant-shared/1373/2
-synapse.variables.add_reference("G", group=global_factor, index='0')
+synapse.G = b2.linked_var(global_factor, "G")
 synapse.wij = 0 * b2.nsiemens
 net.add(synapse)
 


### PR DESCRIPTION
Previously, "linked variables" could not be used with `Synapses`, since the dynamic number of synapses makes a static mapping fragile. With this PR, `Synapses` gains the possibility to link to scalar variables and to variables in groups of size 1, where there is no ambiguity. In addition, all groups (including `Synapses`) can link to other variables using a dedicated index variable (which could even change its values over time, which might be useful for some corner cases). Since this variable would grow together with the number of synapses, it will always be of the right size. However, note that using an index variable means that simulations can crash due to out-of-bounds access. Actually, the `linked_var` documentation already stated:

> index : str or [ndarray](https://numpy.org/doc/stable/reference/generated/numpy.ndarray.html#numpy.ndarray), optional
>
>    An indexing array (or the name of a state variable), providing a mapping from the entries in the link source to the link target.

But before this PR, providing the "name of a state variable"  raised an error... I'm not 100% sure whether this never worked or whether this feature disappeared by accident with some other change :shrug: 