### PR TITLE
Small fixes

### DIFF
--- a/brian2/core/preferences.py
+++ b/brian2/core/preferences.py
@@ -208,7 +208,7 @@ class BrianGlobalPreferences(MutableMapping):
 
     def __getattr__(self, name):
         if name in self.__dict__ or name.startswith("__"):
-            return MutableMapping.__getattr__(self, name)
+            return super().__getattribute__(name)
 
         # This function might get called from BrianGlobalPreferencesView with
         # a prefixed name -- therefore the name can contain dots!
@@ -223,7 +223,14 @@ class BrianGlobalPreferences(MutableMapping):
                 "unregistered. This should never happen!"
             )
 
-        return self[name]
+        try:
+            return self[name]
+        except KeyError as ex:
+            raise AttributeError(
+                f"Object of type {type(self).__name__} does not have an attribute '{ex.args[0]}'",
+                name=ex.args[0],
+                obj=self,
+            ) from ex
 
     def __setattr__(self, name, value):
         # Do not allow to set a category name to something else

--- a/brian2/tests/test_base.py
+++ b/brian2/tests/test_base.py
@@ -1,5 +1,6 @@
 import pytest
 from numpy.testing import assert_equal
+from packaging.version import parse as parse_version
 
 from brian2 import *
 from brian2.devices.device import reinit_and_delete
@@ -93,9 +94,9 @@ def test_version():
     version = brian2.__version__
     assert version.startswith("2.")
 
-    # Check that the version tuple is correct
+    # Check that the version tuple is correct (ignore any local part)
     version_tuple = brian2.__version_tuple__
-    assert version_tuple == tuple(int(i) for i in version.split(".")[:4])
+    assert version_tuple == parse_version(version).release
 
 
 if __name__ == "__main__":

--- a/brian2/tests/test_preferences.py
+++ b/brian2/tests/test_preferences.py
@@ -277,9 +277,13 @@ def test_preference_name_access():
         gp["main.doesnotexist"]
     with pytest.raises(KeyError):
         gp["nonexisting.name"]
-    with pytest.raises(KeyError):
+    # Note that it is important to raise AttributeError here, since some tools like
+    # Google Collab check for a `.shape` attribute to display debugging information
+    # for numpy arrays. More generally, a call like `hasattr(gp, "main.doesnotexist")`
+    # would fail with an error instead of returning `False`
+    with pytest.raises(AttributeError):
         gp.main.doesnotexist
-    with pytest.raises(KeyError):
+    with pytest.raises(AttributeError):
         gp.nonexisting.name
 
     # Check dictionary functionality
@@ -314,6 +318,9 @@ def test_preference_name_access():
     # access to standard attributes
     assert len(gp.prefs)
     assert gp.main._basename == "main"
+
+    # Check that acessing internal attributes work
+    assert len(gp.prefs.__doc__)
 
 
 @pytest.mark.codegen_independent


### PR DESCRIPTION
Two small fixes:
- More robust test for version tuple vs. version string that does not fail for development versions that end with `.postXXX`
- Raise an `AttributeError` instead of a `KeyError`, when accessing non-existing attributes of the preferences object. This prevents errors when using `hasattr` for non-existing attributes which is most likely behind the error seen on Google Collab when the Debugger is active, see https://brian.discourse.group/t/error-in-google-colab/1401