### PR TITLE
Faster pre-commit stage

### DIFF
--- a/.github/workflows/testsuite.yml
+++ b/.github/workflows/testsuite.yml
@@ -34,9 +34,14 @@ jobs:
         with:
           python-version: "3.12"
           cache: "pip"
-          cache-dependency-path: .devcontainer/dev-requirements.txt
-      - name: Install deps
-        run: pip3 install -r .devcontainer/dev-requirements.txt
+      - name: set PY
+        run: echo "PY=$(python -VV | sha256sum | cut -d' ' -f1)" >> $GITHUB_ENV
+      - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: ~/.cache/pre-commit
+          key: pre-commit|${{ env.PY }}|${{ hashFiles('.pre-commit-config.yaml') }}
+      - name: Install pre-commit
+        run: pip3 install pre-commit
       - name: Run pre-commit hooks
         run: pre-commit run --all-files --show-diff-on-failure
 


### PR DESCRIPTION
No need to install dependencies for pre-commit, it runs tools in their own environment.  Together with caching, this step goes down from 1m30 to 11s. Not a major issue, but since this step blocks the following steps, every little improvement helps.