### PR TITLE
No longer build packages for manylinux2014

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -123,7 +123,6 @@ jobs:
         env:
           CIBW_PROJECT_REQUIRES_PYTHON: ">=${{ needs.get_python_versions.outputs.min-python }}"
           CIBW_ARCHS_LINUX: ${{ matrix.config.arch }}
-          CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
           CIBW_SKIP: '*-musllinux_aarch64'
           CIBW_TEST_COMMAND: python {project}/dev/continuous-integration/run_simple_test.py
           CIBW_TEST_REQUIRES: pytest


### PR DESCRIPTION
These images are built on EOL CentOS 7 and recent numpy needs a newer gcc