### PR TITLE
Avoid using Python version >=3.11.9 but <3.12 for tests

### DIFF
--- a/.github/workflows/testsuite.yml
+++ b/.github/workflows/testsuite.yml
@@ -50,11 +50,11 @@ jobs:
         include:
           - os: {image: ubuntu-24.04, triplet: x64-linux}
             standalone: false
-            python-version: "${{ needs.get_python_versions.outputs.min-python }}"
+            python-version: "${{ needs.get_python_versions.outputs.min-python }} < 3.11.9 || ${{ needs.get_python_versions.outputs.min-python }} >= 3.12"
             float_dtype_32: false
           - os: {image: ubuntu-24.04, triplet: x64-linux}
             standalone: true
-            python-version: "${{ needs.get_python_versions.outputs.min-python }}"
+            python-version: "${{ needs.get_python_versions.outputs.min-python }} < 3.11.9 || ${{ needs.get_python_versions.outputs.min-python }} >= 3.12"
             float_dtype_32: false
 
     defaults:


### PR DESCRIPTION
Doctest discovery is broken for wrapped C functions (e.g. from numpy). This is a regression that has been introduced with the last bugfix release of Python 3.11, and will probably not be fixed anymore in 3.11. I guess we could work around the problem in our test suite in some way, but for now we simply do not install an affected Python version during the tests. This will solve itself in April 2026 when we drop Python 3.11 support ;-)

See python/cpython#117692