### PR TITLE
Do not use deprecated `NPY_OWNDATA`

### DIFF
--- a/.github/workflows/test_latest.yml
+++ b/.github/workflows/test_latest.yml
@@ -118,6 +118,13 @@ jobs:
           cache-key: gsl-x64-linux
           revision: master
           token: ${{ github.token }}
+      - name: Set GSL preference for vcpkg
+        shell: bash
+        run: |
+          mkdir ~/.brian/
+          # Replaces backslashes with forward slashes
+          echo "GSL.directory=\"${{ github.workspace }}\\vcpkg\\installed\x64-linux\\include"\" | tr '\\' '/' > ~/.brian/user_preferences
+          cat ~/.brian/user_preferences
       - name: Install Python
         id: python
         uses: actions/setup-python@v5
@@ -158,3 +165,4 @@ jobs:
           AGENT_OS: linux
           STANDALONE: ${{ matrix.standalone }}
           PYTHON_BINARY: ${{ steps.python.outputs.python-path }}
+          DO_NOT_RESET_PREFERENCES: true  # Make sure that GSL setting is used

--- a/brian2/codegen/generators/cython_generator.py
+++ b/brian2/codegen/generators/cython_generator.py
@@ -494,7 +494,7 @@ cdef double _rand(int _idx):
             free(buffer)
         _new_rand = _numpy.random.rand(_BUFFER_SIZE)
         buffer = <double *>_numpy.PyArray_DATA(_new_rand)
-        PyArray_CLEARFLAGS(<_numpy.PyArrayObject*>_new_rand, _numpy.NPY_OWNDATA)
+        PyArray_CLEARFLAGS(<_numpy.PyArrayObject*>_new_rand, _numpy.NPY_ARRAY_OWNDATA)
         buffer_pointer[0] = buffer
 
     cdef double val = buffer[_namespace_rand_buffer_index[0]]


### PR DESCRIPTION
Very minor fix to replace the use of a deprecated variable that will be removed in the upcoming numpy 2.3 release.

Also includes a small fix to our "test against development versions" test suite, which did not correctly run the tests that check for deprecation warnings.