### PR TITLE
Add dtype keyword to StateMonitor

### DIFF
--- a/brian2/monitors/statemonitor.py
+++ b/brian2/monitors/statemonitor.py
@@ -1,9 +1,10 @@
 import numbers
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 
 import numpy as np
 
-from brian2.core.variables import Variables, get_dtype
+from brian2.core.variables import Variables
+from brian2.core.variables import get_dtype as get_index_dtype
 from brian2.groups.group import CodeRunner, Group
 from brian2.units.allunits import second
 from brian2.units.fundamentalunits import Quantity
@@ -12,6 +13,33 @@ from brian2.utils.logger import get_logger
 __all__ = ["StateMonitor"]
 
 logger = get_logger(__name__)
+
+
+def _get_record_dtype(varname, var, dtype):
+    """
+    Determine the dtype to use for recording `varname`, taking into account
+    the (optional) `dtype` argument of `StateMonitor` (either a single dtype
+    used for all variables, or a dictionary mapping variable names to dtypes).
+    """
+    if dtype is None:
+        return var.dtype
+    if isinstance(dtype, Mapping):
+        if varname not in dtype:
+            return var.dtype
+        provided_dtype = np.dtype(dtype[varname])
+    else:
+        provided_dtype = np.dtype(dtype)
+    var_dtype = np.dtype(var.dtype)
+    compatible_kinds = {"b": "b", "i": "iu", "u": "iu", "f": "f"}.get(
+        var_dtype.kind, var_dtype.kind
+    )
+    if provided_dtype.kind not in compatible_kinds:
+        raise TypeError(
+            f"Cannot use dtype '{provided_dtype.name}' for variable "
+            f"'{varname}': it is not compatible with the type of the "
+            f"variable ({var_dtype.name})."
+        )
+    return provided_dtype
 
 
 class StateMonitorView:
@@ -53,7 +81,7 @@ class StateMonitorView:
         Convert the neuron indices to indices into the stored values. For example, if neurons [0, 5, 10] have been
         recorded, [5, 10] is converted to [1, 2].
         """
-        dtype = get_dtype(item)
+        dtype = get_index_dtype(item)
         # scalar value
         if np.issubdtype(dtype, np.signedinteger) and not isinstance(item, np.ndarray):
             indices = np.nonzero(self.monitor.record == item)[0]
@@ -121,6 +149,12 @@ class StateMonitor(Group, CodeRunner):
     name : str, optional
         A unique name for the object, otherwise will use
         ``source.name+'statemonitor_0'``, etc.
+    dtype : (`dtype`, `dict`), optional
+        The `numpy.dtype` that will be used to store the recorded values, or
+        a dictionary specifying the type for individual variable names. If a
+        value is not provided for a variable (or no value is provided at
+        all), the same `dtype` as for the respective variable in `source` is
+        used.
     codeobj_class : `CodeObject`, optional
         The `CodeObject` class to create.
 
@@ -171,6 +205,7 @@ class StateMonitor(Group, CodeRunner):
         when="start",
         order=0,
         name="statemonitor*",
+        dtype=None,
         codeobj_class=None,
     ):
         self.source = source
@@ -304,22 +339,24 @@ class StateMonitor(Group, CodeRunner):
             )
             if index not in ("_idx", "0") and index not in variables:
                 self.variables.add_reference(index, source)
+            record_dtype = _get_record_dtype(varname, var, dtype)
             self.variables.add_dynamic_array(
                 varname,
                 size=(0, len(self.record)),
                 resize_along_first=True,
                 dimensions=var.dim,
-                dtype=var.dtype,
+                dtype=record_dtype,
                 constant=False,
                 read_only=True,
             )
 
         for varname in variables:
             var = self.source.variables[varname]
+            record_dtype = _get_record_dtype(varname, var, dtype)
             self.variables.add_auxiliary_variable(
                 f"_to_record_{varname}",
                 dimensions=var.dim,
-                dtype=var.dtype,
+                dtype=record_dtype,
                 scalar=var.scalar,
             )
 
@@ -346,7 +383,7 @@ class StateMonitor(Group, CodeRunner):
         raise NotImplementedError()
 
     def __getitem__(self, item):
-        dtype = get_dtype(item)
+        dtype = get_index_dtype(item)
         if np.issubdtype(dtype, np.signedinteger):
             return StateMonitorView(self, item)
         elif isinstance(item, Sequence):

--- a/brian2/tests/test_monitor.py
+++ b/brian2/tests/test_monitor.py
@@ -512,6 +512,56 @@ def test_state_monitor_resize():
 
 
 @pytest.mark.standalone_compatible
+def test_state_monitor_dtype():
+    # Test the dtype argument of StateMonitor
+    G = NeuronGroup(
+        2,
+        """
+        v : 1
+        i_var : integer
+        b_var : boolean
+        """,
+    )
+    G.v = [1.5, 2.5]
+    G.i_var = [1, 2]
+    G.b_var = [True, False]
+
+    # No dtype given: use the same dtype as the source variable
+    mon_default = StateMonitor(G, ["v", "i_var", "b_var"], record=True)
+    # Single dtype for all (compatible) variables
+    mon_single = StateMonitor(G, "v", record=True, dtype=np.float32)
+    # dtype given per variable
+    mon_dict = StateMonitor(
+        G,
+        ["v", "i_var", "b_var"],
+        record=True,
+        dtype={"v": np.float32, "i_var": np.int64},
+    )
+    run(defaultclock.dt)
+
+    assert mon_default.variables["v"].dtype == prefs.core.default_float_dtype
+    assert mon_default.variables["i_var"].dtype == G.variables["i_var"].dtype
+    assert mon_default.variables["b_var"].dtype == np.dtype(bool)
+
+    assert mon_single.variables["v"].dtype == np.float32
+
+    assert mon_dict.variables["v"].dtype == np.float32
+    assert mon_dict.variables["i_var"].dtype == np.int64
+    # not specified for b_var, should fall back to the default
+    assert mon_dict.variables["b_var"].dtype == np.dtype(bool)
+
+    assert_allclose(mon_dict.v[:], mon_default.v[:])
+    assert_array_equal(mon_dict.i_var[:], mon_default.i_var[:])
+    assert_array_equal(mon_dict.b_var[:], mon_default.b_var[:])
+
+    # Using an incompatible dtype should raise an error
+    with pytest.raises(TypeError):
+        StateMonitor(G, "b_var", record=True, dtype=np.float32)
+    with pytest.raises(TypeError):
+        StateMonitor(G, "i_var", record=True, dtype=bool)
+
+
+@pytest.mark.standalone_compatible
 def test_state_monitor_synapses():
     # Check that recording from synapses works correctly
     G = NeuronGroup(5, "v : 1", threshold="False", reset="v = 0")


### PR DESCRIPTION
Useful in particular to save memory by using float32 to record a float64 variable

I actually thought we had this already (see my comment at https://brian.discourse.group/t/memory-error-insufficient-disc-space/1471/2) …