### PR TITLE
Fix imports for recent setuptools

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -221,8 +221,8 @@ jobs:
         path: packages
     - run: |
         mkdir dist
-        cp packages/Brian2*cp312-manylinux*_x86_64.whl dist
-        cp packages/Brian2*cp312-manylinux*_aarch64.whl dist
+        cp packages/[Bb]rian2*cp312-manylinux*_x86_64.whl dist
+        cp packages/[Bb]rian2*cp312-manylinux*_aarch64.whl dist
     - name: Build (and potentially push) the Docker image
       uses: docker/build-push-action@v6
       # https://github.com/docker/build-push-action

--- a/brian2/codegen/cpp_prefs.py
+++ b/brian2/codegen/cpp_prefs.py
@@ -21,7 +21,10 @@ import tempfile
 try:
     from setuptools.msvc import msvc14_get_vc_env as _get_vc_env
 except ImportError:  # Setuptools 0.74.0 removed this function
-    from distutils._msvccompiler import _get_vc_env
+    try:
+        from distutils._msvccompiler import _get_vc_env
+    except ImportError:  # Things keep moving around in distutils/setuptools
+        from distutils.compilers.C.msvc import _get_vc_env
 
 from distutils.ccompiler import get_default_compiler
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -33,7 +33,7 @@ RUN python -m pip install --no-cache-dir --only-binary=:all: \
     jupyterlab \
     pytest \
     pytest-xdist \
-    && python -m pip install /tmp/dist/Brian2*_$(uname -m).whl brian2tools \
+    && python -m pip install /tmp/dist/[Bb]rian2*_$(uname -m).whl brian2tools \
     && rm -rf /tmp/dist
 
 # Create a non-root user (password same as username)


### PR DESCRIPTION
Setuptools/distutils keep refactoring their package structure, meaning that our imports for the internal functions related to the MSVC environment have to be adapted.