### PR TITLE
Revert "Avoid Cython 3.1.4 as a temporary measure"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ authors = [
 requires-python = ">=3.12"
 dependencies = [
     "numpy>=2.0.0",
-    'cython>=0.29.21,<3.1.4',
+    'cython>=0.29.21',
     'sympy>=1.2',
     'pyparsing>=3,!=3.2.4',
     'jinja2>=2.7',


### PR DESCRIPTION
Hi,

This reverts commit 42c79faf9b348c5e2dae6e39cf5542e2a0e3f3b0.

CI seems happy about it, so I guess the issue in https://github.com/brian-team/brian2/pull/1687 was fixed