### PR TITLE
Docs: Update developer workflow to prioritize Devcontainers and local setup using uv

### DIFF
--- a/docs_sphinx/developer/index.rst
+++ b/docs_sphinx/developer/index.rst
@@ -5,12 +5,41 @@ This section is intended as a guide to how Brian functions internally for
 people developing Brian itself, or extensions to Brian. It may also be of some
 interest to others wishing to better understand how Brian works internally.
 
-If you use `VS code <https://code.visualstudio.com/>`_ as your development
-environment, it will offer to automatically build a Brian development
-`Docker <https://www.docker.com/>`_ container when you open the repository,
-with all the required dependencies installed and configured. Further
-`documentation <https://github.com/brian-team/brian2/blob/master/.devcontainer/README.md>`_
-for this approach can be found in the ``.devcontainer`` directory.
+Setting up a development environment
+-------------------------------------
+
+Option 1: Devcontainers (Highly Recommended)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The easiest and most reliable way to set up a development environment is to use
+`VS Code Devcontainers <https://code.visualstudio.com/docs/devcontainers/containers>`_.
+When you open the Brian repository in
+`VS Code <https://code.visualstudio.com/>`_, it will offer to automatically
+build a `Docker <https://www.docker.com/>`_ container with all the required
+dependencies installed and configured — no manual setup needed.
+
+For full details, see the
+`Devcontainer README <https://github.com/brian-team/brian2/blob/master/.devcontainer/README.md>`_
+in the ``.devcontainer`` directory.
+
+Option 2: Local Setup using ``uv``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If you prefer a local setup without Docker, you can use
+`uv <https://docs.astral.sh/uv/>`_ to install Brian in development mode.
+``uv`` resolves all dependencies directly from the existing ``pyproject.toml``
+file, keeping the repository clean without needing external dependency files.
+
+1. `Install uv <https://docs.astral.sh/uv/getting-started/installation/>`_ if
+   you haven't already.
+2. From the root of the repository, run:
+
+   .. code-block:: bash
+
+      uv add --dev --editable .[docs,test]
+
+   This will install Brian along with all documentation and testing
+   dependencies in an editable (development) mode.
 
 .. toctree::
    :maxdepth: 2


### PR DESCRIPTION
->Added the standard command `uv add --dev --editable .[docs,test]` so developers can resolve dependencies directly from the existing `pyproject.toml` without needing to maintain redundant dependency files.
->ocal setup instructions with a modern `uv` workflow.
->Restructured the environment setup guide to prominently feature the VS Code Devcontainer approach as the #1 recommended method for new contributors.