### PR TITLE
Increase the test timeout to 1 hour

### DIFF
--- a/brian2/tests/pytest.ini
+++ b/brian2/tests/pytest.ini
@@ -22,5 +22,5 @@ filterwarnings =
     ignore:divide by zero:RuntimeWarning
     ignore:overflow:RuntimeWarning
 
-# Fail tests after 10 minutes
-timeout = 600
+# Fail tests after 1 hour
+timeout = 3600


### PR DESCRIPTION
The increase in commit 1a73a1f2cc72c12389ba0fa9f6629d4ca4ee255b was not sufficient everywhere, e.g. https://buildd.debian.org/status/fetch.php?pkg=brian&arch=riscv64&ver=2.9.0-1&stamp=1757512918&raw=0