### PR TITLE
Fix iSTDP update rule (Eq.15): swap pre/post trace handling

### DIFF
--- a/examples/synapses/homeostatic_stdp_at_inhibitory_synapes.py
+++ b/examples/synapses/homeostatic_stdp_at_inhibitory_synapes.py
@@ -78,12 +78,12 @@ dzi/dt = -zi / tau_stdp : 1 (event-driven)
 dzj/dt = -zj / tau_stdp : 1 (event-driven)
 """
 on_pre = """
-zi += 1.
-wij += eta * G * zj
-"""
-on_post = """
 zj += 1.
 wij += eta * G * (zi + 1)
+"""
+on_post = """
+zi += 1.
+wij += eta * G * zj
 """
 synapse = b2.Synapses(
     presynaptic_neuron, postsynaptic_neuron,


### PR DESCRIPTION
Fix iSTDP update rule (Eq.15): swap pre/post trace handling
- Pre-spike now increments zj and applies Δw = ηG(zi+1)
- Post-spike now increments zi and applies Δw = ηG zj This corrects the flipped implementation of the iSTDP rule.