### PR TITLE
test:add cython synapses regression coverage for #1769

### DIFF
--- a/brian2/tests/test_synapses.py
+++ b/brian2/tests/test_synapses.py
@@ -3730,6 +3730,34 @@ def test_setting_from_weight_matrix():
         assert all(syn.w[i, j] == weights[i, j])
 
 
+def test_synapses_cython_codegen_target_runs():
+    from brian2 import prefs, start_scope, run, ms, NeuronGroup, Synapses
+
+    old_target = prefs.codegen.target
+    prefs.codegen.target = "cython"
+
+    try:
+        start_scope()
+
+        G = NeuronGroup(
+            2,
+            "v : 1",
+            threshold="v > 1",
+            reset="v = 0",
+        )
+
+        S = Synapses(G, G, on_pre="v_post += 1")
+        S.connect(i=0, j=1)
+
+        G.v = [2, 0]
+        run(1 * ms)
+
+        assert G.v[0] == pytest.approx(0)
+        assert G.v[1] == pytest.approx(1)
+    finally:
+        prefs.codegen.target = old_target
+
+
 if __name__ == "__main__":
     SANITY_CHECK_PERMUTATION_ANALYSIS_EXAMPLE = True
     # prefs.codegen.target = 'numpy'
@@ -3832,5 +3860,6 @@ if __name__ == "__main__":
     test_synaptic_subgroups()
     test_incorrect_connect_N_incoming_outgoing()
     test_setting_from_weight_matrix()
+    test_synapses_cython_codegen_target_runs()
 
     print("Tests took", time.time() - start)

--- a/brian2/tests/test_synapses.py
+++ b/brian2/tests/test_synapses.py
@@ -3731,7 +3731,6 @@ def test_setting_from_weight_matrix():
 
 
 def test_synapses_cython_codegen_target_runs():
-    from brian2 import prefs, start_scope, run, ms, NeuronGroup, Synapses
 
     old_target = prefs.codegen.target
     prefs.codegen.target = "cython"
@@ -3752,8 +3751,7 @@ def test_synapses_cython_codegen_target_runs():
         G.v = [2, 0]
         run(1 * ms)
 
-        assert G.v[0] == pytest.approx(0)
-        assert G.v[1] == pytest.approx(1)
+        assert_allclose(G.v[:], [0, 1])
     finally:
         prefs.codegen.target = old_target
 
@@ -3860,6 +3858,6 @@ if __name__ == "__main__":
     test_synaptic_subgroups()
     test_incorrect_connect_N_incoming_outgoing()
     test_setting_from_weight_matrix()
-    test_synapses_cython_codegen_target_runs()
+    
 
     print("Tests took", time.time() - start)


### PR DESCRIPTION
### Summary

This PR adds a regression test for issue #1769 by verifying that a simple `Synapses` example runs correctly with the Cython code generation target.
 
## What this tests

* Sets `prefs.codegen.target = "cython"`
* Creates a minimal `NeuronGroup` + `Synapses` setup
* Runs a simple `on_pre` synaptic update
* Confirms expected state changes after execution

## Why

Issue #1769 involves the Cython execution/codegen path for synapses.
This test helps ensure that the relevant synaptic execution path continues to work correctly and can catch future regressions.

## Validation

Tested locally with:

```bash
pytest brian2/tests/test_synapses.py -k test_synapses_cython_codegen_target_runs -v
```

Also manually validated with a minimal Brian2 script using:

```python
prefs.codegen.target = "cython"
```


