### PR TITLE
Interrupt hook (graceful stop with Ctrl+C)

### DIFF
--- a/brian2/core/core_preferences.py
+++ b/brian2/core/core_preferences.py
@@ -43,6 +43,14 @@ prefs.register_preferences(
         a warning (``False``).
         """,
     ),
+    stop_on_keyboard_interrupt=BrianPreference(
+        default=True,
+        docs="""
+        Whether to "gracefully" stop a simulation after pressing Ctrl+C (defaults to
+        ``True``). Note that pressing Ctrl+C a second time will force the usual
+        interruption mechanism.
+        """,
+    ),
 )
 
 prefs.register_preferences(

--- a/brian2/devices/cpp_standalone/device.py
+++ b/brian2/devices/cpp_standalone/device.py
@@ -24,6 +24,7 @@ from brian2.codegen.cpp_prefs import get_compiler_and_args, get_msvc_env
 from brian2.codegen.generators.cpp_generator import c_data_type
 from brian2.core.functions import Function
 from brian2.core.namespace import get_local_namespace
+from brian2.core.network import Network
 from brian2.core.preferences import BrianPreference, prefs
 from brian2.core.variables import (
     ArrayVariable,
@@ -1287,15 +1288,19 @@ class CPPStandaloneDevice(Device):
                 stdout = None
             if os.name == "nt":
                 start_time = time.time()
+                Network._globally_running = True
                 x = subprocess.call(["main"] + run_args, stdout=stdout)
                 self.timers["run_binary"] = time.time() - start_time
+                Network._globally_running = False
             else:
                 run_cmd = prefs.devices.cpp_standalone.run_cmd_unix
                 if isinstance(run_cmd, str):
                     run_cmd = [run_cmd]
                 start_time = time.time()
+                Network._globally_running = True
                 x = subprocess.call(run_cmd + run_args, stdout=stdout)
                 self.timers["run_binary"] = time.time() - start_time
+                Network._globally_running = False
             if stdout is not None:
                 stdout.close()
             if x:

--- a/brian2/devices/cpp_standalone/templates/main.cpp
+++ b/brian2/devices/cpp_standalone/templates/main.cpp
@@ -1,5 +1,6 @@
 #include <stdlib.h>
 #include "objects.h"
+#include <csignal>
 #include <ctime>
 #include <time.h>
 {{ openmp_pragma('include') }}
@@ -33,8 +34,21 @@ void set_from_command_line(const std::vector<std::string> args)
 		brian::set_variable_by_name(name, value);
 	}
 }
+
+void _int_handler(int signal_num) {
+	if (Network::_globally_running and !Network::_globally_stopped) {
+		Network::_globally_stopped = true;
+	} else {
+		std::signal(signal_num, SIG_DFL);
+		std::raise(signal_num);
+	}
+}
+
 int main(int argc, char **argv)
 {
+	{% if prefs.core.stop_on_keyboard_interrupt %}
+	std::signal(SIGINT, _int_handler);
+	{% endif %}
 	std::random_device _rd;
 	std::vector<std::string> args(argv + 1, argv + argc);
 	if (args.size() >=2 && args[0] == "--results_dir")


### PR DESCRIPTION
This interrupts a "graceful stop" if you interrupt a simulation with Ctrl+C (or e.g. use the interrupt mechanism in a Jupyter notebook). During a simulation run, pressing Ctrl+C will not trigger the usual interrupt (or `KeyboardInterrupt`), but instead do the equivalent of a `Network.stop()`, i.e. finish the current time step and then stop the simulation. This means that in particular for scripts that the code after the simulation run will still be run and can analyse/save/plot results. This works for both runtime and C++ standalone simulations.

@thesamovar @bdevans could you please test this on Windows/macOS? I'd use an example that takes a while to run, e.g. [COBAHH](https://brian2.readthedocs.io/en/stable/examples/COBAHH.html). After it shows "Starting simulation at t=0. s for a duration of 1. s", you can press Ctrl+C which should output a warning and gracefully shut down the simulation at a time < the requested runtime, e.g.:
```
Starting simulation at t=0. s for a duration of 1. s
WARNING    Simulation stop requested. Press Ctrl+C again to interrupt. [brian2]
0.5314 s (53%) simulated in 3s, estimated 3s remaining.
```

If you could test this both in the default runtime mode and with an added `set_device('cpp_standalone')`, this would be great. In particular for the C++ standalone mechanism, I am not 100% sure whether it works the same on all OSes.
Thanks!

Closes #952 