### PR TITLE
brian2cuda: Forward optional compiler_kwds from BinomialFunction generators.

### DIFF
--- a/brian2/input/binomial.py
+++ b/brian2/input/binomial.py
@@ -163,8 +163,8 @@ class BinomialFunction(Function, Nameable):
     #: Container for implementing functions for different targets
     #: This container can be extended by other codegeneration targets/devices
     #: The key has to be the name of the target, the value a function
-    #: that takes three parameters (n, p, use_normal) and returns a tuple of
-    #: (code, dependencies)
+    #: that takes three parameters (n, p, use_normal) and returns either a
+    #: tuple of (code, dependencies) or (code, dependencies, compiler_kwds)
     implementations = {"cpp": _generate_cpp_code, "cython": _generate_cython_code}
 
     @check_units(n=1, p=1)
@@ -205,7 +205,16 @@ class BinomialFunction(Function, Nameable):
         self.implementations.add_implementation("numpy", sample_function)
 
         for target, func in BinomialFunction.implementations.items():
-            code, dependencies = func(n=n, p=p, use_normal=use_normal, name=self.name)
+            result = func(n=n, p=p, use_normal=use_normal, name=self.name)
+            if len(result) == 2:
+                code, dependencies = result
+                compiler_kwds = None
+            elif len(result) == 3:
+                code, dependencies, compiler_kwds = result
             self.implementations.add_implementation(
-                target, code, dependencies=dependencies, name=self.name
+                target,
+                code,
+                dependencies=dependencies,
+                name=self.name,
+                compiler_kwds=compiler_kwds,
             )


### PR DESCRIPTION
An updated generator for `BinomialFunction` now supports returning `(code, dependencies, compiler_kwds)` instead of just `(code, dependencies)`. This fix allows external backends like Brian2CUDA to specify extra compiler settings and include necessary CUDA headers (such as `"rand.h"` or `<curand_kernel.h>`) when generating per-instance code, which was previously unsupported.