### PR TITLE
Improve C99 check on Unix

### DIFF
--- a/.github/workflows/testsuite.yml
+++ b/.github/workflows/testsuite.yml
@@ -156,6 +156,7 @@ jobs:
     - name: Setup Conda and Python
       uses: conda-incubator/setup-miniconda@505e6394dae86d6a5c7fbb6e3fb8938e3e863830 # v3.1.1
       with:
+        conda-remove-defaults: true
         auto-update-conda: true
         auto-activate-base: false
         miniforge-version: latest

--- a/brian2/codegen/cpp_prefs.py
+++ b/brian2/codegen/cpp_prefs.py
@@ -397,9 +397,10 @@ def compiler_supports_c99():
             _compiler_supports_c99 = return_value == 0
             os.remove(tmp_file)
         else:
+            CC = os.environ.get("CC", "cc")
             cmd = (
                 'echo "#if (__STDC_VERSION__ < 199901L)\n#error\n#endif" | '
-                "cc -xc -E - > /dev/null 2>&1"
+                f"'{CC}' -xc -E - > /dev/null 2>&1"
             )
             return_value = os.system(cmd)
             _compiler_supports_c99 = return_value == 0


### PR DESCRIPTION
The current C99 check hardcoded `cc` as the compiler name, which is usually available on Unix systems. In conda environments, however, compilers installed into the environment are not available under this name. Their names are made available via environment variables, though, so the updated code uses the `$CC` value first, and only uses `cc` as a fallback in case that variable is not defined. This should better match the behaviour when we actually compile things for running the simulation.