### PR TITLE
brian2cuda: replace the defualt std c++ version from c++11 to c++17

### DIFF
--- a/brian2/codegen/cpp_prefs.py
+++ b/brian2/codegen/cpp_prefs.py
@@ -112,7 +112,7 @@ else:
             "-ffast-math",
             "-fno-finite-math-only",
             "-march=native",
-            "-std=c++11",
+            "-std=c++17",
         ]
     elif re.match("^(alpha|ppc.*|sparc.*)$", machine):
         default_buildopts = [
@@ -122,7 +122,7 @@ else:
             "-fno-finite-math-only",
             "-mcpu=native",
             "-mtune=native",
-            "-std=c++11",
+            "-std=c++17",
         ]
     elif re.match("^(parisc.*|riscv.*|mips.*|loong64.*)$", machine):
         default_buildopts = [
@@ -130,7 +130,7 @@ else:
             "-O3",
             "-ffast-math",
             "-fno-finite-math-only",
-            "-std=c++11",
+            "-std=c++17",
         ]
     else:
         default_buildopts = ["-w"]

--- a/brian2/memory/cythondynamicarray.pyx
+++ b/brian2/memory/cythondynamicarray.pyx
@@ -1,7 +1,7 @@
 # cython: language_level=3
 # distutils: language = c++
 # distutils: include_dirs = brian2/devices/cpp_standalone/brianlib
-# distutils: extra_compile_args = -std=c++11
+# distutils: extra_compile_args = -std=c++17
 
 
 import numpy as np


### PR DESCRIPTION
This modification is brian2cuda relevant Replace the default std version from c++ 11 to c++ 17. [c++11 will eventually not be supported in future CUDA toolkit](https://github.com/NVIDIA/thrust/blob/main/CHANGELOG.md#thrust-1100-nvidia-hpc-sdk-209-cuda-toolkit-112). And thrust is merged to cccl, which only supports c++17 and c++20.