### PR TITLE
Remove runtime dependency-version checks from __init__.py

### DIFF
--- a/brian2/__init__.py
+++ b/brian2/__init__.py
@@ -92,7 +92,6 @@ __docformat__ = "restructuredtext en"
 from brian2.only import *
 from brian2.only import test
 
-
 # Initialize the logging system
 BrianLogger.initialize()
 logger = get_logger(__name__)

--- a/brian2/__init__.py
+++ b/brian2/__init__.py
@@ -93,38 +93,6 @@ from brian2.only import *
 from brian2.only import test
 
 
-# Check for outdated dependency versions
-def _check_dependency_version(name, version):
-    import sys
-
-    from packaging.version import Version
-
-    from .core.preferences import prefs
-    from .utils.logger import get_logger
-
-    logger = get_logger(__name__)
-
-    module = sys.modules[name]
-    if not isinstance(module.__version__, str):  # mocked module
-        return
-    if not Version(module.__version__) >= Version(version):
-        message = (
-            f"{name} is outdated (got version {module.__version__}, need version"
-            f" {version})"
-        )
-        if prefs.core.outdated_dependency_error:
-            raise ImportError(message)
-        else:
-            logger.warn(message, "outdated_dependency")
-
-
-def _check_dependency_versions():
-    for name, version in [("numpy", "1.10"), ("sympy", "1.2"), ("jinja2", "2.7")]:
-        _check_dependency_version(name, version)
-
-
-_check_dependency_versions()
-
 # Initialize the logging system
 BrianLogger.initialize()
 logger = get_logger(__name__)

--- a/brian2/core/core_preferences.py
+++ b/brian2/core/core_preferences.py
@@ -18,6 +18,20 @@ def default_float_dtype_validator(dtype):
     return dtype in [float32, float64]
 
 
+def outdated_dependency_error_validator(value):
+    if value is not None:
+        import warnings
+
+        warnings.warn(
+            "The 'core.outdated_dependency_error' preference is no longer "
+            "used and will be removed in a future version. Brian2 now "
+            "relies on package managers for dependency management.",
+            UserWarning,
+            stacklevel=2,
+        )
+    return True  # We always accept the value user provides, but warn them
+
+
 prefs.register_preferences(
     "core",
     "Core Brian preferences",
@@ -37,11 +51,17 @@ prefs.register_preferences(
         representor=dtype_repr,
     ),
     outdated_dependency_error=BrianPreference(
-        default=True,
+        default=None,
         docs="""
-        Whether to raise an error for outdated dependencies (``True``) or just
-        a warning (``False``).
+        **DEPRECATED**: This preference is no longer used. Brian2 now relies on
+        package managers (pip, conda) for dependency management instead of runtime
+        version checking. Setting this preference has no effect and it will be
+        removed in a future version.
+
+        Previously controlled whether to raise an error for outdated dependencies
+        (``True``) or just a warning (``False``).
         """,
+        validator=outdated_dependency_error_validator,
     ),
     stop_on_keyboard_interrupt=BrianPreference(
         default=True,


### PR DESCRIPTION
Closes #1443
---
### Description 

 This PR removes the dependency version checks from `brian2/__init__.py`.

 These checks are:

 * Redundant (handled by `pyproject.toml` and pip)
 * Inconsistent (e.g., required `numpy>=1.10` at runtime vs. `>=1.23.5` in `pyproject.toml`)
 * Confusing to users
 * A maintenance burden

 **How other major packages handle this:**

 * NumPy, Pandas, Matplotlib, scikit-learn: no runtime checks, rely on install-time resolution
 * SciPy: uses runtime version checks, but it’s caused numerous user complaints

**Documented problems from SciPy’s runtime checks:**

- **[GitHub Issue #16964](https://github.com/scipy/scipy/issues/16964)**: "BUG: scipy 1.7.3 wheels on PyPI require numpy<1.23 in contradiction with pyproject.toml and documentation"  
- **[Kaggle Docker Issue #1245](https://github.com/Kaggle/docker-python/issues/1245)**: "Numpy version (1.23.5) exceeds Scipy version (1.7.3) requirement"
- **[Intel Community Post](https://community.intel.com/t5/Intel-Distribution-for-Python/Incompatible-numpy-and-scipy-versions-in-the-Intel-channel/m-p/1482452)**: Intel users getting warnings even with tested MKL-optimized versions
- **[Bioconda Issue #45942](https://github.com/bioconda/bioconda-recipes/issues/45942)**: Runtime test failures due to SciPy version warnings
- **[Allsky Discussion #3130](https://github.com/AllskyTeam/allsky/discussions/3130)**: Nightly warning spam from SciPy checks
- **[Stack Overflow Question](https://stackoverflow.com/questions/73072257/resolve-warning-a-numpy-version-1-16-5-and-1-23-0-is-required-for-this-versi)**: Multiple users confused by contradictory version requirements


These examples show that runtime checks often **do more harm than good** — better to let users get a clean ImportError or install-time resolution failure.

This PR removes `_check_dependency_versions()` and all related logic from the codebase.

---

