### PR TITLE
Allow deferred preference validation for device categories

### DIFF
--- a/brian2/core/preferences.py
+++ b/brian2/core/preferences.py
@@ -184,8 +184,17 @@ class BrianGlobalPreferences(MutableMapping):
     def __setitem__(self, name, value):
         basename, endname = parse_preference_name(name)
         if basename not in self.pref_register:
+            parts = basename.split(".")
+            if len(parts) >= 2 and parts[0] == "devices":
+                # This is an unknown preference category, but it is possibly defined
+                # for a device such as brian2cuda. Do not raise an error for now.
+                # If this is a preference for a 3rd-party device package it
+                # will be set and validated at the set_device call.
+                # If the category is wrong even after importing all other packages, it
+                # will raise a warning at the run call (see check_all_validated).
+                return
             raise PreferenceError(
-                "Preference category " + basename + " is unregistered. Spelling error?"
+                f"Preference category '{basename}' is unregistered. Spelling error?"
             )
         prefdefs, _ = self.pref_register[basename]
         if endname in prefdefs:
@@ -590,7 +599,10 @@ class BrianGlobalPreferences(MutableMapping):
                     "preference category."
                 )
             check_preference_name(k)
-            self.prefs_unvalidated[fullname] = v.default
+            if fullname not in self.prefs_unvalidated:
+                # Do not overwrite a preference set before the preference was
+                # registered (e.g. preference set in a file)
+                self.prefs_unvalidated[fullname] = v.default
         self.do_validation()
 
         # Update the docstring (a new toplevel category might have been added)

--- a/brian2/core/preferences.py
+++ b/brian2/core/preferences.py
@@ -185,7 +185,11 @@ class BrianGlobalPreferences(MutableMapping):
         basename, endname = parse_preference_name(name)
         if basename not in self.pref_register:
             parts = basename.split(".")
-            if len(parts) >= 2 and parts[0] == "devices":
+            if (
+                name in self.prefs_unvalidated  # Not for direct setting of preference
+                and len(parts) >= 2
+                and parts[0] == "devices"
+            ):
                 # This is an unknown preference category, but it is possibly defined
                 # for a device such as brian2cuda. Do not raise an error for now.
                 # If this is a preference for a 3rd-party device package it

--- a/brian2/devices/device.py
+++ b/brian2/devices/device.py
@@ -702,6 +702,7 @@ def set_device(device, build_on_run=True, **kwargs):
         that will be given to the `Device.build` call.
     """
     global previous_devices
+
     if active_device is not None:
         prev_build_on_run = getattr(active_device, "build_on_run", True)
         prev_build_options = getattr(active_device, "build_options", {})

--- a/brian2/tests/test_preferences.py
+++ b/brian2/tests/test_preferences.py
@@ -11,6 +11,7 @@ from brian2.core.preferences import (
     DefaultValidator,
     PreferenceError,
 )
+from brian2.utils.logger import catch_logs
 
 
 @pytest.mark.codegen_independent
@@ -237,6 +238,16 @@ def test_deferred_device_preferences_from_file():
 
     # This should be the value from the file, not the default value
     assert gp.devices.cuda_standalone.test_pref == 5
+
+    # Unresolved deferred preferences should trigger a warning.
+    with catch_logs() as logs:
+        gp.check_all_validated()
+
+    assert len(logs) == 1
+    level, name, message = logs[0]
+    assert level == "WARNING"
+    assert name == "brian2.core.preferences"
+    assert "devices.some_other_device.test_pref" in message
 
 
 @pytest.mark.codegen_independent

--- a/brian2/tests/test_preferences.py
+++ b/brian2/tests/test_preferences.py
@@ -220,6 +220,10 @@ def test_deferred_device_preferences_from_file():
         "devices.some_other_device.test_pref": 7,
     }
 
+    # Direct setting of such a preference should still fail
+    with pytest.raises(PreferenceError):
+        gp["devices.cuda_standalone.test_prefs"] = 3
+
     # Register one device category: its preference should validate, the other
     # should still be deferred.
     gp.register_preferences("devices", "Device preferences")

--- a/brian2/tests/test_preferences.py
+++ b/brian2/tests/test_preferences.py
@@ -2,7 +2,6 @@ from io import StringIO
 
 import pytest
 from numpy import float32, float64
-from numpy.testing import assert_equal
 
 from brian2 import amp, restore_initial_state, volt
 from brian2.core.preferences import (
@@ -199,6 +198,44 @@ def test_brianglobalpreferences():
 
 
 @pytest.mark.codegen_independent
+def test_deferred_device_preferences_from_file():
+    # Preferences for a device subcategory can be read before that subcategory
+    # is registered (e.g. when a 3rd-party device package is imported later).
+    gp = BrianGlobalPreferences()
+
+    # Mimic import-time preference loading for devices that are not imported yet.
+    gp.read_preference_file(
+        StringIO(
+            """
+            devices.cuda_standalone.test_pref = 5
+            devices.some_other_device.test_pref = 7
+            """
+        )
+    )
+
+    # Validation during import should defer, not fail, for devices.* entries.
+    gp.do_validation()
+    assert gp.prefs_unvalidated == {
+        "devices.cuda_standalone.test_pref": 5,
+        "devices.some_other_device.test_pref": 7,
+    }
+
+    # Register one device category: its preference should validate, the other
+    # should still be deferred.
+    gp.register_preferences("devices", "Device preferences")
+    gp.register_preferences(
+        "devices.cuda_standalone",
+        "cuda standalone preferences",
+        test_pref=BrianPreference(0, "test preference"),
+    )
+
+    assert gp.prefs_unvalidated == {"devices.some_other_device.test_pref": 7}
+
+    # This should be the value from the file, not the default value
+    assert gp.devices.cuda_standalone.test_pref == 5
+
+
+@pytest.mark.codegen_independent
 def test_preference_name_access():
     """
     Test various ways of accessing preferences
@@ -300,7 +337,7 @@ def test_preference_name_access():
     assert "main.name" in gp
     assert "name" in gp["main"]
     assert "name2" in gp["main.sub"]
-    assert not "name" in gp["main.sub"]
+    assert "name" not in gp["main.sub"]
 
     gp["main.name"] = True
     gp.update({"main.name": False})


### PR DESCRIPTION
This implements a solution to #1340 and brian-team/brian2cuda#281 that doesn't require any fundamental changes: unknown preferences that are in a `devices.*` category do not raise errors but stay unvalidated. They will be validated when the `brian2cuda` package registers the preference.
CC @SinYita 
Closes #1340