### PR TITLE
Draft: Fix #1350 - Preserve exprel, expm1, and log1p during SymPy translation

### DIFF
--- a/brian2/parsing/rendering.py
+++ b/brian2/parsing/rendering.py
@@ -241,8 +241,15 @@ class SympyNodeRenderer(NodeRenderer):
         elif len(node.args) == 0:
             return self.render_func(node.func)(sympy.Symbol("_placeholder_arg"))
         else:
+            unevaluated_funcs = ['exprel', 'expm1', 'log1p']
+            
+            kwargs = {}
+            if getattr(node.func, 'id', None) in unevaluated_funcs:
+                kwargs['evaluate'] = False
+                
             return self.render_func(node.func)(
-                *(self.render_node(arg) for arg in node.args)
+                *(self.render_node(arg) for arg in node.args),
+                **kwargs
             )
 
     def render_Compare(self, node):

--- a/brian2/parsing/rendering.py
+++ b/brian2/parsing/rendering.py
@@ -241,15 +241,14 @@ class SympyNodeRenderer(NodeRenderer):
         elif len(node.args) == 0:
             return self.render_func(node.func)(sympy.Symbol("_placeholder_arg"))
         else:
-            unevaluated_funcs = ['exprel', 'expm1', 'log1p']
-            
+            unevaluated_funcs = ["exprel", "expm1", "log1p"]
+
             kwargs = {}
-            if getattr(node.func, 'id', None) in unevaluated_funcs:
-                kwargs['evaluate'] = False
-                
+            if getattr(node.func, "id", None) in unevaluated_funcs:
+                kwargs["evaluate"] = False
+
             return self.render_func(node.func)(
-                *(self.render_node(arg) for arg in node.args),
-                **kwargs
+                *(self.render_node(arg) for arg in node.args), **kwargs
             )
 
     def render_Compare(self, node):

--- a/brian2/parsing/rendering.py
+++ b/brian2/parsing/rendering.py
@@ -243,12 +243,10 @@ class SympyNodeRenderer(NodeRenderer):
         else:
             unevaluated_funcs = ["exprel", "expm1", "log1p"]
 
-            kwargs = {}
-            if getattr(node.func, "id", None) in unevaluated_funcs:
-                kwargs["evaluate"] = False
+            evaluate = getattr(node.func, "id", None) not in unevaluated_funcs
 
             return self.render_func(node.func)(
-                *(self.render_node(arg) for arg in node.args), **kwargs
+                *(self.render_node(arg) for arg in node.args), evaluate=evaluate
             )
 
     def render_Compare(self, node):

--- a/brian2/tests/test_parsing.py
+++ b/brian2/tests/test_parsing.py
@@ -615,3 +615,11 @@ if __name__ == "__main__":
     test_error_messages()
     test_shadowed_internal_variable_function_call_error()
     test_sympy_infinity()
+
+def test_sympy_evaluation_preservation():
+    """Fix for Issue #1350: ensure exprel, expm1, and log1p are not prematurely evaluated"""
+    from brian2.parsing.sympytools import str_to_sympy
+    
+    assert str(str_to_sympy("expm1(x + 1.0)")) == "expm1(x + 1.0)"
+    assert str(str_to_sympy("log1p(x + 1.0)")) == "log1p(x + 1.0)"
+    assert str(str_to_sympy("exprel(x + 1.0)")) == "exprel(x + 1.0)"

--- a/brian2/tests/test_parsing.py
+++ b/brian2/tests/test_parsing.py
@@ -616,10 +616,11 @@ if __name__ == "__main__":
     test_shadowed_internal_variable_function_call_error()
     test_sympy_infinity()
 
+
 def test_sympy_evaluation_preservation():
     """Fix for Issue #1350: ensure exprel, expm1, and log1p are not prematurely evaluated"""
     from brian2.parsing.sympytools import str_to_sympy
-    
+
     assert str(str_to_sympy("expm1(x + 1.0)")) == "expm1(x + 1.0)"
     assert str(str_to_sympy("log1p(x + 1.0)")) == "log1p(x + 1.0)"
     assert str(str_to_sympy("exprel(x + 1.0)")) == "exprel(x + 1.0)"


### PR DESCRIPTION
Hi @mstimberg,

Got the `evaluate=False` fix working in `rendering.py`. It intercepts `exprel`, `expm1`, and `log1p` during the AST walk and passes the flag directly. 

This preserves the AST nodes for the C++ codegen without touching the global parser or breaking float evaluations downstream.

Tests are passing locally and I've added a regression test, but opening this as a draft so you can verify the architecture.