### PR TITLE
Avoid `ReferenceError` when using `run_args`

### DIFF
--- a/brian2/devices/cpp_standalone/device.py
+++ b/brian2/devices/cpp_standalone/device.py
@@ -1258,11 +1258,14 @@ class CPPStandaloneDevice(Device):
             s = arg.split("=")
             if len(s) == 2:
                 for var in self.array_cache:
-                    if (
-                        hasattr(var.owner, "name")
-                        and var.owner.name + "." + var.name == s[0]
-                    ):
-                        self.array_cache[var] = None
+                    try:
+                        if (
+                            hasattr(var.owner, "name")
+                            and var.owner.name + "." + var.name == s[0]
+                        ):
+                            self.array_cache[var] = None
+                    except ReferenceError:
+                        pass  # Happens when ephemeral subgroups have been used to set a variable
         run_args = ["--results_dir", self.results_dir] + run_args
         # Invalidate the cached end time of the clock and network, to deal with stopped simulations
         for clock in self.clocks:


### PR DESCRIPTION
When using `run_args`, we go through all variables in the array cache, and check whether they should be invalidated. This can lead to a `ReferenceError` if a variable in the cache refers to an ephemeral subgroup. The fix is simply to swallow this error (but maybe these variables shouldn't be in the array cache in the first place?)

Fixes #1673