### PR TITLE
Eliminate Python Layer Calls in `Synapses` Codegen Templates for SpikeQueue Operations

### DIFF
--- a/brian2/codegen/runtime/cython_rt/templates/synapses.pyx
+++ b/brian2/codegen/runtime/cython_rt/templates/synapses.pyx
@@ -1,22 +1,55 @@
-{# USES_VARIABLES { _queue } #}
+{# USES_VARIABLES { _queue_capsule } #}
 {% extends 'common_group.pyx' %}
 
+{% block template_support_code %}
+from cpython.pycapsule cimport PyCapsule_GetPointer
+from libcpp.vector cimport vector
+from cython.operator cimport dereference
+# We declare minimal C++ interface here - only methods we actually want to use
+# This avoids importing the full SpikeQueue wrapper and its dependencies
+cdef extern from "cspikequeue.cpp":
+    cdef cppclass CSpikeQueue:
+        vector[int32_t]* peek();
+        void advance();
+{% endblock %}
+
 {% block maincode %}
-    cdef _numpy.ndarray[int32_t, ndim=1, mode='c'] _spiking_synapses = _queue.peek()
+     # Extract the raw C++ object pointer from the Python capsule.
+    cdef object capsule = _queue_capsule
+    cdef CSpikeQueue* cpp_queue = <CSpikeQueue*>PyCapsule_GetPointer(capsule, "CSpikeQueue")
+
+    # Now we call the C++ peek method directly to get the current spike vector.
+    # This returns a pointer to std::vector<int32_t> containing synapse IDs
+    # that are ready for processing in the current time step.
+    cdef vector[int32_t]* spike_vector = cpp_queue.peek()
+    cdef size_t num_spikes = dereference(spike_vector).size()
+
+    # Early exit for empty queue - avoid all processing overhead
+    if num_spikes == 0:
+        cpp_queue.advance()
+        return
+
+    # Access the underlying raw data pointer of the vector
+    cdef int32_t* spike_data = &dereference(spike_vector)[0]
 
     # scalar code
     _vectorisation_idx = 1
     {{ scalar_code | autoindent }}
 
-    cdef size_t _spiking_synapse_idx
 
-    for _spiking_synapse_idx in range(len(_spiking_synapses)):
-        # vector code
-        _idx = _spiking_synapses[_spiking_synapse_idx]
+    cdef size_t i = 0
+    cdef int32_t synapse_id
+    while i < num_spikes:
+        synapse_id = spike_data[i]
+
+        _idx = synapse_id
         _vectorisation_idx = _idx
+
         {{ vector_code | autoindent }}
 
-    # Advance the spike queue
-    _queue.advance()
+        i += 1
+
+    # Move the queue forward to the next time step
+    cpp_queue.advance()
 
 {% endblock %}

--- a/brian2/codegen/runtime/cython_rt/templates/synapses_push_spikes.pyx
+++ b/brian2/codegen/runtime/cython_rt/templates/synapses_push_spikes.pyx
@@ -1,8 +1,8 @@
+{# USES_VARIABLES { _queue_capsule } #}
 {% extends 'common_group.pyx' %}
 
 {% block template_support_code %}
-from libc.stdint cimport uintptr_t
-
+from cpython.pycapsule cimport PyCapsule_GetPointer
 # We declare minimal C++ interface here - only methods we actually want to use
 # This avoids importing the full SpikeQueue wrapper and its dependencies
 cdef extern from "cspikequeue.cpp":
@@ -17,20 +17,14 @@ cdef extern from "cspikequeue.cpp":
 {% block maincode %}
     {% set eventspace=get_array_name(eventspace_variable)%}
     cdef int spike_count
-    # Get the spike count from the last element
+    # Get the spike count from the last entry in the spike buffer
     spike_count = {{eventspace}}[_num{{eventspace}}-1]
 
-    # POINTER RESURRECTION: Now we convert memory address back to usable C++ object
-    # So as we get the queue pointer from runtime namespace ...
-    cdef uintptr_t queue_address = queue_object_ptr
-    # Step 1: Cast raw integer address (from Python) to a generic void pointer.
-    # Direct casting to specific C++ types is unsafe from Python objects,
-    # so we first cast to void* to ensure proper pointer alignment.
-    cdef void* _void_ptr = <void*>queue_address
-    # Step 2: Now we cast it to specific C++ class pointer ...
-    cdef CSpikeQueue* _queue_ptr = <CSpikeQueue*>_void_ptr
+    # Recover the C++ spike queue object from the PyCapsule passed at runtime
+    cdef object capsule = _queue_capsule
+    cdef CSpikeQueue* cpp_queue = <CSpikeQueue*>PyCapsule_GetPointer(capsule, "CSpikeQueue")
 
     if spike_count > 0:
     # Optimized: avoid the push_spikes method call overhead
-      _queue_ptr.push({{eventspace}},spike_count)
+      cpp_queue.push({{eventspace}},spike_count)
 {% endblock %}

--- a/brian2/codegen/runtime/cython_rt/templates/synapses_push_spikes.pyx
+++ b/brian2/codegen/runtime/cython_rt/templates/synapses_push_spikes.pyx
@@ -16,7 +16,7 @@ cdef extern from "cspikequeue.cpp":
 # so we first cast to void* to ensure proper pointer alignment.
 cdef void* _void_ptr = <void*>{{queue_ptr}}
 # Step 2: Now we cast it to specific C++ class pointer ...
-cdef CSpikeQueue* _queue_ptr = <CSpikeQueue*>{{queue_ptr}}
+cdef CSpikeQueue* _queue_ptr = <CSpikeQueue*>_void_ptr
 
 {% endblock %}
 

--- a/brian2/codegen/runtime/cython_rt/templates/synapses_push_spikes.pyx
+++ b/brian2/codegen/runtime/cython_rt/templates/synapses_push_spikes.pyx
@@ -1,20 +1,38 @@
 {% extends 'common_group.pyx' %}
 
+{% block template_support_code %}
+# We declare minimal C++ interface here - only methods we actually want to use
+# This avoids importing the full SpikeQueue wrapper and its dependencies
+cdef extern from "cspikequeue.cpp":
+    cdef cppclass CSpikeQueue:
+        void push(int32_t *, int)
+
+# POINTER RESURRECTION: Now we convert memory address back to usable C++ object
+# So as we added {{queue_ptr}} to template namespace, it gets template-substituted with actual memory address (e.g., 105553147185984)
+# Now we ensure proper pointer alignment and type safety to use the pointer:
+
+# Step 1: Cast raw integer (from Python) to a generic void pointer.
+# Direct casting to specific C++ types is unsafe from Python objects,
+# so we first cast to void* to ensure proper pointer alignment.
+cdef void* _void_ptr = <void*>{{queue_ptr}}
+# Step 2: Now we cast it to specific C++ class pointer ...
+cdef CSpikeQueue* _queue_ptr = <CSpikeQueue*>{{queue_ptr}}
+
+{% endblock %}
+
 {% block before_code %}
     _owner.initialise_queue()
 {% endblock %}
 
 {% block maincode %}
-    # Optimized: avoid the push_spikes method call overhead
-    cdef object eventspace = _owner.eventspace
-    cdef object queue = _owner.queue
-    cdef int spike_count
+    {% set eventspace=get_array_name(eventspace_variable)%}
 
+    cdef int spike_count
     # Get the spike count from the last element
-    spike_count = eventspace[eventspace.shape[0] - 1]
+    spike_count = {{eventspace}}[_num{{eventspace}}-1]
+
 
     if spike_count > 0:
-        # Extract events and push directly
-        events = eventspace[:spike_count]
-        queue.push(events)
+    # Optimized: avoid the push_spikes method call overhead
+      _queue_ptr.push({{eventspace}},spike_count)
 {% endblock %}

--- a/brian2/codegen/runtime/cython_rt/templates/synapses_push_spikes.pyx
+++ b/brian2/codegen/runtime/cython_rt/templates/synapses_push_spikes.pyx
@@ -1,6 +1,8 @@
 {% extends 'common_group.pyx' %}
 
 {% block template_support_code %}
+from libc.stdint cimport uintptr_t
+
 # We declare minimal C++ interface here - only methods we actually want to use
 # This avoids importing the full SpikeQueue wrapper and its dependencies
 cdef extern from "cspikequeue.cpp":
@@ -20,7 +22,7 @@ cdef extern from "cspikequeue.cpp":
 
     # POINTER RESURRECTION: Now we convert memory address back to usable C++ object
     # So as we get the queue pointer from runtime namespace ...
-    cdef int64_t queue_address = queue_object_ptr
+    cdef uintptr_t queue_address = queue_object_ptr
     # Step 1: Cast raw integer address (from Python) to a generic void pointer.
     # Direct casting to specific C++ types is unsafe from Python objects,
     # so we first cast to void* to ensure proper pointer alignment.

--- a/brian2/codegen/runtime/cython_rt/templates/synapses_push_spikes.pyx
+++ b/brian2/codegen/runtime/cython_rt/templates/synapses_push_spikes.pyx
@@ -5,5 +5,16 @@
 {% endblock %}
 
 {% block maincode %}
-    _owner.push_spikes()
+    # Optimized: avoid the push_spikes method call overhead
+    cdef object eventspace = _owner.eventspace
+    cdef object queue = _owner.queue
+    cdef int spike_count
+
+    # Get the spike count from the last element
+    spike_count = eventspace[eventspace.shape[0] - 1]
+
+    if spike_count > 0:
+        # Extract events and push directly
+        events = eventspace[:spike_count]
+        queue.push(events)
 {% endblock %}

--- a/brian2/synapses/cythonspikequeue.pyx
+++ b/brian2/synapses/cythonspikequeue.pyx
@@ -54,6 +54,20 @@ cdef class SpikeQueue:
     def _full_state(self):
         return self.thisptr._full_state()
 
+    def getptr(self):
+        """
+        Returns the raw memory address of the underlying C++ CSpikeQueue object.
+
+        This is used to pass the queue directly into Cython templates for fast,
+        low-overhead access—bypassing Python calls entirely.
+
+        1. self.thisptr is a C++ pointer (CSpikeQueue*) managed by Cython
+        2. <long> cast converts the pointer to a Python integer (memory address)
+        3. The returned address can be cast back to CSpikeQueue* in templates
+        4. Templates then call C++ methods directly without Python involvement
+        """
+        return <long>self.thisptr
+
     cdef object __weakref__  # Allows weak references to the SpikeQueue
 
     def _restore_from_full_state(self, state):
@@ -80,7 +94,7 @@ cdef class SpikeQueue:
                                  <int32_t*>sources.data,
                                  sources.shape[0], dt)
 
-    def push(self, np.ndarray[int32_t, ndim=1, mode='c'] spikes):
+    cpdef push(self, np.ndarray[int32_t, ndim=1, mode='c'] spikes):
         self.thisptr.push(<int32_t*>spikes.data, spikes.shape[0])
 
     def peek(self):

--- a/brian2/synapses/cythonspikequeue.pyx
+++ b/brian2/synapses/cythonspikequeue.pyx
@@ -5,7 +5,6 @@
 from libcpp.vector cimport vector
 from libcpp.pair cimport pair
 from libcpp.string cimport string
-from libc.stdint cimport uintptr_t
 import cython
 from cython.operator import dereference
 from cython.operator cimport dereference

--- a/brian2/synapses/cythonspikequeue.pyx
+++ b/brian2/synapses/cythonspikequeue.pyx
@@ -98,7 +98,7 @@ cdef class SpikeQueue:
                                  <int32_t*>sources.data,
                                  sources.shape[0], dt)
 
-    cpdef push(self, np.ndarray[int32_t, ndim=1, mode='c'] spikes):
+    def push(self, np.ndarray[int32_t, ndim=1, mode='c'] spikes):
         self.thisptr.push(<int32_t*>spikes.data, spikes.shape[0])
 
     def peek(self):

--- a/brian2/synapses/cythonspikequeue.pyx
+++ b/brian2/synapses/cythonspikequeue.pyx
@@ -5,12 +5,11 @@
 from libcpp.vector cimport vector
 from libcpp.pair cimport pair
 from libcpp.string cimport string
-
+from libc.stdint cimport uintptr_t
 import cython
 from cython.operator import dereference
 from cython.operator cimport dereference
-from libc.stdint cimport uintptr_t
-
+from cpython.pycapsule cimport PyCapsule_New, PyCapsule_GetPointer
 
 cimport numpy as np
 import numpy as np
@@ -69,6 +68,9 @@ cdef class SpikeQueue:
         4. Templates then call C++ methods directly without Python involvement
         """
         return <uintptr_t>self.thisptr
+
+    def get_capsule(self):
+        return PyCapsule_New(<void*>self.thisptr, "CSpikeQueue", NULL)
 
     cdef object __weakref__  # Allows weak references to the SpikeQueue
 

--- a/brian2/synapses/cythonspikequeue.pyx
+++ b/brian2/synapses/cythonspikequeue.pyx
@@ -9,7 +9,8 @@ from libcpp.string cimport string
 import cython
 from cython.operator import dereference
 from cython.operator cimport dereference
-from cpython.pycapsule cimport PyCapsule_New, PyCapsule_GetPointer
+from libc.stdint cimport uintptr_t
+
 
 cimport numpy as np
 import numpy as np

--- a/brian2/synapses/cythonspikequeue.pyx
+++ b/brian2/synapses/cythonspikequeue.pyx
@@ -8,7 +8,7 @@ from libcpp.string cimport string
 import cython
 from cython.operator import dereference
 from cython.operator cimport dereference
-from cpython.pycapsule cimport PyCapsule_New, PyCapsule_GetPointer
+from cpython.pycapsule cimport PyCapsule_New
 
 cimport numpy as np
 import numpy as np

--- a/brian2/synapses/cythonspikequeue.pyx
+++ b/brian2/synapses/cythonspikequeue.pyx
@@ -55,21 +55,13 @@ cdef class SpikeQueue:
     def _full_state(self):
         return self.thisptr._full_state()
 
-    def getptr(self):
-        """
-        Returns the raw memory address of the underlying C++ CSpikeQueue object.
-
-        This is used to pass the queue directly into Cython templates for fast,
-        low-overhead access—bypassing Python calls entirely.
-
-        1. self.thisptr is a C++ pointer (CSpikeQueue*) managed by Cython
-        2. <uintptr_t> cast converts the pointer to a platform-appropriate integer
-        3. The returned address can be cast back to CSpikeQueue* in templates
-        4. Templates then call C++ methods directly without Python involvement
-        """
-        return <uintptr_t>self.thisptr
-
     def get_capsule(self):
+        """
+        Returns a PyCapsule object wrapping the underlying C++ CSpikeQueue pointer.
+
+        PyCapsules are used to safely pass raw C/C++ pointers between Python modules
+        or C extensions without exposing the actual implementation details to Python.
+        """
         return PyCapsule_New(<void*>self.thisptr, "CSpikeQueue", NULL)
 
     cdef object __weakref__  # Allows weak references to the SpikeQueue

--- a/brian2/synapses/cythonspikequeue.pyx
+++ b/brian2/synapses/cythonspikequeue.pyx
@@ -9,6 +9,7 @@ from libcpp.string cimport string
 import cython
 from cython.operator import dereference
 from cython.operator cimport dereference
+from cpython.pycapsule cimport PyCapsule_New, PyCapsule_GetPointer
 
 cimport numpy as np
 import numpy as np
@@ -62,11 +63,11 @@ cdef class SpikeQueue:
         low-overhead access—bypassing Python calls entirely.
 
         1. self.thisptr is a C++ pointer (CSpikeQueue*) managed by Cython
-        2. <long> cast converts the pointer to a Python integer (memory address)
+        2. <uintptr_t> cast converts the pointer to a platform-appropriate integer
         3. The returned address can be cast back to CSpikeQueue* in templates
         4. Templates then call C++ methods directly without Python involvement
         """
-        return <long>self.thisptr
+        return <uintptr_t>self.thisptr
 
     cdef object __weakref__  # Allows weak references to the SpikeQueue
 

--- a/brian2/synapses/synapses.py
+++ b/brian2/synapses/synapses.py
@@ -223,7 +223,7 @@ class SynapticPathway(CodeRunner, Group):
 
         if objname is None:
             objname = prepost
-        print("CodeRunner.__init__", code, synapses)
+
         CodeRunner.__init__(
             self,
             synapses,
@@ -416,7 +416,7 @@ class SynapticPathway(CodeRunner, Group):
 
     def initialise_queue(self):
         self.eventspace = self.source.variables[self.eventspace_name].get_value()
-        print("self.eventspace", self.eventspace)
+
         n_synapses = len(self.synapses)
         if n_synapses == 0 and not self.synapses._connect_called:
             raise TypeError(
@@ -898,11 +898,11 @@ class Synapses(Group):
             if not isinstance(multisynaptic_index, str):
                 raise TypeError("multisynaptic_index argument has to be a string")
             model = model + Equations(f"{multisynaptic_index} : integer")
-            print("multisynaptic_index", model)
+
         # Separate subexpressions depending whether they are considered to be
         # constant over a time step or not
         model, constant_over_dt = extract_constant_subexpressions(model)
-        print("constant_over_dt", model)
+
         # Separate the equations into event-driven equations,
         # continuously updated equations and summed variable updates
         event_driven = []
@@ -940,7 +940,7 @@ class Synapses(Group):
                     event_driven.append(single_equation)
         # Get the dependencies of all equations
         dependencies = model.dependencies
-        print("dependencies", dependencies)
+
         # Check whether there are dependencies between summed
         # variables/clocked-driven equations and event-driven variables
         for eq_name, deps in dependencies.items():
@@ -984,7 +984,7 @@ class Synapses(Group):
                 # Register the array with the `SynapticItemMapping` object so
                 # it gets automatically resized
                 self.register_variable(var)
-        print("registered", self._registered_variables)
+
         # Support 2d indexing
         self._indices = SynapticIndexing(self)
 
@@ -1051,7 +1051,7 @@ class Synapses(Group):
 
         #: Performs numerical integration step
         self.state_updater = None
-        print("pathways", self._pathways)
+
         # We only need a state update if we have differential equations
         if len(self.equations.diff_eq_names):
             self.state_updater = StateUpdater(
@@ -1132,7 +1132,7 @@ class Synapses(Group):
             )
             self.summed_updaters[varname] = updater
             self.contained_objects.append(updater)
-        print("variables", (var for var in self.variables))
+
         # Activate name attribute access
         self._enable_group_attributes()
 


### PR DESCRIPTION
##  Description

This PR removes indirect Python method calls for interacting with the spike queue during synaptic spike propagation and replaces them with **direct C++ access** via Cython, improving runtime performance.

### Problem

Previously, the `synapses_push_spikes.pyx` template (and related code objects) relied on Python methods like:

* `_owner.push_spikes()`
* `_owner._queue.peek()`
* `_owner._queue.advance()`

This created an inefficient call chain:

```
Cython → Python → C++ (via method call)
```


---

### This PR Introduces

A **C++-only access path** through PyCapsules and minimal C++ interfaces:

| Operation       | Old (Python method)    | New (Direct C++ via Cython) |
| --------------- | ---------------------- | --------------------------- |
| Push spikes     | `_owner.push_spikes()` | `cpp_queue->push(...)`      |
| Peek from queue | `_queue.peek()`        | `cpp_queue->peek()`         |
| Advance queue   | `_queue.advance()`     | `cpp_queue->advance()`      |

* The `CSpikeQueue*` pointer is passed via a `PyCapsule` into the Cython template.
* Only minimal C++ methods (`push`, `peek`, `advance`) are declared and used.
* NumPy or Python overhead is completely bypassed in the inner simulation loop.



Closes #1642 