### PR TITLE
Fix setup script: replace distutils.errors with setuptools.errors

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,8 +11,7 @@ import os
 import platform
 from setuptools import setup, Extension
 from setuptools.command.build_ext import build_ext
-from distutils.errors import CompileError, DistutilsPlatformError
-
+from setuptools.errors import CompileError, PlatformError as DistutilsPlatformError
 
 try:
     from Cython.Build import cythonize


### PR DESCRIPTION
This PR replaces distutils.errors with setuptools.errors in setup.py, future-proofing the code as distutils will eventually be removed. PlatformError is also imported as DistutilsPlatformError to maintain consistency with the original code, ensuring compatibility with future Python versions.